### PR TITLE
Avoid race condition when JIT compiling blocks

### DIFF
--- a/src/riscv/lib/src/machine_state/block_cache/block/dispatch.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/block/dispatch.rs
@@ -172,6 +172,12 @@ impl<MC: MemoryConfig + Send, M: JitStateAccess + Send + 'static> OutlineCompile
 
                 while let Ok(msg) = receiver.recv() {
                     if let Some(jitfn) = jit.compile(&msg.instr) {
+                        debug_assert_eq!(
+                            msg.fun.load(Ordering::Acquire),
+                            Jitted::<Self, MC, M>::run_block_not_compiled as usize,
+                            "Unexpected function pointer in dispatch target"
+                        );
+
                         // Safety: this function will be retrieved as a DispatchFn, rather than a
                         // JitFn. The two function signatures are identical, apart from the first and
                         // last parameters. These are both thin-pointers, and ignored by the JitFn.
@@ -220,6 +226,9 @@ impl<MC: MemoryConfig + Send, M: JitStateAccess + Send + 'static> DispatchCompil
         target: &mut DispatchTarget<Self, MC, M>,
         instr: Vec<Instruction>,
     ) -> DispatchFn<Self, MC, M> {
+        let fun = Jitted::run_block_not_compiled;
+        target.set(fun);
+
         let request = CompilationRequest {
             instr,
             fun: target.fun.clone(),
@@ -236,8 +245,6 @@ impl<MC: MemoryConfig + Send, M: JitStateAccess + Send + 'static> DispatchCompil
         // our reference to it, despite the lock itself being poisoned.
         let _ = self.sender.send(request);
 
-        let fun = Jitted::run_block_not_compiled;
-        target.set(fun);
         fun
     }
 }


### PR DESCRIPTION
This PR has been migrated from [this GitLab MR](https://gitlab.com/tezos/tezos/-/merge_requests/18089).

<!--Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".-->

# What

Set the "fallback" dispatch target before kicking off the compilation task.

# Why

This avoids a race condition where the main and compilation background threads may try to write to the same atomic cell. This risks the "not compiled" target prevailing and wasted JIT compilation.

To avoid this, we set the "not compiled" dispatch target before kicking off compilation, which then overrides it once the compilation is complete.

# Manually Testing

```
make -C src/riscv all
```

# Benchmarking

No runtime performance impact

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] Benchmark performance and [populate the section above](#benchmarking) if needed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
