### PR TITLE
Return performed steps rather than mutating variable

### DIFF
--- a/src/riscv/lib/src/machine_state.rs
+++ b/src/riscv/lib/src/machine_state.rs
@@ -217,10 +217,40 @@ pub enum ProgramCounterUpdate<AddressRepr> {
 }
 
 /// Result type when running multiple steps at a time with [`MachineState::step_max`]
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct StepManyResult<E> {
     pub steps: usize,
     pub error: Option<E>,
+}
+
+impl<E> StepManyResult<E> {
+    /// Initial/zero result - no steps taken, no error
+    const ZERO: Self = Self {
+        steps: 0,
+        error: None,
+    };
+
+    /// Merge the result of two step results, returning true if an error occurred.
+    ///
+    /// # Behaviour
+    ///
+    /// Combines the number of steps from both results. The `error` field is taken from the `other`
+    /// instance, overwriting the error stored in `self`.
+    ///
+    /// # Returns
+    ///
+    /// Returns `true` if an error has been merged.
+    fn merge_and_return(&mut self, other: StepManyResult<E>) -> bool {
+        self.steps += other.steps;
+        self.error = other.error;
+        self.error.is_some()
+    }
+}
+
+impl<E> Default for StepManyResult<E> {
+    fn default() -> Self {
+        Self::ZERO
+    }
 }
 
 /// Runs a syscall instruction (ecall, ebreak)
@@ -409,38 +439,56 @@ impl<MC: memory::MemoryConfig, CL: CacheLayouts, B: Block<MC, M>, M: backend::Ma
     where
         M: ManagerReadWrite,
     {
-        self.step_max_inner(&mut 0, 1)
+        match self.step_max_inner(1).error {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
     }
 
-    fn step_max_inner(
-        &mut self,
-        steps: &mut usize,
-        max_steps: usize,
-    ) -> Result<(), EnvironException>
+    fn step_max_inner(&mut self, max_steps: usize) -> StepManyResult<EnvironException>
     where
         M: backend::ManagerReadWrite,
     {
-        self.block_cache
-            .complete_current_block(&mut self.core, steps, max_steps)?;
+        let mut result = StepManyResult::ZERO;
 
-        'run: while *steps < max_steps {
+        let current_block_result = self
+            .block_cache
+            .complete_current_block(&mut self.core, max_steps);
+
+        // Executing the current block may fail
+        if result.merge_and_return(current_block_result) {
+            return result;
+        }
+
+        while result.steps < max_steps {
             // Obtain the pc for the next instruction to be executed
             let instr_pc = self.core.hart.pc.read();
 
             let res = match self.block_cache.get_block(instr_pc) {
                 Some(mut block) => {
-                    block.run_block(&mut self.core, instr_pc, steps, max_steps)?;
+                    let steps_remaining = max_steps - result.steps;
+                    let block_result = block.run_block(&mut self.core, instr_pc, steps_remaining);
 
-                    continue 'run;
+                    // Short-circuit if the block failed
+                    if result.merge_and_return(block_result) {
+                        return result;
+                    }
+
+                    continue;
                 }
+
                 None => self.run_instr_at(instr_pc),
             };
 
-            self.core.handle_step_result(instr_pc, res)?;
-            *steps += 1;
+            if let Err(error) = self.core.handle_step_result(instr_pc, res) {
+                result.error = Some(error);
+                return result;
+            }
+
+            result.steps += 1;
         }
 
-        Ok(())
+        result
     }
 
     /// Perform as many steps as the given `max_steps` bound allows. Returns the number of retired
@@ -450,25 +498,20 @@ impl<MC: memory::MemoryConfig, CL: CacheLayouts, B: Block<MC, M>, M: backend::Ma
     where
         M: backend::ManagerReadWrite,
     {
-        let mut steps = 0;
+        let mut result = StepManyResult::ZERO;
 
         loop {
-            match self.step_max_inner(&mut steps, unwrap_bound(max_steps)) {
-                Ok(_) => {}
-                Err(e) => {
-                    return StepManyResult {
-                        steps,
-                        error: Some(e),
-                    };
-                }
-            };
+            let iter_result = self.step_max_inner(unwrap_bound(max_steps));
 
-            if !less_than_bound(steps, max_steps) {
+            let errored = result.merge_and_return(iter_result);
+            let out_of_steps = !less_than_bound(result.steps, max_steps);
+
+            if errored || out_of_steps {
                 break;
             }
         }
 
-        StepManyResult { steps, error: None }
+        result
     }
 
     /// Similar to [`Self::step_max`] but lets the user handle environment exceptions inside the

--- a/src/riscv/lib/src/machine_state/block_cache/metrics.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/metrics.rs
@@ -34,6 +34,7 @@ pub(crate) use block_metrics;
 
 use super::ICallPlaced;
 use super::block::Block;
+use crate::machine_state::StepManyResult;
 use crate::machine_state::memory::MemoryConfig;
 use crate::state::NewState;
 use crate::state_backend::EnrichedCell;
@@ -41,6 +42,7 @@ use crate::state_backend::ManagerAlloc;
 use crate::state_backend::ManagerBase;
 use crate::state_backend::ManagerRead;
 use crate::storage::Hash;
+use crate::traps::EnvironException;
 
 #[cfg(feature = "metrics")]
 #[doc(hidden)]
@@ -315,9 +317,8 @@ impl<B: Block<MC, M>, MC: MemoryConfig, M: ManagerBase> Block<MC, M> for BlockMe
         &mut self,
         core: &mut crate::machine_state::MachineCoreState<MC, M>,
         instr_pc: crate::machine_state::memory::Address,
-        steps: &mut usize,
         block_builder: &mut Self::BlockBuilder,
-    ) -> Result<(), crate::traps::EnvironException>
+    ) -> StepManyResult<EnvironException>
     where
         M: crate::state_backend::ManagerReadWrite,
     {
@@ -330,7 +331,7 @@ impl<B: Block<MC, M>, MC: MemoryConfig, M: ManagerBase> Block<MC, M> for BlockMe
 
         block_metrics!(hash = &self.block_hash, record_called);
 
-        unsafe { self.block.run_block(core, instr_pc, steps, block_builder) }
+        unsafe { self.block.run_block(core, instr_pc, block_builder) }
     }
 
     fn num_instr(&self) -> usize


### PR DESCRIPTION
Closes RV-650

Migrated from [this GitLab MR](https://gitlab.com/tezos/tezos/-/merge_requests/18054).

# What

Change block dispatch functions and block runner methods to return the number of steps performed, instead of mutating a variable passed in through a reference.

# Why

It is slightly faster now. It will be faster going forward as well, when blocks may be composed, because it allows passing step counters through registers.

# Manually Testing

```
make -C src/riscv all
```

# Benchmarking

|  | `master` | This MR | Improvement |
|--|----------|---------|-------------|
| M3 MBP | 13.675 TPS | 13.748 TPS | +0.53% |
| Benchmark Machine | 9.707 TPS | 9.847 TPS | +1.44% |

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] Put in reasonable effort to ensure that CI will pass.
  - `make -C src/riscv`
  - `dune build src/lib_riscv`
  - `dune build src/rust_deps`
- [x] Benchmark performance and populate the table above if needed.
- [x] Explain changes to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.