### PR TITLE
Notify team members directly instead of using the team only

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Request review from RISC-V PVM team
-* @tezos/risc-v-pvm-developers
+* @victor-dumitrescu @felixp72 @kurtisc @NSant215 @HantangSun @jobjo @emturner @vapourismo 


### PR DESCRIPTION
Small fix to ensure everybody is notified on Pull Requests.

Adding only @tezos/risc-v-pvm-developers is interpreted as "one of this team". So, unfortunately, we need to mention everybody individually.