### PR TITLE
Verify proof deserialisation for streaming bytes

### DIFF
--- a/src/riscv/Makefile
+++ b/src/riscv/Makefile
@@ -93,7 +93,7 @@ test: build
 
 .PHONY: test-long
 test-long:
-	@cargo test --release $(EXTRA_FLAGS) --test test_determinism --test test_proofs -- test_jstz_determinism test_jstz_proofs_one_step --nocapture --ignored
+	@cargo test --release $(EXTRA_FLAGS) --test test_determinism --test test_proofs -- test_jstz_determinism test_jstz_proofs_one_step --nocapture --ignored --test-threads=2
 
 .PHONY: test-miri
 test-miri:

--- a/src/riscv/lib/src/state_backend/proof_backend/proof.rs
+++ b/src/riscv/lib/src/state_backend/proof_backend/proof.rs
@@ -251,12 +251,19 @@ pub fn serialise_proof(proof: &Proof) -> impl Iterator<Item = u8> + '_ {
     // Here we collect the `iter_raw_tags` iterator to be able to chunkify it and transform it
     // by compressing the tags to a byte-array, fully utilising the bytes capacity.
     let final_hash_encoding = proof.final_state_hash.as_ref().iter().copied();
-    let tags_encoding = serialise_raw_tags(iter_raw_tags(&proof.partial_tree)).into_iter();
-    let nodes_encoding = serialise_proof_values(&proof.partial_tree);
+    let proof_tree_encoding = serialise_merkle_tree(proof.tree());
 
-    final_hash_encoding
-        .chain(tags_encoding)
-        .chain(nodes_encoding)
+    final_hash_encoding.chain(proof_tree_encoding)
+}
+
+/// Serialise just the proof tree part of a general [`Proof`] object.
+///
+/// Useful for testing
+pub fn serialise_merkle_tree(tree: &MerkleProof) -> impl Iterator<Item = u8> + '_ {
+    let tags_encoding = serialise_raw_tags(iter_raw_tags(tree)).into_iter();
+    let nodes_encoding = serialise_proof_values(tree);
+
+    tags_encoding.chain(nodes_encoding)
 }
 
 #[derive(Debug, PartialEq, thiserror::Error)]

--- a/src/riscv/lib/src/stepper/pvm.rs
+++ b/src/riscv/lib/src/stepper/pvm.rs
@@ -36,6 +36,7 @@ use crate::state_backend::FnManagerIdent;
 use crate::state_backend::ManagerBase;
 use crate::state_backend::ManagerReadWrite;
 use crate::state_backend::ProofLayout;
+use crate::state_backend::ProofPart;
 use crate::state_backend::ProofTree;
 use crate::state_backend::Ref;
 use crate::state_backend::hash::Hash;
@@ -43,6 +44,8 @@ use crate::state_backend::owned_backend::Owned;
 use crate::state_backend::proof_backend::ProofGen;
 use crate::state_backend::proof_backend::proof::Proof;
 use crate::state_backend::proof_backend::proof::deserialise_owned;
+use crate::state_backend::proof_backend::proof::deserialise_stream::{self};
+use crate::state_backend::proof_backend::proof::serialise_merkle_tree;
 use crate::state_backend::verify_backend::ProofVerificationFailure;
 use crate::state_backend::verify_backend::Verifier;
 use crate::state_backend::verify_backend::handle_stepper_panics;
@@ -272,6 +275,21 @@ impl<'hooks, MC: MemoryConfig, BCC: BlockCacheConfig, M: ManagerReadWrite>
         }
     }
 
+    /// Similar to [`PvmStepper::verify_proof`] but constructs the allocated space by using the raw deserialisation.
+    ///
+    /// Useful for testing the stream deserialisation.
+    pub fn verify_proof_using_raw_bytes(&self, proof: Proof) -> Result<(), ProofVerificationFailure>
+    where
+        AllocatedOf<<BCC as BlockCacheConfig>::Layout, Verifier>: 'static,
+    {
+        let tree_serialisation: Box<[u8]> = serialise_merkle_tree(proof.tree()).collect();
+        let space = deserialise_stream::deserialise::<PvmLayout<MC, BCC>>(&tree_serialisation)
+            .map_err(|_| ProofVerificationFailure::UnexpectedProofShape)?;
+        let stepper = self.as_verify_stepper(space)?;
+
+        stepper.verify_proof_internal(ProofPart::Present(proof.tree()), proof.final_state_hash())
+    }
+
     /// Verify a Merkle proof. The [`PvmStepper`] is used for inbox information.
     pub fn verify_proof(&self, proof: Proof) -> Result<(), ProofVerificationFailure>
     where
@@ -281,8 +299,20 @@ impl<'hooks, MC: MemoryConfig, BCC: BlockCacheConfig, M: ManagerReadWrite>
         let space = deserialise_owned::deserialise::<PvmLayout<MC, BCC>>(proof_tree)
             .map_err(|_| ProofVerificationFailure::UnexpectedProofShape)?;
 
-        let pvm = Pvm::<MC, BCC, Interpreted<_, _>, Verifier>::bind(space, InterpretedBlockBuilder);
-        let stepper = PvmStepper {
+        let stepper = self.as_verify_stepper(space)?;
+        stepper.verify_proof_internal(proof_tree, proof.final_state_hash())
+    }
+
+    fn as_verify_stepper(
+        &self,
+        space: AllocatedOf<PvmLayout<MC, BCC>, Verifier>,
+    ) -> Result<PvmStepper<MC, BCC, Verifier, Interpreted<MC, Verifier>>, ProofVerificationFailure>
+    {
+        let pvm = Pvm::<MC, BCC, Interpreted<MC, Verifier>, Verifier>::bind(
+            space,
+            InterpretedBlockBuilder,
+        );
+        Ok(PvmStepper {
             pvm,
             rollup_address: self.rollup_address,
             origination_level: self.origination_level,
@@ -296,20 +326,7 @@ impl<'hooks, MC: MemoryConfig, BCC: BlockCacheConfig, M: ManagerReadWrite>
             hooks: PvmHooks::none(),
 
             reveal_request_response_map: self.reveal_request_response_map.clone(),
-        };
-
-        let stepper = stepper.try_step_partial()?;
-
-        let refs = stepper.pvm.struct_ref::<FnManagerIdent>();
-        let final_hash = PvmLayout::<MC, BCC>::partial_state_hash(refs, proof_tree)?;
-        if final_hash != proof.final_state_hash() {
-            return Err(ProofVerificationFailure::FinalHashMismatch {
-                expected: proof.final_state_hash(),
-                computed: final_hash,
-            });
-        }
-
-        Ok(())
+        })
     }
 }
 
@@ -345,6 +362,28 @@ impl<MC: MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, Verifier>>
             // the mutex cannot be poisoned.
             Ok(mutex.into_inner().unwrap())
         })?
+    }
+
+    fn verify_proof_internal(
+        self,
+        proof_tree: ProofTree,
+        expected_final_hash: Hash,
+    ) -> Result<(), ProofVerificationFailure>
+    where
+        AllocatedOf<<BCC as BlockCacheConfig>::Layout, Verifier>: 'static,
+    {
+        let stepper = self.try_step_partial()?;
+
+        let refs = stepper.pvm.struct_ref::<FnManagerIdent>();
+        let final_hash = PvmLayout::<MC, BCC>::partial_state_hash(refs, proof_tree)?;
+        if final_hash != expected_final_hash {
+            return Err(ProofVerificationFailure::FinalHashMismatch {
+                expected: expected_final_hash,
+                computed: final_hash,
+            });
+        }
+
+        Ok(())
     }
 }
 

--- a/src/riscv/lib/tests/test_proofs.rs
+++ b/src/riscv/lib/tests/test_proofs.rs
@@ -13,10 +13,12 @@ use common::*;
 use octez_riscv::machine_state::block_cache::BlockCacheConfig;
 use octez_riscv::machine_state::block_cache::DefaultCacheConfig;
 use octez_riscv::machine_state::block_cache::TestCacheConfig;
+use octez_riscv::machine_state::block_cache::block::Interpreted;
 use octez_riscv::machine_state::memory::M64M;
 use octez_riscv::machine_state::memory::MemoryConfig;
 use octez_riscv::state_backend::AllocatedOf;
 use octez_riscv::state_backend::hash;
+use octez_riscv::state_backend::owned_backend::Owned;
 use octez_riscv::state_backend::proof_backend::proof::Proof;
 use octez_riscv::state_backend::proof_backend::proof::serialise_proof;
 use octez_riscv::state_backend::verify_backend::ProofVerificationFailure;
@@ -29,13 +31,25 @@ use rand::Rng;
 #[test]
 #[ignore]
 fn test_jstz_proofs_one_step() {
-    test_jstz_proofs(false)
+    test_jstz_proofs(false, PvmStepper::verify_proof)
+}
+
+#[test]
+#[ignore]
+fn test_jstz_proofs_one_step_stream() {
+    test_jstz_proofs(false, PvmStepper::verify_proof_using_raw_bytes)
 }
 
 #[test]
 #[ignore]
 fn test_jstz_proofs_full() {
-    test_jstz_proofs(true)
+    test_jstz_proofs(true, PvmStepper::verify_proof)
+}
+
+#[test]
+#[ignore]
+fn test_jstz_proofs_full_stream() {
+    test_jstz_proofs(true, PvmStepper::verify_proof_using_raw_bytes)
 }
 
 #[test]
@@ -57,7 +71,10 @@ fn test_jstz_initial_proof_regression() {
     writeln!(proof_capture, "{proof_bytes}").unwrap();
 }
 
-fn test_jstz_proofs(full: bool) {
+fn test_jstz_proofs(
+    full: bool,
+    verify_fn: StepperVerifyFn<'static, M64M, DefaultCacheConfig, Owned>,
+) {
     let make_stepper = make_stepper_factory::<DefaultCacheConfig>();
 
     let mut base_stepper = make_stepper();
@@ -71,17 +88,21 @@ fn test_jstz_proofs(full: bool) {
         // For each step `s`, the stepper will initially step `s-1` steps, then
         // produce a proof of the `s` step. The minimum step size thus needs to be 1.
         let ladder = dissect_steps(steps, 1);
-        run_steps_ladder(&make_stepper, &ladder, Some(base_hash));
+        run_steps_ladder(&make_stepper, &ladder, Some(base_hash), verify_fn);
     } else {
         // Run a number of steps `s` and produce a proof
         let mut rng = rand::thread_rng();
         let step = [rng.gen_range(1..steps)];
-        run_steps_ladder(&make_stepper, &step, None)
+        run_steps_ladder(&make_stepper, &step, None, verify_fn)
     }
 }
 
-fn run_steps_ladder<F>(make_stepper: F, ladder: &[usize], expected_hash: Option<hash::Hash>)
-where
+fn run_steps_ladder<F>(
+    make_stepper: F,
+    ladder: &[usize],
+    expected_hash: Option<hash::Hash>,
+    verify_fn: StepperVerifyFn<'static, M64M, DefaultCacheConfig, Owned>,
+) where
     F: Fn() -> PvmStepper<'static, M64M, DefaultCacheConfig>,
 {
     let expected_steps = ladder.iter().sum::<usize>();
@@ -116,10 +137,10 @@ where
             let final_state_hash = proof.final_state_hash();
 
             eprintln!("> Attempting to verify basic invalid proofs ...");
-            basic_invalid_proofs_are_rejected(&stepper, &proof, initial_state_hash);
+            basic_invalid_proofs_are_rejected(&stepper, &proof, initial_state_hash, verify_fn);
 
             eprintln!("> Verifying proof ...");
-            assert!(stepper.verify_proof(proof).is_ok());
+            assert!(verify_fn(&stepper, proof).is_ok());
 
             // Run one final step, which is the step proven by `proof`, and check that its
             // state hash matches the final state hash of `proof`.
@@ -146,10 +167,16 @@ where
     }
 }
 
+type StepperVerifyFn<'hooks, MC, BCC, M> = fn(
+    &PvmStepper<'hooks, MC, BCC, M, Interpreted<MC, M>>,
+    proof: Proof,
+) -> Result<(), ProofVerificationFailure>;
+
 fn basic_invalid_proofs_are_rejected<MC: MemoryConfig, BCC: BlockCacheConfig>(
     stepper: &PvmStepper<'static, MC, BCC>,
     proof: &Proof,
     state_hash: hash::Hash,
+    verify_fn: StepperVerifyFn<'static, MC, BCC, Owned>,
 ) where
     AllocatedOf<BCC::Layout, Verifier>: 'static,
 {
@@ -158,28 +185,20 @@ fn basic_invalid_proofs_are_rejected<MC: MemoryConfig, BCC: BlockCacheConfig>(
     // for this case.
     let fully_blinded_proof = proof_helpers::fully_blinded(state_hash);
     assert!(
-        stepper
-            .verify_proof(fully_blinded_proof)
+        verify_fn(stepper, fully_blinded_proof)
             .is_err_and(|e| matches!(e, ProofVerificationFailure::AbsentDataAccess(_)))
     );
 
     let empty_proof = proof_helpers::empty(state_hash);
     assert!(
-        stepper
-            .verify_proof(empty_proof)
+        verify_fn(stepper, empty_proof)
             .is_err_and(|e| matches!(e, ProofVerificationFailure::UnexpectedProofShape))
     );
 
     let invalid_final_hash_proof = proof_helpers::with_final_hash(proof, state_hash);
     assert!(
-        stepper
-            .verify_proof(invalid_final_hash_proof)
-            .is_err_and(
-                |e| matches!(e, ProofVerificationFailure::FinalHashMismatch {
-                    expected: _,
-                    computed: _
-                })
-            )
+        verify_fn(stepper, invalid_final_hash_proof)
+            .is_err_and(|e| matches!(e, ProofVerificationFailure::FinalHashMismatch { .. }))
     );
 }
 


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

Part of RV-631

Based on #22 & #15 

# What

<!--
    Summarise the changes in this MR.
-->

Adds 2 more tests similar to `test_jstz_proofs` to check the deserialisation of the streaming implementation of the new deserialiser from #22 

# Why

<!-- 
    Explain why this MR is needed.
-->

Validates the deserialisation of proofs.

# How

<!--
    Explain how the MR achieves its goal. If this is trivial, you may omit it.
-->

Parametrised the `jstz_proofs` tests by the verification function as well. Added `verify_proof_by_`

# Manually Testing

```
cargo test --test test_proofs -- --nocapture --ignored
```


# Benchmarking

<!--
    Measure the impact on performance of this MR on your machine and the benchmark machine.
    Fill in the table below. If there is no runtime performance impact, replace the table with a
    sentence stating so. 
-->

N/A

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] Benchmark performance and [populate the section above](#benchmarking) if needed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
