### PR TITLE
RISC-V: Support FRegisters in ICB

### DIFF
--- a/src/riscv/lib/src/jit/builder.rs
+++ b/src/riscv/lib/src/jit/builder.rs
@@ -37,6 +37,7 @@ use crate::instruction_context::comparable::Comparable;
 use crate::jit::builder::block_state::PCUpdate;
 use crate::machine_state::ProgramCounterUpdate;
 use crate::machine_state::memory::MemoryConfig;
+use crate::machine_state::registers::FRegister;
 use crate::machine_state::registers::NonZeroXRegister;
 use crate::parser::instruction::InstrWidth;
 
@@ -47,6 +48,10 @@ pub struct X64(pub Value);
 /// A newtype for wrapping [`Value`], representing a 32-bit value in the JIT context.
 #[derive(Copy, Clone, Debug)]
 pub struct X32(pub Value);
+
+/// A newtype for wrapping [`Value`], representing a 64-bit floating-point value in the JIT context.
+#[derive(Copy, Clone, Debug)]
+pub struct F64(pub Value);
 
 /// Builder context used when lowering individual instructions within a block.
 pub(crate) struct Builder<'a, MC: MemoryConfig, JSA: JitStateAccess> {
@@ -268,6 +273,7 @@ impl<'a, MC: MemoryConfig, JSA: JitStateAccess> Builder<'a, MC, JSA> {
 
 impl<MC: MemoryConfig, JSA: JitStateAccess> ICB for Builder<'_, MC, JSA> {
     type XValue = X64;
+    type FValue = F64;
     type IResult<Value> = Option<Value>;
 
     /// An `I8` width value.
@@ -333,6 +339,25 @@ impl<MC: MemoryConfig, JSA: JitStateAccess> ICB for Builder<'_, MC, JSA> {
             self.core_ptr_val,
             reg,
             value,
+        )
+    }
+
+    fn fregister_write(&mut self, reg: FRegister, value: Self::FValue) {
+        JSA::ir_freg_write(
+            &mut self.jsa_call,
+            &mut self.builder,
+            self.core_ptr_val,
+            reg,
+            value,
+        )
+    }
+
+    fn fregister_read(&mut self, reg: FRegister) -> Self::FValue {
+        JSA::ir_freg_read(
+            &mut self.jsa_call,
+            &mut self.builder,
+            self.core_ptr_val,
+            reg,
         )
     }
 

--- a/src/riscv/lib/src/jit/state_access/abi.rs
+++ b/src/riscv/lib/src/jit/state_access/abi.rs
@@ -18,6 +18,8 @@ use cranelift_module::Linkage;
 use cranelift_module::Module;
 use cranelift_module::ModuleResult;
 
+use crate::machine_state::registers::FRegister;
+use crate::machine_state::registers::FValue;
 use crate::machine_state::registers::NonZeroXRegister;
 
 /// This struct is used to produce and declare function signatures for external function calls.
@@ -159,6 +161,14 @@ impl<T> ToCraneliftRepr for &T {
 
 impl<T> ToCraneliftRepr for &mut T {
     const CRANELIFT_TYPE: CraneliftRepr = CraneliftRepr::Ptr;
+}
+
+impl ToCraneliftRepr for FRegister {
+    const CRANELIFT_TYPE: CraneliftRepr = get_repr::<Self>();
+}
+
+impl ToCraneliftRepr for FValue {
+    const CRANELIFT_TYPE: CraneliftRepr = get_repr::<Self>();
 }
 
 /// A valid return type for an external function call.


### PR DESCRIPTION
Close RV-659

# What

Add support for FRegisters in ICB, with `fn fregister_read` and `fn fregister_write` added

# Why

Part of the effort to enable internal opcodes to be jit compilable. The MR unlocks lowering of float opcodes.

# How

Added FValue type to ICB

Implemented `fn fregister_read` and `fn fregister_write` in a similar manner to the corresponding functions for XRegisters

Arithmetic operations are not supported yet for FValues in ICB. 

# Manually Testing 

```
make -C src/riscv all
```

# Benchmarking

<!--
    Measure the impact on performance of this MR on your machine and the benchmark machine.
    Fill in the table below. If there is no runtime performance impact, replace the table with a
    sentence stating so. 
-->

|  | `master` | This MR | Improvement |
|--|----------|---------|-------------|
| M2 MBP | 14.150 TPS | 14.035 TPS | -0.81% |
| Benchmark Machine | 9.567 TPS | 9.775 TPS | 2.17 % |

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] Benchmark performance and [populate the section above](#benchmarking) if needed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
