### PR TITLE
Save Nix, Rustup and Cargo cache for main branch only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
           restore-prefixes-first-match: |
             nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}-
             nix-${{ runner.os }}-${{ runner.arch }}-
+          save: ${{ github.ref_name == 'main' }}
 
       - name: Rustup and Cargo cache
         id: rust-cache
@@ -83,6 +84,7 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
+          lookup-only: ${{ github.ref_name != 'main' }}
 
       - name: Rust compilation cache 
         uses: Mozilla-Actions/sccache-action@v0.0.9
@@ -93,7 +95,7 @@ jobs:
       # All downloads should be cached. If there is a cache miss, we should ensure that the cache
       # contains all downloads.
       - name: Prefetch Cargo downloads
-        if: steps.rust-cache.outputs.cache-hit != 'true' 
+        if: steps.rust-cache.outputs.cache-hit != 'true' && github.ref_name == 'main' 
         run: nix develop --command find src/riscv -iname Cargo.lock -execdir cargo fetch \;
 
       - name: Build dependencies
@@ -107,5 +109,5 @@ jobs:
       # Only when the primary-key cache was not found do we actually produce a cache. In that case
       # we need to clean up the Nix store a little to save space.
       - name: Clean up Nix store
-        if: steps.nix-cache.outputs.hit-primary-key != 'true' 
+        if: steps.nix-cache.outputs.hit-primary-key != 'true' && github.ref_name == 'main'
         run: nix store gc


### PR DESCRIPTION
# What

This ensures that the caches for Nix, Rustup and Cargo are not written for non-main branches and pull requests. PRs still benefit from Rust compilation cache.

# Why

This allows us to save a significant amount of space. 

# How

GH caches work on a per-ref basis. PRs and branches benefit from the caches from the main (default) branch and their ref. 

For example, for a PR, the first build will experience a cache miss for the primary key, but it may hit the cache from the main branch. Despite the hit, the PR build will then produce a new cache - unless something has changed in that cache (unlikely for the caches subject to this PR) this will duplicate space without any gain.

Unless your PR changes a Nix or Cargo lock file, it should be unaffected because the main branch cache is sufficient.