### PR TITLE
Move external functions out of JSA trait

### DIFF
--- a/src/riscv/lib/src/jit/state_access/stack.rs
+++ b/src/riscv/lib/src/jit/state_access/stack.rs
@@ -38,7 +38,7 @@
 //! are a good example of this. For now, we choose to pass pointers from values created in rust
 //! code, for safety.
 //!
-//! [`handle_exception`]: super::JitStateAccess::handle_exception
+//! [`handle_exception`]: super::handle_exception
 
 use std::marker::PhantomData;
 


### PR DESCRIPTION
Closes RV-660

# What

Moves the `extern "C"` functions out of the `JitStateAccess` trait.

# Why

These functions are parametrically polymorphic functions. They do not need to be methods of a trait (a mechanism for ad-hoc polymorphism).

# Review Advice

Open this PR in the GitHub editor (press `>` or `.`) for a more digestible review experience.

https://github.com/user-attachments/assets/773bda8e-ba71-461c-834b-9b1d0fb0a51a

# Manually Testing

```
make -C src/riscv all
```

# Benchmarking

Slightly faster on the reference machine. Performance degradation on my laptop is within the error range.

|  | `master` | This MR | Improvement |
|--|----------|---------|-------------|
| M3 MBP | 14.805 TPS | 14.778 TPS | -0.18237082% |
| Benchmark Machine | 9.782 TPS | 9.958 TPS | +1.78% |

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] Benchmark performance and [populate the section above](#benchmarking) if needed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
