### PR TITLE
Update name of branch in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,7 +36,7 @@ make -C src/riscv all
     sentence stating so. 
 -->
 
-|  | `master` | This MR | Improvement |
+|  | `main` | This MR | Improvement |
 |--|----------|---------|-------------|
 | $MyMachine | X.XXX TPS | X.XXX TPS | XX.XX% |
 | Benchmark Machine | Y.YYY TPS | Y.YYY TPS | YY.YY% |

--- a/src/riscv/scripts/benchmark.sh
+++ b/src/riscv/scripts/benchmark.sh
@@ -5,18 +5,18 @@
 # SPDX-License-Identifier: MIT
 
 # Build & run jstz on two different commits,
-# where the first commit is the "base / master" commit hash
+# where the first commit is the "base / main" commit hash
 # and the second commit is the current change / MR tested
 
 set -e
 
 # Iterations for RISCV and for native are different because usually for native you would want way more runs
-USAGE="Usage: -t <num_transfers> -i <num_iterations_riscv> -n <num_iterations_riscv> -c <change_commit_hash> [ -b <base_commit_hash>: default master ]"
+USAGE="Usage: -t <num_transfers> -i <num_iterations_riscv> -n <num_iterations_riscv> -c <change_commit_hash> [ -b <base_commit_hash>: default main ]"
 
 RISCV_IT=""
 NATIVE_IT=""
 TX=""
-BASE_COMM="master"
+BASE_COMM="main"
 CHANGE_COMM=""
 NATIVE=""
 


### PR DESCRIPTION

# What
Renames the name of the trunk branch in the PR template from Gitlab's default `master` to Github's default `main`.
# Why
It annoys me

# Tasks for the Author

- [none] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] Benchmark performance and [populate the section above](#benchmarking) if needed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
