### PR TITLE
Enforce reasons for disabling warnings

### DIFF
--- a/src/riscv/Cargo.toml
+++ b/src/riscv/Cargo.toml
@@ -5,6 +5,7 @@ exclude = ["jstz", "dummy_kernel"]
 
 [workspace.lints.clippy]
 allow_attributes = "deny"
+allow_attributes_without_reason = "deny"
 
 [workspace.lints.rustdoc]
 broken_intra_doc_links = "deny"

--- a/src/riscv/lib/src/bits.rs
+++ b/src/riscv/lib/src/bits.rs
@@ -21,7 +21,7 @@ macro_rules! bits_builtin {
             }
 
             /// Creates a bitmask from a range of bits.
-            #[allow(dead_code)]
+            #[allow(dead_code, reason = "This is generated in a macro and is not guaranteed to be used")]
             #[inline(always)]
             pub const fn mask(start: usize, end: usize) -> $t {
                 if start == $size - 1 && end == 0 {
@@ -45,7 +45,7 @@ macro_rules! bits_builtin {
             }
 
             /// Sets [bit] in `v` to `value`.
-            #[allow(dead_code)]
+            #[allow(dead_code, reason = "This is generated in a macro and is not guaranteed to be used")]
             #[inline(always)]
             pub const fn set_bit(v: $t, bit: usize, value: bool) -> $t {
                 let mask = 1 << bit;
@@ -55,7 +55,7 @@ macro_rules! bits_builtin {
             /// Replaces a strict subset of bits of `v` with `bits`.
             /// If `bits` is larger than the range, the highest bits will be truncated.
             /// Panics if the range covers the whole value.
-            #[allow(dead_code)]
+            #[allow(dead_code, reason = "This is generated in a macro and is not guaranteed to be used")]
             #[inline(always)]
             pub const fn replace_subset(v: $t, start: usize, end: usize, bits: $t) -> $t {
                 let mask = mask_subset(start, end);

--- a/src/riscv/lib/src/instruction_context.rs
+++ b/src/riscv/lib/src/instruction_context.rs
@@ -131,10 +131,10 @@ pub(crate) trait ICB {
     /// Construct an [`ICB::XValue`] from an `imm: i64`.
     fn xvalue_of_imm(&mut self, imm: i64) -> Self::XValue;
 
-    #[expect(unused)]
+    #[expect(unused, reason = "Will Be Used Soon™")]
     fn fregister_read(&mut self, reg: FRegister) -> Self::FValue;
 
-    #[expect(unused)]
+    #[expect(unused, reason = "Will Be Used Soon™")]
     fn fregister_write(&mut self, reg: FRegister, value: Self::FValue);
 
     /// Perform a read of the program counter.
@@ -156,7 +156,7 @@ pub(crate) trait ICB {
     fn extend_signed(&mut self, value: Self::XValue32) -> Self::XValue;
 
     /// Zero-extend an [`XValue32`] to an [`XValue`].
-    #[expect(dead_code)]
+    #[expect(dead_code, reason = "Will Be Used Soon™")]
     fn extend_unsigned(&mut self, value: Self::XValue32) -> Self::XValue;
 
     /// Multiply two [`XValue`] values and return the high 64 bits of the result, with

--- a/src/riscv/lib/src/jit/state_access/abi.rs
+++ b/src/riscv/lib/src/jit/state_access/abi.rs
@@ -121,8 +121,7 @@ const fn get_repr<T>() -> CraneliftRepr {
             assert!(Self::SIZE == 1 || Self::SIZE == 2 || Self::SIZE == 4 || Self::SIZE == 8);
     }
 
-    #[expect(clippy::let_unit_value)]
-    let _ = SupportedSize::<T>::IS_SUPPORTED;
+    let () = SupportedSize::<T>::IS_SUPPORTED;
 
     match SupportedSize::<T>::SIZE {
         1 => CraneliftRepr::Value(I8),

--- a/src/riscv/lib/src/log.rs
+++ b/src/riscv/lib/src/log.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-#![allow(unused_imports, unused_macros, reason = "Not all events may be used")]
+#![expect(unused_imports, unused_macros, reason = "Not all events may be used")]
 
 #[cfg(feature = "log")]
 #[doc(hidden)]

--- a/src/riscv/lib/src/machine_state/block_cache/block/dispatch.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/block/dispatch.rs
@@ -151,7 +151,7 @@ pub struct OutlineCompiler<MC: MemoryConfig, M: JitStateAccess> {
     // We will not touch the jit from the execution thread, however we must maintain
     // a reference to it - to ensure it is not dropped before we are done with execution,
     // even if the background compilation thread panics.
-    #[expect(unused)]
+    #[expect(unused, reason = "Needed to keep the JIT alive")]
     jit: Arc<Mutex<JIT<MC, M>>>,
     sender: Sender<CompilationRequest>,
 }

--- a/src/riscv/lib/src/machine_state/csregisters.rs
+++ b/src/riscv/lib/src/machine_state/csregisters.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-#![allow(non_upper_case_globals)]
-
 pub mod effects;
 mod root;
 pub mod values;

--- a/src/riscv/lib/src/machine_state/registers.rs
+++ b/src/riscv/lib/src/machine_state/registers.rs
@@ -4,7 +4,10 @@
 
 // We have several globals whose names we want to align with the RISC-V
 // specification.
-#![allow(non_upper_case_globals)]
+#![expect(
+    non_upper_case_globals,
+    reason = "Consistent with RISC-V specification"
+)]
 #![expect(
     dead_code,
     reason = "Aliases for register ABI names might not be used everywhere"

--- a/src/riscv/lib/src/parser.rs
+++ b/src/riscv/lib/src/parser.rs
@@ -3,8 +3,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-#![allow(clippy::reversed_empty_ranges)]
-
 pub mod instruction;
 
 use core::ops::Range;

--- a/src/riscv/lib/src/state_backend/proof_backend/proof.rs
+++ b/src/riscv/lib/src/state_backend/proof_backend/proof.rs
@@ -472,9 +472,6 @@ mod tests {
     fn serialise_1_level() {
         // Check serialisation of a node containing some leaves.
 
-        // To allow more readable arrays of bit manipulated values
-        #![allow(clippy::identity_op)]
-
         let h1 = Hash::blake2b_hash_bytes(&[1, 2, 3]).unwrap();
         let h2 = Hash::blake2b_hash_bytes(&[20, 30, 1, 5, 6]).unwrap();
 
@@ -672,7 +669,7 @@ mod tests {
         // Originial shapes
 
         // For readability (tag << 0 operations)
-        #![allow(clippy::identity_op)]
+        #![expect(clippy::identity_op, reason = "For readability")]
 
         let gen_hash_data = |length| {
             let mut data = vec![0; length];
@@ -740,8 +737,7 @@ mod tests {
         // Traversal will be:    root (1234) (12) 1 2 3 4 (56) 5 6
         // Originial shapes
 
-        // For readability (tag << 0 operations)
-        #![allow(clippy::identity_op)]
+        #![expect(clippy::identity_op, reason = "For readability")]
 
         let gen_hash_data = |length| {
             let mut data = vec![0; length];


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

# What

This PR enforces that every instance of a lint or warning being disabled (via #[allow(...)] or similar attributes) must now include a reason for doing so, using Rust’s reason = "..." attribute or equivalent. It updates code throughout the codebase to provide explicit reasons where warnings are suppressed, and adjusts lint configurations to require reasons.

# Why

Requiring explicit reasons for disabling lints improves code clarity and maintainability. It helps reviewers and future contributors understand the intent behind suppressing specific warnings, reducing the likelihood of accidental or unjustified suppression and making it easier to revisit or justify these decisions in the future.

# Manually Testing

```
make -C src/riscv check
```

# Benchmarking

No runtime performance impact.

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] Benchmark performance and [populate the section above](#benchmarking) if needed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
