### PR TITLE
Specialised memory loads

### DIFF
--- a/src/riscv/lib/src/instruction_context/value.rs
+++ b/src/riscv/lib/src/instruction_context/value.rs
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2025 TriliTech <contact@trili.tech>
+//
+// SPDX-License-Identifier: MIT
+
+//! Value types that the ICB can deal with, e.g. in memory load/store operations
+
+use super::LoadStoreWidth;
+use crate::jit::state_access::stack::Stackable;
+use crate::machine_state::registers::XValue;
+use crate::state_backend::Elem;
+
+/// Types which can be loaded and stored using the [`super::ICB`]
+pub trait StoreLoadInt: Stackable + Elem {
+    /// The width of the value in memory
+    const WIDTH: LoadStoreWidth;
+
+    /// Whether the value is signed or unsigned
+    const SIGNED: bool;
+
+    /// Convert the value to an [`XValue`]. This will sign-extend or zero-extend the value.
+    fn to_xvalue(self) -> XValue;
+
+    /// Convert an [`XValue`] to the value type. This truncates the value to the width of the type.
+    fn from_xvalue(xvalue: XValue) -> Self;
+}
+
+macro_rules! impl_store_load_int {
+    ($width:literal, $variant:expr) => {
+        paste::paste! {
+            impl StoreLoadInt for [<u $width>] {
+                const WIDTH: LoadStoreWidth = $variant;
+
+                const SIGNED: bool = false;
+
+                #[inline(always)]
+                fn to_xvalue(self) -> XValue {
+                    self as XValue
+                }
+
+                #[inline(always)]
+                fn from_xvalue(xvalue: XValue) -> Self {
+                    xvalue as Self
+                }
+            }
+
+            impl StoreLoadInt for [<i $width>] {
+                const WIDTH: LoadStoreWidth = $variant;
+
+                const SIGNED: bool = true;
+
+                #[inline(always)]
+                fn to_xvalue(self) -> XValue {
+                    self as XValue
+                }
+
+                #[inline(always)]
+                fn from_xvalue(xvalue: XValue) -> Self {
+                    xvalue as Self
+                }
+            }
+        }
+    };
+}
+
+impl_store_load_int!(8, LoadStoreWidth::Byte);
+impl_store_load_int!(16, LoadStoreWidth::Half);
+impl_store_load_int!(32, LoadStoreWidth::Word);
+impl_store_load_int!(64, LoadStoreWidth::Double);

--- a/src/riscv/lib/src/interpreter/atomics.rs
+++ b/src/riscv/lib/src/interpreter/atomics.rs
@@ -176,9 +176,7 @@ fn run_x64_atomic<I: ICB>(
     let result = icb.atomic_access_fault_guard(address_rs1, LoadStoreWidth::Double);
 
     // Continue with the operation if the address is aligned.
-    let val_rs1_result = I::and_then(result, |_| {
-        icb.main_memory_load(address_rs1, false, LoadStoreWidth::Double)
-    });
+    let val_rs1_result = I::and_then(result, |_| icb.main_memory_load::<u64>(address_rs1));
 
     // Continue with the operation if the load was successful.
     I::and_then(val_rs1_result, |val_rs1| {
@@ -190,7 +188,7 @@ fn run_x64_atomic<I: ICB>(
         icb.xregister_write(rd, val_rs1);
 
         // Store the resulting value to the address in rs1
-        icb.main_memory_store(address_rs1, res, LoadStoreWidth::Double)
+        icb.main_memory_store::<u64>(address_rs1, res)
     })
 }
 

--- a/src/riscv/lib/src/jit/builder.rs
+++ b/src/riscv/lib/src/jit/builder.rs
@@ -30,6 +30,7 @@ use crate::instruction_context::LoadStoreWidth;
 use crate::instruction_context::MulHighType;
 use crate::instruction_context::PhiValue;
 use crate::instruction_context::Predicate;
+use crate::instruction_context::StoreLoadInt;
 use crate::instruction_context::arithmetic::Arithmetic;
 use crate::instruction_context::comparable::Comparable;
 use crate::jit::builder::block_state::PCUpdate;
@@ -475,18 +476,16 @@ impl<MC: MemoryConfig, JSA: JitStateAccess> ICB for Builder<'_, MC, JSA> {
         None
     }
 
-    fn main_memory_store(
+    fn main_memory_store<V: StoreLoadInt>(
         &mut self,
         phys_address: Self::XValue,
         value: Self::XValue,
-        width: LoadStoreWidth,
     ) -> Self::IResult<()> {
-        let errno = self.jsa_call.memory_store(
+        let errno = self.jsa_call.memory_store::<V>(
             &mut self.builder,
             self.core_ptr_val,
             phys_address,
             value,
-            width,
         );
 
         errno.handle(self);
@@ -494,19 +493,13 @@ impl<MC: MemoryConfig, JSA: JitStateAccess> ICB for Builder<'_, MC, JSA> {
         Some(())
     }
 
-    fn main_memory_load(
+    fn main_memory_load<V: StoreLoadInt>(
         &mut self,
         phys_address: Self::XValue,
-        signed: bool,
-        width: LoadStoreWidth,
     ) -> Self::IResult<Self::XValue> {
-        let errno = self.jsa_call.memory_load(
-            &mut self.builder,
-            self.core_ptr_val,
-            phys_address,
-            signed,
-            width,
-        );
+        let errno =
+            self.jsa_call
+                .memory_load::<V>(&mut self.builder, self.core_ptr_val, phys_address);
 
         let res = errno.handle(self);
 

--- a/src/riscv/lib/src/jit/state_access/abi.rs
+++ b/src/riscv/lib/src/jit/state_access/abi.rs
@@ -93,14 +93,6 @@ impl AbiCall<4> {
     impl_abicall!(A1, A2, A3, A4);
 }
 
-impl AbiCall<5> {
-    impl_abicall!(A1, A2, A3, A4, A5);
-}
-
-impl AbiCall<6> {
-    impl_abicall!(A1, A2, A3, A4, A5, A6);
-}
-
 /// Holds the IR representation of a function parameter's type, which is needed for
 /// registering the function's [`Signature`] in the [`JITModule`].
 pub(super) enum CraneliftRepr {
@@ -142,6 +134,10 @@ impl ToCraneliftRepr for u64 {
     const CRANELIFT_TYPE: CraneliftRepr = get_repr::<Self>();
 }
 
+impl ToCraneliftRepr for i64 {
+    const CRANELIFT_TYPE: CraneliftRepr = get_repr::<Self>();
+}
+
 impl ToCraneliftRepr for bool {
     const CRANELIFT_TYPE: CraneliftRepr = get_repr::<Self>();
 }
@@ -151,6 +147,26 @@ impl ToCraneliftRepr for NonZeroXRegister {
 }
 
 impl ToCraneliftRepr for u8 {
+    const CRANELIFT_TYPE: CraneliftRepr = get_repr::<Self>();
+}
+
+impl ToCraneliftRepr for i8 {
+    const CRANELIFT_TYPE: CraneliftRepr = get_repr::<Self>();
+}
+
+impl ToCraneliftRepr for i16 {
+    const CRANELIFT_TYPE: CraneliftRepr = get_repr::<Self>();
+}
+
+impl ToCraneliftRepr for u16 {
+    const CRANELIFT_TYPE: CraneliftRepr = get_repr::<Self>();
+}
+
+impl ToCraneliftRepr for i32 {
+    const CRANELIFT_TYPE: CraneliftRepr = get_repr::<Self>();
+}
+
+impl ToCraneliftRepr for u32 {
     const CRANELIFT_TYPE: CraneliftRepr = get_repr::<Self>();
 }
 


### PR DESCRIPTION
Closes RV-649

# What

This merge request introduces specialised memory load operations to the RISC-V PVM.

# Why

The `match` statement to select which kind of value gets stored or loaded causes a significant performance bottleneck. It can be avoided by using the static compile-time information available to us.

# How

"Specialised" here means there is one dedicated and static function for each kind of value that can be loaded and stored. 

# Manually Testing

```
make -C src/riscv all
```

# Benchmarking

|  | `main` | This MR | Improvement |
|--|----------|---------|-------------|
| M3 MBP | 14.772 TPS | 16.313 TPS | +10.43% |
| Benchmark Machine | 9.795 TPS | 11.196 TPS | +14.30% |


# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] Benchmark performance and [populate the section above](#benchmarking) if needed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
