### PR TITLE
Fix Restore/Save operations of Rustup and Cargo cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,9 @@ jobs:
             nix-${{ runner.os }}-${{ runner.arch }}-
           save: ${{ github.ref_name == 'main' }}
 
-      - name: Rustup and Cargo cache
+      - name: Restore Rustup and Cargo cache
         id: rust-cache
-        uses: actions/cache@v4.2.3
+        uses: actions/cache/restore@v4.2.3
         with:
           key: rust-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain*') }}-v1
           restore-keys: |
@@ -84,7 +84,6 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          lookup-only: ${{ github.ref_name != 'main' }}
 
       - name: Rust compilation cache 
         uses: Mozilla-Actions/sccache-action@v0.0.9
@@ -105,6 +104,18 @@ jobs:
       - name: Run 'make ${{ matrix.make-target }}'
         run: nix develop --command make ${{ matrix.make-target }}
         working-directory: src/riscv
+
+      - name: Save Rustup and Cargo cache
+        if: github.ref_name == 'main'
+        uses: actions/cache/save@v4.2.3
+        with:
+          key: ${{ steps.rust-cache.outputs.cache-primary-key }}
+          path: |
+            ~/.rustup
+            ~/.cargo/bin
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
       
       # Only when the primary-key cache was not found do we actually produce a cache. In that case
       # we need to clean up the Nix store a little to save space.


### PR DESCRIPTION
I made a mistake in the configuration for the "Rustup and Cargo cache" portion of the CI workflow. `lookup-only` doesn't do what I thought it did.

This leads to mistakenly creating too many large Rustup and Cargo cache entries. GitHub repositories have a 10 GiB cache limit. With a cache created for each branch, we're significantly above the limit, which results in GitHub gradually deleting some caches. This may occasionally delete the `main` branch cache.

This PR aims to address this by splitting the workflow steps into "restore" and "save" and only enabling the save step on the `main` branch.

See [this workflow run](https://github.com/tezos/riscv-pvm/actions/runs/15403851177/job/43342449600?pr=39) for a demonstration that the cache is no longer produced for PR runs.