### PR TITLE
RISC-V: Implement `handle_getpid`

### DIFF
--- a/src/riscv/lib/src/pvm/linux.rs
+++ b/src/riscv/lib/src/pvm/linux.rs
@@ -89,6 +89,9 @@ const RT_SIGACTION: u64 = 134;
 /// System call number for `rt_sigprocmask` on RISC-V
 const RT_SIGPROCMASK: u64 = 135;
 
+/// System call number for `getpid` on RISC-V
+const GETPID: u64 = 172;
+
 /// System call number for `brk` on RISC-V
 const BRK: u64 = 214;
 
@@ -709,6 +712,7 @@ impl<M: ManagerBase> SupervisorState<M> {
             READLINKAT => dispatch0!(readlinkat),
             EXIT | EXITGROUP => dispatch1!(exit),
             SET_TID_ADDRESS => dispatch1!(set_tid_address, core),
+            GETPID => dispatch0!(getpid),
             TKILL => dispatch2!(tkill),
             SIGALTSTACK => dispatch2!(sigaltstack, core),
             RT_SIGACTION => dispatch4!(rt_sigaction, core),
@@ -870,6 +874,14 @@ impl<M: ManagerBase> SupervisorState<M> {
             result: 0,
             control_flow: false,
         })
+    }
+
+    /// Handle `getpid` system call.
+    ///
+    /// See: <https://man7.org/linux/man-pages/man2/getpid.2.html>
+    pub(super) fn handle_getpid(&self) -> Result<u64, Infallible> {
+        // We only have one process
+        Ok(1)
     }
 
     /// Handle `clock_gettime` system call. Fills the timespec structure with zeros.


### PR DESCRIPTION
Closes RV-666 😈

# What
Implements `handle_getpid`. As there is only one process, this always returns `Ok(1)`.

# Why
This is one of the unimplemented system call handlers that jstz uses with V8

# How
There's only one process, so we always return 1
# Manually Testing

```
make -C src/riscv all
```

# Benchmarking
No expected impact.

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] Benchmark performance and [populate the section above](#benchmarking) if needed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
