### PR TITLE
Remove obsolete `extern crate` declaration

### DIFF
--- a/src/riscv/lib/src/machine_state.rs
+++ b/src/riscv/lib/src/machine_state.rs
@@ -13,9 +13,6 @@ pub(crate) mod mode;
 pub(crate) mod registers;
 pub(crate) mod reservation_set;
 
-#[cfg(test)]
-extern crate proptest;
-
 use std::ops::Bound;
 
 use block_cache::BlockCache;


### PR DESCRIPTION
`extern crate` declarations aren't needed [since Rust Edition 2018](https://doc.rust-lang.org/edition-guide/rust-2018/path-changes.html#no-more-extern-crate).