### PR TITLE
RISC-V: Implement `set_robust_list` system call handler

### DIFF
--- a/src/riscv/lib/src/pvm/linux.rs
+++ b/src/riscv/lib/src/pvm/linux.rs
@@ -790,17 +790,15 @@ impl<M: ManagerBase> SupervisorState<M> {
     /// Handle `set_robust_list` system call.
     ///
     /// See: <https://www.man7.org/linux/man-pages/man2/set_robust_list.2.html>
-    fn handle_set_robust_list(&self, _head: VirtAddr, size: usize) -> Result<u64, Error> {
+    fn handle_set_robust_list(
+        &self,
+        _head: VirtAddr,
+        _size: parameters::RobustListHeadSize,
+    ) -> Result<u64, Error> {
         // NOTE: `set_robust_list` is mostly important for when a thread terminates. As we don't
         // really support threading yet, we do nothing. In the future, when we add threading, this
         // system call needs to be implemented to support informing other (waiting) threads of the
         // head of the robust futex list in case of this thread dying without cleaning up futexes.
-
-        // VirtAddr is repr(transparent)
-        const ROBUST_LIST_HEAD_SIZE: usize = size_of::<VirtAddr>();
-        if size != ROBUST_LIST_HEAD_SIZE {
-            return Err(Error::InvalidArgument);
-        }
 
         // Return 0 as an indicator of success
         Ok(0)

--- a/src/riscv/lib/src/pvm/linux/parameters.rs
+++ b/src/riscv/lib/src/pvm/linux/parameters.rs
@@ -114,6 +114,25 @@ impl TryFrom<u64> for CpuSetSize {
     }
 }
 
+/// A size parameter passed to `set_robust_list(2)`
+#[derive(Debug, Clone, Copy)]
+pub struct RobustListHeadSize;
+
+impl TryFrom<u64> for RobustListHeadSize {
+    type Error = Error;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        let value: usize = value.try_into()?;
+
+        const ROBUST_LIST_HEAD_SIZE: usize = size_of::<u64>();
+        if value != ROBUST_LIST_HEAD_SIZE {
+            return Err(Error::InvalidArgument);
+        }
+
+        Ok(RobustListHeadSize)
+    }
+}
+
 /// A signal passed to a thread, see `tkill(2)`
 #[derive(Debug, Clone, Copy)]
 pub struct Signal(u7);


### PR DESCRIPTION
Closes RV-673

# What

Implements `set_robust_list`. As there is currently only one thread,
this does nothing but check the size parameter, then returns error or
success.

# Why
This is one of the unimplemented system call handlers that jstz uses with V8

# How
We currently only support one thread, so this only checks parameters and returns error or success.

# Manually Testing

```
make -C src/riscv all
```

# Benchmarking

No change expected

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] Benchmark performance and [populate the section above](#benchmarking) if needed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
