### PR TITLE
Remove excessive JitStateAccess constraints

### DIFF
--- a/src/riscv/lib/src/jit/builder.rs
+++ b/src/riscv/lib/src/jit/builder.rs
@@ -39,6 +39,7 @@ use crate::machine_state::memory::MemoryConfig;
 use crate::machine_state::registers::FRegister;
 use crate::machine_state::registers::NonZeroXRegister;
 use crate::parser::instruction::InstrWidth;
+use crate::state_backend::ManagerBase;
 
 /// A newtype for wrapping [`Value`], representing a 64-bit value in the JIT context.
 #[derive(Copy, Clone, Debug)]
@@ -53,12 +54,12 @@ pub struct X32(pub Value);
 pub struct F64(pub Value);
 
 /// Builder context used when lowering individual instructions within a block.
-pub(crate) struct Builder<'a, MC: MemoryConfig, JSA: JitStateAccess> {
+pub(crate) struct Builder<'a, MC: MemoryConfig, M: ManagerBase> {
     /// Cranelift function builder
     builder: FunctionBuilder<'a>,
 
     /// Helpers for calling locally imported [JitStateAccess] methods.
-    jsa_call: JsaCalls<'a, MC, JSA>,
+    jsa_call: JsaCalls<'a, MC, M>,
 
     /// Value representing a pointer to [`MachineCoreState<MC, JSA>`]
     ///

--- a/src/riscv/lib/src/jit/builder/errno.rs
+++ b/src/riscv/lib/src/jit/builder/errno.rs
@@ -18,6 +18,7 @@ use cranelift::frontend::FunctionBuilder;
 use crate::interpreter::atomics::reset_reservation_set;
 use crate::jit::state_access::JitStateAccess;
 use crate::machine_state::memory::MemoryConfig;
+use crate::state_backend::ManagerBase;
 
 /// Wrapper for `Errno`-type returns.
 ///
@@ -29,13 +30,13 @@ use crate::machine_state::memory::MemoryConfig;
 /// *NB* a trait is used, rather than a structure, to allow us to naturally use
 /// _unboxed closures_ for the function that returns the output values, without needing
 /// to thread extra generics.
-pub(crate) trait Errno<T, MC: MemoryConfig, JSA: JitStateAccess> {
+pub(crate) trait Errno<T, MC: MemoryConfig, M: ManagerBase> {
     /// Insert exception handling branch that will be triggered at runtime
     /// when `errno` indicates failure.
     ///
     /// The caller of this function is put back into the context of the happy path -
     /// ie, where `errno` indicates success and no exception occurred.
-    fn handle(self, builder: &mut super::Builder<'_, MC, JSA>) -> T;
+    fn handle(self, builder: &mut super::Builder<'_, MC, M>) -> T;
 }
 
 /// Helper type for ensuring fallible operations are handled correctly.

--- a/src/riscv/lib/src/machine_state/block_cache/block.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/block.rs
@@ -283,7 +283,7 @@ pub type DispatchFn<D, MC, M> = unsafe extern "C" fn(
 /// unsupported instructions, a fallback to [`Interpreted`] mode occurs.
 ///
 /// Blocks are compiled upon calling [`Block::run_block`], in a *stop the world* fashion.
-pub struct Jitted<D: DispatchCompiler<MC, M>, MC: MemoryConfig, M: JitStateAccess> {
+pub struct Jitted<D: DispatchCompiler<MC, M>, MC: MemoryConfig, M: ManagerBase> {
     fallback: Interpreted<MC, M>,
     dispatch: DispatchTarget<D, MC, M>,
 }


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

# What

Changes overly liberal `JitStateAccess` constraints to `ManagerBase` where possible.

# Why

These constraints can be downgraded. This makes it easier to improve those parts of the code base, as buying into a `ManagerBase` constraint is acceptable, whereas `JitStateAccess` is not always acceptable.

# How

This is the first change of a few that focuses primarly on type declarations.

# Manually Testing

```
make -C src/riscv all
```

# Benchmarking

No runtime performance impact.

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] Benchmark performance and [populate the section above](#benchmarking) if needed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
