### PR TITLE
Simplify access to block builder for JIT-compiled blocks

### DIFF
--- a/src/riscv/lib/tests/test_regression.rs
+++ b/src/riscv/lib/tests/test_regression.rs
@@ -75,10 +75,7 @@ fn test_regression(
     // This needs to run *after* the previous *interpreted* test. Otherwise, we run into trouble when
     // checking and updating the golden files.
     test_regression_for_block::<Jitted<_, _, _>>(
-        (
-            OutlineCompiler::<M64M, Owned>::default(),
-            InterpretedBlockBuilder,
-        ),
+        OutlineCompiler::<M64M, Owned>::default(),
         &golden_dir,
         &kernel_path,
         &inbox_path,


### PR DESCRIPTION
# What

Simplifies how JIT-compiled blocks are provided with the corresponding block builder.

# Why

In short, these changes enable us to simplify our constraint situation, which in turn enables further improvements, especially concerning the block cache and blocks in general. I am spinning these changes out of exploratory efforts to simplify our memory-, block cache size-,  and block config situation as well as decoupling the block cache from the state altogether.

# How

Usage of `<Jitted<D, MC, M> as Block<MC, M>>::BlockBuilder` in `DispatchFn` is equivalent to `D`. However, the `<_ as Block<MC, M>>` introduces a constraint that bubbles up wherever `DispatchFn` is mentioned.

I adapted the above change for the associated methods `run_block_interpreted` and `run_block_not_compiled`.

`Jitted` blocks specified their block builder type to be `(D, InterpretedBlockBuilder)`. 
The specification of `InterpretedBlockBuilder` is unnecessary because it is a singleton zero-sized type (unit). ZSTs do not need to be passed along - expressions like `InterpretedBlockBuilder` or `&mut InterpretedBlockBuilder` are static expressions (link-time evaluations if you will). We can construct those whenever we want.

This change does not need to be replicated to the JIT builder infrastructure because it ignores the builder function argument altogether.

# Manually Testing

```
make -C src/riscv all
```

# Benchmarking

This does not impact runtime performance.

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] Benchmark performance and [populate the section above](#benchmarking) if needed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
