### PR TITLE
Loosen JitStateAccess constraint on InlineCompiler

### DIFF
--- a/src/riscv/lib/src/machine_state/block_cache/block.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/block.rs
@@ -5,7 +5,7 @@
 
 //! Switching of execution strategy for blocks.
 
-mod dispatch;
+pub(crate) mod dispatch;
 
 use dispatch::DispatchCompiler;
 use dispatch::DispatchTarget;

--- a/src/riscv/lib/src/stepper/test/interpreter.rs
+++ b/src/riscv/lib/src/stepper/test/interpreter.rs
@@ -10,10 +10,10 @@ use std::ops::Bound;
 use goldenfile::Mint;
 use paste::paste;
 
-use crate::jit::JIT;
 use crate::machine_state::block_cache::block::Block;
 use crate::machine_state::block_cache::block::Interpreted;
 use crate::machine_state::block_cache::block::Jitted;
+use crate::machine_state::block_cache::block::dispatch::InlineCompiler;
 use crate::machine_state::memory::M1M;
 use crate::machine_state::registers::XRegister;
 use crate::machine_state::registers::XValue;
@@ -92,7 +92,7 @@ fn interpret_test_with_check(path: &str, check_xregs: &[(XRegister, u64)]) {
 /// For the JIT, we run it twice - the first run to build up the blocks, and the
 /// second to run with these blocks already compiled (so that we actually use them).
 fn inline_jit_test_with_check(path: &str, check_xregs: &[(XRegister, u64)]) {
-    type BlockImpl = Jitted<JIT<M1M, Owned>, M1M, Owned>;
+    type BlockImpl = Jitted<InlineCompiler<M1M, Owned>, M1M, Owned>;
 
     let block_builder = Default::default();
     let block_builder = run_test_with_check::<BlockImpl>(path, check_xregs, block_builder);


### PR DESCRIPTION
# What

Introduces a new type for the inline compiler, rather than reusing the shared `JIT` type. Additionally, it loosens the `JitStateAccess` constraint such that it is not required on `M` upfront.

# Why

Being more consistent about type split makes it easier to iterate on improvements. The additional change to loosen the JSA constraint demonstrates this. I would not have been able to make it if the `OutlineCompiler` were to share the same `JIT` compiler type.

It can be important not to require unnecessary constraints up front. For example, `Ref` is a manager wrapper. It does not provide `ManagerWrite` or `ManagerReadWrite`. It is useful to have, but it cannot be used if the manager is required to implement `JitStateAccess`. The solution is to constrain the root manager (i.e. the manager being wrapped). This gives you access to the read-only usefulness of `Ref` while forbidding functions that require `M = M::ManagerRoot` (like `ManagerWrite`).

# Manually Testing

```
make -C src/riscv all
```

# Benchmark

No runtime performance impact has been measured.

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] Benchmark performance and [populate the section above](#benchmarking) if needed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
