### PR TITLE
RISC-V: Implement `prlimit64` system call handle_prlimit64

### DIFF
--- a/src/riscv/lib/src/pvm/linux/error.rs
+++ b/src/riscv/lib/src/pvm/linux/error.rs
@@ -19,6 +19,11 @@ use crate::state_backend::ManagerWrite;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(i32)]
 pub enum Error {
+    /// Operation not permitted
+    ///
+    /// See [`EPERM`](https://github.com/torvalds/linux/blob/0ad2507d5d93f39619fc42372c347d6006b64319/include/uapi/asm-generic/errno-base.h#L5)
+    NotPermitted = 1,
+
     /// Process or thread not found
     ///
     /// See [`ESRCH`](https://github.com/torvalds/linux/blob/0ad2507d5d93f39619fc42372c347d6006b64319/include/uapi/asm-generic/errno-base.h#L7)


### PR DESCRIPTION
Closes RV-671

# What

Implements `prlimit64`. Following the limits set with this system call is undesirable and non-mandatory, so this is just a stub.

# Why

This is one of the unimplemented system call handlers that jstz uses with V8

# How

jstz only uses this to set the limits for the stack size. Privileged processes (read: we) don't need to follow these limits - and we don't want to. So this is just a stub implementation.

jstz calls:
```
prlimit64(0, RLIMIT_STACK, NULL, {rlim_cur=8192*1024, rlim_max=RLIM64_INFINITY}) = 0
``` 

The manpage notes:
>[A privileged process (under Linux: one with the CAP_SYS_RESOURCE capability) may make arbitrary changes to either limit value. ](https://man7.org/linux/man-pages/man2/prlimit.2.html)

# Manually Testing

```
make -C src/riscv all
```

# Benchmarking

No change expected

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] Benchmark performance and [populate the section above](#benchmarking) if needed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
