### PR TITLE
RISC-V: Implement `ioctl` system call handler

### DIFF
--- a/src/riscv/lib/src/pvm/linux.rs
+++ b/src/riscv/lib/src/pvm/linux.rs
@@ -53,6 +53,9 @@ const MAIN_THREAD_ID: u64 = 1;
 /// System call number for `getcwd` on RISC-V
 const GETCWD: u64 = 17;
 
+/// System call number for `ioctl` on RISC-V
+const IOCTL: u64 = 29;
+
 /// System call number for `facessat` on RISC-V
 const FACCESSAT: u64 = 48;
 
@@ -720,6 +723,7 @@ impl<M: ManagerBase> SupervisorState<M> {
 
         let result = match system_call_no {
             GETCWD => dispatch2!(getcwd, core),
+            IOCTL => dispatch0!(ioctl),
             FACCESSAT => dispatch0!(faccessat),
             OPENAT => dispatch0!(openat),
             CLOSE => dispatch0!(close),

--- a/src/riscv/lib/src/pvm/linux/fds.rs
+++ b/src/riscv/lib/src/pvm/linux/fds.rs
@@ -19,6 +19,17 @@ use crate::state_backend::ManagerRead;
 use crate::state_backend::ManagerReadWrite;
 
 impl<M: ManagerBase> SupervisorState<M> {
+    /// Handle `ioctl` system call.
+    ///
+    /// See: <https://www.man7.org/linux/man-pages/man2/ioctl.2.html>
+    pub fn handle_ioctl(&self) -> Result<u64, Error> {
+        // In jstz this is only used to set the baud rate of the serial port when `/dev/urandom` is
+        // opened. This has no meaning to us, so is ignored.
+
+        // Return 0 as an indicator of success
+        Ok(0)
+    }
+
     /// Write to a file descriptor.
     fn write_to_fd(
         &self,


### PR DESCRIPTION
Closes RV-670

# What

Implements `ioctl`. This is only used by jstz to set the baud rate of the serial port, so it is ignored and this is just a stub.

# Why

This is one of the unimplemented system call handlers that jstz uses with V8

# How

In jstz this is only used to set the baud rate of the serial port when `/dev/urandom` is opened, so it is ignored.

jstz calls:

```
openat(AT_FDCWD, "/dev/urandom", O_RDONLY) = 3
fstat(3, {st_mode=S_IFCHR|0666, st_rdev=makedev(0x1, 0x9), ...}) = 0
ioctl(3, TCGETS, 0xffffde866000)        = -1 EINVAL (Invalid argument)
```
See:
https://man7.org/linux/man-pages/man2/ioctl.2.html

https://man7.org/linux/man-pages/man2/TCSETS.2const.html

# Manually Testing

```
make -C src/riscv all
```

# Benchmarking

No change expected

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] Benchmark performance and [populate the section above](#benchmarking) if needed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
