### PR TITLE
Fix Sandbox with inline JIT compilation

### DIFF
--- a/src/riscv/lib/src/machine_state/block_cache/block.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/block.rs
@@ -10,6 +10,7 @@ mod interpreted;
 mod jitted;
 
 pub use dispatch::DispatchFn;
+pub use dispatch::InlineCompiler;
 pub use dispatch::OutlineCompiler;
 pub use interpreted::Interpreted;
 pub use interpreted::InterpretedBlockBuilder;

--- a/src/riscv/sandbox/src/commands/run.rs
+++ b/src/riscv/sandbox/src/commands/run.rs
@@ -31,7 +31,7 @@ cfg_if::cfg_if! {
         type BlockImplInner = block::Interpreted<M1G, Owned>;
     } else if #[cfg(feature = "inline-jit")] {
         /// Inner execution strategy for blocks.
-        type BlockImplInner = block::Jitted<octez_riscv::jit::JIT<M1G, Owned>, M1G, Owned>;
+        type BlockImplInner = block::Jitted<octez_riscv::machine_state::block_cache::block::InlineCompiler<M1G, Owned>, M1G, Owned>;
     } else {
         /// Inner execution strategy for blocks.
         type BlockImplInner = block::Jitted<


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

# What

Exposes the `InlineCompiler` for use by the Sandbox.

# Why

The inline JIT compilation is not usable without this change in the Sandbox.

# Manually Testing

```
cargo build -F inline-jit
```

# Benchmarking

This does not impact runtime performance.

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] Benchmark performance and [populate the section above](#benchmarking) if needed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
