### PR TITLE
RISC-V: Lower atomic min/max doubles

### DIFF
--- a/src/riscv/lib/src/instruction_context/arithmetic.rs
+++ b/src/riscv/lib/src/instruction_context/arithmetic.rs
@@ -60,6 +60,9 @@ pub trait Arithmetic<I: ICB + ?Sized>: Copy {
 
     /// Return the signed minimum of two **XValues**.
     fn min_signed(self, other: Self, icb: &mut I) -> Self;
+
+    /// Return the unsigned minimum of two **XValues**.
+    fn min_unsigned(self, other: Self, icb: &mut I) -> Self;
 }
 
 impl<I: ICB> Arithmetic<I> for XValue {
@@ -118,6 +121,10 @@ impl<I: ICB> Arithmetic<I> for XValue {
     fn min_signed(self, other: Self, _: &mut I) -> Self {
         (self as i64).min(other as i64) as Self
     }
+
+    fn min_unsigned(self, other: Self, _: &mut I) -> Self {
+        self.min(other)
+    }
 }
 
 impl<I: ICB> Arithmetic<I> for XValue32 {
@@ -175,5 +182,9 @@ impl<I: ICB> Arithmetic<I> for XValue32 {
 
     fn min_signed(self, other: Self, _: &mut I) -> Self {
         (self as i32).min(other as i32) as Self
+    }
+
+    fn min_unsigned(self, other: Self, _: &mut I) -> Self {
+        self.min(other)
     }
 }

--- a/src/riscv/lib/src/instruction_context/arithmetic.rs
+++ b/src/riscv/lib/src/instruction_context/arithmetic.rs
@@ -63,6 +63,9 @@ pub trait Arithmetic<I: ICB + ?Sized>: Copy {
 
     /// Return the unsigned minimum of two **XValues**.
     fn min_unsigned(self, other: Self, icb: &mut I) -> Self;
+
+    /// Return the signed maximum of two **XValues**.
+    fn max_signed(self, other: Self, icb: &mut I) -> Self;
 }
 
 impl<I: ICB> Arithmetic<I> for XValue {
@@ -125,6 +128,10 @@ impl<I: ICB> Arithmetic<I> for XValue {
     fn min_unsigned(self, other: Self, _: &mut I) -> Self {
         self.min(other)
     }
+
+    fn max_signed(self, other: Self, _: &mut I) -> Self {
+        (self as i64).max(other as i64) as Self
+    }
 }
 
 impl<I: ICB> Arithmetic<I> for XValue32 {
@@ -186,5 +193,9 @@ impl<I: ICB> Arithmetic<I> for XValue32 {
 
     fn min_unsigned(self, other: Self, _: &mut I) -> Self {
         self.min(other)
+    }
+
+    fn max_signed(self, other: Self, _: &mut I) -> Self {
+        (self as i32).max(other as i32) as Self
     }
 }

--- a/src/riscv/lib/src/instruction_context/arithmetic.rs
+++ b/src/riscv/lib/src/instruction_context/arithmetic.rs
@@ -66,6 +66,9 @@ pub trait Arithmetic<I: ICB + ?Sized>: Copy {
 
     /// Return the signed maximum of two **XValues**.
     fn max_signed(self, other: Self, icb: &mut I) -> Self;
+
+    /// Return the unsigned maximum of two **XValues**.
+    fn max_unsigned(self, other: Self, icb: &mut I) -> Self;
 }
 
 impl<I: ICB> Arithmetic<I> for XValue {
@@ -132,6 +135,10 @@ impl<I: ICB> Arithmetic<I> for XValue {
     fn max_signed(self, other: Self, _: &mut I) -> Self {
         (self as i64).max(other as i64) as Self
     }
+
+    fn max_unsigned(self, other: Self, _: &mut I) -> Self {
+        self.max(other)
+    }
 }
 
 impl<I: ICB> Arithmetic<I> for XValue32 {
@@ -197,5 +204,9 @@ impl<I: ICB> Arithmetic<I> for XValue32 {
 
     fn max_signed(self, other: Self, _: &mut I) -> Self {
         (self as i32).max(other as i32) as Self
+    }
+
+    fn max_unsigned(self, other: Self, _: &mut I) -> Self {
+        self.max(other)
     }
 }

--- a/src/riscv/lib/src/interpreter/atomics.rs
+++ b/src/riscv/lib/src/interpreter/atomics.rs
@@ -230,6 +230,23 @@ pub fn run_x64_atomic_max_signed<I: ICB>(
     run_x64_atomic(icb, rs1, rs2, rd, |x, y, icb| x.max_signed(y, icb))
 }
 
+/// Loads in `rd` the value from the address in `rs1` and stores the maximum
+/// between it and `val(rs2)` back to the address in `rs1`, treating both as
+/// unsigned values.
+///
+/// The `aq` and `rl` bits specify additional memory constraints in
+/// multi-hart environments so they are currently ignored.
+pub fn run_x64_atomic_max_unsigned<I: ICB>(
+    icb: &mut I,
+    rs1: XRegister,
+    rs2: XRegister,
+    rd: XRegister,
+    _aq: bool,
+    _rl: bool,
+) -> I::IResult<()> {
+    run_x64_atomic(icb, rs1, rs2, rd, |x, y, icb| x.max_unsigned(y, icb))
+}
+
 /// Loads in `rd` the sign-extended value from the address in `rs1`(32-bit) and
 /// stores the result of adding it to `val(rs2)`(32-bit) back to the address in `rs1`.
 ///
@@ -668,6 +685,14 @@ pub(crate) mod test {
         test_run_x64_atomic_max_signed,
         super::run_x64_atomic_max_signed,
         |r1_val, r2_val| i64::max(r1_val as i64, r2_val as i64) as u64,
+        8,
+        u64
+    );
+
+    test_atomic!(
+        test_run_x64_atomic_max_unsigned,
+        super::run_x64_atomic_max_unsigned,
+        u64::max,
         8,
         u64
     );

--- a/src/riscv/lib/src/interpreter/atomics.rs
+++ b/src/riscv/lib/src/interpreter/atomics.rs
@@ -197,6 +197,22 @@ pub fn run_x64_atomic_min_signed<I: ICB>(
     run_x64_atomic(icb, rs1, rs2, rd, |x, y, icb| x.min_signed(y, icb))
 }
 
+/// Loads in `rd` the value from the address in `rs1` and stores the minimum
+/// between it and `val(rs2)` back to the address in `rs1`, treating both as
+/// unsigned values.
+/// The `aq` and `rl` bits specify additional memory constraints in
+/// multi-hart environments so they are currently ignored.
+pub fn run_x64_atomic_min_unsigned<I: ICB>(
+    icb: &mut I,
+    rs1: XRegister,
+    rs2: XRegister,
+    rd: XRegister,
+    _aq: bool,
+    _rl: bool,
+) -> I::IResult<()> {
+    run_x64_atomic(icb, rs1, rs2, rd, |x, y, icb| x.min_unsigned(y, icb))
+}
+
 /// Loads in `rd` the sign-extended value from the address in `rs1`(32-bit) and
 /// stores the result of adding it to `val(rs2)`(32-bit) back to the address in `rs1`.
 ///
@@ -619,6 +635,14 @@ pub(crate) mod test {
         test_run_x64_atomic_min_signed,
         super::run_x64_atomic_min_signed,
         |r1_val, r2_val| i64::min(r1_val as i64, r2_val as i64) as u64,
+        8,
+        u64
+    );
+
+    test_atomic!(
+        test_run_x64_atomic_min_unsigned,
+        super::run_x64_atomic_min_unsigned,
+        |r1_val, r2_val| u64::min(r1_val, r2_val),
         8,
         u64
     );

--- a/src/riscv/lib/src/interpreter/atomics.rs
+++ b/src/riscv/lib/src/interpreter/atomics.rs
@@ -200,6 +200,7 @@ pub fn run_x64_atomic_min_signed<I: ICB>(
 /// Loads in `rd` the value from the address in `rs1` and stores the minimum
 /// between it and `val(rs2)` back to the address in `rs1`, treating both as
 /// unsigned values.
+///
 /// The `aq` and `rl` bits specify additional memory constraints in
 /// multi-hart environments so they are currently ignored.
 pub fn run_x64_atomic_min_unsigned<I: ICB>(
@@ -211,6 +212,22 @@ pub fn run_x64_atomic_min_unsigned<I: ICB>(
     _rl: bool,
 ) -> I::IResult<()> {
     run_x64_atomic(icb, rs1, rs2, rd, |x, y, icb| x.min_unsigned(y, icb))
+}
+
+/// Loads in `rd` the value from the address in `rs1` and stores the maximum
+/// between it and `val(rs2)` back to the address in `rs1`.
+///
+/// The `aq` and `rl` bits specify additional memory constraints in
+/// multi-hart environments so they are currently ignored.
+pub fn run_x64_atomic_max_signed<I: ICB>(
+    icb: &mut I,
+    rs1: XRegister,
+    rs2: XRegister,
+    rd: XRegister,
+    _aq: bool,
+    _rl: bool,
+) -> I::IResult<()> {
+    run_x64_atomic(icb, rs1, rs2, rd, |x, y, icb| x.max_signed(y, icb))
 }
 
 /// Loads in `rd` the sign-extended value from the address in `rs1`(32-bit) and
@@ -643,6 +660,14 @@ pub(crate) mod test {
         test_run_x64_atomic_min_unsigned,
         super::run_x64_atomic_min_unsigned,
         |r1_val, r2_val| u64::min(r1_val, r2_val),
+        8,
+        u64
+    );
+
+    test_atomic!(
+        test_run_x64_atomic_max_signed,
+        super::run_x64_atomic_max_signed,
+        |r1_val, r2_val| i64::max(r1_val as i64, r2_val as i64) as u64,
         8,
         u64
     );

--- a/src/riscv/lib/src/interpreter/rv64a.rs
+++ b/src/riscv/lib/src/interpreter/rv64a.rs
@@ -72,24 +72,6 @@ where
     ) -> Result<(), Exception> {
         self.run_amo_d(rs1, rs2, rd, u64::bitor)
     }
-
-    /// `AMOMAXU.D` R-type instruction
-    ///
-    /// Loads in rd the value from the address in rs1 and stores the maximum
-    /// between it and val(rs2) back to the address in rs1, treating both as
-    /// unsigned values.
-    /// The `aq` and `rl` bits specify additional memory constraints in
-    /// multi-hart environments so they are currently ignored.
-    pub fn run_amomaxud(
-        &mut self,
-        rs1: XRegister,
-        rs2: XRegister,
-        rd: XRegister,
-        _rl: bool,
-        _aq: bool,
-    ) -> Result<(), Exception> {
-        self.run_amo_d(rs1, rs2, rd, u64::max)
-    }
 }
 
 #[cfg(test)]
@@ -112,6 +94,4 @@ mod test {
     test_amo!(run_amoandd, u64::bitand, 8, u64);
 
     test_amo!(run_amoord, u64::bitor, 8, u64);
-
-    test_amo!(run_amomaxud, u64::max, 8, u64);
 }

--- a/src/riscv/lib/src/interpreter/rv64a.rs
+++ b/src/riscv/lib/src/interpreter/rv64a.rs
@@ -92,24 +92,6 @@ where
         })
     }
 
-    /// `AMOMINU.D` R-type instruction
-    ///
-    /// Loads in rd the value from the address in rs1 and stores the minimum
-    /// between it and val(rs2) back to the address in rs1, treating both as
-    /// unsigned values.
-    /// The `aq` and `rl` bits specify additional memory constraints in
-    /// multi-hart environments so they are currently ignored.
-    pub fn run_amominud(
-        &mut self,
-        rs1: XRegister,
-        rs2: XRegister,
-        rd: XRegister,
-        _rl: bool,
-        _aq: bool,
-    ) -> Result<(), Exception> {
-        self.run_amo_d(rs1, rs2, rd, u64::min)
-    }
-
     /// `AMOMAXU.D` R-type instruction
     ///
     /// Loads in rd the value from the address in rs1 and stores the maximum
@@ -156,8 +138,6 @@ mod test {
         8,
         u64
     );
-
-    test_amo!(run_amominud, u64::min, 8, u64);
 
     test_amo!(run_amomaxud, u64::max, 8, u64);
 }

--- a/src/riscv/lib/src/interpreter/rv64a.rs
+++ b/src/riscv/lib/src/interpreter/rv64a.rs
@@ -73,25 +73,6 @@ where
         self.run_amo_d(rs1, rs2, rd, u64::bitor)
     }
 
-    /// `AMOMAX.D` R-type instruction
-    ///
-    /// Loads in rd the value from the address in rs1 and stores the maximum
-    /// between it and val(rs2) back to the address in rs1.
-    /// The `aq` and `rl` bits specify additional memory constraints in
-    /// multi-hart environments so they are currently ignored.
-    pub fn run_amomaxd(
-        &mut self,
-        rs1: XRegister,
-        rs2: XRegister,
-        rd: XRegister,
-        _rl: bool,
-        _aq: bool,
-    ) -> Result<(), Exception> {
-        self.run_amo_d(rs1, rs2, rd, |value_rs1, value_rs2| {
-            (value_rs1 as i64).max(value_rs2 as i64) as u64
-        })
-    }
-
     /// `AMOMAXU.D` R-type instruction
     ///
     /// Loads in rd the value from the address in rs1 and stores the maximum
@@ -131,13 +112,6 @@ mod test {
     test_amo!(run_amoandd, u64::bitand, 8, u64);
 
     test_amo!(run_amoord, u64::bitor, 8, u64);
-
-    test_amo!(
-        run_amomaxd,
-        |r1_val, r2_val| i64::max(r1_val as i64, r2_val as i64) as u64,
-        8,
-        u64
-    );
 
     test_amo!(run_amomaxud, u64::max, 8, u64);
 }

--- a/src/riscv/lib/src/jit.rs
+++ b/src/riscv/lib/src/jit.rs
@@ -2416,6 +2416,8 @@ mod tests {
             invalid_x64_atomic_unsigned(I::new_x64_atomic_add, 10, 30, u64::wrapping_add),
             valid_x64_atomic_signed(I::new_x64_atomic_min_signed, -10, 30, i64::min),
             invalid_x64_atomic_signed(I::new_x64_atomic_min_signed, 10, -30, i64::min),
+            valid_x64_atomic_unsigned(I::new_x64_atomic_min_unsigned, 10, 30, u64::min),
+            invalid_x64_atomic_unsigned(I::new_x64_atomic_min_unsigned, 10, 30, u64::min),
         ];
 
         let mut jit = JIT::<M4K, F::Manager>::new().unwrap();

--- a/src/riscv/lib/src/jit.rs
+++ b/src/riscv/lib/src/jit.rs
@@ -2417,9 +2417,13 @@ mod tests {
             valid_x64_atomic_signed(I::new_x64_atomic_min_signed, -10, 30, i64::min),
             invalid_x64_atomic_signed(I::new_x64_atomic_min_signed, 10, -30, i64::min),
             valid_x64_atomic_unsigned(I::new_x64_atomic_min_unsigned, 10, 30, u64::min),
+            valid_x64_atomic_unsigned(I::new_x64_atomic_min_unsigned, 10, -30_i64 as u64, u64::min),
             invalid_x64_atomic_unsigned(I::new_x64_atomic_min_unsigned, 10, 30, u64::min),
             valid_x64_atomic_signed(I::new_x64_atomic_max_signed, -10, 30, i64::max),
             invalid_x64_atomic_signed(I::new_x64_atomic_max_signed, 10, -30, i64::max),
+            valid_x64_atomic_unsigned(I::new_x64_atomic_max_unsigned, 10, 30, u64::max),
+            valid_x64_atomic_unsigned(I::new_x64_atomic_max_unsigned, 10, -30_i64 as u64, u64::max),
+            invalid_x64_atomic_unsigned(I::new_x64_atomic_max_unsigned, 10, 30, u64::max),
         ];
 
         let mut jit = JIT::<M4K, F::Manager>::new().unwrap();

--- a/src/riscv/lib/src/jit.rs
+++ b/src/riscv/lib/src/jit.rs
@@ -2418,6 +2418,8 @@ mod tests {
             invalid_x64_atomic_signed(I::new_x64_atomic_min_signed, 10, -30, i64::min),
             valid_x64_atomic_unsigned(I::new_x64_atomic_min_unsigned, 10, 30, u64::min),
             invalid_x64_atomic_unsigned(I::new_x64_atomic_min_unsigned, 10, 30, u64::min),
+            valid_x64_atomic_signed(I::new_x64_atomic_max_signed, -10, 30, i64::max),
+            invalid_x64_atomic_signed(I::new_x64_atomic_max_signed, 10, -30, i64::max),
         ];
 
         let mut jit = JIT::<M4K, F::Manager>::new().unwrap();

--- a/src/riscv/lib/src/jit/builder/arithmetic.rs
+++ b/src/riscv/lib/src/jit/builder/arithmetic.rs
@@ -82,6 +82,10 @@ impl<MC: MemoryConfig, JSA: JitStateAccess> Arithmetic<Builder<'_, MC, JSA>> for
     fn min_unsigned(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
         X64(icb.builder.ins().umin(self.0, other.0))
     }
+
+    fn max_signed(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
+        X64(icb.builder.ins().smax(self.0, other.0))
+    }
 }
 
 impl<MC: MemoryConfig, JSA: JitStateAccess> Arithmetic<Builder<'_, MC, JSA>> for X32 {
@@ -151,5 +155,9 @@ impl<MC: MemoryConfig, JSA: JitStateAccess> Arithmetic<Builder<'_, MC, JSA>> for
 
     fn min_unsigned(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
         X32(icb.builder.ins().umin(self.0, other.0))
+    }
+
+    fn max_signed(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
+        X32(icb.builder.ins().smax(self.0, other.0))
     }
 }

--- a/src/riscv/lib/src/jit/builder/arithmetic.rs
+++ b/src/riscv/lib/src/jit/builder/arithmetic.rs
@@ -86,6 +86,10 @@ impl<MC: MemoryConfig, JSA: JitStateAccess> Arithmetic<Builder<'_, MC, JSA>> for
     fn max_signed(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
         X64(icb.builder.ins().smax(self.0, other.0))
     }
+
+    fn max_unsigned(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
+        X64(icb.builder.ins().umax(self.0, other.0))
+    }
 }
 
 impl<MC: MemoryConfig, JSA: JitStateAccess> Arithmetic<Builder<'_, MC, JSA>> for X32 {
@@ -159,5 +163,9 @@ impl<MC: MemoryConfig, JSA: JitStateAccess> Arithmetic<Builder<'_, MC, JSA>> for
 
     fn max_signed(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
         X32(icb.builder.ins().smax(self.0, other.0))
+    }
+
+    fn max_unsigned(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
+        X32(icb.builder.ins().umax(self.0, other.0))
     }
 }

--- a/src/riscv/lib/src/jit/builder/arithmetic.rs
+++ b/src/riscv/lib/src/jit/builder/arithmetic.rs
@@ -78,6 +78,10 @@ impl<MC: MemoryConfig, JSA: JitStateAccess> Arithmetic<Builder<'_, MC, JSA>> for
     fn min_signed(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
         X64(icb.builder.ins().smin(self.0, other.0))
     }
+
+    fn min_unsigned(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
+        X64(icb.builder.ins().umin(self.0, other.0))
+    }
 }
 
 impl<MC: MemoryConfig, JSA: JitStateAccess> Arithmetic<Builder<'_, MC, JSA>> for X32 {
@@ -143,5 +147,9 @@ impl<MC: MemoryConfig, JSA: JitStateAccess> Arithmetic<Builder<'_, MC, JSA>> for
 
     fn min_signed(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
         X32(icb.builder.ins().smin(self.0, other.0))
+    }
+
+    fn min_unsigned(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
+        X32(icb.builder.ins().umin(self.0, other.0))
     }
 }

--- a/src/riscv/lib/src/machine_state/instruction.rs
+++ b/src/riscv/lib/src/machine_state/instruction.rs
@@ -283,7 +283,7 @@ pub enum OpCode {
     Amoord,
     X64AtomicMinSigned,
     Amomaxd,
-    Amominud,
+    X64AtomicMinUnsigned,
     Amomaxud,
 
     // RV64M division instructions
@@ -502,7 +502,7 @@ impl OpCode {
             Self::Amoord => Args::run_amoord,
             Self::X64AtomicMinSigned => Args::run_x64_atomic_min_signed,
             Self::Amomaxd => Args::run_amomaxd,
-            Self::Amominud => Args::run_amominud,
+            Self::X64AtomicMinUnsigned => Args::run_x64_atomic_min_unsigned,
             Self::Amomaxud => Args::run_amomaxud,
             Self::X64RemSigned => Args::run_x64_rem_signed,
             Self::X64RemUnsigned => Args::run_x64_rem_unsigned,
@@ -717,6 +717,7 @@ impl OpCode {
             Self::X32AtomicSwap => Some(Args::run_x32_atomic_swap),
             Self::X64AtomicSwap => Some(Args::run_x64_atomic_swap),
             Self::X64AtomicMinSigned => Some(Args::run_x64_atomic_min_signed),
+            Self::X64AtomicMinUnsigned => Some(Args::run_x64_atomic_min_unsigned),
             Self::X32AtomicAdd => Some(Args::run_x32_atomic_add),
 
             // Errors
@@ -1505,7 +1506,10 @@ impl Args {
         run_x64_atomic_min_signed
     );
     impl_amo_type!(run_amomaxd);
-    impl_amo_type!(run_amominud);
+    impl_amo_type!(
+        atomics::run_x64_atomic_min_unsigned,
+        run_x64_atomic_min_unsigned
+    );
     impl_amo_type!(run_amomaxud);
 
     // RV64M multiplication and division instructions
@@ -1969,10 +1973,14 @@ impl From<&InstrCacheable> for Instruction {
                 opcode: OpCode::Amomaxd,
                 args: args.into(),
             },
-            InstrCacheable::Amominud(args) => Instruction {
-                opcode: OpCode::Amominud,
-                args: args.into(),
-            },
+            InstrCacheable::Amominud(args) => Instruction::new_x64_atomic_min_unsigned(
+                args.rd,
+                args.rs1,
+                args.rs2,
+                args.aq,
+                args.rl,
+                InstrWidth::Uncompressed,
+            ),
             InstrCacheable::Amomaxud(args) => Instruction {
                 opcode: OpCode::Amomaxud,
                 args: args.into(),

--- a/src/riscv/lib/src/machine_state/instruction.rs
+++ b/src/riscv/lib/src/machine_state/instruction.rs
@@ -284,7 +284,7 @@ pub enum OpCode {
     X64AtomicMinSigned,
     X64AtomicMaxSigned,
     X64AtomicMinUnsigned,
-    Amomaxud,
+    X64AtomicMaxUnsigned,
 
     // RV64M division instructions
     X64RemSigned,
@@ -503,7 +503,7 @@ impl OpCode {
             Self::X64AtomicMinSigned => Args::run_x64_atomic_min_signed,
             Self::X64AtomicMaxSigned => Args::run_x64_atomic_max_signed,
             Self::X64AtomicMinUnsigned => Args::run_x64_atomic_min_unsigned,
-            Self::Amomaxud => Args::run_amomaxud,
+            Self::X64AtomicMaxUnsigned => Args::run_x64_atomic_max_unsigned,
             Self::X64RemSigned => Args::run_x64_rem_signed,
             Self::X64RemUnsigned => Args::run_x64_rem_unsigned,
             Self::X32RemSigned => Args::run_x32_rem_signed,
@@ -719,6 +719,7 @@ impl OpCode {
             Self::X64AtomicMinSigned => Some(Args::run_x64_atomic_min_signed),
             Self::X64AtomicMinUnsigned => Some(Args::run_x64_atomic_min_unsigned),
             Self::X64AtomicMaxSigned => Some(Args::run_x64_atomic_max_signed),
+            Self::X64AtomicMaxUnsigned => Some(Args::run_x64_atomic_max_unsigned),
             Self::X32AtomicAdd => Some(Args::run_x32_atomic_add),
 
             // Errors
@@ -1514,7 +1515,10 @@ impl Args {
         atomics::run_x64_atomic_min_unsigned,
         run_x64_atomic_min_unsigned
     );
-    impl_amo_type!(run_amomaxud);
+    impl_amo_type!(
+        atomics::run_x64_atomic_max_unsigned,
+        run_x64_atomic_max_unsigned
+    );
 
     // RV64M multiplication and division instructions
     impl_r_type!(integer::run_x64_rem_signed, run_x64_rem_signed, non_zero_rd);
@@ -1989,10 +1993,14 @@ impl From<&InstrCacheable> for Instruction {
                 args.rl,
                 InstrWidth::Uncompressed,
             ),
-            InstrCacheable::Amomaxud(args) => Instruction {
-                opcode: OpCode::Amomaxud,
-                args: args.into(),
-            },
+            InstrCacheable::Amomaxud(args) => Instruction::new_x64_atomic_max_unsigned(
+                args.rd,
+                args.rs1,
+                args.rs2,
+                args.aq,
+                args.rl,
+                InstrWidth::Uncompressed,
+            ),
 
             // RV64M multiplication and division instructions
             InstrCacheable::Rem(args) => Instruction::from_ic_rem(args),

--- a/src/riscv/lib/src/machine_state/instruction.rs
+++ b/src/riscv/lib/src/machine_state/instruction.rs
@@ -282,7 +282,7 @@ pub enum OpCode {
     Amoandd,
     Amoord,
     X64AtomicMinSigned,
-    Amomaxd,
+    X64AtomicMaxSigned,
     X64AtomicMinUnsigned,
     Amomaxud,
 
@@ -501,7 +501,7 @@ impl OpCode {
             Self::Amoandd => Args::run_amoandd,
             Self::Amoord => Args::run_amoord,
             Self::X64AtomicMinSigned => Args::run_x64_atomic_min_signed,
-            Self::Amomaxd => Args::run_amomaxd,
+            Self::X64AtomicMaxSigned => Args::run_x64_atomic_max_signed,
             Self::X64AtomicMinUnsigned => Args::run_x64_atomic_min_unsigned,
             Self::Amomaxud => Args::run_amomaxud,
             Self::X64RemSigned => Args::run_x64_rem_signed,
@@ -718,6 +718,7 @@ impl OpCode {
             Self::X64AtomicSwap => Some(Args::run_x64_atomic_swap),
             Self::X64AtomicMinSigned => Some(Args::run_x64_atomic_min_signed),
             Self::X64AtomicMinUnsigned => Some(Args::run_x64_atomic_min_unsigned),
+            Self::X64AtomicMaxSigned => Some(Args::run_x64_atomic_max_signed),
             Self::X32AtomicAdd => Some(Args::run_x32_atomic_add),
 
             // Errors
@@ -1505,7 +1506,10 @@ impl Args {
         atomics::run_x64_atomic_min_signed,
         run_x64_atomic_min_signed
     );
-    impl_amo_type!(run_amomaxd);
+    impl_amo_type!(
+        atomics::run_x64_atomic_max_signed,
+        run_x64_atomic_max_signed
+    );
     impl_amo_type!(
         atomics::run_x64_atomic_min_unsigned,
         run_x64_atomic_min_unsigned
@@ -1969,10 +1973,14 @@ impl From<&InstrCacheable> for Instruction {
                 args.rl,
                 InstrWidth::Uncompressed,
             ),
-            InstrCacheable::Amomaxd(args) => Instruction {
-                opcode: OpCode::Amomaxd,
-                args: args.into(),
-            },
+            InstrCacheable::Amomaxd(args) => Instruction::new_x64_atomic_max_signed(
+                args.rd,
+                args.rs1,
+                args.rs2,
+                args.aq,
+                args.rl,
+                InstrWidth::Uncompressed,
+            ),
             InstrCacheable::Amominud(args) => Instruction::new_x64_atomic_min_unsigned(
                 args.rd,
                 args.rs1,

--- a/src/riscv/lib/src/machine_state/instruction/constructors.rs
+++ b/src/riscv/lib/src/machine_state/instruction/constructors.rs
@@ -1470,6 +1470,29 @@ impl Instruction {
         }
     }
 
+    /// Create a new [`Instruction`] with the appropriate [`super::ArgsShape`] for [`OpCode::X64AtomicMaxUnsigned`].
+    pub(crate) fn new_x64_atomic_max_unsigned(
+        rd: XRegister,
+        rs1: XRegister,
+        rs2: XRegister,
+        aq: bool,
+        rl: bool,
+        width: InstrWidth,
+    ) -> Self {
+        Self {
+            opcode: OpCode::X64AtomicMaxUnsigned,
+            args: Args {
+                rd: rd.into(),
+                rs1: rs1.into(),
+                rs2: rs2.into(),
+                aq,
+                rl,
+                width,
+                ..Args::DEFAULT
+            },
+        }
+    }
+
     /// Create a new [`Instruction`] with the appropriate [`super::ArgsShape`] for [`OpCode::X32AtomicLoad`].
     pub(crate) fn new_x32_atomic_load(
         rd: XRegister,

--- a/src/riscv/lib/src/machine_state/instruction/constructors.rs
+++ b/src/riscv/lib/src/machine_state/instruction/constructors.rs
@@ -1424,6 +1424,29 @@ impl Instruction {
         }
     }
 
+    /// Create a new [`Instruction`] with the appropriate [`super::ArgsShape`] for [`OpCode::X64AtomicMinUnsigned`].
+    pub(crate) fn new_x64_atomic_min_unsigned(
+        rd: XRegister,
+        rs1: XRegister,
+        rs2: XRegister,
+        aq: bool,
+        rl: bool,
+        width: InstrWidth,
+    ) -> Self {
+        Self {
+            opcode: OpCode::X64AtomicMinUnsigned,
+            args: Args {
+                rd: rd.into(),
+                rs1: rs1.into(),
+                rs2: rs2.into(),
+                aq,
+                rl,
+                width,
+                ..Args::DEFAULT
+            },
+        }
+    }
+
     /// Create a new [`Instruction`] with the appropriate [`super::ArgsShape`] for [`OpCode::X32AtomicLoad`].
     pub(crate) fn new_x32_atomic_load(
         rd: XRegister,

--- a/src/riscv/lib/src/machine_state/instruction/constructors.rs
+++ b/src/riscv/lib/src/machine_state/instruction/constructors.rs
@@ -1447,6 +1447,29 @@ impl Instruction {
         }
     }
 
+    /// Create a new [`Instruction`] with the appropriate [`super::ArgsShape`] for [`OpCode::X64AtomicMaxSigned`].
+    pub(crate) fn new_x64_atomic_max_signed(
+        rd: XRegister,
+        rs1: XRegister,
+        rs2: XRegister,
+        aq: bool,
+        rl: bool,
+        width: InstrWidth,
+    ) -> Self {
+        Self {
+            opcode: OpCode::X64AtomicMaxSigned,
+            args: Args {
+                rd: rd.into(),
+                rs1: rs1.into(),
+                rs2: rs2.into(),
+                aq,
+                rl,
+                width,
+                ..Args::DEFAULT
+            },
+        }
+    }
+
     /// Create a new [`Instruction`] with the appropriate [`super::ArgsShape`] for [`OpCode::X32AtomicLoad`].
     pub(crate) fn new_x32_atomic_load(
         rd: XRegister,

--- a/src/riscv/lib/src/machine_state/instruction/tagged_instruction.rs
+++ b/src/riscv/lib/src/machine_state/instruction/tagged_instruction.rs
@@ -344,8 +344,8 @@ pub fn opcode_to_argsshape(opcode: &OpCode) -> ArgsShape {
         | X32AtomicLoad | X32AtomicStore | X32AtomicSwap | X32AtomicAdd | Amoxorw | Amoandw
         | Amoorw | Amominw | Amomaxw | Amominuw | Amomaxuw | X64AtomicLoad | X64AtomicStore
         | X64AtomicSwap | X64AtomicAdd | Amoxord | Amoandd | Amoord | X64AtomicMinSigned
-        | Amomaxd | X64AtomicMinUnsigned | Amomaxud | X32Mul | Csrrw | Csrrs | Csrrc | Csrrwi
-        | Csrrsi | Csrrci => ArgsShape::XSrcXDest,
+        | X64AtomicMaxSigned | X64AtomicMinUnsigned | Amomaxud | X32Mul | Csrrw | Csrrs | Csrrc
+        | Csrrwi | Csrrsi | Csrrci => ArgsShape::XSrcXDest,
 
         Fadds | Fsubs | Fmuls | Fdivs | Fsqrts | Fmins | Fmaxs | Fsgnjs | Fsgnjns | Fsgnjxs
         | Fmadds | Fmsubs | Fnmsubs | Fnmadds | Faddd | Fsubd | Fmuld | Fdivd | Fsqrtd | Fmind

--- a/src/riscv/lib/src/machine_state/instruction/tagged_instruction.rs
+++ b/src/riscv/lib/src/machine_state/instruction/tagged_instruction.rs
@@ -344,8 +344,8 @@ pub fn opcode_to_argsshape(opcode: &OpCode) -> ArgsShape {
         | X32AtomicLoad | X32AtomicStore | X32AtomicSwap | X32AtomicAdd | Amoxorw | Amoandw
         | Amoorw | Amominw | Amomaxw | Amominuw | Amomaxuw | X64AtomicLoad | X64AtomicStore
         | X64AtomicSwap | X64AtomicAdd | Amoxord | Amoandd | Amoord | X64AtomicMinSigned
-        | X64AtomicMaxSigned | X64AtomicMinUnsigned | Amomaxud | X32Mul | Csrrw | Csrrs | Csrrc
-        | Csrrwi | Csrrsi | Csrrci => ArgsShape::XSrcXDest,
+        | X64AtomicMaxSigned | X64AtomicMinUnsigned | X64AtomicMaxUnsigned | X32Mul | Csrrw
+        | Csrrs | Csrrc | Csrrwi | Csrrsi | Csrrci => ArgsShape::XSrcXDest,
 
         Fadds | Fsubs | Fmuls | Fdivs | Fsqrts | Fmins | Fmaxs | Fsgnjs | Fsgnjns | Fsgnjxs
         | Fmadds | Fmsubs | Fnmsubs | Fnmadds | Faddd | Fsubd | Fmuld | Fdivd | Fsqrtd | Fmind

--- a/src/riscv/lib/src/machine_state/instruction/tagged_instruction.rs
+++ b/src/riscv/lib/src/machine_state/instruction/tagged_instruction.rs
@@ -344,8 +344,8 @@ pub fn opcode_to_argsshape(opcode: &OpCode) -> ArgsShape {
         | X32AtomicLoad | X32AtomicStore | X32AtomicSwap | X32AtomicAdd | Amoxorw | Amoandw
         | Amoorw | Amominw | Amomaxw | Amominuw | Amomaxuw | X64AtomicLoad | X64AtomicStore
         | X64AtomicSwap | X64AtomicAdd | Amoxord | Amoandd | Amoord | X64AtomicMinSigned
-        | Amomaxd | Amominud | Amomaxud | X32Mul | Csrrw | Csrrs | Csrrc | Csrrwi | Csrrsi
-        | Csrrci => ArgsShape::XSrcXDest,
+        | Amomaxd | X64AtomicMinUnsigned | Amomaxud | X32Mul | Csrrw | Csrrs | Csrrc | Csrrwi
+        | Csrrsi | Csrrci => ArgsShape::XSrcXDest,
 
         Fadds | Fsubs | Fmuls | Fdivs | Fsqrts | Fmins | Fmaxs | Fsgnjs | Fsgnjns | Fsgnjxs
         | Fmadds | Fmsubs | Fnmsubs | Fnmadds | Faddd | Fsubd | Fmuld | Fdivd | Fsqrtd | Fmind

--- a/src/riscv/lib/src/parser/instruction.rs
+++ b/src/riscv/lib/src/parser/instruction.rs
@@ -500,6 +500,8 @@ pub enum InstrCacheable {
     /// `AMOMIN.D` Loads in `rd` the value from the address in `rs1` and stores the minimum
     /// between it and `val(rs2)` back to the address in `rs1`.
     Amomind(AmoArgs),
+    /// `AMOMAX.D` Loads in `rd` the value from the address in `rs1` and stores the maximum
+    /// between it and `val(rs2)` back to the address in `rs1`.
     Amomaxd(AmoArgs),
     /// `AMOMINU.D` Loads in `rd` the value from the address in `rs1` and stores the minimum
     /// between it and `val(rs2)` back to the address in `rs1`, treating both as

--- a/src/riscv/lib/src/parser/instruction.rs
+++ b/src/riscv/lib/src/parser/instruction.rs
@@ -457,10 +457,8 @@ pub enum InstrCacheable {
     /// In case of success, write 0 in `rd`, otherwise write 1.
     /// See also [crate::machine_state::reservation_set].
     Scw(AmoArgs),
-    ///`AMOSWAP.W` - Loads in rd the value from the address in rs1 and writes val(rs2)
-    /// back to the address in rs1.
-    /// The `aq` and `rl` bits specify additional memory constraints in
-    /// multi-hart environments so they are currently ignored.
+    ///`AMOSWAP.W` - Atomically loads in rd the value from the address in rs1 and
+    /// writes val(rs2) back to the address in rs1.
     Amoswapw(AmoArgs),
     /// `AMOADD.W` - Loads in rd the value from the address in rs1 and stores the result of
     /// adding it to val(rs2) back to the address in rs1.
@@ -483,30 +481,28 @@ pub enum InstrCacheable {
     /// In case of success, write 0 in `rd`, otherwise write 1.
     /// See also [crate::machine_state::reservation_set].
     Scd(AmoArgs),
-    /// `AMOSWAP.D` - Loads in rd the value from the address in rs1 and writes val(rs2)
-    /// back to the address in rs1.
-    /// The `aq` and `rl` bits specify additional memory constraints in
-    /// multi-hart environments so they are currently ignored.
+    /// `AMOSWAP.D` - Atomically loads in rd the value from the address in rs1 and
+    /// writes val(rs2) back to the address in rs1.
     Amoswapd(AmoArgs),
-    ///`AMOADD.D` - Loads in rd the value from the address in rs1 and stores the result of
-    /// adding it to val(rs2) back to the address in rs1.
-    ///
-    /// The `aq` and `rl` bits specify additional memory constraints in
-    /// multi-hart environments so they are currently ignored.
+    ///`AMOADD.D` - Atomically loads in rd the value from the address in rs1 and
+    /// stores the result of adding it to val(rs2) back to the address in rs1.
     Amoaddd(AmoArgs),
     Amoxord(AmoArgs),
     Amoandd(AmoArgs),
     Amoord(AmoArgs),
-    /// `AMOMIN.D` Loads in `rd` the value from the address in `rs1` and stores the minimum
-    /// between it and `val(rs2)` back to the address in `rs1`.
+    /// `AMOMIN.D` Atomically loads in `rd` the value from the address in `rs1` and
+    /// stores the minimum between it and `val(rs2)` back to the address in `rs1`.
     Amomind(AmoArgs),
-    /// `AMOMAX.D` Loads in `rd` the value from the address in `rs1` and stores the maximum
-    /// between it and `val(rs2)` back to the address in `rs1`.
+    /// `AMOMAX.D` Atomically loads in `rd` the value from the address in `rs1` and
+    /// stores the maximum between it and `val(rs2)` back to the address in `rs1`.
     Amomaxd(AmoArgs),
-    /// `AMOMINU.D` Loads in `rd` the value from the address in `rs1` and stores the minimum
-    /// between it and `val(rs2)` back to the address in `rs1`, treating both as
-    /// unsigned values.
+    /// `AMOMINU.D` Atomically loads in `rd` the value from the address in `rs1` and
+    /// stores the minimum between it and `val(rs2)` back to the address in `rs1`,
+    /// treating both as unsigned values.
     Amominud(AmoArgs),
+    /// `AMOMAXU.D` Atomically loads in `rd` the value from the address in `rs1` and
+    /// stores the maximum between it and `val(rs2)` back to the address in `rs1`,
+    /// treating both as unsigned values.
     Amomaxud(AmoArgs),
 
     // RV64M division instructions

--- a/src/riscv/lib/src/parser/instruction.rs
+++ b/src/riscv/lib/src/parser/instruction.rs
@@ -501,6 +501,9 @@ pub enum InstrCacheable {
     /// between it and `val(rs2)` back to the address in `rs1`.
     Amomind(AmoArgs),
     Amomaxd(AmoArgs),
+    /// `AMOMINU.D` Loads in `rd` the value from the address in `rs1` and stores the minimum
+    /// between it and `val(rs2)` back to the address in `rs1`, treating both as
+    /// unsigned values.
     Amominud(AmoArgs),
     Amomaxud(AmoArgs),
 


### PR DESCRIPTION
Relates to RV-682. 

# What

Commit 1:
- introduce unsigned min operation
- lowered amomin_u.d to ICB support
- renamed to `X64AtomicMinUnsigned`.

Commit 2:
- introduced signed max operation
- lowered amomax.d to ICB support
- renamed to `X64AtomicMaxSigned`

Commit 3:
- introduced unsigned max operation
- lowered amomax.u.d to ICB support
- renamed to `X64AtomicMaxUnsigned`

# Why

Part of work for instruction coverage. 

# Manually Testing

```
make -C src/riscv all
```

# Benchmarking

<!--
    Measure the impact on performance of this MR on your machine and the benchmark machine.
    Fill in the table below. If there is no runtime performance impact, replace the table with a
    sentence stating so. 
-->

|  | `main` | This MR | Improvement |
|--|----------|---------|-------------|
| M3 MBP | 16.967 TPS | 16.873 TPS | -0.55% |
| Benchmark Machine | 11.771 TPS | 11.706 TPS | -0.55% |

# Regressions

<!--
    Explain changes to regression test captures. If there are no changes to these, delete this
    section.
-->

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] Benchmark performance and [populate the section above](#benchmarking) if needed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
