### PR TITLE
Turn PVM hooks into a trait

### DIFF
--- a/src/riscv/lib/src/pvm.rs
+++ b/src/riscv/lib/src/pvm.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 mod common;
+pub mod hooks;
 pub(crate) mod linux;
 pub mod node_pvm;
 mod reveals;

--- a/src/riscv/lib/src/pvm/hooks.rs
+++ b/src/riscv/lib/src/pvm/hooks.rs
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2025 TriliTech <contact@trili.tech>
+//
+// SPDX-License-Identifier: MIT
+
+//! PVM hooks
+//!
+//! Hooks are used to handle requests from the PVM inline without needing to suspend it.
+//!
+//! For example, the PVM might want to write to the debug log. This happens fairly frequently.
+//! Hence, it is not ideal to suspend the PVM for every single write. Instead, we use the hooks to
+//! handle each request inline (where it is raised) therefore saving the overhead of suspending the
+//! PVM.
+
+use std::io::Write;
+use std::io::stdout;
+
+use tezos_smart_rollup_utils::console::Console;
+
+/// PVM hooks
+pub trait PvmHooks {
+    /// Write bytes to the debug output.
+    fn write_debug_bytes(&mut self, bytes: &[u8]);
+
+    /// Write a single byte to the debug output.
+    fn write_debug_byte(&mut self, char: u8) {
+        self.write_debug_bytes(&[char]);
+    }
+}
+
+impl<H: PvmHooks> PvmHooks for &mut H {
+    fn write_debug_byte(&mut self, char: u8) {
+        H::write_debug_byte(self, char)
+    }
+
+    fn write_debug_bytes(&mut self, bytes: &[u8]) {
+        H::write_debug_bytes(self, bytes)
+    }
+}
+
+impl PvmHooks for Console<'_> {
+    fn write_debug_bytes(&mut self, bytes: &[u8]) {
+        self.write_all(bytes).unwrap();
+    }
+}
+
+impl PvmHooks for Vec<u8> {
+    fn write_debug_bytes(&mut self, bytes: &[u8]) {
+        self.extend_from_slice(bytes);
+    }
+}
+
+/// PVM hooks that write debug information to the standard output
+pub struct StdoutDebugHooks;
+
+impl PvmHooks for StdoutDebugHooks {
+    fn write_debug_bytes(&mut self, bytes: &[u8]) {
+        stdout().write_all(bytes).unwrap();
+    }
+}
+
+/// Do nothing with the hooks
+pub struct NoHooks;
+
+impl PvmHooks for NoHooks {
+    fn write_debug_byte(&mut self, _char: u8) {}
+
+    fn write_debug_bytes(&mut self, _bytes: &[u8]) {}
+}

--- a/src/riscv/lib/src/pvm/linux.rs
+++ b/src/riscv/lib/src/pvm/linux.rs
@@ -20,7 +20,6 @@ use self::addr::VirtAddr;
 use self::error::Error;
 use self::memory::STACK_SIZE;
 use super::Pvm;
-use super::PvmHooks;
 use crate::machine_state::MachineCoreState;
 use crate::machine_state::MachineError;
 use crate::machine_state::MachineState;
@@ -33,6 +32,7 @@ use crate::machine_state::memory::PAGE_SIZE;
 use crate::machine_state::memory::Permissions;
 use crate::machine_state::registers;
 use crate::program::Program;
+use crate::pvm::hooks::PvmHooks;
 use crate::state::NewState;
 use crate::state_backend::AllocatedOf;
 use crate::state_backend::Atom;
@@ -511,7 +511,7 @@ impl<M: ManagerBase> SupervisorState<M> {
     pub fn handle_system_call<MC, BCC, B>(
         &mut self,
         machine: &mut MachineState<MC, BCC, B, M>,
-        hooks: &mut PvmHooks,
+        hooks: impl PvmHooks,
         on_tezos: impl FnOnce(&mut MachineCoreState<MC, M>) -> bool,
     ) -> bool
     where
@@ -1148,6 +1148,7 @@ mod tests {
     use crate::machine_state::block_cache::block::Interpreted;
     use crate::machine_state::block_cache::block::InterpretedBlockBuilder;
     use crate::machine_state::memory::M4K;
+    use crate::pvm::hooks::StdoutDebugHooks;
     use crate::pvm::linux::error::Error;
     use crate::pvm::linux::parameters::NoFileDescriptor;
     use crate::pvm::linux::parameters::Zero;
@@ -1192,7 +1193,7 @@ mod tests {
 
         let result = supervisor_state.handle_system_call(
             &mut machine_state,
-            &mut PvmHooks::default(),
+            StdoutDebugHooks,
             default_on_tezos_handler,
         );
         assert!(result);
@@ -1255,7 +1256,7 @@ mod tests {
 
             let result = supervisor_state.handle_system_call(
                 &mut machine_state,
-                &mut PvmHooks::default(),
+                StdoutDebugHooks,
                 default_on_tezos_handler,
             );
             assert!(result);
@@ -1332,7 +1333,7 @@ mod tests {
         // Perform the system call
         let result = supervisor_state.handle_system_call(
             &mut machine_state,
-            &mut PvmHooks::default(),
+            StdoutDebugHooks,
             default_on_tezos_handler,
         );
         assert!(result);
@@ -1375,7 +1376,7 @@ mod tests {
         // Perform the system call
         let result = supervisor_state.handle_system_call(
             &mut machine_state,
-            &mut PvmHooks::default(),
+            StdoutDebugHooks,
             default_on_tezos_handler,
         );
         assert!(result);
@@ -1441,7 +1442,7 @@ mod tests {
             // Perform the system call
             let result = supervisor_state.handle_system_call(
                 &mut machine_state,
-                &mut PvmHooks::default(),
+                StdoutDebugHooks,
                 default_on_tezos_handler,
             );
 
@@ -1510,7 +1511,7 @@ mod tests {
         // Perform the system call
         let result = supervisor_state.handle_system_call(
             &mut machine_state,
-            &mut PvmHooks::default(),
+            StdoutDebugHooks,
             default_on_tezos_handler,
         );
 
@@ -1582,7 +1583,7 @@ mod tests {
         // Perform the system call
         let result = supervisor_state.handle_system_call(
             &mut machine_state,
-            &mut PvmHooks::default(),
+            StdoutDebugHooks,
             default_on_tezos_handler,
         );
 
@@ -1642,7 +1643,7 @@ mod tests {
         // Perform the system call
         let result = supervisor_state.handle_system_call(
             &mut machine_state,
-            &mut PvmHooks::default(),
+            StdoutDebugHooks,
             default_on_tezos_handler,
         );
         assert!(result);
@@ -1696,7 +1697,7 @@ mod tests {
         // Perform the system call
         let result = supervisor_state.handle_system_call(
             &mut machine_state,
-            &mut PvmHooks::default(),
+            StdoutDebugHooks,
             default_on_tezos_handler,
         );
         assert!(result);
@@ -1756,7 +1757,7 @@ mod tests {
         // Perform the system call
         let result = supervisor_state.handle_system_call(
             &mut machine_state,
-            &mut PvmHooks::default(),
+            StdoutDebugHooks,
             default_on_tezos_handler,
         );
         assert!(result);
@@ -1837,7 +1838,7 @@ mod tests {
         // Perform the system call
         let result = supervisor_state.handle_system_call(
             &mut machine_state,
-            &mut PvmHooks::default(),
+            StdoutDebugHooks,
             default_on_tezos_handler,
         );
         assert!(result);

--- a/src/riscv/lib/src/pvm/node_pvm.rs
+++ b/src/riscv/lib/src/pvm/node_pvm.rs
@@ -16,9 +16,9 @@ use crate::machine_state::block_cache::block::Interpreted;
 use crate::machine_state::block_cache::block::InterpretedBlockBuilder;
 use crate::program::Program;
 use crate::pvm::InputRequest;
-use crate::pvm::common::PvmHooks;
 use crate::pvm::common::PvmInput;
 use crate::pvm::common::PvmStatus;
+use crate::pvm::hooks::PvmHooks;
 use crate::state::NewState;
 use crate::state_backend;
 use crate::state_backend::AllocatedOf;
@@ -126,14 +126,14 @@ impl<M: state_backend::ManagerBase> NodePvm<M> {
         })
     }
 
-    pub fn compute_step(&mut self, pvm_hooks: &mut PvmHooks)
+    pub fn compute_step(&mut self, pvm_hooks: impl PvmHooks)
     where
         M: state_backend::ManagerReadWrite,
     {
         self.with_backend_mut(|pvm| pvm.eval_one(pvm_hooks))
     }
 
-    pub fn compute_step_many(&mut self, pvm_hooks: &mut PvmHooks, max_steps: usize) -> i64
+    pub fn compute_step_many(&mut self, pvm_hooks: impl PvmHooks, max_steps: usize) -> i64
     where
         M: state_backend::ManagerReadWrite,
     {
@@ -178,7 +178,7 @@ impl NodePvm {
     pub fn produce_proof(
         &self,
         input: Option<PvmInput>,
-        pvm_hooks: &mut PvmHooks,
+        pvm_hooks: impl PvmHooks,
     ) -> Option<Proof> {
         let mut proof_state = self.state.start_proof();
 
@@ -204,7 +204,7 @@ impl NodePvm<Verifier> {
         merkle_proof_tree: &MerkleProof,
         final_state_hash: &Hash,
         input: Option<PvmInput>,
-        pvm_hooks: &mut PvmHooks,
+        pvm_hooks: impl PvmHooks,
     ) -> Option<InputRequest> {
         self.with_backend_mut(|pvm| {
             match input {

--- a/src/riscv/lib/tests/common/mod.rs
+++ b/src/riscv/lib/tests/common/mod.rs
@@ -7,13 +7,13 @@ use std::fs;
 use octez_riscv::machine_state::block_cache::BlockCacheConfig;
 use octez_riscv::machine_state::block_cache::block::InterpretedBlockBuilder;
 use octez_riscv::machine_state::memory::M64M;
-use octez_riscv::pvm::PvmHooks;
+use octez_riscv::pvm::hooks::NoHooks;
 use octez_riscv::stepper::pvm::PvmStepper;
 use rand::Rng;
 use rand::seq::SliceRandom;
 use tezos_smart_rollup_utils::inbox::InboxBuilder;
 
-pub fn make_stepper_factory<BCC: BlockCacheConfig>() -> impl Fn() -> PvmStepper<'static, M64M, BCC>
+pub fn make_stepper_factory<BCC: BlockCacheConfig>() -> impl Fn() -> PvmStepper<NoHooks, M64M, BCC>
 {
     let program = fs::read("../assets/jstz").unwrap();
 
@@ -26,13 +26,12 @@ pub fn make_stepper_factory<BCC: BlockCacheConfig>() -> impl Fn() -> PvmStepper<
     let address = [0; 20];
 
     move || {
-        let hooks = PvmHooks::none();
         let block_builder = InterpretedBlockBuilder;
 
-        PvmStepper::<'_, M64M, BCC>::new(
+        PvmStepper::<NoHooks, M64M, BCC>::new(
             &program,
             inbox.clone(),
-            hooks,
+            NoHooks,
             address,
             1,
             None,

--- a/src/riscv/lib/tests/test_determinism.rs
+++ b/src/riscv/lib/tests/test_determinism.rs
@@ -11,6 +11,7 @@ use octez_riscv::machine_state::block_cache::DefaultCacheConfig;
 use octez_riscv::machine_state::block_cache::block::InterpretedBlockBuilder;
 use octez_riscv::machine_state::memory::M64M;
 use octez_riscv::pvm::PvmLayout;
+use octez_riscv::pvm::hooks::NoHooks;
 use octez_riscv::state_backend::RefOwnedAlloc;
 use octez_riscv::state_backend::hash;
 use octez_riscv::stepper::Stepper;
@@ -51,7 +52,7 @@ fn run_steps_ladder<F>(
     expected_refs: &RefOwnedAlloc<PvmLayout<M64M, DefaultCacheConfig>>,
     expected_hash: hash::Hash,
 ) where
-    F: Fn() -> PvmStepper<'static, M64M, DefaultCacheConfig>,
+    F: Fn() -> PvmStepper<NoHooks, M64M, DefaultCacheConfig>,
 {
     let expected_steps = ladder.iter().sum::<usize>();
     let mut stepper_lhs = make_stepper();

--- a/src/riscv/sandbox/src/commands/gdb.rs
+++ b/src/riscv/sandbox/src/commands/gdb.rs
@@ -41,7 +41,7 @@ use octez_riscv::machine_state::block_cache::block::InterpretedBlockBuilder;
 use octez_riscv::machine_state::memory::BadMemoryAccess;
 use octez_riscv::machine_state::memory::M1G;
 use octez_riscv::machine_state::memory::Memory;
-use octez_riscv::pvm::PvmHooks;
+use octez_riscv::pvm::hooks::StdoutDebugHooks;
 use octez_riscv::state_backend::FnManagerIdent;
 use octez_riscv::stepper::StepResult;
 use octez_riscv::stepper::Stepper;
@@ -69,10 +69,10 @@ pub fn gdb_server(opts: GdbServerOptions) -> Result<(), Box<dyn Error>> {
 
     let rollup_address = SmartRollupAddress::from_b58check(opts.inbox.address.as_str())?;
 
-    let mut stepper = PvmStepper::<M1G>::new(
+    let mut stepper = PvmStepper::<_, M1G>::new(
         program.as_slice(),
         inbox,
-        PvmHooks::default(),
+        StdoutDebugHooks,
         rollup_address.into_hash().as_ref().try_into()?,
         opts.inbox.origination_level,
         opts.preimage.preimages_dir,


### PR DESCRIPTION
Part of RV-153

GL MR: [!18540](https://gitlab.com/tezos/tezos/-/merge_requests/18540)

# What

Turn the `PvmHooks` type into a trait.

# Why

The current `PvmHooks` type is inconvenient as it leaks a lifetime into everywhere it is used. A type representing the behaviour is a better abstraction.

# Manually Testing

```
make -C src/riscv all
```

# Benchmarking

No runtime performance impact.

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] Benchmark performance and [populate the section above](#benchmarking) if needed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
