### PR TITLE
System call handlers need to operate on BlockCache

### DIFF
--- a/src/riscv/lib/src/pvm/common.rs
+++ b/src/riscv/lib/src/pvm/common.rs
@@ -272,7 +272,7 @@ impl<MC: MemoryConfig, BCC: BlockCacheConfig, B: block::Block<MC, M>, M: state_b
         M: state_backend::ManagerReadWrite,
     {
         handle_system_call(
-            &mut self.machine_state.core,
+            &mut self.machine_state,
             &mut self.system_state,
             &mut self.status,
             &mut self.reveal_request,
@@ -334,7 +334,7 @@ impl<MC: MemoryConfig, BCC: BlockCacheConfig, B: block::Block<MC, M>, M: state_b
             .machine_state
             .step_max_handle::<Infallible>(step_bounds, |machine_state, _exception| {
                 Ok(handle_system_call(
-                    &mut machine_state.core,
+                    machine_state,
                     &mut self.system_state,
                     &mut self.status,
                     &mut self.reveal_request,
@@ -494,8 +494,8 @@ impl<
     }
 }
 
-fn handle_system_call<MC, M>(
-    core: &mut machine_state::MachineCoreState<MC, M>,
+fn handle_system_call<MC, BCC, B, M>(
+    machine: &mut machine_state::MachineState<MC, BCC, B, M>,
     system_state: &mut linux::SupervisorState<M>,
     status: &mut Cell<PvmStatus, M>,
     reveal_request: &mut RevealRequest<M>,
@@ -503,9 +503,11 @@ fn handle_system_call<MC, M>(
 ) -> bool
 where
     MC: MemoryConfig,
+    BCC: BlockCacheConfig,
+    B: Block<MC, M>,
     M: state_backend::ManagerReadWrite,
 {
-    system_state.handle_system_call(core, hooks, |core| {
+    system_state.handle_system_call(machine, hooks, |core| {
         tezos::handle_tezos(core, status, reveal_request);
         status.read() == PvmStatus::Evaluating
     })

--- a/src/riscv/lib/src/pvm/linux.rs
+++ b/src/riscv/lib/src/pvm/linux.rs
@@ -570,7 +570,7 @@ impl<M: ManagerBase> SupervisorState<M> {
         // `dispatch0!(system_call_no [, optional_arguments_passed_to_handler])`
         // Converts the system call name to the handler
         macro_rules! dispatch0 {
-            ($system_call:ty$(, $arg:ident)*) => {{
+            ($system_call:ty$(, $arg:expr)*) => {{
                 try_blocks::try_block! {
                     paste::paste! {
                         trace_call!($system_call);
@@ -584,7 +584,7 @@ impl<M: ManagerBase> SupervisorState<M> {
         // `dispatch1!(system_call_no [, optional_arguments_passed_to_handler])`
         // Converts the system call name to the handler
         macro_rules! dispatch1 {
-            ($system_call:ty$(, $arg:ident)*) => {{
+            ($system_call:ty$(, $arg:expr)*) => {{
                 try_blocks::try_block! {
                     paste::paste! {
                         let arg1 = read_arg!($system_call, a0);
@@ -599,7 +599,7 @@ impl<M: ManagerBase> SupervisorState<M> {
         // `dispatch2!(system_call_no [, optional_arguments_passed_to_handler])`
         // Converts the system call name to the handler
         macro_rules! dispatch2 {
-            ($system_call:ty$(, $arg:ident)*) => {{
+            ($system_call:ty$(, $arg:expr)*) => {{
                 try_blocks::try_block! {
                     paste::paste! {
                         let arg1 = read_arg!($system_call, a0);
@@ -615,7 +615,7 @@ impl<M: ManagerBase> SupervisorState<M> {
         // `dispatch3!(system_call_no [, optional_arguments_passed_to_handler])`
         // Converts the system call name to the handler
         macro_rules! dispatch3 {
-            ($system_call:ty$(, $arg:ident)*) => {{
+            ($system_call:ty$(, $arg:expr)*) => {{
                 try_blocks::try_block! {
                     paste::paste! {
                         let arg1 = read_arg!($system_call, a0);
@@ -632,7 +632,7 @@ impl<M: ManagerBase> SupervisorState<M> {
         // `dispatch4!(system_call_no [, optional_arguments_passed_to_handler])`
         // Converts the system call name to the handler
         macro_rules! dispatch4 {
-            ($system_call:ty$(, $arg:ident)*) => {{
+            ($system_call:ty$(, $arg:expr)*) => {{
                 try_blocks::try_block! {
                     paste::paste! {
                         let arg1 = read_arg!($system_call, a0);
@@ -654,7 +654,7 @@ impl<M: ManagerBase> SupervisorState<M> {
             reason = "There is no system call handler with 5 parameters yet"
         )]
         macro_rules! dispatch5 {
-            ($system_call:ty$(, $arg:ident)*) => {{
+            ($system_call:ty$(, $arg:expr)*) => {{
                 try_blocks::try_block! {
                     paste::paste! {
                         let arg1 = read_arg!($system_call, a0);
@@ -673,7 +673,7 @@ impl<M: ManagerBase> SupervisorState<M> {
         // `dispatch6!(system_call_no [, optional_arguments_passed_to_handler])`
         // Converts the system call name to the handler
         macro_rules! dispatch6 {
-            ($system_call:ty$(, $arg:ident)*) => {{
+            ($system_call:ty$(, $arg:expr)*) => {{
                 try_blocks::try_block! {
                     paste::paste! {
                         let arg1 = read_arg!($system_call, a0);
@@ -697,7 +697,7 @@ impl<M: ManagerBase> SupervisorState<M> {
             reason = "There is no system call handler with 7 parameters yet"
         )]
         macro_rules! dispatch7 {
-            ($system_call:ty$(, $arg:ident)*) => {{
+            ($system_call:ty$(, $arg:expr)*) => {{
                 try_blocks::try_block! {
                     paste::paste! {
                         let arg1 = read_arg!($system_call, a0);


### PR DESCRIPTION
Closes RV-686

# What

Changes the Linux system call handlers to work on the `MachineState` instead of `MachineCoreState`.

# Why

The block cache, once removed, needs to be invalidated by system calls `mmap`, `munmap` and `mprotect`. The block cache is part of `MachineState`, but not `MachineCoreState`.

# Manually Testing

```
make -C src/riscv all
```

# Benchmarking

Runtime is unaffected by this change.

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] Benchmark performance and [populate the section above](#benchmarking) if needed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
