### PR TITLE
Return `OwnedProofPart` as part of `into_verifier_alloc`

### DIFF
--- a/src/riscv/lib/src/machine_state/memory/buddy/branch_combinations.rs
+++ b/src/riscv/lib/src/machine_state/memory/buddy/branch_combinations.rs
@@ -32,7 +32,6 @@ use crate::state_backend::ProofTree;
 use crate::state_backend::Ref;
 use crate::state_backend::RefProofGenOwnedAlloc;
 use crate::state_backend::RefVerifierAlloc;
-use crate::state_backend::VerifierAlloc;
 use crate::state_backend::proof_backend::merkle::MerkleTree;
 use crate::state_backend::proof_backend::proof::deserialiser::Deserialiser;
 use crate::state_backend::proof_backend::proof::deserialiser::Result;
@@ -118,9 +117,9 @@ macro_rules! combined_buddy_branch {
                     <[<$buddy1 Layout>]<[<$buddy2 Layout>]<B>>>::to_merkle_tree(state.0)
                 }
 
-                fn to_verifier_alloc<D: Deserialiser>(proof: D) -> Result<D::Suspended<VerifierAlloc<Self>>> {
-                    let inner = <[<$buddy1 Layout>]<[<$buddy2 Layout>]<B>>>::to_verifier_alloc(proof)?;
-                    Ok(inner.map(|inner| [<$name Alloc>](inner)))
+                fn into_verifier_alloc<D: Deserialiser>(proof: D) -> $crate::state_backend::VerifierAllocResult<D, Self> {
+                    let inner = <[<$buddy1 Layout>]<[<$buddy2 Layout>]<B>>>::into_verifier_alloc(proof)?;
+                    Ok(inner.map(|(inner, merkle)| ([<$name Alloc>](inner), merkle)))
                 }
 
                 fn partial_state_hash(

--- a/src/riscv/lib/src/machine_state/memory/buddy/leaf.rs
+++ b/src/riscv/lib/src/machine_state/memory/buddy/leaf.rs
@@ -30,7 +30,6 @@ use crate::state_backend::ProofTree;
 use crate::state_backend::Ref;
 use crate::state_backend::RefProofGenOwnedAlloc;
 use crate::state_backend::RefVerifierAlloc;
-use crate::state_backend::VerifierAlloc;
 use crate::state_backend::proof_backend::merkle::MerkleTree;
 use crate::state_backend::proof_backend::proof::deserialiser::Suspended;
 use crate::storage::Hash;
@@ -54,15 +53,13 @@ impl<const PAGES: u64> ProofLayout for BuddyLeafLayout<PAGES> {
         Atom::to_merkle_tree(state.set)
     }
 
-    fn to_verifier_alloc<
+    fn into_verifier_alloc<
         D: crate::state_backend::proof_backend::proof::deserialiser::Deserialiser,
     >(
         proof: D,
-    ) -> crate::state_backend::proof_backend::proof::deserialiser::Result<
-        D::Suspended<VerifierAlloc<Self>>,
-    > {
-        let parser = Atom::to_verifier_alloc(proof)?;
-        Ok(parser.map(|cell| Self::Allocated { set: cell }))
+    ) -> crate::state_backend::VerifierAllocResult<D, Self> {
+        let parser = Atom::into_verifier_alloc(proof)?;
+        Ok(parser.map(|(cell, merkle)| (Self::Allocated { set: cell }, merkle)))
     }
 
     fn partial_state_hash(

--- a/src/riscv/lib/src/machine_state/memory/buddy/proxy.rs
+++ b/src/riscv/lib/src/machine_state/memory/buddy/proxy.rs
@@ -22,7 +22,7 @@ use crate::state_backend::ProofTree;
 use crate::state_backend::Ref;
 use crate::state_backend::RefProofGenOwnedAlloc;
 use crate::state_backend::RefVerifierAlloc;
-use crate::state_backend::VerifierAlloc;
+use crate::state_backend::VerifierAllocResult;
 use crate::state_backend::proof_backend::merkle::MerkleTree;
 use crate::state_backend::proof_backend::proof::deserialiser;
 use crate::storage::Hash;
@@ -55,10 +55,10 @@ where
         <PickLayout<PAGES> as ProofLayout>::to_merkle_tree(state)
     }
 
-    fn to_verifier_alloc<D: deserialiser::Deserialiser>(
+    fn into_verifier_alloc<D: deserialiser::Deserialiser>(
         proof: D,
-    ) -> deserialiser::Result<D::Suspended<VerifierAlloc<Self>>> {
-        <PickLayout<PAGES> as ProofLayout>::to_verifier_alloc(proof)
+    ) -> VerifierAllocResult<D, Self> {
+        <PickLayout<PAGES> as ProofLayout>::into_verifier_alloc(proof)
     }
 
     fn partial_state_hash(

--- a/src/riscv/lib/src/pvm/common.rs
+++ b/src/riscv/lib/src/pvm/common.rs
@@ -466,8 +466,9 @@ impl<MC: MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, Verifier>> Pvm<MC, BC
     where
         AllocatedOf<BCC::Layout, Verifier>: 'static,
     {
-        let space =
-            deserialise_owned::deserialise::<PvmLayout<MC, BCC>>(ProofTree::Present(proof)).ok()?;
+        let space = deserialise_owned::deserialise::<PvmLayout<MC, BCC>>(ProofTree::Present(proof))
+            .ok()?
+            .0;
         Some(Self::bind(space, block_builder))
     }
 }

--- a/src/riscv/lib/src/state_backend/layout.rs
+++ b/src/riscv/lib/src/state_backend/layout.rs
@@ -176,25 +176,23 @@ macro_rules! struct_layout {
                 }
 
                 #[inline]
-                fn to_verifier_alloc<D: $crate::state_backend::proof_backend::proof::deserialiser::Deserialiser>(
+                fn into_verifier_alloc<D: $crate::state_backend::proof_backend::proof::deserialiser::Deserialiser>(
                     proof: D,
-                ) -> Result<
-                    D::Suspended<$crate::state_backend::VerifierAlloc<Self>>,
-                    $crate::state_backend::FromProofError
-                > {
+                ) -> $crate::state_backend::VerifierAllocResult<D, Self> {
 
                     use $crate::state_backend::proof_layout::tuple_branches_proof_layout;
                     use $crate::state_backend::proof_backend::proof::deserialiser::DeserialiserNode;
 
                     let ctx = tuple_branches_proof_layout!(@no_done; proof $(, [<$field_name:camel>])+);
 
-                    let ctx = ctx.map(|res| {
+                    let ctx = ctx.map(|(res, merkle)| {
                         let ( $($field_name,)+ ) = res;
-                        Self::Allocated {
-                        $(
-                            $field_name
-                        ),+
-                        }
+                        let allocated = Self::Allocated {
+                            $(
+                                $field_name
+                            ),+
+                        };
+                        (allocated, merkle)
                     });
 
                     ctx.done()
@@ -415,7 +413,9 @@ mod tests {
             // Verify the proof and check the final hash
             handle_stepper_panics(|| {
                 let mut verify_foo =
-                    deserialise_owned::deserialise::<Foo>(ProofPart::Present(&proof)).unwrap();
+                    deserialise_owned::deserialise::<Foo>(ProofPart::Present(&proof))
+                        .unwrap()
+                        .0;
                 assert_eq!(bar, verify_foo.bar.read());
                 assert_eq!(qux, verify_foo.qux.read_all().as_slice());
 

--- a/src/riscv/lib/src/state_backend/proof_backend/proof.rs
+++ b/src/riscv/lib/src/state_backend/proof_backend/proof.rs
@@ -101,6 +101,16 @@ pub enum MerkleProofLeaf {
 }
 
 impl MerkleProof {
+    /// Create a new Merkle proof as a read leaf.
+    pub fn leaf_read(data: Vec<u8>) -> Self {
+        MerkleProof::Leaf(MerkleProofLeaf::Read(data))
+    }
+
+    /// Create a new Merkle proof as a blind leaf.
+    pub fn leaf_blind(hash: Hash) -> Self {
+        MerkleProof::Leaf(MerkleProofLeaf::Blind(hash))
+    }
+
     /// Return a 2-bit tag for the variant of the node in the proof.
     pub fn to_raw_tag(&self) -> Tag {
         match self {

--- a/src/riscv/lib/src/state_backend/proof_backend/proof/deserialise_owned.rs
+++ b/src/riscv/lib/src/state_backend/proof_backend/proof/deserialise_owned.rs
@@ -15,6 +15,7 @@ use super::deserialiser::Result;
 use super::deserialiser::Suspended;
 use crate::state_backend::AllocatedOf;
 use crate::state_backend::FromProofError;
+use crate::state_backend::OwnedProofPart;
 use crate::state_backend::ProofLayout;
 use crate::state_backend::ProofPart;
 use crate::state_backend::ProofTree;
@@ -46,9 +47,9 @@ impl<'t> Deserialiser for ProofTreeDeserialiser<'t> {
             .map(OwnedParserComb::new)
     }
 
-    fn into_leaf<T: DeserializeOwned>(self) -> Result<Self::Suspended<Partial<T>>> {
+    fn into_leaf<T: DeserializeOwned>(self) -> Result<Self::Suspended<Partial<(T, Vec<u8>)>>> {
         self.deserialise_as_leaf()?
-            .map_present_fallible(|data| Ok(binary::deserialise::<T>(data.as_ref())?))
+            .map_present_fallible(|data| Ok((binary::deserialise::<T>(data.as_ref())?, data)))
             .map(OwnedParserComb::new)
     }
 
@@ -229,7 +230,7 @@ impl<R> OwnedParserComb<'_, R> {
 /// Given a [`ProofTree`] deserialise it into an allocated [`Verifier`] backend.
 pub fn deserialise<L: ProofLayout>(
     proof: ProofTree,
-) -> Result<AllocatedOf<L, Verifier>, DeserError> {
-    let comp_fn = L::to_verifier_alloc::<ProofTreeDeserialiser>(proof.into())?;
+) -> Result<(AllocatedOf<L, Verifier>, OwnedProofPart), DeserError> {
+    let comp_fn = L::into_verifier_alloc::<ProofTreeDeserialiser>(proof.into())?;
     Ok(comp_fn.into_result())
 }

--- a/src/riscv/lib/src/state_backend/proof_backend/proof/deserialiser.rs
+++ b/src/riscv/lib/src/state_backend/proof_backend/proof/deserialiser.rs
@@ -16,7 +16,9 @@
 use serde::de::DeserializeOwned;
 
 use crate::state_backend::FromProofError;
+use crate::state_backend::OwnedProofPart;
 use crate::state_backend::hash::Hash;
+use crate::state_backend::proof_backend::merkle::MERKLE_LEAF_SIZE;
 
 /// Error used when deserialising using [`Deserialiser`] methods
 pub type DeserError = FromProofError;
@@ -26,6 +28,7 @@ pub type Result<R, E = DeserError> = std::result::Result<R, E>;
 
 /// Possible outcomes when parsing a node or a leaf from a Merkle proof
 /// where the leaf is assumed to have type `T`.
+#[derive(Clone)]
 pub enum Partial<T> {
     /// The leaf / node is altogether absent from the proof.
     Absent,
@@ -58,6 +61,31 @@ impl<T> Partial<T> {
     }
 }
 
+impl Partial<Vec<u8>> {
+    /// Convert a [`Partial<Vec<u8>>`] into an owned proof part.
+    pub fn into_leaf_proof_tree(self) -> OwnedProofPart {
+        OwnedProofPart::leaf_from_partial(self, |data| data)
+    }
+}
+
+impl Partial<Box<[u8; MERKLE_LEAF_SIZE.get()]>> {
+    /// Convert a [`Partial<Box<[u8; MERKLE_LEAF_SIZE]>>`] into an owned proof part.
+    pub fn into_leaf_proof_tree(self) -> OwnedProofPart {
+        OwnedProofPart::leaf_from_partial(self, |data| data.to_vec())
+    }
+}
+
+impl<A, B> Partial<(A, B)> {
+    /// Split a [`Partial<(A, B)>`] into [`Partial<A>`] and [`Partial<B>`].
+    pub fn split(self) -> (Partial<A>, Partial<B>) {
+        match self {
+            Partial::Absent => (Partial::Absent, Partial::Absent),
+            Partial::Blinded(hash) => (Partial::Blinded(hash), Partial::Blinded(hash)),
+            Partial::Present((a, b)) => (Partial::Present(a), Partial::Present(b)),
+        }
+    }
+}
+
 /// The main trait used for deserialising a proof.
 ///
 /// Having an object of this trait is equivalent to having a proof and being able to deserialise it.
@@ -77,7 +105,13 @@ pub trait Deserialiser {
     fn into_leaf_raw<const LEN: usize>(self) -> Result<Self::Suspended<Partial<Box<[u8; LEN]>>>>;
 
     /// It is expected for the proof to be a leaf. Parse the raw bytes of that leaf into a type `T`.
-    fn into_leaf<T: DeserializeOwned + 'static>(self) -> Result<Self::Suspended<Partial<T>>>;
+    #[expect(
+        clippy::type_complexity,
+        reason = "Adding an alias for Partial<(T, Vec<u8>)> would only decrease readability"
+    )]
+    fn into_leaf<T: DeserializeOwned + 'static>(
+        self,
+    ) -> Result<Self::Suspended<Partial<(T, Vec<u8>)>>>;
 
     /// It is expected for the proof to be a node. Obtain the deserialiser for the branch case.
     fn into_node(self) -> Result<Self::DeserialiserNode<Partial<()>>>;
@@ -186,7 +220,7 @@ mod tests {
             Partial::Absent => 0,
             // This blinded hash can be of the nested leaf or the root
             Partial::Blinded(_hash) => -1,
-            Partial::Present(nr) => nr,
+            Partial::Present((nr, _)) => nr,
         }))
     }
 
@@ -209,7 +243,7 @@ mod tests {
                 .next_branch(|br_proof| br_proof.into_leaf::<i32>())?
                 .map(|(acc, val)| {
                     acc.map_present(|mut acc| {
-                        if let Partial::Present(val) = val {
+                        if let Partial::Present((val, _)) = val {
                             acc.push(val);
                         }
                         acc

--- a/src/riscv/lib/src/state_backend/proof_layout.rs
+++ b/src/riscv/lib/src/state_backend/proof_layout.rs
@@ -250,12 +250,8 @@ impl OwnedProofPart {
     pub fn leaf_from_partial<T>(partial: Partial<T>, f: impl FnOnce(T) -> Vec<u8>) -> Self {
         match partial {
             Partial::Absent => OwnedProofPart::Absent,
-            Partial::Blinded(hash) => {
-                OwnedProofPart::Present(MerkleProof::Leaf(MerkleProofLeaf::Blind(hash)))
-            }
-            Partial::Present(data) => {
-                OwnedProofPart::Present(MerkleProof::Leaf(MerkleProofLeaf::Read(f(data))))
-            }
+            Partial::Blinded(hash) => OwnedProofPart::Present(MerkleProof::leaf_blind(hash)),
+            Partial::Present(data) => OwnedProofPart::Present(MerkleProof::leaf_read(f(data))),
         }
     }
 
@@ -263,9 +259,7 @@ impl OwnedProofPart {
     pub fn node_from_partial(partial: Partial<Vec<MerkleProof>>) -> Self {
         match partial {
             Partial::Absent => OwnedProofPart::Absent,
-            Partial::Blinded(hash) => {
-                OwnedProofPart::Present(MerkleProof::Leaf(MerkleProofLeaf::Blind(hash)))
-            }
+            Partial::Blinded(hash) => OwnedProofPart::Present(MerkleProof::leaf_blind(hash)),
             Partial::Present(children) => OwnedProofPart::Present(MerkleProof::Node(children)),
         }
     }
@@ -442,13 +436,11 @@ impl<const LEN: usize> ProofLayout for DynArray<LEN> {
                     Partial::Absent => (vec![], OwnedProofPart::Absent),
                     Partial::Blinded(hash) => (
                         vec![],
-                        OwnedProofPart::Present(MerkleProof::Leaf(MerkleProofLeaf::Blind(hash))),
+                        OwnedProofPart::Present(MerkleProof::leaf_blind(hash)),
                     ),
                     Partial::Present(data) => (
                         vec![(page, data.clone())],
-                        OwnedProofPart::Present(MerkleProof::Leaf(MerkleProofLeaf::Read(
-                            data.to_vec(),
-                        ))),
+                        OwnedProofPart::Present(MerkleProof::leaf_read(data.to_vec())),
                     ),
                 });
                 Ok(ctx)
@@ -970,7 +962,7 @@ where
                     (acc, match merkle_children {
                         Partial::Absent => OwnedProofPart::Absent,
                         Partial::Blinded(hash) => {
-                            OwnedProofPart::Present(MerkleProof::Leaf(MerkleProofLeaf::Blind(hash)))
+                            OwnedProofPart::Present(MerkleProof::leaf_blind(hash))
                         }
                         Partial::Present(children) => {
                             OwnedProofPart::Present(MerkleProof::Node(children))

--- a/src/riscv/lib/src/state_backend/proof_layout.rs
+++ b/src/riscv/lib/src/state_backend/proof_layout.rs
@@ -71,6 +71,13 @@ pub enum FromProofError {
 
 type Result<T, E = FromProofError> = std::result::Result<T, E>;
 
+/// Common result type for parsing a Merkle proof.
+pub(crate) type VerifierAllocResult<D, L> =
+    Result<<D as Deserialiser>::Suspended<(VerifierAlloc<L>, OwnedProofPart)>>;
+
+/// Regions for the verifier backend for a specific layout.
+pub type VerifierAlloc<L> = <L as Layout>::Allocated<verify_backend::Verifier>;
+
 /// Errors that may occur when hashing a [`verify_backend::Verifier`] state
 #[derive(Debug, thiserror::Error)]
 pub enum PartialHashError {
@@ -93,10 +100,8 @@ pub enum PartialHashError {
     Fatal,
 }
 
-/// Common result type for parsing a Merkle proof
-pub type VerifierAlloc<L> = <L as Layout>::Allocated<verify_backend::Verifier>;
-
 /// Part of a tree that may be absent
+#[derive(Debug, PartialEq)]
 pub enum ProofPart<'a, T: ?Sized> {
     /// This part of the tree is absent.
     Absent,
@@ -231,6 +236,54 @@ impl<'a> ProofTree<'a> {
     }
 }
 
+/// Similar to [`ProofPart`], but owns the underlying [`MerkleProof`].
+#[derive(Clone)]
+pub enum OwnedProofPart {
+    /// This part of the tree is absent.
+    Absent,
+    /// There is a proof for this part of the tree.
+    Present(MerkleProof),
+}
+
+impl OwnedProofPart {
+    /// Obtain an [`OwnedProofPart`] from a [`Partial<T>`] considering it a leaf.
+    pub fn leaf_from_partial<T>(partial: Partial<T>, f: impl FnOnce(T) -> Vec<u8>) -> Self {
+        match partial {
+            Partial::Absent => OwnedProofPart::Absent,
+            Partial::Blinded(hash) => {
+                OwnedProofPart::Present(MerkleProof::Leaf(MerkleProofLeaf::Blind(hash)))
+            }
+            Partial::Present(data) => {
+                OwnedProofPart::Present(MerkleProof::Leaf(MerkleProofLeaf::Read(f(data))))
+            }
+        }
+    }
+
+    /// Obtain an [`OwnedProofPart`] from a [`Partial<Vec<MerkleProof>>`] considering it a node.
+    pub fn node_from_partial(partial: Partial<Vec<MerkleProof>>) -> Self {
+        match partial {
+            Partial::Absent => OwnedProofPart::Absent,
+            Partial::Blinded(hash) => {
+                OwnedProofPart::Present(MerkleProof::Leaf(MerkleProofLeaf::Blind(hash)))
+            }
+            Partial::Present(children) => OwnedProofPart::Present(MerkleProof::Node(children)),
+        }
+    }
+
+    /// Map the inner [`MerkleProof`] if the proof is present.
+    ///
+    /// Panic: In debug mode, panic if the proof is absent.
+    pub(crate) fn map_present_unchecked(self, f: impl FnOnce(MerkleProof)) {
+        match self {
+            OwnedProofPart::Absent => debug_assert!(
+                false,
+                "If the node is present, then the branch is also present"
+            ),
+            OwnedProofPart::Present(proof) => f(proof),
+        }
+    }
+}
+
 /// [`Layouts`] which may be used in a Merkle proof
 ///
 /// [`Layouts`]: crate::state_backend::Layout
@@ -240,7 +293,7 @@ pub trait ProofLayout: Layout {
     fn to_merkle_tree(state: RefProofGenOwnedAlloc<Self>) -> Result<MerkleTree, HashError>;
 
     /// Parse a Merkle proof into the allocated form of this layout.
-    fn to_verifier_alloc<D: Deserialiser>(proof: D) -> Result<D::Suspended<VerifierAlloc<Self>>>;
+    fn into_verifier_alloc<D: Deserialiser>(proof: D) -> VerifierAllocResult<D, Self>;
 
     /// Compute the state hash of a partial `Verifier` state using its
     /// corresponding proof tree where data is missing.
@@ -258,8 +311,8 @@ where
         T::to_merkle_tree(*state)
     }
 
-    fn to_verifier_alloc<D: Deserialiser>(proof: D) -> Result<D::Suspended<VerifierAlloc<Self>>> {
-        Ok(T::to_verifier_alloc(proof)?.map(Box::new))
+    fn into_verifier_alloc<D: Deserialiser>(proof: D) -> VerifierAllocResult<D, Self> {
+        Ok(T::into_verifier_alloc(proof)?.map(|(data, merkle)| (Box::new(data), merkle)))
     }
 
     fn partial_state_hash(
@@ -285,9 +338,9 @@ where
         MerkleTree::make_merkle_leaf(serialised, access_info)
     }
 
-    fn to_verifier_alloc<D: Deserialiser>(proof: D) -> Result<D::Suspended<VerifierAlloc<Self>>> {
-        let f = Array::<T, 1>::to_verifier_alloc(proof)?;
-        Ok(f.map(super::Cell::from))
+    fn into_verifier_alloc<D: Deserialiser>(proof: D) -> VerifierAllocResult<D, Self> {
+        let f = Array::<T, 1>::into_verifier_alloc(proof)?;
+        Ok(f.map(|(data, merkle)| (super::Cell::from(data), merkle)))
     }
 
     fn partial_state_hash(
@@ -321,20 +374,21 @@ where
         MerkleTree::make_merkle_leaf(serialised, access_info)
     }
 
-    fn to_verifier_alloc<D: Deserialiser>(proof: D) -> Result<D::Suspended<VerifierAlloc<Self>>> {
+    fn into_verifier_alloc<D: Deserialiser>(proof: D) -> VerifierAllocResult<D, Self> {
         use super::proof_backend::proof::deserialiser::Partial;
 
         Ok(proof
             .into_leaf::<super::Cells<T, LEN, Owned>>()?
             .map(|leaf| {
-                let region = match leaf {
+                let (region, merkle) = leaf.split();
+                let region = match region {
                     Partial::Absent | Partial::Blinded(_) => verify_backend::Region::Absent,
                     Partial::Present(cells) => {
                         let arr: Box<[Option<T>; LEN]> = Box::new(cells.into_region().map(Some));
                         verify_backend::Region::Partial(arr)
                     }
                 };
-                super::Cells::bind(region)
+                (super::Cells::bind(region), merkle.into_leaf_proof_tree())
             }))
     }
 
@@ -367,7 +421,7 @@ impl<const LEN: usize> ProofLayout for DynArray<LEN> {
         writer.finalise()
     }
 
-    fn to_verifier_alloc<D: Deserialiser>(proof: D) -> Result<D::Suspended<VerifierAlloc<Self>>> {
+    fn into_verifier_alloc<D: Deserialiser>(proof: D) -> VerifierAllocResult<D, Self> {
         type PageData = (
             PageId<{ MERKLE_LEAF_SIZE.get() }>,
             Box<[u8; MERKLE_LEAF_SIZE.get()]>,
@@ -379,41 +433,60 @@ impl<const LEN: usize> ProofLayout for DynArray<LEN> {
             start: usize,
             left_length: usize,
             proof: D,
-        ) -> Result<D::Suspended<Vec<PageData>>> {
+        ) -> Result<D::Suspended<(Vec<PageData>, OwnedProofPart)>> {
             let page = verify_backend::PageId::from_address(start);
 
             if left_length <= MERKLE_LEAF_SIZE.get() {
                 let ctx = proof.into_leaf_raw()?;
                 let ctx = ctx.map(move |data| match data {
-                    Partial::Blinded(_) | Partial::Absent => vec![],
-                    Partial::Present(data) => vec![(page, data)],
+                    Partial::Absent => (vec![], OwnedProofPart::Absent),
+                    Partial::Blinded(hash) => (
+                        vec![],
+                        OwnedProofPart::Present(MerkleProof::Leaf(MerkleProofLeaf::Blind(hash))),
+                    ),
+                    Partial::Present(data) => (
+                        vec![(page, data.clone())],
+                        OwnedProofPart::Present(MerkleProof::Leaf(MerkleProofLeaf::Read(
+                            data.to_vec(),
+                        ))),
+                    ),
                 });
                 Ok(ctx)
             } else {
-                let ctx: <D as Deserialiser>::DeserialiserNode<Vec<PageData>> =
-                    proof.into_node()?.map(|_| vec![]);
+                let ctx = proof
+                    .into_node()?
+                    .map(|node_partial| (vec![], node_partial.map_present(|()| vec![])));
                 let ctx = Ok::<_, FromProofError>(ctx);
                 let r = work_merkle_params::<MERKLE_ARITY>(start, left_length).fold(
                     ctx,
                     |ctx, (start, length)| {
                         Ok(ctx?
                             .next_branch(|proof| parse_pages_fn_getter(start, length, proof))?
-                            .map(|(mut acc, mut br_data)| {
-                                acc.append(&mut br_data);
-                                acc
+                            .map(|((mut acc, merkle_acc), (br_data, br_merkle))| {
+                                let merkle_acc = merkle_acc.map_present(|mut acc| {
+                                    br_merkle.map_present_unchecked(|br_proof| acc.push(br_proof));
+                                    acc
+                                });
+                                acc.extend(br_data);
+                                (acc, merkle_acc)
                             }))
                     },
                 );
-                Ok(r?.done()?)
+
+                Ok(r?
+                    .map(|(acc, merkle_children)| {
+                        (acc, OwnedProofPart::node_from_partial(merkle_children))
+                    })
+                    .done()?)
             }
         }
 
         let pages_handler = parse_pages_fn_getter::<D>(0, LEN, proof)?;
 
         // After the recursive parsing, convert all pages into cells.
-        Ok(pages_handler.map(|pages| {
+        Ok(pages_handler.map(|(pages, merkle)| {
             let region = verify_backend::DynRegion::from_pages(pages);
-            super::DynCells::bind(region)
+            (super::DynCells::bind(region), merkle)
         }))
     }
 
@@ -511,7 +584,7 @@ impl<const LEN: usize> ProofLayout for DynArray<LEN> {
 ///
 /// fn compute_branch_case<A: ProofLayout, B: ProofLayout, D: Deserialiser>(
 ///     de: D,
-/// ) -> Result<D::Suspended<VerifierAlloc<(A, B)>>, FromProofError>
+/// ) -> VerifierAllocResult<D, (A, B)>
 /// {
 ///     tuple_branches_proof_layout!(de, A, B)
 /// }
@@ -519,7 +592,7 @@ impl<const LEN: usize> ProofLayout for DynArray<LEN> {
 macro_rules! tuple_branches_proof_layout {
     (@no_done; $proof:expr, $($branches:path),+) => {
         {
-            let ctx = $proof.into_node()?.map(|_unit_partial_res| ());
+            let ctx = $proof.into_node()?.map(|node_partial| ((), node_partial.map_present(|()| vec![])));
 
             tuple_branches_proof_layout!(@internal; ctx, [], $($branches),+)
         }
@@ -536,17 +609,30 @@ macro_rules! tuple_branches_proof_layout {
             use $crate::state_backend::proof_backend::proof::deserialiser::DeserialiserNode;
             use tuples::CombinRight;
 
-            let de = $de
-                .next_branch(|child_proof| <$curr_br>::to_verifier_alloc(child_proof))?
-                .map(|(acc, a)|  {
-                    acc.push_right(a)
+            let de = $de.next_branch(|child_proof| <$curr_br>::into_verifier_alloc(child_proof))?
+                .map(|((acc, merkle_acc), (br, br_merkle))| {
+                    (
+                        acc.push_right(br),
+                        merkle_acc.map_present(|mut acc| {
+                            br_merkle.map_present_unchecked(|br_proof| {
+                                acc.push(br_proof);
+                            });
+                            acc
+                        }),
+                    )
                 });
 
             tuple_branches_proof_layout!(@internal; de, [ $($acc_br,)* $curr_br ] $(, $rest_br)*)
         }
     };
     (@internal; $de:expr, [$($acc_br:path),*]) => {
-        $de
+        {
+            use $crate::state_backend::proof_layout::OwnedProofPart;
+
+            $de.map(|(acc, merkle_children)| {
+                (acc, OwnedProofPart::node_from_partial(merkle_children))
+            })
+        }
     };
 }
 
@@ -564,9 +650,7 @@ where
         MerkleTree::make_merkle_node(children)
     }
 
-    fn to_verifier_alloc<De: Deserialiser>(
-        proof: De,
-    ) -> Result<De::Suspended<VerifierAlloc<Self>>> {
+    fn into_verifier_alloc<De: Deserialiser>(proof: De) -> VerifierAllocResult<De, Self> {
         tuple_branches_proof_layout!(proof, A, B)
     }
 
@@ -603,9 +687,7 @@ where
         MerkleTree::make_merkle_node(children)
     }
 
-    fn to_verifier_alloc<De: Deserialiser>(
-        proof: De,
-    ) -> Result<De::Suspended<VerifierAlloc<Self>>> {
+    fn into_verifier_alloc<De: Deserialiser>(proof: De) -> VerifierAllocResult<De, Self> {
         tuple_branches_proof_layout!(proof, A, B, C)
     }
 
@@ -646,9 +728,7 @@ where
         MerkleTree::make_merkle_node(children)
     }
 
-    fn to_verifier_alloc<De: Deserialiser>(
-        proof: De,
-    ) -> Result<De::Suspended<VerifierAlloc<Self>>> {
+    fn into_verifier_alloc<De: Deserialiser>(proof: De) -> VerifierAllocResult<De, Self> {
         tuple_branches_proof_layout!(proof, A, B, C, D)
     }
 
@@ -693,9 +773,7 @@ where
         MerkleTree::make_merkle_node(children)
     }
 
-    fn to_verifier_alloc<De: Deserialiser>(
-        proof: De,
-    ) -> Result<De::Suspended<VerifierAlloc<Self>>> {
+    fn into_verifier_alloc<De: Deserialiser>(proof: De) -> VerifierAllocResult<De, Self> {
         tuple_branches_proof_layout!(proof, A, B, C, D, E)
     }
     fn partial_state_hash(
@@ -743,9 +821,7 @@ where
         MerkleTree::make_merkle_node(children)
     }
 
-    fn to_verifier_alloc<De: Deserialiser>(
-        proof: De,
-    ) -> Result<De::Suspended<VerifierAlloc<Self>>> {
+    fn into_verifier_alloc<De: Deserialiser>(proof: De) -> VerifierAllocResult<De, Self> {
         tuple_branches_proof_layout!(proof, A, B, C, D, E, F)
     }
 
@@ -782,26 +858,37 @@ where
         MerkleTree::make_merkle_node(children)
     }
 
-    fn to_verifier_alloc<D: Deserialiser>(proof: D) -> Result<D::Suspended<VerifierAlloc<Self>>> {
-        let mut ctx: D::DeserialiserNode<Vec<AllocatedOf<T, Verifier>>> =
-            proof.into_node()?.map(|_| vec![]);
+    fn into_verifier_alloc<D: Deserialiser>(proof: D) -> VerifierAllocResult<D, Self> {
+        let mut ctx = proof
+            .into_node()?
+            .map(|node_partial| (vec![], node_partial.map_present(|()| vec![])));
 
         for _ in 0..LEN {
             ctx = ctx
-                .next_branch(|child_proof| T::to_verifier_alloc(child_proof))?
-                .map(|(mut acc, br_res)| {
+                .next_branch(|child_proof| T::into_verifier_alloc(child_proof))?
+                .map(|((mut acc, merkle_acc), (br_res, br_merkle))| {
                     acc.push(br_res);
-                    acc
+                    (
+                        acc,
+                        merkle_acc.map_present(|mut acc| {
+                            br_merkle.map_present_unchecked(|br_proof| {
+                                acc.push(br_proof);
+                            });
+                            acc
+                        }),
+                    )
                 });
         }
 
-        let ctx = ctx.map(|data| {
-            data.try_into()
+        let ctx = ctx.map(|(data, merkle_acc)| {
+            let data = data
+                .try_into()
                 .map_err(|_| {
                     // We can't use expected because the error can't be displayed
                     unreachable!("Conversion to array of fixed length doesn't fail")
                 })
-                .expect("Conversion to array of fixed length failed unexpectedly")
+                .expect("Conversion to array of fixed length failed unexpectedly");
+            (data, OwnedProofPart::node_from_partial(merkle_acc))
         });
 
         ctx.done()
@@ -835,35 +922,61 @@ where
         build_custom_merkle_tree(MERKLE_ARITY, leaves)
     }
 
-    fn to_verifier_alloc<D: Deserialiser>(proof: D) -> Result<D::Suspended<VerifierAlloc<Self>>> {
+    fn into_verifier_alloc<D: Deserialiser>(proof: D) -> VerifierAllocResult<D, Self> {
+        // Avoids clippy warnings about the type being too complex.
+        type NestedSuspendedResult<T> = (Vec<AllocatedOf<T, Verifier>>, OwnedProofPart);
+
         // Obtain a deserialiser for a given length, i.e. Many<T, length>
         // We know that AllocatedOf<Many<T, LEN>, Verifier> = Vec<AllocatedOf<T, Verifier>>.
 
-        // Ideally, this function should return Result<D::Suspended<Many<T, LEN>>>
-        // but the function is recursive & dynamic in length
+        // Ideally, this function should return Many<T, LEN> (wrapped in suspended + result)
+        // but the function is recursive & dynamic in LEN
         fn parametrised_deserialiser<T: ProofLayout, D: Deserialiser>(
             length: usize,
             proof: D,
-        ) -> Result<D::Suspended<Vec<AllocatedOf<T, Verifier>>>>
+        ) -> Result<D::Suspended<NestedSuspendedResult<T>>>
         where
             AllocatedOf<T, Verifier>: 'static,
         {
             let child_length_iter = work_merkle_params::<MERKLE_ARITY>(0, length);
 
             if length == 1 {
-                Ok(T::to_verifier_alloc(proof)?.map(|data| vec![data]))
+                Ok(T::into_verifier_alloc(proof)?.map(|(data, merkle)| (vec![data], merkle)))
             } else {
-                let mut ctx = proof.into_node()?.map(|_| vec![]);
+                let mut ctx = proof
+                    .into_node()?
+                    .map(|node_partial| (vec![], node_partial.map_present(|()| (vec![]))));
                 for (_, child_length) in child_length_iter {
                     ctx = ctx
                         .next_branch(|child_proof| {
                             parametrised_deserialiser::<T, D>(child_length, child_proof)
                         })?
-                        .map(|(mut acc, mut br_res)| {
-                            acc.append(&mut br_res);
-                            acc
+                        .map(|((mut acc, merkle_acc), (br, merkle_br))| {
+                            acc.extend(br);
+                            let merkle_acc = merkle_acc.map_present(|mut acc| {
+                                match merkle_br {
+                                    OwnedProofPart::Absent => debug_assert!(
+                                        false,
+                                        "If the node is present, then the branch is also present"
+                                    ),
+                                    OwnedProofPart::Present(proof) => acc.push(proof),
+                                };
+                                acc
+                            });
+                            (acc, merkle_acc)
                         });
                 }
+                let ctx = ctx.map(|(acc, merkle_children)| {
+                    (acc, match merkle_children {
+                        Partial::Absent => OwnedProofPart::Absent,
+                        Partial::Blinded(hash) => {
+                            OwnedProofPart::Present(MerkleProof::Leaf(MerkleProofLeaf::Blind(hash)))
+                        }
+                        Partial::Present(children) => {
+                            OwnedProofPart::Present(MerkleProof::Node(children))
+                        }
+                    })
+                });
                 ctx.done()
             }
         }
@@ -1086,17 +1199,17 @@ mod tests {
 
             // The first component of the state was present in the proof, can be
             // fully read, and contains the initial state.
-            prop_assert_eq!(verifier_state.0.read_all(), vec![value_before; CELLS_SIZE]);
+            prop_assert_eq!(verifier_state.0.0.read_all(), vec![value_before; CELLS_SIZE]);
 
             // The second component of the state is fully blinded: no values can
             // be read from the array.
             for i in 0..CELLS_SIZE {
-                prop_assert!(handle_stepper_panics(|| verifier_state.1.read(i)).is_err());
+                prop_assert!(handle_stepper_panics(|| verifier_state.0.1.read(i)).is_err());
             };
 
             let ref_verifier_state = (
-                verifier_state.0.struct_ref::<FnManagerIdent>(),
-                verifier_state.1.struct_ref::<FnManagerIdent>(),
+                verifier_state.0.0.struct_ref::<FnManagerIdent>(),
+                verifier_state.0.1.struct_ref::<FnManagerIdent>(),
             );
             prop_assert!(
                 <TestLayout as ProofLayout>::partial_state_hash(ref_verifier_state, ProofTree::Present(&merkle_proof)).is_ok()

--- a/src/riscv/lib/src/stepper/pvm.rs
+++ b/src/riscv/lib/src/stepper/pvm.rs
@@ -35,6 +35,7 @@ use crate::state_backend::AllocatedOf;
 use crate::state_backend::FnManagerIdent;
 use crate::state_backend::ManagerBase;
 use crate::state_backend::ManagerReadWrite;
+use crate::state_backend::OwnedProofPart;
 use crate::state_backend::ProofLayout;
 use crate::state_backend::ProofPart;
 use crate::state_backend::ProofTree;
@@ -283,8 +284,20 @@ impl<'hooks, MC: MemoryConfig, BCC: BlockCacheConfig, M: ManagerReadWrite>
         AllocatedOf<<BCC as BlockCacheConfig>::Layout, Verifier>: 'static,
     {
         let tree_serialisation: Box<[u8]> = serialise_merkle_tree(proof.tree()).collect();
-        let space = deserialise_stream::deserialise::<PvmLayout<MC, BCC>>(&tree_serialisation)
-            .map_err(|_| ProofVerificationFailure::UnexpectedProofShape)?;
+        let (space, merkle_tree) =
+            deserialise_stream::deserialise::<PvmLayout<MC, BCC>>(&tree_serialisation)
+                .map_err(|_| ProofVerificationFailure::UnexpectedProofShape)?;
+
+        let deserialised_proof_tree = match merkle_tree {
+            OwnedProofPart::Present(ref merkle_tree) => ProofTree::Present(merkle_tree),
+            OwnedProofPart::Absent => ProofTree::Absent,
+        };
+        debug_assert_eq!(
+            ProofTree::Present(proof.tree()),
+            deserialised_proof_tree,
+            "The Merkle proof tree obtained through deserialisation should match the original proof tree"
+        );
+
         let stepper = self.as_verify_stepper(space)?;
 
         stepper.verify_proof_internal(ProofPart::Present(proof.tree()), proof.final_state_hash())
@@ -296,8 +309,18 @@ impl<'hooks, MC: MemoryConfig, BCC: BlockCacheConfig, M: ManagerReadWrite>
         AllocatedOf<BCC::Layout, Verifier>: 'static,
     {
         let proof_tree = ProofTree::Present(proof.tree());
-        let space = deserialise_owned::deserialise::<PvmLayout<MC, BCC>>(proof_tree)
-            .map_err(|_| ProofVerificationFailure::UnexpectedProofShape)?;
+        let (space, deserialised_proof_tree) =
+            deserialise_owned::deserialise::<PvmLayout<MC, BCC>>(proof_tree)
+                .map_err(|_| ProofVerificationFailure::UnexpectedProofShape)?;
+
+        let deserialised_proof_tree = match deserialised_proof_tree {
+            OwnedProofPart::Present(ref merkle_tree) => ProofTree::Present(merkle_tree),
+            OwnedProofPart::Absent => ProofTree::Absent,
+        };
+        debug_assert_eq!(
+            proof_tree, deserialised_proof_tree,
+            "The Merkle proof tree obtained through deserialisation should match the original proof tree"
+        );
 
         let stepper = self.as_verify_stepper(space)?;
         stepper.verify_proof_internal(proof_tree, proof.final_state_hash())


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

Part of RV-612

# What

<!--
    Summarise the changes in this MR.
-->

Add `OwnedProofPart` to return type of `to_verifier_alloc` from the `ProofLayout` trait.
 
# Why

<!-- 
    Explain why this MR is needed.
-->

Needed to implement the `octez_riscv_deserialise_proof` ocaml binding. The parsed merkle tree will be used to compute the initial state hash of the proof.

# How

* Amend all `to_verifier_alloc` functions from the `ProofLayout` trait. This allows calling `partial_state_hash` over the `NodePvm<Verifier>` held in the `Proof` type in the protocol - required to compute the initial state hash.

<!--
    Explain how the MR achieves its goal. If this is trivial, you may omit it.
-->

# Manually Testing

```
cargo test --test test_proofs -- --nocapture --ignored
```

# Benchmarking

<!--
    Measure the impact on performance of this MR on your machine and the benchmark machine.
    Fill in the table below. If there is no runtime performance impact, replace the table with a
    sentence stating so. 
-->

Not impacted

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] Benchmark performance and [populate the section above](#benchmarking) if needed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
