### PR TITLE
Add job to run benchmarks on the reference machine

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -37,9 +37,7 @@ jobs:
         run: |
           scp src/riscv/scripts/ci-bench.sh ${{ secrets.BENCH_HOST }}:bench-${{ github.run_id }}.sh
 
-          echo '```' >> $GITHUB_STEP_SUMMARY
           ssh ${{ secrets.BENCH_HOST }} ./bench-${{ github.run_id }}.sh -r "${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
 
           # Delete the benchmark script if the job suceeded, otherwise keep it for investigation
           ssh ${{ secrets.BENCH_HOST }} rm ./bench-${{ github.run_id }}.sh

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,45 @@
+name: Benchmark
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+  push:
+    branches: [main]
+
+# Only one job may reserve the reference machine at a time
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  benchmark:
+    name: Benchmark
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Configure SSH
+        uses: webfactory/ssh-agent@v0.9.1
+        with:
+          ssh-private-key: ${{ secrets.BENCH_SSH_KEY }}
+
+      - name: Configure SSH's known hosts
+        run: echo "${{ secrets.BENCH_KNOWN_HOSTS }}" >> ~/.ssh/known_hosts
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Benchmark
+        run: |
+          scp src/riscv/scripts/ci-bench.sh ${{ secrets.BENCH_HOST }}:bench-${{ github.run_id }}.sh
+
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          ssh ${{ secrets.BENCH_HOST }} ./bench-${{ github.run_id }}.sh -r "${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+          # Delete the benchmark script if the job suceeded, otherwise keep it for investigation
+          ssh ${{ secrets.BENCH_HOST }} rm ./bench-${{ github.run_id }}.sh

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -20,6 +20,10 @@ jobs:
   benchmark:
     name: Benchmark
     runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name != 'pull_request'
+
+    permissions:
+      pull-requests: write
 
     steps:
       - name: Configure SSH
@@ -41,3 +45,14 @@ jobs:
 
           # Delete the benchmark script if the job suceeded, otherwise keep it for investigation
           ssh ${{ secrets.BENCH_HOST }} rm ./bench-${{ github.run_id }}.sh
+
+          echo "Benchmark results for revision ${{ github.sha }}:" >> pr-comment.md
+          echo >> pr-comment.md
+          cat $GITHUB_STEP_SUMMARY >> pr-comment.md
+
+      - name: Comment results on PR
+        if: github.event_name == 'pull_request'
+        uses: thollander/actions-comment-pull-request@v3.0.1
+        with:
+          file-path: pr-comment.md
+          comment-tag: bench-result

--- a/src/riscv/jstz/Cargo.lock
+++ b/src/riscv/jstz/Cargo.lock
@@ -433,6 +433,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "comfy-table"
+version = "7.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +463,28 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "parking_lot",
+ "rustix",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -714,6 +747,16 @@ checksum = "24e2389d65ab4fab27dc2a5de7b191e1f6617d1f1c8855c0dc569c94a4cbb18d"
 dependencies = [
  "serde",
  "typeid",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1024,6 +1067,7 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "clap",
+ "comfy-table",
  "hex",
  "http",
  "jstz_crypto",
@@ -1275,6 +1319,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
 name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1420,6 +1470,16 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "sha2 0.9.9",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1764,6 +1824,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2361,6 +2434,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "url"

--- a/src/riscv/jstz/Cargo.toml
+++ b/src/riscv/jstz/Cargo.toml
@@ -32,6 +32,7 @@ http = "1.1.0"
 bincode = "2.0.0-rc.3"
 regex = "1.10.4"
 serde_json = "1.0.115"
+comfy-table = "7.1.4"
 
 [workspace.dependencies.tezos-smart-rollup]
 version = "0.2.2"

--- a/src/riscv/jstz/bench/Cargo.toml
+++ b/src/riscv/jstz/bench/Cargo.toml
@@ -16,3 +16,4 @@ http.workspace = true
 bincode.workspace = true
 regex.workspace = true
 tezos_data_encoding.workspace = true
+comfy-table.workspace = true

--- a/src/riscv/sandbox/src/cli.rs
+++ b/src/riscv/sandbox/src/cli.rs
@@ -252,7 +252,7 @@ pub struct InboxOptions {
     pub keep_going: bool,
 
     /// Rollup address
-    #[arg(short, long, default_value = "sr1UNDWPUYVeomgG15wn5jSw689EJ4RNnVQa")]
+    #[arg(short, long, default_value = "sr163Lv22CdE8QagCwf48PWDTquk6isQwv57")]
     pub address: String,
 
     /// Rollup origination level

--- a/src/riscv/scripts/ci-bench.sh
+++ b/src/riscv/scripts/ci-bench.sh
@@ -58,3 +58,6 @@ done
 
 # Collect results and display them
 nix develop --command cargo run --quiet --manifest-path src/riscv/jstz/Cargo.toml --bin inbox-bench -- results --inbox-file "$inbox_file" --expected-transfers 15 "${result_args[@]}"
+
+# Clean up
+rm -rf "$inbox_file" "$dir" "$result_dir"

--- a/src/riscv/scripts/ci-bench.sh
+++ b/src/riscv/scripts/ci-bench.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Git ref to checkout
+ref=""
+
+# Parse command line arguments
+while getopts "r:" OPTION; do
+  case "$OPTION" in
+  r)
+    ref="$OPTARG"
+    ;;
+  *)
+    echo "Invalid parameter"
+    exit 1
+    ;;
+  esac
+done
+
+# Make sure a ref is provided, otherwise we have nothing to benchmark
+if [[ -z "$ref" ]]; then
+  echo "No ref provided"
+  exit 1
+fi
+
+# Make sure this process and all its children run with the highest priority to avoid flakiness
+# during the benchmark runs
+sudo renice -20 -p $$ >/dev/null
+
+# We need to source the Nix environment to gain access to our favourite tools
+. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+
+# Check out the repository so we have the source code to benchmark
+dir=$(mktemp -d)
+
+cd "$dir"
+git init --quiet .
+git config --local gc.auto 0
+git remote add origin git@github.com:tezos/riscv-pvm.git
+git fetch --quiet --depth 1 origin "+$ref"
+git checkout --quiet FETCH_HEAD
+
+# Build prerequisites ahead of time
+nix develop --command make -C src/riscv/jstz build-kernel &>/dev/null
+
+# Generate inbox file for benchmark runs
+inbox_file=$(mktemp)
+nix develop --command cargo run --quiet --manifest-path src/riscv/jstz/Cargo.toml --bin inbox-bench -- generate --transfers 15 --inbox-file "$inbox_file"
+
+# Run the benchmark
+result_dir=$(mktemp -d)
+result_args=()
+for i in $(seq 1 10); do 
+  nix develop --command cargo run --release --quiet --manifest-path src/riscv/Cargo.toml -- run --input src/riscv/jstz/target/riscv64gc-unknown-linux-musl/release/jstz --inbox-file "$inbox_file" --timings > $result_dir/$i.json
+  result_args+=("--log-file=$result_dir/$i.json")
+done
+
+# Collect results and display them
+nix develop --command cargo run --quiet --manifest-path src/riscv/jstz/Cargo.toml --bin inbox-bench -- results --inbox-file "$inbox_file" --expected-transfers 15 "${result_args[@]}"


### PR DESCRIPTION
Closes RV-689

# What

Introduces a CI job that runs a benchmark run on the reference machine.

The results get posted to the PR as a comment. The bot also updates the comment for each successful run. The PRs in draft are ignored.

# Why

Saves developers some time.

# How

To simplify the script that runs on the reference machine, I needed to consolidate the default rollup address across our tools.

# Manually Testing

```
make -C src/riscv all
```

# Benchmarking

This does not impact performance.

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] Benchmark performance and [populate the section above](#benchmarking) if needed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
