### PR TITLE
Prevent blocks with 1 instruction from being JIT compiled

### DIFF
--- a/src/riscv/lib/src/machine_state/block_cache/block/dispatch.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/block/dispatch.rs
@@ -308,6 +308,11 @@ impl<MC: MemoryConfig + Send, M: JitStateAccess + Send + 'static> DispatchCompil
         let fun = Jitted::run_block_not_compiled;
         target.set(fun);
 
+        // Single instruction blocks don't perform as well when compiled
+        if instr.len() <= 1 {
+            return fun;
+        }
+
         let request = CompilationRequest {
             instr,
             fun: target.fun.clone(),


### PR DESCRIPTION
# What

Only compile blocks that have at least 2 instructions.

# Why

Blocks that consist of a single instruction perform consistently worse when JIT compiled.


# Manually Testing

```
make -C src/riscv all
```

# Benchmarking

|  | `main` | This MR | Improvement |
|--|----------|---------|-------------|
| M3 MBP | 17.269 TPS | 18.400 TPS | +6.55% |
| Benchmark Machine | 11.224 TPS | 11.766 TPS | +4.92% |

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] Benchmark performance and [populate the section above](#benchmarking) if needed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
