### PR TITLE
RISC-V: Introduce cache for XRegisters within JIT

### DIFF
--- a/src/riscv/lib/src/jit/builder.rs
+++ b/src/riscv/lib/src/jit/builder.rs
@@ -236,7 +236,7 @@ impl<'a, MC: MemoryConfig, JSA: JitStateAccess> Builder<'a, MC, JSA> {
         // both IR blocks need access to the dynamic values at this point in time.
         // These are modified by the jump to the end block below, and possibly by the
         // `on_branching` function.
-        let snapshot = self.dynamic;
+        let snapshot = self.dynamic.clone();
 
         self.builder.switch_to_block(on_branch);
 
@@ -401,7 +401,7 @@ impl<MC: MemoryConfig, JSA: JitStateAccess> ICB for Builder<'_, MC, JSA> {
 
         // both IR blocks need access to the dynamic values at this point in time.
         // These can be modified by the `true_branch` and `false_branch` functions.
-        let snapshot = self.dynamic;
+        let snapshot = self.dynamic.clone();
         self.builder.switch_to_block(true_block);
 
         let res_val = Phi::to_ir_vals(true_branch(self));

--- a/src/riscv/lib/src/jit/builder/block_state.rs
+++ b/src/riscv/lib/src/jit/builder/block_state.rs
@@ -47,7 +47,7 @@ impl From<ProgramCounterUpdate<X64>> for PCUpdate {
 /// The non-branching block, can otherwise be considered as the 'fallthrough' block.
 /// That is to say, the fallthrough block is the block taken when execution 'falls through'
 /// a branching instruction--the branch is not taken.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct DynamicValues {
     /// The number of steps taken within the current compilation context.
     steps: usize,

--- a/src/riscv/lib/src/jit/builder/block_state.rs
+++ b/src/riscv/lib/src/jit/builder/block_state.rs
@@ -4,11 +4,15 @@
 
 //! State that is kept per Cranelift-IR block.
 
+use std::collections::HashMap;
+
 use cranelift::codegen::ir::InstBuilder;
+use cranelift::codegen::ir::{self};
 use cranelift::frontend::FunctionBuilder;
 
 use super::X64;
 use crate::machine_state::ProgramCounterUpdate;
+use crate::machine_state::registers::NonZeroXRegister;
 
 /// Program Counter update, within the context of JIT-compilation.
 ///
@@ -64,6 +68,9 @@ pub struct DynamicValues {
     /// The current offset of the pc, as a result of steps taken
     /// so far.
     pc_offset: i64,
+
+    /// XRegister cache
+    xregs: HashMap<NonZeroXRegister, ir::Value>,
 }
 
 impl DynamicValues {
@@ -73,6 +80,7 @@ impl DynamicValues {
             pc_val,
             steps: 0,
             pc_offset: 0,
+            xregs: HashMap::with_capacity(16),
         }
     }
 
@@ -116,5 +124,21 @@ impl DynamicValues {
     /// where 'step' maps to the lowering of an instruction.
     pub fn steps(&self) -> usize {
         self.steps
+    }
+
+    /// Get a value for the given XRegister, if it exists.
+    /// If it does not exist, `None` is returned.
+    pub fn get_cached_xreg_val(&self, xreg: NonZeroXRegister) -> Option<ir::Value> {
+        self.xregs.get(&xreg).copied()
+    }
+
+    /// Set a value for the given XRegister, caching it for later use.
+    pub fn cache_xreg_val(&mut self, xreg: NonZeroXRegister, value: ir::Value) {
+        self.xregs.insert(xreg, value);
+    }
+
+    /// Clear the cache of XRegister values.
+    pub fn clear_xreg_cache(&mut self) {
+        self.xregs.clear();
     }
 }

--- a/src/riscv/lib/src/jit/builder/errno.rs
+++ b/src/riscv/lib/src/jit/builder/errno.rs
@@ -88,7 +88,7 @@ where
             .ins()
             .brif(errno_code, on_error, &[], on_ok, &[]);
 
-        let snapshot = builder.dynamic;
+        let snapshot = builder.dynamic.clone();
 
         builder.builder.switch_to_block(on_error);
         // Handle the exception in the 'error occurred' block
@@ -144,7 +144,7 @@ impl<MC: MemoryConfig, JSA: JitStateAccess> Errno<(), MC, JSA> for AtomicAccessG
         // both IR blocks need access to the dynamic values at this point in time.
         // These are modified by the jump to the end block below, and possibly by the
         // `on_branching` function.
-        let snapshot = builder.dynamic;
+        let snapshot = builder.dynamic.clone();
 
         builder.builder.switch_to_block(error_branch);
 


### PR DESCRIPTION
Closes RV-692. 

# What

Introduces an `XRegister Cache` within the builder for JIT functions. 

# Why

Values obtained will be recorded in the cache, so that they can be used multiple times over the course of the function, rather than needing to read from the `XRegisters` again each time. 

# How

Introduce a `Hashmap<NonZeroXRegister, ir::Value>`. Whenever we read or write, we check/write to the hashmap (as well) wherever appropriate. 

NOTE:
Including this cache requires careful consideration on when we need to invalidate it due to possibly having a mismatch between the values in the cache and the current values of XRegisters. 

Currently, we only need to reset the cache after a branch merge. This is because the cache is populated at compile-time with `Values` representing register values, which can be different in each side of a branch-merge. We are unable to know the 'correct' cache to use after the merge, so we clear it to ensure safety.

In any other case of branching, we are either exiting the block (therefore the cache will stop being needed), or falling through (so it is still valid). 

# Manually Testing

```
make -C src/riscv all
```

# Benchmarking

<!--
    Measure the impact on performance of this MR on your machine and the benchmark machine.
    Fill in the table below. If there is no runtime performance impact, replace the table with a
    sentence stating so. 
-->

|  | `main` | This MR | Improvement |
|--|----------|---------|-------------|
| M3 MBP | 17.220 TPS | 17.410 TPS | 1.1% |
| Benchmark Machine | 11.640 TPS | 11.878 TPS | 2.04% |


# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] Benchmark performance and [populate the section above](#benchmarking) if needed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
