### PR TITLE
Run benchmark for PRs in draft via "benchmark-trigger" label

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,6 +7,7 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+      - labeled
 
   push:
     branches: [main]
@@ -20,7 +21,7 @@ jobs:
   benchmark:
     name: Benchmark
     runs-on: ubuntu-latest
-    if: (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name != 'pull_request'
+    if: (github.event_name == 'pull_request' && (github.event.pull_request.draft == false || contains(github.event.pull_request.labels.*.name, 'benchmark-trigger'))) || github.event_name != 'pull_request'
 
     permissions:
       pull-requests: write
@@ -56,3 +57,8 @@ jobs:
         with:
           file-path: pr-comment.md
           comment-tag: bench-result
+
+      - name: Remove PR labels
+        uses: actions-ecosystem/action-remove-labels@v1.3.0
+        with:
+          labels: benchmark-trigger


### PR DESCRIPTION
Sometimes you want to trigger a benchmark run, but your PR is still in draft. By default, the benchmark workflow won't run to avoid reserving the reference machine for nothing.

Now you can trigger a benchmark by assigning the `benchmark-trigger` label.

The label gets removed once the Benchmark workflow has finished.