### PR TITLE
Move BlockBuilder to MachineState such that it can be shared

### DIFF
--- a/src/riscv/lib/src/machine_state/block_cache/config.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/config.rs
@@ -68,10 +68,7 @@ impl<const SIZE: usize> super::BlockCacheConfig for BlockCacheConfig<SIZE> {
 
     type State<MC: MemoryConfig, B: Block<MC, M>, M: ManagerBase> = BlockCache<SIZE, B, MC, M>;
 
-    fn bind<MC, B, M>(
-        space: AllocatedOf<Self::Layout, M>,
-        block_builder: B::BlockBuilder,
-    ) -> Self::State<MC, B, M>
+    fn bind<MC, B, M>(space: AllocatedOf<Self::Layout, M>) -> Self::State<MC, B, M>
     where
         MC: MemoryConfig,
         B: Block<MC, M>,
@@ -91,7 +88,6 @@ impl<const SIZE: usize> super::BlockCacheConfig for BlockCacheConfig<SIZE> {
                 .try_into()
                 .map_err(|_| "mismatching vector lengths for instruction cache")
                 .unwrap(),
-            block_builder,
         }
     }
 

--- a/src/riscv/lib/src/stepper/test.rs
+++ b/src/riscv/lib/src/stepper/test.rs
@@ -106,7 +106,7 @@ impl<MC: MemoryConfig, B: Block<MC, Owned>> TestStepper<MC, TestCacheConfig, B> 
     ///
     /// [`BlockBuilder`]: Block::BlockBuilder
     pub fn recover_builder(self) -> B::BlockBuilder {
-        self.machine_state.block_cache.block_builder
+        self.machine_state.block_builder
     }
 
     /// Initialise an interpreter with a given `program`. Returns both the interpreter and the fully


### PR DESCRIPTION
Closes RV-693

# What

Move the `block_builder: B::BlockBuilder` field from the `BlockCache` to the `MachineState`.

# Why

Currently, the block builder is stored in the block cache. However, with [RV-685](https://linear.app/tezos/issue/RV-685/decouple-block-cache-from-pvm-state), there will be one block cache per contiguous RX memory mapping. 

This means that, without further changes, there could be multiple instances of the `BlockBuilder` that would need to share state. 

Moving the `block_builder` field to `MachineState` helps us avoid this.

# Manually Testing

```
make -C src/riscv all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
