### PR TITLE
RISC-V: Lower f.cvtdlu and rename to F64FromX64Unsigned

### DIFF
--- a/src/riscv/lib/src/interpreter/rv64d.rs
+++ b/src/riscv/lib/src/interpreter/rv64d.rs
@@ -287,18 +287,6 @@ where
         self.run_fcvt_int_fmt(rs1, rm, rd, |u| u as i64 as i128, Double::from_i128_r)
     }
 
-    /// `FCVT.D.WU` R-type instruction.
-    ///
-    /// See [Self::run_fcvt_int_fmt].
-    pub fn run_fcvt_d_lu(
-        &mut self,
-        rs1: XRegister,
-        rm: InstrRoundingMode,
-        rd: FRegister,
-    ) -> Result<(), Exception> {
-        self.run_fcvt_int_fmt(rs1, rm, rd, |u| u as u128, Double::from_u128_r)
-    }
-
     /// `FCVT.D.S` R-type instruction.
     ///
     /// See [Self::run_fcvt_fmt_fmt].

--- a/src/riscv/lib/src/jit.rs
+++ b/src/riscv/lib/src/jit.rs
@@ -7,7 +7,6 @@
 
 pub(crate) mod builder;
 pub(crate) mod state_access;
-
 use std::collections::HashMap;
 use std::ffi::c_void;
 
@@ -258,10 +257,14 @@ mod tests {
     use std::ptr::null;
 
     use Instruction as I;
+    use rustc_apfloat::Float;
+    use rustc_apfloat::Round;
+    use rustc_apfloat::ieee::Double;
 
     use super::*;
     use crate::backend_test;
     use crate::instruction_context::LoadStoreWidth;
+    use crate::interpreter::float::RoundingMode;
     use crate::machine_state::MachineCoreState;
     use crate::machine_state::StepManyResult;
     use crate::machine_state::block_cache::block::Block;
@@ -270,9 +273,11 @@ mod tests {
     use crate::machine_state::memory::M4K;
     use crate::machine_state::memory::Memory;
     use crate::machine_state::memory::MemoryConfig;
+    use crate::machine_state::registers::FValue;
     use crate::machine_state::registers::NonZeroXRegister;
     use crate::machine_state::registers::XRegister;
     use crate::machine_state::registers::nz;
+    use crate::parser::instruction::InstrRoundingMode;
     use crate::parser::instruction::InstrWidth;
     use crate::parser::instruction::InstrWidth::*;
     use crate::state::NewState;
@@ -373,6 +378,7 @@ mod tests {
                 "Interpreted mode ran for {}, compared to jit-mode of {jitted_steps}",
                 interpreted_res.steps
             );
+
             assert_eq_struct(
                 &interpreted.struct_ref::<FnManagerIdent>(),
                 &jitted.struct_ref::<FnManagerIdent>(),
@@ -3156,5 +3162,65 @@ mod tests {
         for scenario in scenarios {
             scenario.run(&mut jit, &mut interpreted_bb);
         }
+    });
+
+    backend_test!(test_f64_from_x64_unsigned_jit, F, {
+        use Instruction as I;
+
+        use crate::machine_state::registers::FRegister::*;
+        use crate::machine_state::registers::NonZeroXRegister as NZ;
+        use crate::machine_state::registers::XRegister::*;
+
+        let scenarios: &[Scenario<F>] = &[
+            ScenarioBuilder::default()
+                .set_instructions(&[
+                    I::new_li(NZ::x1, 13872, Uncompressed),
+                    I::new_f64_from_x64_unsigned(
+                        f2,
+                        x1,
+                        InstrRoundingMode::Static(RoundingMode::RTZ),
+                        Compressed,
+                    ),
+                    I::new_nop(InstrWidth::Uncompressed),
+                ])
+                .set_expected_steps(3)
+                .set_assert_hook(assert_hook!(core, F, {
+                    let res = core.hart.fregisters.read(f2);
+                    let expected: FValue = (Double::from_u128_r(13872u128, Round::TowardZero))
+                        .value
+                        .into();
+                    assert_eq!(res, expected, "Expected {:?}, found {:?}", expected, res);
+                }))
+                .build(),
+            ScenarioBuilder::default()
+                .set_setup_hook(setup_hook!(core, F, {
+                    // resets the rounding mode in `frm` of `fcsr` register to NTE.
+                    core.hart.csregisters.reset();
+                }))
+                .set_instructions(&[
+                    I::new_li(NZ::x1, 13872, Uncompressed),
+                    I::new_f64_from_x64_unsigned(f2, x1, InstrRoundingMode::Dynamic, Compressed),
+                    I::new_nop(InstrWidth::Uncompressed),
+                ])
+                .set_expected_steps(3)
+                .set_assert_hook(assert_hook!(core, F, {
+                    let res = core.hart.fregisters.read(f2);
+                    let expected: FValue =
+                        (Double::from_u128_r(13872u128, Round::NearestTiesToEven))
+                            .value
+                            .into();
+                    assert_eq!(res, expected, "Expected {:?}, found {:?}", expected, res);
+                }))
+                .build(),
+        ];
+
+        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut interpreted_bb = InterpretedBlockBuilder;
+
+        for scenario in scenarios {
+            scenario.run(&mut jit, &mut interpreted_bb);
+        }
+
+        //invalid csr repr
     });
 }

--- a/src/riscv/lib/src/jit/state_access/abi.rs
+++ b/src/riscv/lib/src/jit/state_access/abi.rs
@@ -12,6 +12,7 @@ use cranelift::codegen::ir::types::I16;
 use cranelift::codegen::ir::types::I32;
 use cranelift::codegen::ir::types::I64;
 use cranelift::prelude::isa::CallConv;
+use cranelift::prelude::types::F64;
 use cranelift_jit::JITModule;
 use cranelift_module::FuncId;
 use cranelift_module::Linkage;
@@ -19,7 +20,6 @@ use cranelift_module::Module;
 use cranelift_module::ModuleResult;
 
 use crate::machine_state::registers::FRegister;
-use crate::machine_state::registers::FValue;
 use crate::machine_state::registers::NonZeroXRegister;
 
 /// This struct is used to produce and declare function signatures for external function calls.
@@ -182,8 +182,8 @@ impl ToCraneliftRepr for FRegister {
     const CRANELIFT_TYPE: CraneliftRepr = get_repr::<Self>();
 }
 
-impl ToCraneliftRepr for FValue {
-    const CRANELIFT_TYPE: CraneliftRepr = get_repr::<Self>();
+impl ToCraneliftRepr for f64 {
+    const CRANELIFT_TYPE: CraneliftRepr = CraneliftRepr::Value(F64);
 }
 
 /// A valid return type for an external function call.

--- a/src/riscv/lib/src/jit/state_access/abi.rs
+++ b/src/riscv/lib/src/jit/state_access/abi.rs
@@ -103,27 +103,6 @@ pub(super) enum CraneliftRepr {
     Value(Type),
 }
 
-/// Match the size of the type to a cranelift IR type.
-const fn get_repr<T>() -> CraneliftRepr {
-    struct SupportedSize<T>(T);
-    impl<T> SupportedSize<T> {
-        const SIZE: usize = std::mem::size_of::<T>();
-
-        const IS_SUPPORTED: () =
-            assert!(Self::SIZE == 1 || Self::SIZE == 2 || Self::SIZE == 4 || Self::SIZE == 8);
-    }
-
-    let () = SupportedSize::<T>::IS_SUPPORTED;
-
-    match SupportedSize::<T>::SIZE {
-        1 => CraneliftRepr::Value(I8),
-        2 => CraneliftRepr::Value(I16),
-        4 => CraneliftRepr::Value(I32),
-        8 => CraneliftRepr::Value(I64),
-        _ => unreachable!(),
-    }
-}
-
 /// This Type can be transformed into a cranelift IR Type.
 pub(super) trait ToCraneliftRepr {
     /// Associated constant to determine the Cranelift type at compile time.
@@ -131,43 +110,43 @@ pub(super) trait ToCraneliftRepr {
 }
 
 impl ToCraneliftRepr for u64 {
-    const CRANELIFT_TYPE: CraneliftRepr = get_repr::<Self>();
+    const CRANELIFT_TYPE: CraneliftRepr = CraneliftRepr::Value(I64);
 }
 
 impl ToCraneliftRepr for i64 {
-    const CRANELIFT_TYPE: CraneliftRepr = get_repr::<Self>();
+    const CRANELIFT_TYPE: CraneliftRepr = CraneliftRepr::Value(I64);
 }
 
 impl ToCraneliftRepr for bool {
-    const CRANELIFT_TYPE: CraneliftRepr = get_repr::<Self>();
+    const CRANELIFT_TYPE: CraneliftRepr = CraneliftRepr::Value(I8);
 }
 
 impl ToCraneliftRepr for NonZeroXRegister {
-    const CRANELIFT_TYPE: CraneliftRepr = get_repr::<Self>();
+    const CRANELIFT_TYPE: CraneliftRepr = CraneliftRepr::Value(I8);
 }
 
 impl ToCraneliftRepr for u8 {
-    const CRANELIFT_TYPE: CraneliftRepr = get_repr::<Self>();
+    const CRANELIFT_TYPE: CraneliftRepr = CraneliftRepr::Value(I8);
 }
 
 impl ToCraneliftRepr for i8 {
-    const CRANELIFT_TYPE: CraneliftRepr = get_repr::<Self>();
+    const CRANELIFT_TYPE: CraneliftRepr = CraneliftRepr::Value(I8);
 }
 
 impl ToCraneliftRepr for i16 {
-    const CRANELIFT_TYPE: CraneliftRepr = get_repr::<Self>();
+    const CRANELIFT_TYPE: CraneliftRepr = CraneliftRepr::Value(I16);
 }
 
 impl ToCraneliftRepr for u16 {
-    const CRANELIFT_TYPE: CraneliftRepr = get_repr::<Self>();
+    const CRANELIFT_TYPE: CraneliftRepr = CraneliftRepr::Value(I16);
 }
 
 impl ToCraneliftRepr for i32 {
-    const CRANELIFT_TYPE: CraneliftRepr = get_repr::<Self>();
+    const CRANELIFT_TYPE: CraneliftRepr = CraneliftRepr::Value(I32);
 }
 
 impl ToCraneliftRepr for u32 {
-    const CRANELIFT_TYPE: CraneliftRepr = get_repr::<Self>();
+    const CRANELIFT_TYPE: CraneliftRepr = CraneliftRepr::Value(I32);
 }
 
 impl<T> ToCraneliftRepr for &T {
@@ -179,7 +158,7 @@ impl<T> ToCraneliftRepr for &mut T {
 }
 
 impl ToCraneliftRepr for FRegister {
-    const CRANELIFT_TYPE: CraneliftRepr = get_repr::<Self>();
+    const CRANELIFT_TYPE: CraneliftRepr = CraneliftRepr::Value(I8);
 }
 
 impl ToCraneliftRepr for f64 {

--- a/src/riscv/lib/src/jit/state_access/stack.rs
+++ b/src/riscv/lib/src/jit/state_access/stack.rs
@@ -50,6 +50,7 @@ use cranelift::codegen::ir::Type;
 use cranelift::codegen::ir::Value;
 use cranelift::codegen::ir::types::I64;
 use cranelift::frontend::FunctionBuilder;
+use cranelift::prelude::types::F64;
 use cranelift::prelude::types::I8;
 use cranelift::prelude::types::I16;
 use cranelift::prelude::types::I32;
@@ -138,6 +139,14 @@ impl StackAddressable for Address {
 
 impl Stackable for Address {
     const IR_TYPE: Type = I64;
+}
+
+impl StackAddressable for f64 {
+    type Underlying = f64;
+}
+
+impl Stackable for f64 {
+    const IR_TYPE: Type = F64;
 }
 
 /// Dedicated space on the stack to store a value of the underlying type.

--- a/src/riscv/lib/src/machine_state/instruction/constructors.rs
+++ b/src/riscv/lib/src/machine_state/instruction/constructors.rs
@@ -6,6 +6,7 @@ use super::Args;
 use super::Instruction;
 use super::OpCode;
 use crate::default::ConstDefault;
+use crate::machine_state::registers::FRegister;
 use crate::machine_state::registers::NonZeroXRegister;
 use crate::machine_state::registers::XRegister;
 use crate::machine_state::registers::nz;
@@ -13,6 +14,7 @@ use crate::parser::XRegisterParsed;
 use crate::parser::instruction::CIBTypeArgs;
 use crate::parser::instruction::CRTypeArgs;
 use crate::parser::instruction::ITypeArgs;
+use crate::parser::instruction::InstrRoundingMode;
 use crate::parser::instruction::InstrWidth;
 use crate::parser::instruction::NonZeroRdITypeArgs;
 use crate::parser::instruction::NonZeroRdRTypeArgs;
@@ -1949,6 +1951,25 @@ impl Instruction {
                 rs2: rs2.into(),
                 aq,
                 rl,
+                width,
+                ..Args::DEFAULT
+            },
+        }
+    }
+
+    /// Create a new [`Instruction`] with the appropriate [`super::ArgsShape`] for [`OpCode::F64FromX64Unsigned`].
+    pub(crate) fn new_f64_from_x64_unsigned(
+        rd: FRegister,
+        rs1: XRegister,
+        rm: InstrRoundingMode,
+        width: InstrWidth,
+    ) -> Self {
+        Self {
+            opcode: OpCode::F64FromX64Unsigned,
+            args: Args {
+                rd: rd.into(),
+                rs1: rs1.into(),
+                rm,
                 width,
                 ..Args::DEFAULT
             },

--- a/src/riscv/lib/src/machine_state/instruction/tagged_instruction.rs
+++ b/src/riscv/lib/src/machine_state/instruction/tagged_instruction.rs
@@ -354,7 +354,7 @@ pub fn opcode_to_argsshape(opcode: &OpCode) -> ArgsShape {
         | Fnmaddd => ArgsShape::FSrcFDest,
 
         Flw | Fld | FmvWX | Fcvtsw | Fcvtswu | Fcvtsl | Fcvtslu | FmvDX | Fcvtdw | Fcvtdwu
-        | Fcvtdl | Fcvtdlu | CFld | CFldsp => ArgsShape::XSrcFDest,
+        | Fcvtdl | F64FromX64Unsigned | CFld | CFldsp => ArgsShape::XSrcFDest,
 
         Feqs | Fles | Flts | Feqd | Fled | Fltd | FclassS | FmvXW | Fcvtws | Fcvtwus | Fcvtls
         | Fcvtlus | FclassD | FmvXD | Fcvtwd | Fcvtwud | Fcvtld | Fcvtlud => ArgsShape::FSrcXDest,

--- a/src/riscv/lib/src/machine_state/registers.rs
+++ b/src/riscv/lib/src/machine_state/registers.rs
@@ -573,6 +573,13 @@ impl ConstDefault for FValue {
     const DEFAULT: Self = Self(0);
 }
 
+impl FValue {
+    /// Convert to [`f64`] bitwise.
+    pub(crate) fn bits(self) -> f64 {
+        f64::from_bits(self.0)
+    }
+}
+
 impl backend::Elem for FValue {
     #[inline(always)]
     fn store(&mut self, source: &Self) {

--- a/src/riscv/lib/src/parser/instruction.rs
+++ b/src/riscv/lib/src/parser/instruction.rs
@@ -649,6 +649,9 @@ pub enum InstrCacheable {
     Fcvtdw(XRegToFRegArgsWithRounding),
     Fcvtdwu(XRegToFRegArgsWithRounding),
     Fcvtdl(XRegToFRegArgsWithRounding),
+    /// `FCVT.D.LU` - Converts a 64 bit unsigned integer into a 64 bit float, with rounding.
+    ///
+    /// Returns `Exception::IllegalInstruction` on an invalid rounding mode.
     Fcvtdlu(XRegToFRegArgsWithRounding),
     Fcvtds(FR1ArgWithRounding),
     Fcvtsd(FR1ArgWithRounding),


### PR DESCRIPTION
Relates to RV-657. 

# What

Introduce external function call for `F64FromX64Unsigned` and uses it for running the instruction. Rename opcode from `Fcvtdlu` to `F64FromX64Unsigned. 

# Why

Part of the instruction coverage work. 

# How

Within JIT, the calling of the function routes through to the interpreter method of calling. This needs to be done by representing all arguments through cranelift-representable values, so the `rounding-mode` is converted to an `I32` and back, using the same coding as the initial decoding of binary into an `rm` value. 

# Manually Testing

```
make -C src/riscv all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
