### PR TITLE
Add support for reads/writes that skip checks using static information

### DIFF
--- a/src/riscv/lib/src/instruction_context/value.rs
+++ b/src/riscv/lib/src/instruction_context/value.rs
@@ -133,7 +133,7 @@ impl PhiValue for XValue {
         params: &[ir::Value],
         _: &mut jit::builder::Builder<'_, MC, JSA>,
     ) -> Self::IcbValue<jit::builder::Builder<'a, MC, JSA>> {
-        jit::builder::X64(params[0])
+        jit::builder::X64(params[0], Default::default())
     }
 
     const IR_TYPES: &'static [ir::Type] = &[I64];

--- a/src/riscv/lib/src/instruction_context/value.rs
+++ b/src/riscv/lib/src/instruction_context/value.rs
@@ -133,7 +133,7 @@ impl PhiValue for XValue {
         params: &[ir::Value],
         _: &mut jit::builder::Builder<'_, MC, JSA>,
     ) -> Self::IcbValue<jit::builder::Builder<'a, MC, JSA>> {
-        jit::builder::X64(params[0], Default::default(), Default::default())
+        jit::builder::X64(params[0])
     }
 
     const IR_TYPES: &'static [ir::Type] = &[I64];

--- a/src/riscv/lib/src/instruction_context/value.rs
+++ b/src/riscv/lib/src/instruction_context/value.rs
@@ -133,7 +133,7 @@ impl PhiValue for XValue {
         params: &[ir::Value],
         _: &mut jit::builder::Builder<'_, MC, JSA>,
     ) -> Self::IcbValue<jit::builder::Builder<'a, MC, JSA>> {
-        jit::builder::X64(params[0], Default::default())
+        jit::builder::X64(params[0], Default::default(), Default::default())
     }
 
     const IR_TYPES: &'static [ir::Type] = &[I64];

--- a/src/riscv/lib/src/jit/builder.rs
+++ b/src/riscv/lib/src/jit/builder.rs
@@ -34,7 +34,6 @@ use crate::instruction_context::arithmetic::Arithmetic;
 use crate::instruction_context::comparable::Comparable;
 use crate::instruction_context::value::PhiValue;
 use crate::interpreter::atomics::ReservationSetOption;
-use crate::jit::builder::arithmetic::Alignment;
 use crate::jit::builder::block_state::PCUpdate;
 use crate::machine_state::ProgramCounterUpdate;
 use crate::machine_state::memory::MemoryConfig;
@@ -43,17 +42,9 @@ use crate::machine_state::registers::NonZeroXRegister;
 use crate::parser::instruction::InstrWidth;
 use crate::state_backend::ManagerBase;
 
-/// Known bounds of addresses which have values that aren't known at runtime
-#[derive(Copy, Clone, Debug, Default)]
-pub enum Bounded {
-    #[default]
-    Unbound,
-    Bounded,
-}
-
 /// A newtype for wrapping [`Value`], representing a 64-bit value in the JIT context.
 #[derive(Copy, Clone, Debug)]
-pub struct X64(pub Value, pub Alignment, pub Bounded);
+pub struct X64(pub Value);
 
 /// A newtype for wrapping [`Value`], representing a 32-bit value in the JIT context.
 #[derive(Copy, Clone, Debug)]
@@ -107,8 +98,6 @@ impl<'a, MC: MemoryConfig, JSA: JitStateAccess> Builder<'a, MC, JSA> {
         let core_ptr_val = builder.block_params(entry_block)[1];
         let pc_val = X64(
             builder.block_params(entry_block)[2],
-            Alignment::Eight,
-            Bounded::Bounded,
         );
         let result_ptr_val = builder.block_params(entry_block)[3];
         // last param ignored
@@ -142,7 +131,7 @@ impl<'a, MC: MemoryConfig, JSA: JitStateAccess> Builder<'a, MC, JSA> {
         self.jsa_call.pc_write(
             &mut self.builder,
             self.core_ptr_val,
-            X64(pc_val, Alignment::Two, Bounded::Bounded),
+            X64(pc_val),
         );
 
         self.builder.ins().return_(&[steps_val]);
@@ -287,16 +276,12 @@ impl<MC: MemoryConfig, JSA: JitStateAccess> ICB for Builder<'_, MC, JSA> {
     fn extend_signed(&mut self, value: Self::XValue32) -> Self::XValue {
         X64(
             self.builder.ins().sextend(I64, value.0),
-            Default::default(),
-            Default::default(),
         )
     }
 
     fn extend_unsigned(&mut self, value: Self::XValue32) -> Self::XValue {
         X64(
             self.builder.ins().uextend(I64, value.0),
-            Default::default(),
-            Default::default(),
         )
     }
 
@@ -323,13 +308,13 @@ impl<MC: MemoryConfig, JSA: JitStateAccess> ICB for Builder<'_, MC, JSA> {
         let result = self.builder.ins().imul(lhs, rhs);
         let (_low, high) = self.builder.ins().isplit(result);
 
-        X64(high, Default::default(), Default::default())
+        X64(high)
     }
 
     fn xregister_read_nz(&mut self, reg: NonZeroXRegister) -> Self::XValue {
         // check the xregister cache first, to avoid unnecessary reads.
         if let Some(value) = self.dynamic.get_cached_xreg_val(reg) {
-            return X64(value, Default::default(), Default::default());
+            return X64(value);
         }
         let val = JSA::ir_xreg_read(
             &mut self.jsa_call,
@@ -376,8 +361,6 @@ impl<MC: MemoryConfig, JSA: JitStateAccess> ICB for Builder<'_, MC, JSA> {
     fn xvalue_of_imm(&mut self, imm: i64) -> Self::XValue {
         X64(
             self.builder.ins().iconst(I64, imm),
-            Default::default(),
-            Default::default(),
         )
     }
 
@@ -389,8 +372,6 @@ impl<MC: MemoryConfig, JSA: JitStateAccess> ICB for Builder<'_, MC, JSA> {
         // unsigned extension works as boolean can never be negative (only 0 or 1)
         X64(
             self.builder.ins().uextend(I64, value),
-            Default::default(),
-            Default::default(),
         )
     }
 

--- a/src/riscv/lib/src/jit/builder/arithmetic.rs
+++ b/src/riscv/lib/src/jit/builder/arithmetic.rs
@@ -4,7 +4,20 @@
 
 //! Implementation of arithmetic instructions in JIT mode.
 
+use std::ops::Add;
+use std::ops::BitAnd;
+use std::ops::BitOr;
+use std::ops::BitXor;
+use std::ops::Div;
+use std::ops::Mul;
+use std::ops::Neg;
+use std::ops::Rem;
+use std::ops::Shl;
+use std::ops::Shr;
+use std::ops::Sub;
+
 use cranelift::codegen::ir::InstBuilder;
+use cranelift::codegen::ir::Value;
 
 use super::Builder;
 use super::X32;
@@ -14,81 +27,232 @@ use crate::instruction_context::arithmetic::Arithmetic;
 use crate::jit::state_access::JitStateAccess;
 use crate::machine_state::memory::MemoryConfig;
 
+/// Known alignments of addresses which have values that aren't known at runtime. The arithmetic is
+/// counter-intuitively non-associative - see the tests for examples.
+#[derive(Copy, Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+pub enum Alignment {
+    #[default]
+    One,
+    Two,
+    Four,
+    Eight,
+}
+
+impl From<i64> for Alignment {
+    fn from(address: i64) -> Self {
+        match address as isize % align_of::<i64>() as isize {
+            -6 => Alignment::Two,
+            -4 => Alignment::Four,
+            -2 => Alignment::Two,
+            0 => Alignment::Eight,
+            2 => Alignment::Two,
+            4 => Alignment::Four,
+            6 => Alignment::Two,
+            _ => Alignment::One,
+        }
+    }
+}
+
+impl From<u64> for Alignment {
+    fn from(address: u64) -> Self {
+        match address as usize % align_of::<u64>() {
+            0 => Alignment::Eight,
+            2 => Alignment::Two,
+            4 => Alignment::Four,
+            6 => Alignment::Two,
+            _ => Alignment::One,
+        }
+    }
+}
+
+impl Add for Alignment {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self {
+        match self {
+            Alignment::One => Alignment::One,
+            Alignment::Two => match rhs {
+                Alignment::One => Alignment::One,
+                _ => Alignment::Two,
+            },
+            Alignment::Four => match rhs {
+                Alignment::One => Alignment::One,
+                Alignment::Two => Alignment::Two,
+                _ => Alignment::Four,
+            },
+            Alignment::Eight => match rhs {
+                Alignment::One => Alignment::One,
+                Alignment::Two => Alignment::Two,
+                Alignment::Four => Alignment::Four,
+                Alignment::Eight => Alignment::Eight,
+            },
+        }
+    }
+}
+
+impl BitAnd for Alignment {
+    type Output = Self;
+
+    fn bitand(self, _rhs: Self) -> Self {
+        Alignment::Eight
+    }
+}
+
+impl BitOr for Alignment {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self {
+        std::cmp::min(self, rhs)
+    }
+}
+
+impl BitXor for Alignment {
+    type Output = Self;
+
+    fn bitxor(self, rhs: Self) -> Self {
+        std::cmp::min(self, rhs)
+    }
+}
+
+impl Div for Alignment {
+    type Output = Self;
+
+    fn div(self, rhs: Self) -> Self {
+        std::cmp::min(self, rhs)
+    }
+}
+
+impl Mul for Alignment {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self {
+        std::cmp::max(self, rhs)
+    }
+}
+
+impl Neg for Alignment {
+    type Output = Self;
+
+    fn neg(self) -> Self {
+        self
+    }
+}
+
+impl Rem for Alignment {
+    type Output = Self;
+
+    fn rem(self, rhs: Self) -> Self {
+        std::cmp::min(self, rhs)
+    }
+}
+
+impl Shl<Value> for Alignment {
+    type Output = Self;
+
+    // The SSA values are opaque, so assume the worst
+    fn shl(self, _rhs: Value) -> Self {
+        Alignment::One
+    }
+}
+
+impl Shr<Value> for Alignment {
+    type Output = Self;
+
+    // The SSA values are opaque, so assume the worst
+    fn shr(self, _rhs: Value) -> Self {
+        Alignment::One
+    }
+}
+
+impl Sub for Alignment {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self {
+        Self::add(self, rhs)
+    }
+}
+
 impl<MC: MemoryConfig, JSA: JitStateAccess> Arithmetic<Builder<'_, MC, JSA>> for X64 {
     fn add(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        let res = icb.builder.ins().iadd(self.0, other.0);
-        X64(res)
+        X64(icb.builder.ins().iadd(self.0, other.0), self.1 + other.1)
     }
 
     fn sub(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        let res = icb.builder.ins().isub(self.0, other.0);
-        X64(res)
+        X64(icb.builder.ins().isub(self.0, other.0), self.1 - other.1)
     }
 
     fn and(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        let res = icb.builder.ins().band(self.0, other.0);
-        X64(res)
+        X64(icb.builder.ins().band(self.0, other.0), self.1 & other.1)
     }
 
     fn or(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        let res = icb.builder.ins().bor(self.0, other.0);
-        X64(res)
+        X64(icb.builder.ins().bor(self.0, other.0), self.1 | other.1)
     }
 
     fn xor(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        let res = icb.builder.ins().bxor(self.0, other.0);
-        X64(res)
+        X64(icb.builder.ins().bxor(self.0, other.0), self.1 ^ other.1)
     }
 
     fn mul(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        let res = icb.builder.ins().imul(self.0, other.0);
-        X64(res)
+        X64(icb.builder.ins().imul(self.0, other.0), self.1 * other.1)
     }
 
     fn div_unsigned(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        let res = icb.builder.ins().udiv(self.0, other.0);
-        X64(res)
+        X64(icb.builder.ins().udiv(self.0, other.0), self.1 / other.1)
     }
 
     fn div_signed(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        let res = icb.builder.ins().sdiv(self.0, other.0);
-        X64(res)
+        X64(icb.builder.ins().sdiv(self.0, other.0), self.1 / other.1)
     }
 
     fn negate(self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        X64(icb.builder.ins().ineg(self.0))
+        X64(icb.builder.ins().ineg(self.0), -self.1)
     }
 
     fn shift(self, shift: Shift, amount: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
         match shift {
-            Shift::Left => X64(icb.builder.ins().ishl(self.0, amount.0)),
-            Shift::RightUnsigned => X64(icb.builder.ins().ushr(self.0, amount.0)),
-            Shift::RightSigned => X64(icb.builder.ins().sshr(self.0, amount.0)),
+            Shift::Left => X64(icb.builder.ins().ishl(self.0, amount.0), self.1 << amount.0),
+            Shift::RightUnsigned => {
+                X64(icb.builder.ins().ushr(self.0, amount.0), self.1 >> amount.0)
+            }
+            Shift::RightSigned => X64(icb.builder.ins().sshr(self.0, amount.0), self.1 >> amount.0),
         }
     }
 
     fn modulus_unsigned(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        X64(icb.builder.ins().urem(self.0, other.0))
+        X64(icb.builder.ins().urem(self.0, other.0), self.1 % other.1)
     }
 
     fn modulus_signed(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        X64(icb.builder.ins().srem(self.0, other.0))
+        X64(icb.builder.ins().srem(self.0, other.0), self.1 % other.1)
     }
 
     fn min_signed(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        X64(icb.builder.ins().smin(self.0, other.0))
+        X64(
+            icb.builder.ins().smin(self.0, other.0),
+            std::cmp::min(self.1, other.1), // Assume the worst of the two alignments
+        )
     }
 
     fn min_unsigned(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        X64(icb.builder.ins().umin(self.0, other.0))
+        X64(
+            icb.builder.ins().umin(self.0, other.0),
+            std::cmp::min(self.1, other.1), // Assume the worst of the two alignments
+        )
     }
 
     fn max_signed(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        X64(icb.builder.ins().smax(self.0, other.0))
+        X64(
+            icb.builder.ins().smax(self.0, other.0),
+            std::cmp::min(self.1, other.1), // Assume the worst of the two alignments
+        )
     }
 
     fn max_unsigned(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        X64(icb.builder.ins().umax(self.0, other.0))
+        X64(
+            icb.builder.ins().umax(self.0, other.0),
+            std::cmp::min(self.1, other.1), // Assume the worst of the two alignments
+        )
     }
 }
 
@@ -167,5 +331,190 @@ impl<MC: MemoryConfig, JSA: JitStateAccess> Arithmetic<Builder<'_, MC, JSA>> for
 
     fn max_unsigned(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
         X32(icb.builder.ins().umax(self.0, other.0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cranelift::codegen::ir::Value;
+
+    use crate::jit::builder::arithmetic::Alignment;
+
+    #[test]
+    fn test_alignment_add() {
+        let zero: Alignment = 0u64.into();
+        let one = 1u64.into();
+
+        assert_eq!(zero, Alignment::Eight);
+        assert_eq!(one, Alignment::One);
+        assert_eq!(zero + one, Alignment::One);
+        assert_eq!(one + one, Alignment::One);
+
+        let two = 2u64.into();
+        assert!(one + one != two);
+
+        let three: Alignment = 3u64.into();
+        assert_eq!(three, Alignment::One);
+        assert!(Alignment::One + one != Alignment::Two);
+        assert!(three + one != Alignment::Two);
+        assert!(three + one != Alignment::Four);
+        assert_eq!(three + one, Alignment::One);
+        let four: Alignment = (3u64 + 1u64).into();
+        assert_eq!(four, Alignment::Four);
+    }
+
+    #[test]
+    fn test_alignment_bitand() {
+        const ZERO: u64 = 0b0;
+        const ONE: u64 = 0b1;
+        const TWO: u64 = 0b10;
+        const FOUR: u64 = 0b100;
+
+        let zero: Alignment = ZERO.into();
+        let one: Alignment = ONE.into();
+        let two: Alignment = TWO.into();
+        let four: Alignment = FOUR.into();
+
+        assert_eq!(ZERO & ONE, 0b0);
+        assert_eq!(zero & one, Alignment::Eight);
+
+        assert_eq!(ONE & TWO, 0b00);
+        assert_eq!(one & two, Alignment::Eight);
+
+        assert_eq!(TWO & FOUR, 0b000);
+        assert_eq!(two & four, Alignment::Eight);
+    }
+
+    #[test]
+    fn test_alignment_bitor() {
+        const ZERO: u64 = 0b0;
+        const ONE: u64 = 0b1;
+        const TWO: u64 = 0b10;
+        const FOUR: u64 = 0b100;
+
+        let zero: Alignment = ZERO.into();
+        let one: Alignment = ONE.into();
+        let two: Alignment = TWO.into();
+        let four: Alignment = FOUR.into();
+
+        assert_eq!(ZERO | ONE, 0b1);
+        assert_eq!(zero | one, Alignment::One);
+
+        assert_eq!(ONE | TWO, 0b11);
+        assert_eq!(one | two, Alignment::One);
+
+        assert_eq!(TWO | FOUR, 0b110);
+        assert_eq!(two | four, Alignment::Two);
+    }
+
+    #[test]
+    fn test_alignment_bitxor() {
+        const ZERO: u64 = 0b0;
+        const ONE: u64 = 0b1;
+        const TWO: u64 = 0b10;
+        const FOUR: u64 = 0b100;
+
+        let zero: Alignment = ZERO.into();
+        let one: Alignment = ONE.into();
+        let two: Alignment = TWO.into();
+        let four: Alignment = FOUR.into();
+
+        assert_eq!(ZERO ^ ONE, ZERO | ONE);
+        assert_eq!(zero ^ one, Alignment::One);
+
+        assert_eq!(ONE ^ TWO, ONE | TWO);
+        assert_eq!(one ^ two, Alignment::One);
+
+        assert_eq!(TWO ^ FOUR, TWO | FOUR);
+        assert_eq!(two ^ four, Alignment::Two);
+    }
+
+    #[test]
+    fn test_alignment_div() {
+        const ONE: u64 = 0b1;
+        const TWO: u64 = 0b10;
+        const THREE: u64 = 0b11;
+        const FIVE: u64 = 0b101;
+
+        let one: Alignment = ONE.into();
+        let two: Alignment = TWO.into();
+        let three: Alignment = THREE.into();
+        let five: Alignment = FIVE.into();
+
+        assert_eq!(THREE / TWO, ONE);
+        assert_eq!(three / two, Alignment::One);
+
+        assert_eq!(five, Alignment::One);
+        assert_eq!(one / two, Alignment::One);
+        assert_eq!(five / two, Alignment::One);
+
+        assert_eq!(one / three, Alignment::One);
+        assert_eq!(five / three, Alignment::One);
+    }
+
+    #[test]
+    fn test_alignment_mul() {
+        const TWO: u64 = 0b10;
+        const THREE: u64 = 0b11;
+        const FIVE: u64 = 0b101;
+        const SIX: u64 = 0b110;
+
+        let two: Alignment = TWO.into();
+        let three: Alignment = THREE.into();
+        let five: Alignment = FIVE.into();
+        let six: Alignment = SIX.into();
+
+        assert_eq!(THREE * TWO, SIX);
+        assert_eq!(three * two, Alignment::Two);
+
+        assert_eq!((FIVE * THREE) & 0b1, 0b1);
+        assert_eq!(five * three, Alignment::One);
+
+        assert_eq!((FIVE * SIX) & 0b1, 0b0);
+        assert_eq!(five * six, Alignment::Two);
+    }
+
+    #[test]
+    fn test_alignment_rem() {
+        let two: Alignment = 2u64.into();
+        let three: Alignment = 3u64.into();
+        let five: Alignment = 5u64.into();
+        let six: Alignment = 6u64.into();
+        let ten: Alignment = 10u64.into();
+
+        assert_eq!(two, Alignment::Two);
+        assert_eq!(six, Alignment::Two);
+        assert_eq!(ten, Alignment::Two);
+        // True alignment is Eight, but we can only guess at the worst case...
+        assert_eq!(6 % 2, 0);
+        assert_eq!(six % two, Alignment::Two);
+        // ... because the same alignments can have a true output of four
+        assert_eq!(10 % 6, 4);
+        assert_eq!(ten % six, Alignment::Two);
+
+        // This even applies for what should be a noop
+        assert_eq!(two % three, Alignment::One);
+
+        assert_eq!(ten % five, Alignment::One);
+        assert_eq!(10 % 3, 1);
+        assert_eq!(ten % three, Alignment::One);
+    }
+
+    #[test]
+    fn test_alignment_shl() {
+        let one: Alignment = 1u64.into();
+
+        assert_eq!(one << Value::from_u32(1), Alignment::One);
+        assert_eq!(one << Value::from_u32(2), Alignment::One);
+        assert_eq!(one << Value::from_u32(3), Alignment::One);
+    }
+
+    #[test]
+    fn test_alignment_shr() {
+        let zero: Alignment = 0u64.into();
+
+        assert_eq!(zero >> Value::from_u32(1), Alignment::One);
+        assert_eq!(zero >> Value::from_u32(2), Alignment::One);
+        assert_eq!(zero >> Value::from_u32(3), Alignment::One);
     }
 }

--- a/src/riscv/lib/src/jit/builder/arithmetic.rs
+++ b/src/riscv/lib/src/jit/builder/arithmetic.rs
@@ -174,63 +174,114 @@ impl Sub for Alignment {
 
 impl<MC: MemoryConfig, JSA: JitStateAccess> Arithmetic<Builder<'_, MC, JSA>> for X64 {
     fn add(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        X64(icb.builder.ins().iadd(self.0, other.0), self.1 + other.1)
+        X64(
+            icb.builder.ins().iadd(self.0, other.0),
+            self.1 + other.1,
+            Default::default(),
+        )
     }
 
     fn sub(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        X64(icb.builder.ins().isub(self.0, other.0), self.1 - other.1)
+        X64(
+            icb.builder.ins().isub(self.0, other.0),
+            self.1 - other.1,
+            Default::default(),
+        )
     }
 
     fn and(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        X64(icb.builder.ins().band(self.0, other.0), self.1 & other.1)
+        X64(
+            icb.builder.ins().band(self.0, other.0),
+            self.1 & other.1,
+            Default::default(),
+        )
     }
 
     fn or(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        X64(icb.builder.ins().bor(self.0, other.0), self.1 | other.1)
+        X64(
+            icb.builder.ins().bor(self.0, other.0),
+            self.1 | other.1,
+            Default::default(),
+        )
     }
 
     fn xor(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        X64(icb.builder.ins().bxor(self.0, other.0), self.1 ^ other.1)
+        X64(
+            icb.builder.ins().bxor(self.0, other.0),
+            self.1 ^ other.1,
+            Default::default(),
+        )
     }
 
     fn mul(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        X64(icb.builder.ins().imul(self.0, other.0), self.1 * other.1)
+        X64(
+            icb.builder.ins().imul(self.0, other.0),
+            self.1 * other.1,
+            Default::default(),
+        )
     }
 
     fn div_unsigned(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        X64(icb.builder.ins().udiv(self.0, other.0), self.1 / other.1)
+        X64(
+            icb.builder.ins().udiv(self.0, other.0),
+            self.1 / other.1,
+            Default::default(),
+        )
     }
 
     fn div_signed(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        X64(icb.builder.ins().sdiv(self.0, other.0), self.1 / other.1)
+        X64(
+            icb.builder.ins().sdiv(self.0, other.0),
+            self.1 / other.1,
+            Default::default(),
+        )
     }
 
     fn negate(self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        X64(icb.builder.ins().ineg(self.0), -self.1)
+        X64(icb.builder.ins().ineg(self.0), -self.1, Default::default())
     }
 
     fn shift(self, shift: Shift, amount: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
         match shift {
-            Shift::Left => X64(icb.builder.ins().ishl(self.0, amount.0), self.1 << amount.0),
-            Shift::RightUnsigned => {
-                X64(icb.builder.ins().ushr(self.0, amount.0), self.1 >> amount.0)
-            }
-            Shift::RightSigned => X64(icb.builder.ins().sshr(self.0, amount.0), self.1 >> amount.0),
+            Shift::Left => X64(
+                icb.builder.ins().ishl(self.0, amount.0),
+                self.1 << amount.0,
+                Default::default(),
+            ),
+            Shift::RightUnsigned => X64(
+                icb.builder.ins().ushr(self.0, amount.0),
+                self.1 >> amount.0,
+                Default::default(),
+            ),
+            Shift::RightSigned => X64(
+                icb.builder.ins().sshr(self.0, amount.0),
+                self.1 >> amount.0,
+                Default::default(),
+            ),
         }
     }
 
     fn modulus_unsigned(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        X64(icb.builder.ins().urem(self.0, other.0), self.1 % other.1)
+        X64(
+            icb.builder.ins().urem(self.0, other.0),
+            self.1 % other.1,
+            Default::default(),
+        )
     }
 
     fn modulus_signed(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        X64(icb.builder.ins().srem(self.0, other.0), self.1 % other.1)
+        X64(
+            icb.builder.ins().srem(self.0, other.0),
+            self.1 % other.1,
+            Default::default(),
+        )
     }
 
     fn min_signed(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
         X64(
             icb.builder.ins().smin(self.0, other.0),
             std::cmp::min(self.1, other.1), // Assume the worst of the two alignments
+            Default::default(),
         )
     }
 
@@ -238,6 +289,7 @@ impl<MC: MemoryConfig, JSA: JitStateAccess> Arithmetic<Builder<'_, MC, JSA>> for
         X64(
             icb.builder.ins().umin(self.0, other.0),
             std::cmp::min(self.1, other.1), // Assume the worst of the two alignments
+            Default::default(),
         )
     }
 
@@ -245,6 +297,7 @@ impl<MC: MemoryConfig, JSA: JitStateAccess> Arithmetic<Builder<'_, MC, JSA>> for
         X64(
             icb.builder.ins().smax(self.0, other.0),
             std::cmp::min(self.1, other.1), // Assume the worst of the two alignments
+            Default::default(),
         )
     }
 
@@ -252,6 +305,7 @@ impl<MC: MemoryConfig, JSA: JitStateAccess> Arithmetic<Builder<'_, MC, JSA>> for
         X64(
             icb.builder.ins().umax(self.0, other.0),
             std::cmp::min(self.1, other.1), // Assume the worst of the two alignments
+            Default::default(),
         )
     }
 }

--- a/src/riscv/lib/src/jit/builder/arithmetic.rs
+++ b/src/riscv/lib/src/jit/builder/arithmetic.rs
@@ -176,87 +176,65 @@ impl<MC: MemoryConfig, JSA: JitStateAccess> Arithmetic<Builder<'_, MC, JSA>> for
     fn add(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
         X64(
             icb.builder.ins().iadd(self.0, other.0),
-            self.1 + other.1,
-            Default::default(),
         )
     }
 
     fn sub(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
         X64(
             icb.builder.ins().isub(self.0, other.0),
-            self.1 - other.1,
-            Default::default(),
         )
     }
 
     fn and(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
         X64(
             icb.builder.ins().band(self.0, other.0),
-            self.1 & other.1,
-            Default::default(),
         )
     }
 
     fn or(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
         X64(
             icb.builder.ins().bor(self.0, other.0),
-            self.1 | other.1,
-            Default::default(),
         )
     }
 
     fn xor(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
         X64(
             icb.builder.ins().bxor(self.0, other.0),
-            self.1 ^ other.1,
-            Default::default(),
         )
     }
 
     fn mul(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
         X64(
             icb.builder.ins().imul(self.0, other.0),
-            self.1 * other.1,
-            Default::default(),
         )
     }
 
     fn div_unsigned(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
         X64(
             icb.builder.ins().udiv(self.0, other.0),
-            self.1 / other.1,
-            Default::default(),
         )
     }
 
     fn div_signed(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
         X64(
             icb.builder.ins().sdiv(self.0, other.0),
-            self.1 / other.1,
-            Default::default(),
         )
     }
 
     fn negate(self, icb: &mut Builder<'_, MC, JSA>) -> Self {
-        X64(icb.builder.ins().ineg(self.0), -self.1, Default::default())
+        X64(icb.builder.ins().ineg(self.0))
     }
 
     fn shift(self, shift: Shift, amount: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
         match shift {
             Shift::Left => X64(
                 icb.builder.ins().ishl(self.0, amount.0),
-                self.1 << amount.0,
-                Default::default(),
             ),
             Shift::RightUnsigned => X64(
                 icb.builder.ins().ushr(self.0, amount.0),
-                self.1 >> amount.0,
-                Default::default(),
             ),
             Shift::RightSigned => X64(
                 icb.builder.ins().sshr(self.0, amount.0),
-                self.1 >> amount.0,
-                Default::default(),
             ),
         }
     }
@@ -264,48 +242,36 @@ impl<MC: MemoryConfig, JSA: JitStateAccess> Arithmetic<Builder<'_, MC, JSA>> for
     fn modulus_unsigned(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
         X64(
             icb.builder.ins().urem(self.0, other.0),
-            self.1 % other.1,
-            Default::default(),
         )
     }
 
     fn modulus_signed(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
         X64(
             icb.builder.ins().srem(self.0, other.0),
-            self.1 % other.1,
-            Default::default(),
         )
     }
 
     fn min_signed(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
         X64(
             icb.builder.ins().smin(self.0, other.0),
-            std::cmp::min(self.1, other.1), // Assume the worst of the two alignments
-            Default::default(),
         )
     }
 
     fn min_unsigned(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
         X64(
             icb.builder.ins().umin(self.0, other.0),
-            std::cmp::min(self.1, other.1), // Assume the worst of the two alignments
-            Default::default(),
         )
     }
 
     fn max_signed(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
         X64(
             icb.builder.ins().smax(self.0, other.0),
-            std::cmp::min(self.1, other.1), // Assume the worst of the two alignments
-            Default::default(),
         )
     }
 
     fn max_unsigned(self, other: Self, icb: &mut Builder<'_, MC, JSA>) -> Self {
         X64(
             icb.builder.ins().umax(self.0, other.0),
-            std::cmp::min(self.1, other.1), // Assume the worst of the two alignments
-            Default::default(),
         )
     }
 }

--- a/src/riscv/lib/src/jit/builder/block_state.rs
+++ b/src/riscv/lib/src/jit/builder/block_state.rs
@@ -93,10 +93,10 @@ impl DynamicValues {
 
         let new_pc = builder.ins().iadd_imm(self.pc_val.0, self.pc_offset);
 
-        self.pc_val = X64(new_pc);
+        self.pc_val = X64(new_pc, self.pc_val.1);
         self.pc_offset = 0;
 
-        X64(new_pc)
+        X64(new_pc, self.pc_val.1 + self.pc_offset.into())
     }
 
     /// Complete a step, updating the program counter in the process.

--- a/src/riscv/lib/src/jit/builder/block_state.rs
+++ b/src/riscv/lib/src/jit/builder/block_state.rs
@@ -11,7 +11,6 @@ use cranelift::codegen::ir::{self};
 use cranelift::frontend::FunctionBuilder;
 
 use super::X64;
-use crate::jit::builder::Bounded;
 use crate::machine_state::ProgramCounterUpdate;
 use crate::machine_state::registers::NonZeroXRegister;
 
@@ -94,13 +93,11 @@ impl DynamicValues {
 
         let new_pc = builder.ins().iadd_imm(self.pc_val.0, self.pc_offset);
 
-        self.pc_val = X64(new_pc, self.pc_val.1, Bounded::Bounded);
+        self.pc_val = X64(new_pc);
         self.pc_offset = 0;
 
         X64(
             new_pc,
-            self.pc_val.1 + self.pc_offset.into(),
-            Bounded::Bounded,
         )
     }
 

--- a/src/riscv/lib/src/jit/builder/block_state.rs
+++ b/src/riscv/lib/src/jit/builder/block_state.rs
@@ -11,6 +11,7 @@ use cranelift::codegen::ir::{self};
 use cranelift::frontend::FunctionBuilder;
 
 use super::X64;
+use crate::jit::builder::Bounded;
 use crate::machine_state::ProgramCounterUpdate;
 use crate::machine_state::registers::NonZeroXRegister;
 
@@ -93,10 +94,14 @@ impl DynamicValues {
 
         let new_pc = builder.ins().iadd_imm(self.pc_val.0, self.pc_offset);
 
-        self.pc_val = X64(new_pc, self.pc_val.1);
+        self.pc_val = X64(new_pc, self.pc_val.1, Bounded::Bounded);
         self.pc_offset = 0;
 
-        X64(new_pc, self.pc_val.1 + self.pc_offset.into())
+        X64(
+            new_pc,
+            self.pc_val.1 + self.pc_offset.into(),
+            Bounded::Bounded,
+        )
     }
 
     /// Complete a step, updating the program counter in the process.

--- a/src/riscv/lib/src/jit/state_access.rs
+++ b/src/riscv/lib/src/jit/state_access.rs
@@ -59,6 +59,7 @@ use crate::machine_state::registers::FValue;
 use crate::machine_state::registers::NonZeroXRegister;
 use crate::machine_state::registers::XRegisters;
 use crate::machine_state::registers::XValue;
+use crate::state_backend::AlignedElem;
 use crate::state_backend::Elem;
 use crate::state_backend::ManagerBase;
 use crate::state_backend::ManagerReadWrite;
@@ -116,18 +117,30 @@ register_jsa_functions!(
     raise_illegal_instruction_exception => (raise_illegal_instruction_exception, AbiCall<1>::args),
     raise_store_amo_access_fault_exception => (raise_store_amo_access_fault_exception, AbiCall<2>::args),
     ecall_from_mode => (ecall::<MC, JSA>, AbiCall<2>::args),
-    memory_store_u8 => (memory_store::<u8, MC, JSA>, AbiCall<4>::args),
-    memory_store_u16 => (memory_store::<u16, MC, JSA>, AbiCall<4>::args),
-    memory_store_u32 => (memory_store::<u32, MC, JSA>, AbiCall<4>::args),
-    memory_store_u64 => (memory_store::<u64, MC, JSA>, AbiCall<4>::args),
-    memory_load_i8 => (memory_load::<i8, MC, JSA>, AbiCall<4>::args),
-    memory_load_u8 => (memory_load::<u8, MC, JSA>, AbiCall<4>::args),
-    memory_load_i16 => (memory_load::<i16, MC, JSA>, AbiCall<4>::args),
-    memory_load_u16 => (memory_load::<u16, MC, JSA>, AbiCall<4>::args),
-    memory_load_i32 => (memory_load::<i32, MC, JSA>, AbiCall<4>::args),
-    memory_load_u32 => (memory_load::<u32, MC, JSA>, AbiCall<4>::args),
-    memory_load_i64 => (memory_load::<i64, MC, JSA>, AbiCall<4>::args),
-    memory_load_u64 => (memory_load::<u64, MC, JSA>, AbiCall<4>::args),
+    memory_store_u8 => (memory_store::<u8, MC, JSA, false>, AbiCall<4>::args),
+    memory_store_u16 => (memory_store::<u16, MC, JSA, false>, AbiCall<4>::args),
+    memory_store_u32 => (memory_store::<u32, MC, JSA, false>, AbiCall<4>::args),
+    memory_store_u64 => (memory_store::<u64, MC, JSA, false>, AbiCall<4>::args),
+    memory_store_u8_aligned => (memory_store::<u8, MC, JSA, true>, AbiCall<4>::args),
+    memory_store_u16_aligned => (memory_store::<u16, MC, JSA, true>, AbiCall<4>::args),
+    memory_store_u32_aligned => (memory_store::<u32, MC, JSA, true>, AbiCall<4>::args),
+    memory_store_u64_aligned => (memory_store::<u64, MC, JSA, true>, AbiCall<4>::args),
+    memory_load_i8 => (memory_load::<i8, MC, JSA, false>, AbiCall<4>::args),
+    memory_load_u8 => (memory_load::<u8, MC, JSA, false>, AbiCall<4>::args),
+    memory_load_i16 => (memory_load::<i16, MC, JSA, false>, AbiCall<4>::args),
+    memory_load_u16 => (memory_load::<u16, MC, JSA, false>, AbiCall<4>::args),
+    memory_load_i32 => (memory_load::<i32, MC, JSA, false>, AbiCall<4>::args),
+    memory_load_u32 => (memory_load::<u32, MC, JSA, false>, AbiCall<4>::args),
+    memory_load_i64 => (memory_load::<i64, MC, JSA, false>, AbiCall<4>::args),
+    memory_load_u64 => (memory_load::<u64, MC, JSA, false>, AbiCall<4>::args),
+    memory_load_i8_aligned => (memory_load::<i8, MC, JSA, true>, AbiCall<4>::args),
+    memory_load_u8_aligned => (memory_load::<u8, MC, JSA, true>, AbiCall<4>::args),
+    memory_load_i16_aligned => (memory_load::<i16, MC, JSA, true>, AbiCall<4>::args),
+    memory_load_u16_aligned => (memory_load::<u16, MC, JSA, true>, AbiCall<4>::args),
+    memory_load_i32_aligned => (memory_load::<i32, MC, JSA, true>, AbiCall<4>::args),
+    memory_load_u32_aligned => (memory_load::<u32, MC, JSA, true>, AbiCall<4>::args),
+    memory_load_i64_aligned => (memory_load::<i64, MC, JSA, true>, AbiCall<4>::args),
+    memory_load_u64_aligned => (memory_load::<u64, MC, JSA, true>, AbiCall<4>::args),
     reservation_set_write => (reservation_set_write::<MC, JSA>, AbiCall<2>::args),
     reservation_set_read => (reservation_set_read::<MC, JSA>, AbiCall<1>::args),
 );
@@ -249,18 +262,32 @@ extern "C" fn ecall<MC: MemoryConfig, M: ManagerReadWrite>(
 /// # Panics
 ///
 /// Panics if the `width` passed is not a supported [`LoadStoreWidth`].
-extern "C" fn memory_store<E: Elem, MC: MemoryConfig, M: ManagerReadWrite>(
+extern "C" fn memory_store<E: Elem, MC: MemoryConfig, M: ManagerReadWrite, const ALIGNED: bool>(
     core: &mut MachineCoreState<MC, M>,
     address: u64,
     value: E,
     exception_out: &mut MaybeUninit<Exception>,
 ) -> bool {
-    match core.main_memory.write(address, value) {
-        Ok(()) => false,
-        Err(BadMemoryAccess) => {
-            exception_out.write(Exception::StoreAMOAccessFault(address));
-            true
+    match ALIGNED {
+        true => {
+            match core
+                .main_memory
+                .write::<AlignedElem<E>>(address, AlignedElem::<E>(value))
+            {
+                Ok(()) => false,
+                Err(BadMemoryAccess) => {
+                    exception_out.write(Exception::StoreAMOAccessFault(address));
+                    true
+                }
+            }
         }
+        false => match core.main_memory.write(address, value) {
+            Ok(()) => false,
+            Err(BadMemoryAccess) => {
+                exception_out.write(Exception::StoreAMOAccessFault(address));
+                true
+            }
+        },
     }
 }
 
@@ -276,21 +303,33 @@ extern "C" fn memory_store<E: Elem, MC: MemoryConfig, M: ManagerReadWrite>(
 /// # Panics
 ///
 /// Panics if the `width` passed is not a supported [`LoadStoreWidth`].
-extern "C" fn memory_load<E: Elem, MC: MemoryConfig, M: ManagerReadWrite>(
+extern "C" fn memory_load<E: Elem, MC: MemoryConfig, M: ManagerReadWrite, const ALIGNED: bool>(
     core: &mut MachineCoreState<MC, M>,
     address: u64,
     xval_out: &mut MaybeUninit<E>,
     exception_out: &mut MaybeUninit<Exception>,
 ) -> bool {
-    match core.main_memory.read::<E>(address) {
-        Ok(value) => {
-            xval_out.write(value);
-            false
-        }
-        Err(BadMemoryAccess) => {
-            exception_out.write(Exception::LoadAccessFault(address));
-            true
-        }
+    match ALIGNED {
+        true => match core.main_memory.read::<AlignedElem<E>>(address) {
+            Ok(value) => {
+                xval_out.write(value.0);
+                false
+            }
+            Err(BadMemoryAccess) => {
+                exception_out.write(Exception::LoadAccessFault(address));
+                true
+            }
+        },
+        false => match core.main_memory.read::<E>(address) {
+            Ok(value) => {
+                xval_out.write(value);
+                false
+            }
+            Err(BadMemoryAccess) => {
+                exception_out.write(Exception::LoadAccessFault(address));
+                true
+            }
+        },
     }
 }
 
@@ -444,6 +483,10 @@ pub struct JsaCalls<'a, MC: MemoryConfig, M: ManagerBase> {
     memory_store_u16: Option<FuncRef>,
     memory_store_u32: Option<FuncRef>,
     memory_store_u64: Option<FuncRef>,
+    memory_store_u8_aligned: Option<FuncRef>,
+    memory_store_u16_aligned: Option<FuncRef>,
+    memory_store_u32_aligned: Option<FuncRef>,
+    memory_store_u64_aligned: Option<FuncRef>,
     memory_load_i8: Option<FuncRef>,
     memory_load_u8: Option<FuncRef>,
     memory_load_i16: Option<FuncRef>,
@@ -452,6 +495,14 @@ pub struct JsaCalls<'a, MC: MemoryConfig, M: ManagerBase> {
     memory_load_u32: Option<FuncRef>,
     memory_load_i64: Option<FuncRef>,
     memory_load_u64: Option<FuncRef>,
+    memory_load_i8_aligned: Option<FuncRef>,
+    memory_load_u8_aligned: Option<FuncRef>,
+    memory_load_i16_aligned: Option<FuncRef>,
+    memory_load_u16_aligned: Option<FuncRef>,
+    memory_load_i32_aligned: Option<FuncRef>,
+    memory_load_u32_aligned: Option<FuncRef>,
+    memory_load_i64_aligned: Option<FuncRef>,
+    memory_load_u64_aligned: Option<FuncRef>,
     reservation_set_write: Option<FuncRef>,
     reservation_set_read: Option<FuncRef>,
 
@@ -502,6 +553,10 @@ impl<'a, MC: MemoryConfig, M: JitStateAccess> JsaCalls<'a, MC, M> {
             memory_store_u16: None,
             memory_store_u32: None,
             memory_store_u64: None,
+            memory_store_u8_aligned: None,
+            memory_store_u16_aligned: None,
+            memory_store_u32_aligned: None,
+            memory_store_u64_aligned: None,
             memory_load_i8: None,
             memory_load_u8: None,
             memory_load_i16: None,
@@ -510,6 +565,14 @@ impl<'a, MC: MemoryConfig, M: JitStateAccess> JsaCalls<'a, MC, M> {
             memory_load_u32: None,
             memory_load_i64: None,
             memory_load_u64: None,
+            memory_load_i8_aligned: None,
+            memory_load_u8_aligned: None,
+            memory_load_i16_aligned: None,
+            memory_load_u16_aligned: None,
+            memory_load_i32_aligned: None,
+            memory_load_u32_aligned: None,
+            memory_load_i64_aligned: None,
+            memory_load_u64_aligned: None,
             reservation_set_write: None,
             reservation_set_read: None,
             exception_ptr_slot: None,
@@ -658,20 +721,44 @@ impl<'a, MC: MemoryConfig, M: JitStateAccess> JsaCalls<'a, MC, M> {
         let exception_slot = self.exception_ptr_slot(builder);
         let exception_ptr = exception_slot.ptr(builder);
 
-        let memory_store = match V::WIDTH {
-            LoadStoreWidth::Byte => self.memory_store_u8.get_or_insert_with(|| {
+        let memory_store = match (V::WIDTH, phys_address.1) {
+            (LoadStoreWidth::Byte, Alignment::Eight) => {
+                self.memory_store_u8_aligned.get_or_insert_with(|| {
+                    self.module
+                        .declare_func_in_func(self.imports.memory_store_u8_aligned, builder.func)
+                })
+            }
+            (LoadStoreWidth::Half, Alignment::Eight) => {
+                self.memory_store_u16_aligned.get_or_insert_with(|| {
+                    self.module
+                        .declare_func_in_func(self.imports.memory_store_u16_aligned, builder.func)
+                })
+            }
+            (LoadStoreWidth::Word, Alignment::Eight) => {
+                self.memory_store_u32_aligned.get_or_insert_with(|| {
+                    self.module
+                        .declare_func_in_func(self.imports.memory_store_u32_aligned, builder.func)
+                })
+            }
+            (LoadStoreWidth::Double, Alignment::Eight) => {
+                self.memory_store_u64_aligned.get_or_insert_with(|| {
+                    self.module
+                        .declare_func_in_func(self.imports.memory_store_u64_aligned, builder.func)
+                })
+            }
+            (LoadStoreWidth::Byte, _) => self.memory_store_u8.get_or_insert_with(|| {
                 self.module
                     .declare_func_in_func(self.imports.memory_store_u8, builder.func)
             }),
-            LoadStoreWidth::Half => self.memory_store_u16.get_or_insert_with(|| {
+            (LoadStoreWidth::Half, _) => self.memory_store_u16.get_or_insert_with(|| {
                 self.module
                     .declare_func_in_func(self.imports.memory_store_u16, builder.func)
             }),
-            LoadStoreWidth::Word => self.memory_store_u32.get_or_insert_with(|| {
+            (LoadStoreWidth::Word, _) => self.memory_store_u32.get_or_insert_with(|| {
                 self.module
                     .declare_func_in_func(self.imports.memory_store_u32, builder.func)
             }),
-            LoadStoreWidth::Double => self.memory_store_u64.get_or_insert_with(|| {
+            (LoadStoreWidth::Double, _) => self.memory_store_u64.get_or_insert_with(|| {
                 self.module
                     .declare_func_in_func(self.imports.memory_store_u64, builder.func)
             }),
@@ -710,36 +797,84 @@ impl<'a, MC: MemoryConfig, M: JitStateAccess> JsaCalls<'a, MC, M> {
 
         let xval_ptr = stack::Slot::<V>::new(self.ptr_type, builder).ptr(builder);
 
-        let memory_load = match (V::WIDTH, V::SIGNED) {
-            (LoadStoreWidth::Byte, true) => self.memory_load_i8.get_or_insert_with(|| {
+        let memory_load = match (V::WIDTH, V::SIGNED, phys_address.1) {
+            (LoadStoreWidth::Byte, true, Alignment::Eight) => {
+                self.memory_load_i8_aligned.get_or_insert_with(|| {
+                    self.module
+                        .declare_func_in_func(self.imports.memory_load_i8_aligned, builder.func)
+                })
+            }
+            (LoadStoreWidth::Byte, false, Alignment::Eight) => {
+                self.memory_load_u8_aligned.get_or_insert_with(|| {
+                    self.module
+                        .declare_func_in_func(self.imports.memory_load_u8_aligned, builder.func)
+                })
+            }
+            (LoadStoreWidth::Half, true, Alignment::Eight) => {
+                self.memory_load_i16_aligned.get_or_insert_with(|| {
+                    self.module
+                        .declare_func_in_func(self.imports.memory_load_i16_aligned, builder.func)
+                })
+            }
+            (LoadStoreWidth::Half, false, Alignment::Eight) => {
+                self.memory_load_u16_aligned.get_or_insert_with(|| {
+                    self.module
+                        .declare_func_in_func(self.imports.memory_load_u16_aligned, builder.func)
+                })
+            }
+            (LoadStoreWidth::Word, true, Alignment::Eight) => {
+                self.memory_load_i32_aligned.get_or_insert_with(|| {
+                    self.module
+                        .declare_func_in_func(self.imports.memory_load_i32_aligned, builder.func)
+                })
+            }
+            (LoadStoreWidth::Word, false, Alignment::Eight) => {
+                self.memory_load_u32_aligned.get_or_insert_with(|| {
+                    self.module
+                        .declare_func_in_func(self.imports.memory_load_u32_aligned, builder.func)
+                })
+            }
+            (LoadStoreWidth::Double, true, Alignment::Eight) => {
+                self.memory_load_i64_aligned.get_or_insert_with(|| {
+                    self.module
+                        .declare_func_in_func(self.imports.memory_load_i64_aligned, builder.func)
+                })
+            }
+            (LoadStoreWidth::Double, false, Alignment::Eight) => {
+                self.memory_load_u64_aligned.get_or_insert_with(|| {
+                    self.module
+                        .declare_func_in_func(self.imports.memory_load_u64_aligned, builder.func)
+                })
+            }
+            (LoadStoreWidth::Byte, true, _) => self.memory_load_i8.get_or_insert_with(|| {
                 self.module
                     .declare_func_in_func(self.imports.memory_load_i8, builder.func)
             }),
-            (LoadStoreWidth::Byte, false) => self.memory_load_u8.get_or_insert_with(|| {
+            (LoadStoreWidth::Byte, false, _) => self.memory_load_u8.get_or_insert_with(|| {
                 self.module
                     .declare_func_in_func(self.imports.memory_load_u8, builder.func)
             }),
-            (LoadStoreWidth::Half, true) => self.memory_load_i16.get_or_insert_with(|| {
+            (LoadStoreWidth::Half, true, _) => self.memory_load_i16.get_or_insert_with(|| {
                 self.module
                     .declare_func_in_func(self.imports.memory_load_i16, builder.func)
             }),
-            (LoadStoreWidth::Half, false) => self.memory_load_u16.get_or_insert_with(|| {
+            (LoadStoreWidth::Half, false, _) => self.memory_load_u16.get_or_insert_with(|| {
                 self.module
                     .declare_func_in_func(self.imports.memory_load_u16, builder.func)
             }),
-            (LoadStoreWidth::Word, true) => self.memory_load_i32.get_or_insert_with(|| {
+            (LoadStoreWidth::Word, true, _) => self.memory_load_i32.get_or_insert_with(|| {
                 self.module
                     .declare_func_in_func(self.imports.memory_load_i32, builder.func)
             }),
-            (LoadStoreWidth::Word, false) => self.memory_load_u32.get_or_insert_with(|| {
+            (LoadStoreWidth::Word, false, _) => self.memory_load_u32.get_or_insert_with(|| {
                 self.module
                     .declare_func_in_func(self.imports.memory_load_u32, builder.func)
             }),
-            (LoadStoreWidth::Double, true) => self.memory_load_i64.get_or_insert_with(|| {
+            (LoadStoreWidth::Double, true, _) => self.memory_load_i64.get_or_insert_with(|| {
                 self.module
                     .declare_func_in_func(self.imports.memory_load_i64, builder.func)
             }),
-            (LoadStoreWidth::Double, false) => self.memory_load_u64.get_or_insert_with(|| {
+            (LoadStoreWidth::Double, false, _) => self.memory_load_u64.get_or_insert_with(|| {
                 self.module
                     .declare_func_in_func(self.imports.memory_load_u64, builder.func)
             }),

--- a/src/riscv/lib/src/jit/state_access.rs
+++ b/src/riscv/lib/src/jit/state_access.rs
@@ -48,6 +48,7 @@ use super::builder::errno::ErrnoImpl;
 use crate::instruction_context::ICB;
 use crate::instruction_context::LoadStoreWidth;
 use crate::instruction_context::StoreLoadInt;
+use crate::jit::builder::arithmetic::Alignment;
 use crate::machine_state::MachineCoreState;
 use crate::machine_state::memory::Address;
 use crate::machine_state::memory::BadMemoryAccess;
@@ -330,7 +331,7 @@ pub trait JitStateAccess: ManagerReadWrite {
         });
         let reg = builder.ins().iconst(I8, reg as i64);
         let call = builder.ins().call(*xreg_read, &[core_ptr, reg]);
-        X64(builder.inst_results(call)[0])
+        X64(builder.inst_results(call)[0], Default::default())
     }
 
     /// Emit the required IR to write the value to the given xregister.
@@ -401,7 +402,7 @@ impl JitStateAccess for Owned {
             .ins()
             .load(ir::types::I64, MemFlags::trusted(), core_ptr, offset as i32);
 
-        X64(val)
+        X64(val, Default::default())
     }
 
     fn ir_xreg_write<MC: MemoryConfig>(
@@ -569,7 +570,7 @@ impl<'a, MC: MemoryConfig, M: JitStateAccess> JsaCalls<'a, MC, M> {
 
         ExceptionHandledOutcome {
             handled,
-            new_pc: X64(new_pc),
+            new_pc: X64(new_pc, Alignment::Two),
         }
     }
 
@@ -766,7 +767,7 @@ impl<'a, MC: MemoryConfig, M: JitStateAccess> JsaCalls<'a, MC, M> {
                 builder.ins().uextend(ir::types::I64, xval)
             };
 
-            X64(xval)
+            X64(xval, phys_address.1)
         })
     }
 
@@ -803,7 +804,7 @@ impl<'a, MC: MemoryConfig, M: JitStateAccess> JsaCalls<'a, MC, M> {
         });
 
         let call = builder.ins().call(*reservation_set_read, &[core_ptr]);
-        X64(builder.inst_results(call)[0])
+        X64(builder.inst_results(call)[0], Alignment::Eight)
     }
 }
 

--- a/src/riscv/lib/src/state_backend/owned_backend.rs
+++ b/src/riscv/lib/src/state_backend/owned_backend.rs
@@ -132,7 +132,7 @@ impl ManagerRead for Owned {
                 .as_ptr()
                 .add(address)
                 .cast::<E>()
-                .copy_to(values.as_mut_ptr(), values.len());
+                .copy_to_nonoverlapping(values.as_mut_ptr(), values.len());
         }
 
         for elem in values.iter_mut() {

--- a/src/riscv/lib/src/state_backend/region.rs
+++ b/src/riscv/lib/src/state_backend/region.rs
@@ -376,7 +376,7 @@ impl<E: 'static, const LEN: usize, M: ManagerBase> Cells<E, LEN, M> {
     }
 }
 
-impl<E: 'static, const LEN: usize> Cells<E, LEN, Owned> {
+impl<E: Elem + 'static, const LEN: usize> Cells<E, LEN, Owned> {
     /// Obtain the byte offset from a pointer to `Cells<E, LEN, M>` to the memory of the elem at
     /// `index`.
     pub(crate) const fn region_elem_offset(index: usize) -> usize {


### PR DESCRIPTION
Closes RV-694

Reviewing each commit separately is recommended.

# What
Currently, reads and writes are performed with the assumption that an address could be out of alignment and out of bounds. In some cases, we can statically know that they're aligned or in-bounds, even without knowing the opaque values of the X64 values.

This adds support for:
 - Reading and writing using APIs that take aligned values
 - Skipping bounds checks for values known to be in bounds
 
It also changes `dyn_region_read_all` in the owned backend to use a method that assumes the addresses are non-overlapping. I think we can (and could always) assume this, since it's copying from a distinct area of memory. Unfortunately we can't skip the ub checks here, but they [always were assuming it was aligned!](https://doc.rust-lang.org/beta/src/core/intrinsics/mod.rs.html#3840)

A downside to this is that the X64 type, which implements Copy, has been extended with two enums.

# Why

Faster :)

# How

 - Adds Alignment and Bounded types to the X64 type. 
 - Splits the memory load C interface into distinct interfaces for unaligned + unbounded/aligned/bounded/aligned + bounded
 - Extends the Elem type
 - Splits execution of reading/writing based on constant information

# Manually Testing

```
make -C src/riscv all
```

# Regressions

None

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [ ] Self-review your changes to ensure they are high-quality.
- [ ] Complete all of the above before assigning this MR to reviewers.
