### PR TITLE
RISC-V: Implement `fstat` system call handlers

### DIFF
--- a/src/riscv/lib/src/pvm/linux.rs
+++ b/src/riscv/lib/src/pvm/linux.rs
@@ -56,6 +56,9 @@ const GETCWD: u64 = 17;
 /// System call number for `ioctl` on RISC-V
 const IOCTL: u64 = 29;
 
+/// System call number for `fstat` on RISC-V
+const FSTAT: u64 = 44;
+
 /// System call number for `facessat` on RISC-V
 const FACCESSAT: u64 = 48;
 
@@ -79,6 +82,12 @@ const PPOLL: u64 = 73;
 
 /// System call number for `readlinkat` on RISC-V
 const READLINKAT: u64 = 78;
+
+/// System call number for `fstatat`/`newfstatat` on RISC-V
+const NEWFSTATAT: u64 = 79;
+
+/// System call number for `newfstat` on RISC-V
+const NEWFSTAT: u64 = 80;
 
 /// System call number for `exit` on RISC-V
 const EXIT: u64 = 93;
@@ -731,6 +740,8 @@ impl<M: ManagerBase> SupervisorState<M> {
         let result = match system_call_no {
             GETCWD => dispatch2!(getcwd, &mut machine.core),
             IOCTL => dispatch2!(ioctl),
+            NEWFSTATAT => dispatch0!(fstatat),
+            FSTAT | NEWFSTAT => dispatch0!(fstat),
             FACCESSAT => dispatch0!(faccessat),
             OPENAT => dispatch0!(openat),
             CLOSE => dispatch0!(close),

--- a/src/riscv/lib/src/pvm/linux/fs.rs
+++ b/src/riscv/lib/src/pvm/linux/fs.rs
@@ -13,6 +13,20 @@ use crate::state_backend::ManagerBase;
 use crate::state_backend::ManagerReadWrite;
 
 impl<M: ManagerBase> SupervisorState<M> {
+    /// Handle the `fstatat` system call. All access to the file system is denied.
+    ///
+    /// See: <https://man7.org/linux/man-pages/man2/fstatat.2.html>
+    pub(super) fn handle_fstatat(&self) -> Result<u64, Error> {
+        Err(Error::Access)
+    }
+
+    /// Handle the `fstat` system call. All access to the file system is denied.
+    ///
+    /// See: <https://man7.org/linux/man-pages/man2/fstat.2.html>
+    pub(super) fn handle_fstat(&self) -> Result<u64, Error> {
+        Err(Error::BadFileDescriptor)
+    }
+
     /// Handle the `faccessat` system call. All access to the file system is denied.
     ///
     /// See: <https://www.man7.org/linux/man-pages/man3/faccessat.3p.html>


### PR DESCRIPTION
Closes RV-668

# What

Implements `fstat` and the related system calls. All access to the filesystem is denied.

The `*fstat` handlers use file descriptors, so return EBADF:

> fd is not a valid open file descriptor.

# Why
This is one of the unimplemented system call handlers that jstz uses with V8

# How
The functions are all stubbed. We don't allow access to the filesystem.

The jstz strace only uses these for:
 - loading shared libraries (we can statically link instead)
 - getting random numbers (we don't want random numbers)

# Manually Testing

```
make -C src/riscv all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artifacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
