### PR TITLE
RISC-V: Introduce `Relative` `ProgramCounterUpdate` variant. Utilise for `J` Opcode and rename to `JumpPC`

### DIFF
--- a/src/riscv/lib/src/instruction_context.rs
+++ b/src/riscv/lib/src/instruction_context.rs
@@ -288,7 +288,7 @@ impl<MC: MemoryConfig, M: ManagerReadWrite> ICB for MachineCoreState<MC, M> {
     ) -> ProgramCounterUpdate<Self::XValue> {
         if predicate {
             let pc = self.pc_read();
-            let address = pc.wrapping_add(offset as u64);
+            let address = pc.wrapping_add_signed(offset);
             ProgramCounterUpdate::Set(address)
         } else {
             ProgramCounterUpdate::Next(instr_width)

--- a/src/riscv/lib/src/interpreter/atomics.rs
+++ b/src/riscv/lib/src/interpreter/atomics.rs
@@ -705,7 +705,7 @@ pub(crate) mod test {
                     let res = state.hart.xregisters.read(a2);
                     let val: $t = state.read_from_address(r1_addr)?;
                     prop_assert_eq!(res, SC_SUCCESS);
-                    prop_assert_eq!(val, r1_val.wrapping_add(imm as u64) as $t);
+                    prop_assert_eq!(val, r1_val.wrapping_add_signed(imm) as $t);
 
                     // SC.x fails when a previous SC.x has been executed
                     $sc(&mut *state, a0, a1, a2, false, false)?;

--- a/src/riscv/lib/src/interpreter/branching.rs
+++ b/src/riscv/lib/src/interpreter/branching.rs
@@ -289,7 +289,7 @@ mod tests {
             let new_pc = run_jal(&mut state, imm, rd, InstrWidth::Uncompressed);
 
             assert_eq!(state.hart.pc.read(), init_pc);
-            assert_eq!(new_pc, init_pc.wrapping_add(imm as u64));
+            assert_eq!(new_pc, init_pc.wrapping_add_signed(imm));
             assert_eq!(state.hart.xregisters.read_nz(rd), res_rd);
 
             // TEST JalrAbsolute
@@ -380,7 +380,7 @@ mod tests {
             prop_assume!(r1_val != r2_val);
             // to ensure branch_pc, init_pc, next_pc are different
             prop_assume!(imm > 10);
-            let branch_pcu = ProgramCounterUpdate::Set(init_pc.wrapping_add(imm as u64));
+            let branch_pcu = ProgramCounterUpdate::Set(init_pc.wrapping_add_signed(imm));
             let width = InstrWidth::Uncompressed;
             let next_pcu = ProgramCounterUpdate::Next(InstrWidth::Uncompressed);
             let init_pcu = ProgramCounterUpdate::Set(init_pc);
@@ -426,7 +426,7 @@ mod tests {
         )| {
             // to ensure branch_pc and init_pc are different
             prop_assume!(imm > 10);
-            let branch_pcu = ProgramCounterUpdate::Set(init_pc.wrapping_add(imm as u64));
+            let branch_pcu = ProgramCounterUpdate::Set(init_pc.wrapping_add_signed(imm));
             let width = InstrWidth::Uncompressed;
             let next_pcu = ProgramCounterUpdate::Next(InstrWidth::Uncompressed);
             let init_pcu = ProgramCounterUpdate::Set(init_pc);
@@ -467,7 +467,7 @@ mod tests {
         )| {
             // to ensure branch_pc and init_pc are different
             prop_assume!(imm > 10);
-            let branch_pcu = ProgramCounterUpdate::Set(init_pc.wrapping_add(imm as u64));
+            let branch_pcu = ProgramCounterUpdate::Set(init_pc.wrapping_add_signed(imm));
             let width = InstrWidth::Uncompressed;
             let next_pcu = ProgramCounterUpdate::Next(InstrWidth::Uncompressed);
 
@@ -503,7 +503,7 @@ mod tests {
             prop_assume!(r1_val < r2_val);
             // to ensure branch_pc and init_pc are different
             prop_assume!(imm > 10);
-            let branch_pcu = ProgramCounterUpdate::Set(init_pc.wrapping_add(imm as u64));
+            let branch_pcu = ProgramCounterUpdate::Set(init_pc.wrapping_add_signed(imm));
             let width = InstrWidth::Uncompressed;
             let next_pcu = ProgramCounterUpdate::Next(InstrWidth::Uncompressed);
             let pc_update_init_pcu = ProgramCounterUpdate::Set(init_pc);
@@ -554,7 +554,7 @@ mod tests {
         )| {
             // to ensure branch_pc, init_pc, next_pc are different
             prop_assume!(imm > 10);
-            let branch_pcu = ProgramCounterUpdate::Set(init_pc.wrapping_add(imm as u64));
+            let branch_pcu = ProgramCounterUpdate::Set(init_pc.wrapping_add_signed(imm));
             let width = InstrWidth::Uncompressed;
             let next_pcu = ProgramCounterUpdate::Next(InstrWidth::Uncompressed);
             let init_pcu = ProgramCounterUpdate::Set(init_pc);

--- a/src/riscv/lib/src/interpreter/branching.rs
+++ b/src/riscv/lib/src/interpreter/branching.rs
@@ -16,13 +16,7 @@ use crate::parser::instruction::InstrWidth;
 
 /// Performs an unconditional control transfer. The immediate is added to
 /// the pc to form the jump target address.
-///
-/// Relevant RISC-V opcodes:
-/// - C.J
-/// - JAL
-/// - BEQ
-/// - C.BEQZ
-pub fn run_j<I: ICB>(icb: &mut I, imm: i64) -> <I as ICB>::XValue {
+pub fn run_jump_pc<I: ICB>(icb: &mut I, imm: i64) -> <I as ICB>::XValue {
     let imm = icb.xvalue_of_imm(imm);
     let current_pc = icb.pc_read();
     current_pc.add(imm, icb)

--- a/src/riscv/lib/src/interpreter/branching.rs
+++ b/src/riscv/lib/src/interpreter/branching.rs
@@ -14,14 +14,6 @@ use crate::machine_state::registers::read_xregister_nz;
 use crate::machine_state::registers::write_xregister_nz;
 use crate::parser::instruction::InstrWidth;
 
-/// Performs an unconditional control transfer. The immediate is added to
-/// the pc to form the jump target address.
-pub fn run_jump_pc<I: ICB>(icb: &mut I, imm: i64) -> <I as ICB>::XValue {
-    let imm = icb.xvalue_of_imm(imm);
-    let current_pc = icb.pc_read();
-    current_pc.add(imm, icb)
-}
-
 /// Performs an unconditional control transfer to the address in register `rs1`.
 pub fn run_jr<I: ICB>(icb: &mut I, rs1: NonZeroXRegister) -> <I as ICB>::XValue {
     // The target address is obtained by setting the
@@ -187,7 +179,7 @@ pub fn run_branch<I: ICB>(
     rs1: NonZeroXRegister,
     rs2: NonZeroXRegister,
     width: InstrWidth,
-) -> ProgramCounterUpdate<<I as ICB>::XValue> {
+) -> ProgramCounterUpdate<I::XValue> {
     let lhs = read_xregister_nz(icb, rs1);
     let rhs = read_xregister_nz(icb, rs2);
     let cond = lhs.compare(rhs, predicate, icb);
@@ -215,7 +207,7 @@ pub fn run_branch_compare_zero<I: ICB>(
     imm: i64,
     rs1: NonZeroXRegister,
     width: InstrWidth,
-) -> ProgramCounterUpdate<<I as ICB>::XValue> {
+) -> ProgramCounterUpdate<I::XValue> {
     let lhs = read_xregister_nz(icb, rs1);
     let rhs = icb.xvalue_of_imm(0);
     let cond = lhs.compare(rhs, predicate, icb);

--- a/src/riscv/lib/src/interpreter/common_memory.rs
+++ b/src/riscv/lib/src/interpreter/common_memory.rs
@@ -32,7 +32,7 @@ where
         imm: i64,
         rs1: XRegister,
     ) -> Result<T, Exception> {
-        let address = self.hart.xregisters.read(rs1).wrapping_add(imm as u64);
+        let address = self.hart.xregisters.read(rs1).wrapping_add_signed(imm);
         self.read_from_address(address)
     }
 
@@ -54,7 +54,7 @@ where
         rs1: XRegister,
         value: T,
     ) -> Result<(), Exception> {
-        let address = self.hart.xregisters.read(rs1).wrapping_add(imm as u64);
+        let address = self.hart.xregisters.read(rs1).wrapping_add_signed(imm);
         self.write_to_address(address, value)
     }
 }

--- a/src/riscv/lib/src/interpreter/rv32c.rs
+++ b/src/riscv/lib/src/interpreter/rv32c.rs
@@ -26,14 +26,14 @@ where
 #[cfg(test)]
 mod tests {
     use crate::backend_test;
-    use crate::interpreter::branching::run_j;
     use crate::interpreter::branching::run_jr;
+    use crate::interpreter::branching::run_jump_pc;
     use crate::machine_state::MachineCoreState;
     use crate::machine_state::memory::M4K;
     use crate::machine_state::registers::nz;
     use crate::state::NewState;
 
-    backend_test!(test_run_j, F, {
+    backend_test!(test_run_jump_pc, F, {
         let test_case = [
             (42, 42, 84),
             (0, 1000, 1000),
@@ -45,7 +45,7 @@ mod tests {
             let mut state = MachineCoreState::<M4K, F>::new();
 
             state.hart.pc.write(init_pc);
-            let new_pc = run_j(&mut state, imm);
+            let new_pc = run_jump_pc(&mut state, imm);
 
             assert_eq!(state.hart.pc.read(), init_pc);
             assert_eq!(new_pc, res_pc);

--- a/src/riscv/lib/src/interpreter/rv32c.rs
+++ b/src/riscv/lib/src/interpreter/rv32c.rs
@@ -27,30 +27,10 @@ where
 mod tests {
     use crate::backend_test;
     use crate::interpreter::branching::run_jr;
-    use crate::interpreter::branching::run_jump_pc;
     use crate::machine_state::MachineCoreState;
     use crate::machine_state::memory::M4K;
     use crate::machine_state::registers::nz;
     use crate::state::NewState;
-
-    backend_test!(test_run_jump_pc, F, {
-        let test_case = [
-            (42, 42, 84),
-            (0, 1000, 1000),
-            (100, -50, 50),
-            (50, -100, -50_i64 as u64),
-            (u64::MAX - 1, 100, 98_i64 as u64),
-        ];
-        for (init_pc, imm, res_pc) in test_case {
-            let mut state = MachineCoreState::<M4K, F>::new();
-
-            state.hart.pc.write(init_pc);
-            let new_pc = run_jump_pc(&mut state, imm);
-
-            assert_eq!(state.hart.pc.read(), init_pc);
-            assert_eq!(new_pc, res_pc);
-        }
-    });
 
     backend_test!(test_cjr, F, {
         let scenarios = [

--- a/src/riscv/lib/src/interpreter/rv64c.rs
+++ b/src/riscv/lib/src/interpreter/rv64c.rs
@@ -24,7 +24,7 @@ where
         // We do not need to explicitly truncate for the lower bits since wrapping_add
         // has the same semantics & result on the lower 32 bits irrespective of bit width
         let rval = self.read_nz(rd_rs1);
-        let result = rval.wrapping_add(imm as u64);
+        let result = rval.wrapping_add_signed(imm);
         // Truncate result to use only the lower 32 bits, then sign-extend to 64 bits.
         let result = result as i32 as u64;
         self.write_nz(rd_rs1, result);

--- a/src/riscv/lib/src/jit.rs
+++ b/src/riscv/lib/src/jit.rs
@@ -1513,7 +1513,7 @@ mod tests {
              -> Scenario {
                 let initial_pc: u64 = 0x1000;
                 let imm: i64 = -0x2000;
-                let expected_pc_branch = initial_pc.wrapping_add(imm as u64).wrapping_add(8);
+                let expected_pc_branch = initial_pc.wrapping_add_signed(imm).wrapping_add(8);
 
                 ScenarioBuilder::default()
                     .set_initial_pc(initial_pc)

--- a/src/riscv/lib/src/jit.rs
+++ b/src/riscv/lib/src/jit.rs
@@ -1058,14 +1058,14 @@ mod tests {
     }
 
     #[test]
-    fn test_j() {
+    fn test_jump_pc() {
         let scenarios: &[Scenario] = &[
             ScenarioBuilder::default()
                 // Jumping to the next instruction should exit the block
                 .set_instructions(&[
                     I::new_nop(Compressed),
                     I::new_nop(Compressed),
-                    I::new_j(2, Compressed),
+                    I::new_jump_pc(2, Compressed),
                 ])
                 .set_assert_hook(assert_hook!(|core| {
                     assert_eq!(core.hart.pc.read(), 6);
@@ -1074,7 +1074,7 @@ mod tests {
                 .build(),
             ScenarioBuilder::default()
                 // Jump past 0 - in both worlds we should wrap around.
-                .set_instructions(&[I::new_j(-4, Compressed)])
+                .set_instructions(&[I::new_jump_pc(-4, Compressed)])
                 .set_assert_hook(assert_hook!(|core| {
                     assert_eq!(core.hart.pc.read(), u64::MAX - 3);
                 }))
@@ -1086,7 +1086,7 @@ mod tests {
                 .set_instructions(&[
                     I::new_nop(Uncompressed),
                     I::new_nop(Uncompressed),
-                    I::new_j(i64::MAX, Uncompressed),
+                    I::new_jump_pc(i64::MAX, Uncompressed),
                     I::new_nop(Compressed),
                     I::new_nop(Uncompressed),
                 ])
@@ -1100,7 +1100,7 @@ mod tests {
                 // jump by nothing
                 .set_instructions(&[
                     I::new_nop(Compressed),
-                    I::new_j(0, Compressed),
+                    I::new_jump_pc(0, Compressed),
                     I::new_nop(Uncompressed),
                 ])
                 .set_assert_hook(assert_hook!(|core| {
@@ -1113,7 +1113,7 @@ mod tests {
                 .set_instructions(&[
                     I::new_nop(Compressed),
                     I::new_nop(Compressed),
-                    I::new_j(-4, Compressed),
+                    I::new_jump_pc(-4, Compressed),
                     I::new_nop(Uncompressed),
                 ])
                 .set_assert_hook(assert_hook!(|core| {

--- a/src/riscv/lib/src/jit/builder/instruction.rs
+++ b/src/riscv/lib/src/jit/builder/instruction.rs
@@ -267,6 +267,7 @@ impl<'seq, 'jit, MC: MemoryConfig> InstructionBuilder<'seq, 'jit, MC> {
                         destination: address,
                         hook,
                     },
+                    ProgramCounterUpdate::Relative(offset) => Outcome::KnownBranch { offset, hook },
                     ProgramCounterUpdate::Next(_width) => Outcome::Next { hook },
                 };
                 lowered.outcomes.push(outcome);

--- a/src/riscv/lib/src/machine_state.rs
+++ b/src/riscv/lib/src/machine_state.rs
@@ -101,7 +101,8 @@ impl<MC: memory::MemoryConfig, M: backend::ManagerBase> MachineCoreState<MC, M> 
             Err(exc) => self.address_on_exception(exc, instr_pc)?,
             Ok(update) => match update {
                 ProgramCounterUpdate::Set(address) => address,
-                ProgramCounterUpdate::Next(width) => instr_pc + width as u64,
+                ProgramCounterUpdate::Next(width) => instr_pc.wrapping_add(width as u64),
+                ProgramCounterUpdate::Relative(offset) => instr_pc.wrapping_add_signed(offset),
             },
         };
 
@@ -215,6 +216,8 @@ pub enum ProgramCounterUpdate<AddressRepr> {
     Set(AddressRepr),
     /// Offset to the next instruction by current instruction width
     Next(InstrWidth),
+    /// Jump to an address relative to the current program counter
+    Relative(i64),
 }
 
 /// Result type when running multiple steps at a time with [`MachineState::step_max`]

--- a/src/riscv/lib/src/machine_state.rs
+++ b/src/riscv/lib/src/machine_state.rs
@@ -969,7 +969,7 @@ mod tests {
                 },
             },
             TaggedInstruction {
-                opcode: OpCode::J,
+                opcode: OpCode::JumpPC,
                 args: TaggedArgs {
                     imm: -12,
                     ..TaggedArgs::DEFAULT
@@ -1014,7 +1014,7 @@ mod tests {
                 },
             },
             TaggedInstruction {
-                opcode: OpCode::J,
+                opcode: OpCode::JumpPC,
                 args: TaggedArgs {
                     imm: -12,
                     ..TaggedArgs::DEFAULT

--- a/src/riscv/lib/src/machine_state/block_cache/block.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/block.rs
@@ -137,8 +137,15 @@ fn run_block_inner<MC: MemoryConfig, M: ManagerReadWrite>(
 
             Ok(ProgramCounterUpdate::Set(instr_pc)) => {
                 // Setting the instr_pc implies execution continuing
-                // elsewhere - and no longer within the current block.
+                // elsewhere and no longer within the current block, so the
+                // current block instr_pc does not need updating.
                 core.hart.pc.write(instr_pc);
+                result.steps += 1;
+                break;
+            }
+
+            Ok(ProgramCounterUpdate::Relative(offset)) => {
+                core.hart.pc.write(instr_pc.wrapping_add_signed(offset));
                 result.steps += 1;
                 break;
             }

--- a/src/riscv/lib/src/machine_state/block_cache/state.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/state.rs
@@ -150,7 +150,16 @@ impl<M: ManagerBase> PartialBlock<M> {
 
                 Ok(ProgramCounterUpdate::Set(instr_pc)) => {
                     // Setting the instr_pc implies execution continuing
-                    // elsewhere - and no longer within the current block.
+                    // elsewhere and no longer within the current block, so the
+                    // current block instr_pc does not need updating.
+                    core.hart.pc.write(instr_pc);
+                    result.steps += 1;
+                    self.reset();
+                    return result;
+                }
+
+                Ok(ProgramCounterUpdate::Relative(offset)) => {
+                    instr_pc = instr_pc.wrapping_add_signed(offset);
                     core.hart.pc.write(instr_pc);
                     result.steps += 1;
                     self.reset();

--- a/src/riscv/lib/src/machine_state/instruction.rs
+++ b/src/riscv/lib/src/machine_state/instruction.rs
@@ -390,7 +390,7 @@ pub enum OpCode {
     // Internal OpCodes
     BranchEqualZero,
     BranchNotEqualZero,
-    J,
+    JumpPC,
     Mv,
     Li,
     Nop,
@@ -586,7 +586,7 @@ impl OpCode {
             Self::Csrrwi => Args::run_csrrwi,
             Self::Csrrsi => Args::run_csrrsi,
             Self::Csrrci => Args::run_csrrci,
-            Self::J => Args::run_j,
+            Self::JumpPC => Args::run_jump_pc,
             Self::JAbsolute => Args::run_j_absolute,
             Self::Jr => Args::run_jr,
             Self::Jalr => Args::run_jalr,
@@ -647,7 +647,7 @@ impl OpCode {
             Self::X32RemUnsigned => Some(Args::run_x32_rem_unsigned),
             Self::Li => Some(Args::run_li),
             Self::AddImmediateToPC => Some(Args::run_add_immediate_to_pc),
-            Self::J => Some(Args::run_j),
+            Self::JumpPC => Some(Args::run_jump_pc),
             Self::Jr => Some(Args::run_jr),
             Self::JrImm => Some(Args::run_jr_imm),
             Self::JAbsolute => Some(Args::run_j_absolute),
@@ -1647,8 +1647,8 @@ impl Args {
     impl_cr_nz_type!(integer::run_neg, run_neg);
     impl_ci_type!(load_store::run_li, run_li, non_zero);
 
-    fn run_j<I: ICB>(&self, icb: &mut I) -> IcbFnResult<I> {
-        let addr = branching::run_j(icb, self.imm);
+    fn run_jump_pc<I: ICB>(&self, icb: &mut I) -> IcbFnResult<I> {
+        let addr = branching::run_jump_pc(icb, self.imm);
         let pcu = ProgramCounterUpdate::Set(addr);
         icb.ok(pcu)
     }
@@ -2388,7 +2388,7 @@ impl From<&InstrCacheable> for Instruction {
                 debug_assert!(args.imm >= 0 && args.imm % 4 == 0);
                 Instruction::new_x32_store(sp, args.rs2, args.imm, InstrWidth::Compressed)
             }
-            InstrCacheable::CJ(args) => Instruction::new_j(args.imm, InstrWidth::Compressed),
+            InstrCacheable::CJ(args) => Instruction::new_jump_pc(args.imm, InstrWidth::Compressed),
             InstrCacheable::CJr(args) => Instruction::new_jr(args.rs1, InstrWidth::Compressed),
             InstrCacheable::CJalr(args) => {
                 Instruction::new_jalr(nz::ra, args.rs1, InstrWidth::Compressed)

--- a/src/riscv/lib/src/machine_state/instruction/constructors.rs
+++ b/src/riscv/lib/src/machine_state/instruction/constructors.rs
@@ -616,10 +616,10 @@ impl Instruction {
         }
     }
 
-    /// Create a new [`Instruction`] with the appropriate [`super::ArgsShape`] for [`OpCode::J`].
-    pub(crate) fn new_j(imm: i64, width: InstrWidth) -> Self {
+    /// Create a new [`Instruction`] with the appropriate [`super::ArgsShape`] for [`OpCode::JumpPC`].
+    pub(crate) fn new_jump_pc(imm: i64, width: InstrWidth) -> Self {
         Self {
-            opcode: OpCode::J,
+            opcode: OpCode::JumpPC,
             args: Args {
                 imm,
                 width,
@@ -2422,7 +2422,7 @@ impl Instruction {
         use XRegisterParsed as X;
         match split_x0(args.rd) {
             // If rd is 0, we are just doing an unconditional jump and not storing the current pc.
-            X::X0 => Instruction::new_j(args.imm, InstrWidth::Uncompressed),
+            X::X0 => Instruction::new_jump_pc(args.imm, InstrWidth::Uncompressed),
             X::NonZero(rd) => Instruction::new_jal(rd, args.imm, InstrWidth::Uncompressed),
         }
     }
@@ -2434,9 +2434,9 @@ impl Instruction {
         use XRegisterParsed as X;
         match (split_x0(args.rs1), split_x0(args.rs2)) {
             // If the registers are the same, then the instruction is an unconditional jump.
-            (X::X0, X::X0) => Instruction::new_j(args.imm, InstrWidth::Uncompressed),
+            (X::X0, X::X0) => Instruction::new_jump_pc(args.imm, InstrWidth::Uncompressed),
             (X::NonZero(rs1), X::NonZero(rs2)) if rs1 == rs2 => {
-                Instruction::new_j(args.imm, InstrWidth::Uncompressed)
+                Instruction::new_jump_pc(args.imm, InstrWidth::Uncompressed)
             }
             // If either register is x0, then the condition to branch is whether the other register stores 0.
             (X::NonZero(rs1), X::X0) | (X::X0, X::NonZero(rs1)) => {
@@ -2455,7 +2455,7 @@ impl Instruction {
         use XRegisterParsed as X;
         match split_x0(args.rd_rs1) {
             // If `rd_rs1` is zero, the result is an unconditional jump
-            X::X0 => Instruction::new_j(args.imm, InstrWidth::Compressed),
+            X::X0 => Instruction::new_jump_pc(args.imm, InstrWidth::Compressed),
             X::NonZero(rd_rs1) => {
                 Instruction::new_branch_equal_zero(rd_rs1, args.imm, InstrWidth::Compressed)
             }
@@ -2564,9 +2564,9 @@ impl Instruction {
         use XRegisterParsed as X;
         match (split_x0(args.rs1), split_x0(args.rs2)) {
             // If the registers are the same, the values are the same so we always branch.
-            (X::X0, X::X0) => Instruction::new_j(args.imm, InstrWidth::Uncompressed),
+            (X::X0, X::X0) => Instruction::new_jump_pc(args.imm, InstrWidth::Uncompressed),
             (X::NonZero(rs1), X::NonZero(rs2)) if rs1 == rs2 => {
-                Instruction::new_j(args.imm, InstrWidth::Uncompressed)
+                Instruction::new_jump_pc(args.imm, InstrWidth::Uncompressed)
             }
             // If rs1 is x0, the condition to branch is whether `val(rs2) <= 0`.
             (X::X0, X::NonZero(rs1)) => Instruction::new_branch_less_than_or_equal_zero(
@@ -2623,10 +2623,10 @@ impl Instruction {
         use XRegisterParsed as X;
         match (split_x0(args.rs1), split_x0(args.rs2)) {
             // If rs2 is x0, rs1 is either the same or more than rs2, so we always branch.
-            (_, X::X0) => Instruction::new_j(args.imm, InstrWidth::Uncompressed),
+            (_, X::X0) => Instruction::new_jump_pc(args.imm, InstrWidth::Uncompressed),
             // If the registers are the same, the values are the same so we always branch.
             (X::NonZero(rs1), X::NonZero(rs2)) if rs1 == rs2 => {
-                Instruction::new_j(args.imm, InstrWidth::Uncompressed)
+                Instruction::new_jump_pc(args.imm, InstrWidth::Uncompressed)
             }
             // If rs1 is x0, the condition to branch is whether `val(rs2) == 0`.
             (X::X0, X::NonZero(rs1)) => {

--- a/src/riscv/lib/src/machine_state/instruction/tagged_instruction.rs
+++ b/src/riscv/lib/src/machine_state/instruction/tagged_instruction.rs
@@ -386,7 +386,7 @@ pub fn opcode_to_argsshape(opcode: &OpCode) -> ArgsShape {
         | X32ShiftRightImmUnsigned
         | X32ShiftRightImmSigned
         | Jal
-        | J
+        | JumpPC
         | JrImm
         | JAbsolute
         | JalrAbsolute


### PR DESCRIPTION
Relates to RV-701

# What

Previously `J` instructions (now `JumpPC`) would construct an absolute address and return it when lowered. This MR changes this to being a relative offset to the current PC, and the address will be constructed after the lowered function returns. 

# Why

This change is a pre-cursor to enabling intra-block jumping for certain opcodes, so that we don't have to exit a JIT function if we have a possibility of jumping to an instruction contained in the current block. 

The name change is part of the opcode redesign work. 

# How

We add a new variant to the `ProgramCounterUpdate` enum of `Relative`. Only the `run_jump_pc` function uses this so far. When this variant is encountered on a lowered function return, the code will, at that point, construct the absolute address to jump to and do so, exitting the function, similar to current implementation of `Set`. 

# Manually Testing

```
make -C src/riscv all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
