### PR TITLE
Restore inline annotations for CSR operations

### DIFF
--- a/src/riscv/lib/src/machine_state/csregisters.rs
+++ b/src/riscv/lib/src/machine_state/csregisters.rs
@@ -177,6 +177,7 @@ pub struct CSRegisters<M: backend::ManagerBase> {
 
 impl<M: backend::ManagerBase> CSRegisters<M> {
     /// Write to a CSR.
+    #[inline]
     pub fn write<V: Bits64>(&mut self, reg: CSRegister, value: V)
     where
         M: backend::ManagerWrite,
@@ -238,6 +239,7 @@ impl<M: backend::ManagerBase> CSRegisters<M> {
     }
 
     /// Read from a CSR.
+    #[inline]
     pub fn read<V: Bits64>(&self, reg: CSRegister) -> V
     where
         M: backend::ManagerRead,


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

# What

Restores 2 `#[inline]` annotations that should not have been deleted.

# Why

Improves performance as those functions benefit a lot from inlining.

# Manually Testing

```
make -C src/riscv all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
