### PR TITLE
Refactor ManagerAlloc & new methods

### DIFF
--- a/src/riscv/Cargo.lock
+++ b/src/riscv/Cargo.lock
@@ -1413,6 +1413,7 @@ dependencies = [
  "tezos_crypto_rs",
  "thiserror",
  "tracing",
+ "trait-set",
  "try-blocks",
  "tuples",
  "vm-fdt",
@@ -2631,6 +2632,17 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "trait-set"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79e2e9c9ab44c6d7c20d5976961b47e8f49ac199154daa514b77cd1ab536625"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/src/riscv/Cargo.toml
+++ b/src/riscv/Cargo.toml
@@ -44,6 +44,7 @@ sha2 = "0.10.9"
 sha3 = "0.10.8"
 tempfile = "3.20.0"
 thiserror = "1.0.69"
+trait-set = "0.3.0"
 try-blocks = "0.1.4"
 tuples = "1.16.0"
 vm-fdt = "0.3.0"
@@ -97,4 +98,4 @@ version = "0.1.41"
 
 [workspace.dependencies.tracing-subscriber]
 version = "0.3.19"
-features = ["json", "env-filter"] 
+features = ["json", "env-filter"]

--- a/src/riscv/lib/Cargo.toml
+++ b/src/riscv/lib/Cargo.toml
@@ -38,6 +38,7 @@ vm-fdt.workspace = true
 itertools.workspace = true
 range-collections.workspace = true
 elf.workspace = true
+trait-set.workspace = true
 
 [dependencies.__tracing_do_not_use_directly]
 workspace = true

--- a/src/riscv/lib/src/interpreter/atomics.rs
+++ b/src/riscv/lib/src/interpreter/atomics.rs
@@ -653,7 +653,7 @@ pub(crate) mod test {
                 use $crate::machine_state::memory::M4K;
                 use $crate::state::NewState;
 
-                let state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+                let state = MachineCoreState::<M4K, F>::new();
                 let state_cell = std::cell::RefCell::new(state);
 
                 proptest!(|(
@@ -699,7 +699,7 @@ pub(crate) mod test {
                 use $crate::machine_state::memory::M4K;
                 use $crate::state::NewState;
 
-                let state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+                let state = MachineCoreState::<M4K, F>::new();
                 let state_cell = std::cell::RefCell::new(state);
 
                 proptest!(|(
@@ -909,7 +909,7 @@ pub(crate) mod test {
     );
 
     backend_test!(test_alignment, F, {
-        let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+        let mut state = MachineCoreState::<M4K, F>::new();
         state.main_memory.set_all_readable_writeable();
         state.hart.xregisters.write(a0, 80); // LR.D starting address.
         state.hart.xregisters.write(a1, 84); // SC.W starting address.

--- a/src/riscv/lib/src/interpreter/branching.rs
+++ b/src/riscv/lib/src/interpreter/branching.rs
@@ -270,7 +270,7 @@ mod tests {
             ),
         ];
         for (init_pc, imm, init_rs1, rs1, rd, res_pc, res_rd) in ipc_imm_irs1_rs1_rd_fpc_frd {
-            let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+            let mut state = MachineCoreState::<M4K, F>::new();
 
             // TEST JalrImm
             state.hart.pc.write(init_pc);
@@ -333,7 +333,7 @@ mod tests {
         ];
 
         for (init_pc, imm, res, rd) in pc_imm_res_rd {
-            let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+            let mut state = MachineCoreState::<M4K, F>::new();
 
             state.hart.pc.write(init_pc);
             super::run_add_immediate_to_pc(&mut state, imm, rd);
@@ -389,7 +389,7 @@ mod tests {
             let next_pcu = ProgramCounterUpdate::Next(InstrWidth::Uncompressed);
             let init_pcu = ProgramCounterUpdate::Set(init_pc);
 
-            let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+            let mut state = MachineCoreState::<M4K, F>::new();
 
             // BEQ: different
             test_branch!(state, Predicate::Equal, imm, nz::t1, r1_val, nz::t2, r2_val, width, init_pc, &next_pcu);
@@ -435,7 +435,7 @@ mod tests {
             let next_pcu = ProgramCounterUpdate::Next(InstrWidth::Uncompressed);
             let init_pcu = ProgramCounterUpdate::Set(init_pc);
 
-            let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+            let mut state = MachineCoreState::<M4K, F>::new();
 
             // lhs < rhs
             test_branch!(state, Predicate::LessThanSigned, imm, nz::t1, 0, nz::t2, 1, width, init_pc, &branch_pcu);
@@ -475,7 +475,7 @@ mod tests {
             let width = InstrWidth::Uncompressed;
             let next_pcu = ProgramCounterUpdate::Next(InstrWidth::Uncompressed);
 
-            let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+            let mut state = MachineCoreState::<M4K, F>::new();
 
             // lhs < 0
             test_branch_compare_zero!(state, Predicate::LessThanSigned, imm, nz::t1, -1_i64 as u64, width, init_pc, &branch_pcu);
@@ -512,7 +512,7 @@ mod tests {
             let next_pcu = ProgramCounterUpdate::Next(InstrWidth::Uncompressed);
             let pc_update_init_pcu = ProgramCounterUpdate::Set(init_pc);
 
-            let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+            let mut state = MachineCoreState::<M4K, F>::new();
 
             // lhs < rhs
             test_branch!(state, Predicate::LessThanUnsigned, imm, nz::t1, r1_val, nz::t2, r2_val, width, init_pc, &branch_pcu);
@@ -563,7 +563,7 @@ mod tests {
             let next_pcu = ProgramCounterUpdate::Next(InstrWidth::Uncompressed);
             let init_pcu = ProgramCounterUpdate::Set(init_pc);
 
-            let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+            let mut state = MachineCoreState::<M4K, F>::new();
 
             // BEQZ
             if r1_val == 0 {

--- a/src/riscv/lib/src/interpreter/float.rs
+++ b/src/riscv/lib/src/interpreter/float.rs
@@ -722,7 +722,7 @@ mod test {
             r1_val in any::<u64>(),
             rm in rounding_mode_strategy(),
         )| {
-            let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+            let mut state = MachineCoreState::<M4K, F>::new();
 
             let fval = match rm {
                 InstrRoundingMode::Static(rm) => Double::from_u128_r(r1_val as u128, rm.into()),

--- a/src/riscv/lib/src/interpreter/integer.rs
+++ b/src/riscv/lib/src/interpreter/integer.rs
@@ -779,7 +779,7 @@ mod tests {
         ];
 
         for (rs2, rd, res) in rs2val_rd_res {
-            let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+            let mut state = MachineCoreState::<M4K, F>::new();
 
             state.hart.xregisters.write_nz(nz::a0, rs2);
             run_neg(&mut state, rd, nz::a0);
@@ -798,7 +798,7 @@ mod tests {
         ];
 
         for (imm, rs1, res) in imm_rs1_res {
-            let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+            let mut state = MachineCoreState::<M4K, F>::new();
 
             state.hart.xregisters.write_nz(nz::a3, rs1);
             state.hart.xregisters.write_nz(nz::a4, imm as u64);
@@ -831,7 +831,7 @@ mod tests {
         ];
 
         for (imm, rs1, rd, res) in imm_rs1_rd_res {
-            let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+            let mut state = MachineCoreState::<M4K, F>::new();
 
             state.hart.xregisters.write_nz(nz::a0, rs1);
             state.hart.xregisters.write_nz(nz::t0, imm as u64);
@@ -855,7 +855,7 @@ mod tests {
             v1 in any::<i64>(),
             v2 in any::<i64>())|
         {
-            let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+            let mut state = MachineCoreState::<M4K, F>::new();
             state.hart.xregisters.write(t0, v1 as u64);
             state.hart.xregisters.write(a0, v2 as u64);
             run_sub_word(&mut state, t0, a0, nz::a1);
@@ -870,7 +870,7 @@ mod tests {
     });
 
     backend_test!(test_set_less_than, F, {
-        let mut core = MachineCoreState::<M4K, _>::new(&mut F::manager());
+        let mut core = MachineCoreState::<M4K, F>::new();
 
         let v1_v2_exp_expu = [
             (0, 0, 0, 0),
@@ -948,7 +948,7 @@ mod tests {
     }
 
     backend_test!(test_shift, F, {
-        let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+        let mut state = MachineCoreState::<M4K, F>::new();
 
         // imm = 0
         test_both_shift_instr!(state, Shift::Left, t0, 0, a0, 0x1234_ABEF, a1, 0x1234_ABEF);
@@ -1129,7 +1129,7 @@ mod tests {
     }
 
     backend_test!(test_shift_word, F, {
-        let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+        let mut state = MachineCoreState::<M4K, F>::new();
 
         test_both_shift_word_instr!(
             state,
@@ -1255,7 +1255,7 @@ mod tests {
 
     backend_test!(test_bitwise_intruction, F, {
         proptest!(|(val1 in any::<u64>(), val2 in any::<u64>())| {
-            let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+            let mut state = MachineCoreState::<M4K, F>::new();
 
             // The sign-extension of an immediate on 12 bits has bits 31:11 equal the sign-bit
             let prefix_mask = 0xFFFF_FFFF_FFFF_F800;
@@ -1290,7 +1290,7 @@ mod tests {
             r1_val in any::<u64>(),
             r2_val in any::<u64>(),
         )| {
-            let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+            let mut state = MachineCoreState::<M4K, F>::new();
 
             state.hart.xregisters.write(a0, r1_val);
             state.hart.xregisters.write(a1, r2_val);
@@ -1310,7 +1310,7 @@ mod tests {
             r1_val in any::<u64>(),
             r2_val in any::<u64>(),
         )| {
-            let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+            let mut state = MachineCoreState::<M4K, F>::new();
 
             state.hart.xregisters.write(a0, r1_val);
             state.hart.xregisters.write(a1, r2_val);
@@ -1330,7 +1330,7 @@ mod tests {
             r1_val in any::<u64>(),
             r2_val in any::<u64>(),
         )| {
-            let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+            let mut state = MachineCoreState::<M4K, F>::new();
 
             state.hart.xregisters.write(a0, r1_val);
             state.hart.xregisters.write(a1, r2_val);
@@ -1350,7 +1350,7 @@ mod tests {
             r1_val in any::<u64>(),
             r2_val in any::<u64>(),
         )| {
-            let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+            let mut state = MachineCoreState::<M4K, F>::new();
 
             state.hart.xregisters.write(a0, r1_val);
             state.hart.xregisters.write(a1, r2_val);
@@ -1375,7 +1375,7 @@ mod tests {
     }
 
     backend_test!(test_x64_mul_high, F, {
-        let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+        let mut state = MachineCoreState::<M4K, F>::new();
 
         // MULH (Signed × Signed)
         test_x64_mul_high!(

--- a/src/riscv/lib/src/interpreter/load_store.rs
+++ b/src/riscv/lib/src/interpreter/load_store.rs
@@ -114,7 +114,7 @@ mod test {
         ];
 
         for (imm, rd_rs1, res) in imm_rdrs1_res {
-            let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+            let mut state = MachineCoreState::<M4K, F>::new();
             super::run_li(&mut state, imm, rd_rs1);
             assert_eq!(state.hart.xregisters.read_nz(rd_rs1), res);
         }
@@ -122,7 +122,7 @@ mod test {
 
     backend_test!(test_lui, F, {
         proptest!(|(imm in any::<i64>())| {
-            let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+            let mut state = MachineCoreState::<M4K, F>::new();
             state.hart.xregisters.write(a2, 0);
             state.hart.xregisters.write(a4, 0);
 
@@ -138,7 +138,7 @@ mod test {
     });
 
     backend_test!(test_load_store, F, {
-        let state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+        let state = MachineCoreState::<M4K, F>::new();
         let state_cell = std::cell::RefCell::new(state);
 
         proptest!(|(

--- a/src/riscv/lib/src/interpreter/rv32c.rs
+++ b/src/riscv/lib/src/interpreter/rv32c.rs
@@ -42,7 +42,7 @@ mod tests {
             (u64::MAX - 1, 100, 98_i64 as u64),
         ];
         for (init_pc, imm, res_pc) in test_case {
-            let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+            let mut state = MachineCoreState::<M4K, F>::new();
 
             state.hart.pc.write(init_pc);
             let new_pc = run_j(&mut state, imm);
@@ -64,7 +64,7 @@ mod tests {
             ),
         ];
         for (init_pc, init_rs1, rs1, res_pc) in scenarios {
-            let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+            let mut state = MachineCoreState::<M4K, F>::new();
 
             // Test C.JR
             // save program counter and value for rs1.

--- a/src/riscv/lib/src/interpreter/rv32i.rs
+++ b/src/riscv/lib/src/interpreter/rv32i.rs
@@ -70,7 +70,7 @@ mod tests {
 
     backend_test!(test_bitwise, F, {
         proptest!(|(val in any::<u64>(), imm in any::<u64>())| {
-            let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+            let mut state = MachineCoreState::<M4K, F>::new();
 
             // The sign-extension of an immediate on 12 bits has bits 31:11 equal the sign-bit
             let prefix_mask = 0xFFFF_FFFF_FFFF_F800;
@@ -90,7 +90,7 @@ mod tests {
     backend_test!(test_bitwise_reg, F, {
         // TODO: RV-512: move to integer.rs once all are supported.
         proptest!(|(v1 in any::<u64>(), v2 in any::<u64>())| {
-            let mut state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+            let mut state = MachineCoreState::<M4K, F>::new();
 
             state.hart.xregisters.write(a0, v1);
             state.hart.xregisters.write(t3, v2);
@@ -112,14 +112,14 @@ mod tests {
     });
 
     backend_test!(test_ebreak, F, {
-        let state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+        let state = MachineCoreState::<M4K, F>::new();
 
         let ret_val = state.hart.run_ebreak();
         assert_eq!(ret_val, Exception::Breakpoint);
     });
 
     backend_test!(test_fence, F, {
-        let state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+        let state = MachineCoreState::<M4K, F>::new();
         let state_cell = std::cell::RefCell::new(state);
 
         proptest!(|(
@@ -141,7 +141,7 @@ mod tests {
     });
 
     backend_test!(test_ecall, F, {
-        let state = HartState::new(&mut F::manager());
+        let state = HartState::<F>::new();
 
         let instr_res = state.run_ecall();
         assert!(instr_res == Exception::EnvCall);

--- a/src/riscv/lib/src/interpreter/rv64c.rs
+++ b/src/riscv/lib/src/interpreter/rv64c.rs
@@ -47,7 +47,7 @@ mod tests {
             imm in any::<i64>(),
             reg_val in any::<i64>())|
         {
-            let mut state = HartState::new(&mut F::manager());
+            let mut state = HartState::<F>::new();
 
             state.xregisters.write_nz(nz::a0, reg_val as u64);
             state.xregisters.run_caddiw(imm, nz::a0);

--- a/src/riscv/lib/src/interpreter/rv64d.rs
+++ b/src/riscv/lib/src/interpreter/rv64d.rs
@@ -486,7 +486,7 @@ mod tests {
     use crate::traps::Exception;
 
     backend_test!(test_fmv_d, F, {
-        let state = HartState::new(&mut F::manager());
+        let state = HartState::<F>::new();
         let state_cell = std::cell::RefCell::new(state);
 
         proptest!(|(
@@ -510,7 +510,7 @@ mod tests {
     });
 
     backend_test!(test_load_store, F, {
-        let state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+        let state = MachineCoreState::<M4K, F>::new();
         let state_cell = std::cell::RefCell::new(state);
 
         proptest!(|(

--- a/src/riscv/lib/src/interpreter/rv64dc.rs
+++ b/src/riscv/lib/src/interpreter/rv64dc.rs
@@ -92,7 +92,7 @@ mod test {
     const OUT_OF_BOUNDS_OFFSET: i64 = MC::TOTAL_BYTES as i64;
 
     backend_test!(test_cfsd_cfld, F, {
-        let state = MachineCoreState::<MC, _>::new(&mut F::manager());
+        let state = MachineCoreState::<MC, F>::new();
         let state_cell = std::cell::RefCell::new(state);
 
         proptest!(|(
@@ -128,7 +128,7 @@ mod test {
     });
 
     backend_test!(test_cfsdsp_cfldsp, F, {
-        let state = MachineCoreState::<MC, _>::new(&mut F::manager());
+        let state = MachineCoreState::<MC, F>::new();
         let state_cell = std::cell::RefCell::new(state);
 
         proptest!(|(

--- a/src/riscv/lib/src/interpreter/rv64f.rs
+++ b/src/riscv/lib/src/interpreter/rv64f.rs
@@ -519,7 +519,7 @@ mod tests {
             rs1_f in (1_u8..31).prop_map(u5::new).prop_map(parse_fregister),
             rs2 in (1_u8..31).prop_map(u5::new).prop_map(parse_xregister),
         )| {
-            let mut state = HartState::new(&mut F::manager());
+            let mut state = HartState::<F>::new();
 
             state.xregisters.write(rs1, f as u64);
 
@@ -546,7 +546,7 @@ mod tests {
     });
 
     backend_test!(test_load_store, F, {
-        let state = MachineCoreState::<M4K, _>::new(&mut F::manager());
+        let state = MachineCoreState::<M4K, F>::new();
         let state_cell = std::cell::RefCell::new(state);
 
         proptest!(|(

--- a/src/riscv/lib/src/jit.rs
+++ b/src/riscv/lib/src/jit.rs
@@ -333,8 +333,8 @@ mod tests {
         instr.iter().map(|cell| cell.read_stored()).collect()
     }
 
-    type SetupHook<F> = dyn Fn(&mut MachineCoreState<M4K, <F as TestBackendFactory>::Manager>);
-    type AssertHook<F> = dyn Fn(&MachineCoreState<M4K, <F as TestBackendFactory>::Manager>);
+    type SetupHook<F> = dyn Fn(&mut MachineCoreState<M4K, F>);
+    type AssertHook<F> = dyn Fn(&MachineCoreState<M4K, F>);
 
     struct Scenario<F: TestBackendFactory> {
         initial_pc: Option<u64>,
@@ -357,21 +357,16 @@ mod tests {
 
         /// Run a test scenario over both the Interpreted & JIT modes of compilation,
         /// to ensure they behave identically.
-        fn run(
-            &self,
-            jit: &mut JIT<M4K, F::Manager>,
-            interpreted_bb: &mut InterpretedBlockBuilder,
-        ) {
+        fn run(&self, jit: &mut JIT<M4K, F>, interpreted_bb: &mut InterpretedBlockBuilder) {
             // Create the states for the interpreted and jitted runs.
-            let mut manager = F::manager();
-            let mut interpreted = MachineCoreState::<M4K, _>::new(&mut manager);
+            let mut interpreted = MachineCoreState::<M4K, F>::new();
             interpreted.main_memory.set_all_readable_writeable();
 
-            let mut jitted = MachineCoreState::<M4K, _>::new(&mut manager);
+            let mut jitted = MachineCoreState::<M4K, F>::new();
             jitted.main_memory.set_all_readable_writeable();
 
             // Create the block of instructions.
-            let mut block = Interpreted::<M4K, _>::new(&mut manager);
+            let mut block = Interpreted::<M4K, F>::new();
             block.start_block();
             for instr in self.instructions.iter() {
                 block.push_instr(*instr);
@@ -499,13 +494,13 @@ mod tests {
 
     macro_rules! setup_hook {
         ($core:ident, $F:ident, $block:expr) => {
-            Box::new(move |$core: &mut MachineCoreState<M4K, $F::Manager>| $block)
+            Box::new(move |$core: &mut MachineCoreState<M4K, $F>| $block)
         };
     }
 
     macro_rules! assert_hook {
         ($core:ident, $F:ident, $block:expr) => {
-            Box::new(move |$core: &MachineCoreState<M4K, $F::Manager>| $block)
+            Box::new(move |$core: &MachineCoreState<M4K, $F>| $block)
         };
     }
 
@@ -520,7 +515,7 @@ mod tests {
             ]),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -558,7 +553,7 @@ mod tests {
                 .build(),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -606,7 +601,7 @@ mod tests {
                 .build(),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -632,7 +627,7 @@ mod tests {
             .set_assert_hook(assert_x1_is_five)
             .build();
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         scenario.run(&mut jit, &mut interpreted_bb);
@@ -675,7 +670,7 @@ mod tests {
                 .build(),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -717,7 +712,7 @@ mod tests {
                 .build(),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -762,7 +757,7 @@ mod tests {
                 .build(),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -804,7 +799,7 @@ mod tests {
                 .build(),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -851,7 +846,7 @@ mod tests {
                 .build(),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -916,7 +911,7 @@ mod tests {
                 .build(),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -962,7 +957,7 @@ mod tests {
                 .build(),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -1010,7 +1005,7 @@ mod tests {
             test_x32_mul(0x80000000, 0x80000000, 0, Compressed),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -1055,7 +1050,7 @@ mod tests {
             test_division(40, -80, 0),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -1128,7 +1123,7 @@ mod tests {
                 .build(),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -1292,7 +1287,7 @@ mod tests {
             test_jal(1000, 1000, 2000, 1004, Uncompressed),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -1334,7 +1329,7 @@ mod tests {
                 .build(),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -1381,7 +1376,7 @@ mod tests {
                 .build(),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -1496,7 +1491,7 @@ mod tests {
             test_slt_imm(I::new_set_less_than_immediate_unsigned, (x3, -7), -6, TRUE),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -1586,7 +1581,7 @@ mod tests {
             ),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -1661,7 +1656,7 @@ mod tests {
             ),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -1679,7 +1674,7 @@ mod tests {
             ])
             .build()];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -1697,7 +1692,7 @@ mod tests {
             ])
             .build();
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         scenario.run(&mut jit, &mut interpreted_bb);
@@ -1721,13 +1716,11 @@ mod tests {
 
         let success: &[I] = &[I::new_nop(Compressed)];
 
-        let mut manager = F::manager();
-
         for failure in failure_scenarios.iter() {
-            let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+            let mut jit = JIT::<M4K, F>::new().unwrap();
 
-            let mut jitted = MachineCoreState::<M4K, _>::new(&mut manager);
-            let mut block = Interpreted::<M4K, _>::new(&mut manager);
+            let mut jitted = MachineCoreState::<M4K, F>::new();
+            let mut block = Interpreted::<M4K, F>::new();
 
             block.start_block();
             for instr in failure.iter() {
@@ -1801,7 +1794,7 @@ mod tests {
                 .build(),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -1968,7 +1961,7 @@ mod tests {
             ),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -2072,7 +2065,7 @@ mod tests {
             ),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -2154,7 +2147,7 @@ mod tests {
             invalid_store(I::new_x8_store, LoadStoreWidth::Byte),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -2240,7 +2233,7 @@ mod tests {
             invalid_load(I::new_x8_load_unsigned, LoadStoreWidth::Byte),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -2293,7 +2286,7 @@ mod tests {
             bitwise_test_xor(x1, 0xFFF0, x3, 0x0FFF, 0xF00F),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -2462,7 +2455,7 @@ mod tests {
             invalid_x64_atomic_unsigned(I::new_x64_atomic_max_unsigned, 10, 30, u64::max),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -2568,7 +2561,7 @@ mod tests {
             test_mul_high(I::new_x64_mul_high_unsigned, x1, 0u64, x3, u64::MAX, 0u64),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -2714,7 +2707,7 @@ mod tests {
                 .build(),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -2882,7 +2875,7 @@ mod tests {
                 .build(),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -2982,7 +2975,7 @@ mod tests {
             ),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -3062,7 +3055,7 @@ mod tests {
             ),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -3195,7 +3188,7 @@ mod tests {
             invalid_x32_atomic(I::new_x32_atomic_max_signed, 10, 20, signed_max),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {
@@ -3253,7 +3246,7 @@ mod tests {
                 .build(),
         ];
 
-        let mut jit = JIT::<M4K, F::Manager>::new().unwrap();
+        let mut jit = JIT::<M4K, F>::new().unwrap();
         let mut interpreted_bb = InterpretedBlockBuilder;
 
         for scenario in scenarios {

--- a/src/riscv/lib/src/machine_state.rs
+++ b/src/riscv/lib/src/machine_state.rs
@@ -151,13 +151,13 @@ impl<MC: memory::MemoryConfig, M: backend::ManagerBase> MachineCoreState<MC, M> 
 }
 
 impl<MC: memory::MemoryConfig, M: backend::ManagerBase> NewState<M> for MachineCoreState<MC, M> {
-    fn new(manager: &mut M) -> Self
+    fn new() -> Self
     where
         M: backend::ManagerAlloc,
     {
         Self {
-            hart: HartState::new(manager),
-            main_memory: NewState::new(manager),
+            hart: HartState::new(),
+            main_memory: NewState::new(),
         }
     }
 }
@@ -271,13 +271,13 @@ impl<MC: memory::MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: backen
     MachineState<MC, BCC, B, M>
 {
     /// Allocate a new machine state.
-    pub fn new(manager: &mut M, block_builder: B::BlockBuilder) -> Self
+    pub fn new(block_builder: B::BlockBuilder) -> Self
     where
         M: backend::ManagerAlloc,
     {
         Self {
-            core: MachineCoreState::new(manager),
-            block_cache: BlockCache::new(manager),
+            core: MachineCoreState::new(),
+            block_cache: BlockCache::new(),
             block_builder,
         }
     }
@@ -636,14 +636,12 @@ mod tests {
     use crate::parser::instruction::SplitITypeArgs;
     use crate::parser::parse_block;
     use crate::state_backend::FnManagerIdent;
-    use crate::state_backend::test_helpers::TestBackendFactory;
     use crate::state_backend::test_helpers::assert_eq_struct;
     use crate::state_backend::test_helpers::copy_via_serde;
     use crate::traps::EnvironException;
 
     backend_test!(test_step, F, {
-        let state = MachineState::<M4K, DefaultCacheConfig, Interpreted<M4K, _>, _>::new(
-            &mut F::manager(),
+        let state = MachineState::<M4K, DefaultCacheConfig, Interpreted<M4K, F>, F>::new(
             InterpretedBlockBuilder,
         );
 
@@ -690,8 +688,7 @@ mod tests {
     });
 
     backend_test!(test_step_env_exc, F, {
-        let state = MachineState::<M4K, DefaultCacheConfig, Interpreted<M4K, _>, _>::new(
-            &mut F::manager(),
+        let state = MachineState::<M4K, DefaultCacheConfig, Interpreted<M4K, F>, F>::new(
             InterpretedBlockBuilder,
         );
 
@@ -716,8 +713,7 @@ mod tests {
     });
 
     backend_test!(test_step_exc_us, F, {
-        let state = MachineState::<M4K, DefaultCacheConfig, Interpreted<M4K, _>, _>::new(
-            &mut F::manager(),
+        let state = MachineState::<M4K, DefaultCacheConfig, Interpreted<M4K, F>, F>::new(
             InterpretedBlockBuilder,
         );
 
@@ -773,15 +769,13 @@ mod tests {
 
         type LocalLayout = MachineStateLayout<M4K, TestCacheConfig>;
 
-        type BlockRunner<F> = Interpreted<M4K, <F as TestBackendFactory>::Manager>;
+        type BlockRunner<F> = Interpreted<M4K, F>;
 
-        type LocalMachineState<F> =
-            MachineState<M4K, TestCacheConfig, BlockRunner<F>, <F as TestBackendFactory>::Manager>;
+        type LocalMachineState<F> = MachineState<M4K, TestCacheConfig, BlockRunner<F>, F>;
 
         // Configure the machine state.
         let base_state = {
             let mut state = MachineState::<M4K, TestCacheConfig, BlockRunner<F>, _>::new(
-                &mut F::manager(),
                 InterpretedBlockBuilder,
             );
 
@@ -866,8 +860,7 @@ mod tests {
 
     // Ensure that cloning the machine state does not result in a stack overflow
     backend_test!(test_machine_state_cloneable, F, {
-        let state = MachineState::<M1M, DefaultCacheConfig, Interpreted<M1M, _>, _>::new(
-            &mut F::manager(),
+        let state = MachineState::<M1M, DefaultCacheConfig, Interpreted<M1M, F>, F>::new(
             InterpretedBlockBuilder,
         );
 
@@ -880,8 +873,7 @@ mod tests {
     });
 
     backend_test!(test_block_cache_crossing_pages_creates_new_block, F, {
-        let mut state = MachineState::<M8K, DefaultCacheConfig, Interpreted<M8K, _>, _>::new(
-            &mut F::manager(),
+        let mut state = MachineState::<M8K, DefaultCacheConfig, Interpreted<M8K, F>, F>::new(
             InterpretedBlockBuilder,
         );
 
@@ -1030,8 +1022,7 @@ mod tests {
             },
         ];
 
-        let mut state = MachineState::<M4K, DefaultCacheConfig, Interpreted<M4K, _>, _>::new(
-            &mut F::manager(),
+        let mut state = MachineState::<M4K, DefaultCacheConfig, Interpreted<M4K, F>, F>::new(
             InterpretedBlockBuilder,
         );
 

--- a/src/riscv/lib/src/machine_state/block_cache.rs
+++ b/src/riscv/lib/src/machine_state/block_cache.rs
@@ -212,7 +212,7 @@ fn run_instr<MC: MemoryConfig, M: ManagerReadWrite>(
 /// Block cache implementation
 pub trait BlockCache<MC: MemoryConfig, B: Block<MC, M>, M: ManagerBase> {
     /// Instantiate a new block cache instance.
-    fn new(manager: &mut M) -> Self
+    fn new() -> Self
     where
         M: ManagerAlloc;
 

--- a/src/riscv/lib/src/machine_state/block_cache/block/interpreted.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/block/interpreted.rs
@@ -47,13 +47,13 @@ pub struct Interpreted<MC: MemoryConfig, M: ManagerBase> {
 }
 
 impl<MC: MemoryConfig, M: ManagerBase> NewState<M> for Interpreted<MC, M> {
-    fn new(manager: &mut M) -> Self
+    fn new() -> Self
     where
         M: ManagerAlloc,
     {
         Self {
-            len_instr: Cell::new(manager),
-            instr: NewState::new(manager),
+            len_instr: Cell::new(),
+            instr: NewState::new(),
         }
     }
 }

--- a/src/riscv/lib/src/machine_state/block_cache/block/jitted.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/block/jitted.rs
@@ -113,12 +113,12 @@ impl<D: DispatchCompiler<MC, M>, MC: MemoryConfig, M: JitStateAccess> Jitted<D, 
 impl<D: DispatchCompiler<MC, M>, MC: MemoryConfig, M: JitStateAccess> NewState<M>
     for Jitted<D, MC, M>
 {
-    fn new(manager: &mut M) -> Self
+    fn new() -> Self
     where
         M: ManagerAlloc,
     {
         Self {
-            fallback: interpreted::Interpreted::new(manager),
+            fallback: interpreted::Interpreted::new(),
             dispatch: DispatchTarget::default(),
         }
     }

--- a/src/riscv/lib/src/machine_state/block_cache/metrics.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/metrics.rs
@@ -281,12 +281,12 @@ pub struct BlockMetrics<B> {
 }
 
 impl<B: NewState<M>, M: ManagerBase> NewState<M> for BlockMetrics<B> {
-    fn new(manager: &mut M) -> Self
+    fn new() -> Self
     where
         M: ManagerAlloc,
     {
         Self {
-            block: B::new(manager),
+            block: B::new(),
             block_hash: BlockHash::Dirty,
         }
     }

--- a/src/riscv/lib/src/machine_state/csregisters.rs
+++ b/src/riscv/lib/src/machine_state/csregisters.rs
@@ -371,13 +371,13 @@ impl<M: backend::ManagerBase> CSRegisters<M> {
 }
 
 impl<M: backend::ManagerBase> NewState<M> for CSRegisters<M> {
-    fn new(manager: &mut M) -> Self
+    fn new() -> Self
     where
         M: backend::ManagerAlloc,
     {
         Self {
-            fflags: Cell::new(manager),
-            frm: Cell::new(manager),
+            fflags: Cell::new(),
+            frm: Cell::new(),
         }
     }
 }
@@ -425,7 +425,7 @@ mod tests {
     }
 
     backend_test!(test_fcsr, F, {
-        let mut csrs = CSRegisters::new(&mut F::manager());
+        let mut csrs = CSRegisters::<F>::new();
 
         // check starting values
         assert_eq!(0, csrs.read::<CSRRepr>(CSRegister::fcsr));

--- a/src/riscv/lib/src/machine_state/hart_state.rs
+++ b/src/riscv/lib/src/machine_state/hart_state.rs
@@ -80,16 +80,16 @@ impl<M: backend::ManagerBase> HartState<M> {
 }
 
 impl<M: backend::ManagerBase> NewState<M> for HartState<M> {
-    fn new(manager: &mut M) -> Self
+    fn new() -> Self
     where
         M: backend::ManagerAlloc,
     {
         Self {
-            xregisters: registers::XRegisters::new(manager),
-            fregisters: registers::FRegisters::new(manager),
-            csregisters: csregisters::CSRegisters::new(manager),
-            pc: Cell::new(manager),
-            reservation_set: ReservationSet::new(manager),
+            xregisters: registers::XRegisters::new(),
+            fregisters: registers::FRegisters::new(),
+            csregisters: csregisters::CSRegisters::new(),
+            pc: Cell::new(),
+            reservation_set: ReservationSet::new(),
         }
     }
 }

--- a/src/riscv/lib/src/machine_state/memory/buddy.rs
+++ b/src/riscv/lib/src/machine_state/memory/buddy.rs
@@ -122,8 +122,7 @@ mod tests {
     backend_test!(buddy_alloc_only, F, {
         type BuddyHeapLayout = BuddyLayoutProxy<{ 1024 * 1024 }>;
 
-        let mut manager = F::manager();
-        let mut state = <BuddyHeapLayout as BuddyLayout>::Buddy::new(&mut manager);
+        let mut state = <BuddyHeapLayout as BuddyLayout>::Buddy::<F>::new();
 
         let total_pages = state.longest_free_sequence();
 
@@ -147,8 +146,7 @@ mod tests {
     backend_test!(buddy_alloc_dealloc, F, {
         type BuddyHeapLayout = BuddyLayoutProxy<{ 1024 * 1024 }>;
 
-        let mut manager = F::manager();
-        let mut state = <BuddyHeapLayout as BuddyLayout>::Buddy::new(&mut manager);
+        let mut state = <BuddyHeapLayout as BuddyLayout>::Buddy::<F>::new();
 
         let total_pages = state.longest_free_sequence();
 
@@ -182,8 +180,7 @@ mod tests {
     backend_test!(buddy_alloc_fixed, F, {
         type BuddyHeapLayout = BuddyLayoutProxy<{ 1024 * 1024 }>;
 
-        let mut manager = F::manager();
-        let mut state = <BuddyHeapLayout as BuddyLayout>::Buddy::new(&mut manager);
+        let mut state = <BuddyHeapLayout as BuddyLayout>::Buddy::<F>::new();
 
         // Create a distribution of allocation sizes that when used together would allocate all
         // available memory

--- a/src/riscv/lib/src/machine_state/memory/buddy/branch.rs
+++ b/src/riscv/lib/src/machine_state/memory/buddy/branch.rs
@@ -109,12 +109,12 @@ where
     B: Buddy<M>,
     M: ManagerBase,
 {
-    fn new(manager: &mut M) -> Self
+    fn new() -> Self
     where
         M: ManagerAlloc,
     {
         Self {
-            free_info: Cell::new_with(manager, FreeInfo {
+            free_info: Cell::new_with(FreeInfo {
                 left_longest_free_sequence: B::PAGES,
                 left_free_start: B::PAGES,
                 left_free_end: B::PAGES,
@@ -122,8 +122,8 @@ where
                 right_free_start: B::PAGES,
                 right_free_end: B::PAGES,
             }),
-            left: Box::new(B::new(manager)),
-            right: Box::new(B::new(manager)),
+            left: Box::new(B::new()),
+            right: Box::new(B::new()),
         }
     }
 }

--- a/src/riscv/lib/src/machine_state/memory/buddy/branch_combinations.rs
+++ b/src/riscv/lib/src/machine_state/memory/buddy/branch_combinations.rs
@@ -188,11 +188,11 @@ macro_rules! combined_buddy_branch {
             B: Buddy<M>,
             M: ManagerBase,
         {
-            fn new(manager: &mut M) -> Self
+            fn new() -> Self
             where
                 M: ManagerAlloc,
             {
-                Self(NewState::new(manager))
+                Self(NewState::new())
             }
         }
 

--- a/src/riscv/lib/src/machine_state/memory/buddy/leaf.rs
+++ b/src/riscv/lib/src/machine_state/memory/buddy/leaf.rs
@@ -95,13 +95,11 @@ pub struct BuddyLeaf<const PAGES: u64, M: ManagerBase> {
 }
 
 impl<const PAGES: u64, M: ManagerBase> NewState<M> for BuddyLeaf<PAGES, M> {
-    fn new(manager: &mut M) -> Self
+    fn new() -> Self
     where
         M: ManagerAlloc,
     {
-        Self {
-            set: Cell::new(manager),
-        }
+        Self { set: Cell::new() }
     }
 }
 

--- a/src/riscv/lib/src/machine_state/memory/config.rs
+++ b/src/riscv/lib/src/machine_state/memory/config.rs
@@ -25,16 +25,16 @@ where
     B: NewState<M>,
     M: ManagerBase,
 {
-    fn new(manager: &mut M) -> Self
+    fn new() -> Self
     where
         M: ManagerAlloc,
     {
         MemoryImpl {
-            data: DynCells::new(manager),
-            readable_pages: PagePermissions::new(manager),
-            writable_pages: PagePermissions::new(manager),
-            executable_pages: PagePermissions::new(manager),
-            allocated_pages: B::new(manager),
+            data: DynCells::new(),
+            readable_pages: PagePermissions::new(),
+            writable_pages: PagePermissions::new(),
+            executable_pages: PagePermissions::new(),
+            allocated_pages: B::new(),
         }
     }
 }

--- a/src/riscv/lib/src/machine_state/memory/protection.rs
+++ b/src/riscv/lib/src/machine_state/memory/protection.rs
@@ -128,12 +128,12 @@ impl<const PAGES: usize, M: ManagerBase> PagePermissions<PAGES, M> {
 }
 
 impl<const PAGES: usize, M: ManagerBase> NewState<M> for PagePermissions<PAGES, M> {
-    fn new(manager: &mut M) -> Self
+    fn new() -> Self
     where
         M: ManagerAlloc,
     {
         PagePermissions {
-            pages: boxed_from_fn(|| Cell::new(manager)),
+            pages: boxed_from_fn(|| Cell::new()),
         }
     }
 }

--- a/src/riscv/lib/src/machine_state/memory/state.rs
+++ b/src/riscv/lib/src/machine_state/memory/state.rs
@@ -379,8 +379,7 @@ pub mod tests {
         use crate::machine_state::memory::PAGE_SIZE;
         use crate::machine_state::memory::Permissions;
 
-        let mut manager = F::manager();
-        let mut memory = <<M4K as MemoryConfig>::State<_>>::new(&mut manager);
+        let mut memory = <<M4K as MemoryConfig>::State<F>>::new();
 
         // Write a pattern to ensure memory contains non-zero values
         for i in 0..PAGE_SIZE.get() {
@@ -409,8 +408,7 @@ pub mod tests {
     });
 
     backend_test!(test_endianess, F, {
-        let mut manager = F::manager();
-        let mut memory = <<M4K as MemoryConfig>::State<_>>::new(&mut manager);
+        let mut memory = <<M4K as MemoryConfig>::State<F>>::new();
 
         memory
             .write_instruction_unchecked(0, 0x1122334455667788u64)

--- a/src/riscv/lib/src/machine_state/registers.rs
+++ b/src/riscv/lib/src/machine_state/registers.rs
@@ -283,12 +283,12 @@ impl XRegisters<Owned> {
 }
 
 impl<M: backend::ManagerBase> NewState<M> for XRegisters<M> {
-    fn new(manager: &mut M) -> Self
+    fn new() -> Self
     where
         M: backend::ManagerAlloc,
     {
         XRegisters {
-            registers: backend::Cells::new(manager),
+            registers: backend::Cells::new(),
         }
     }
 }
@@ -607,16 +607,6 @@ pub struct FRegisters<M: backend::ManagerBase> {
 }
 
 impl<M: backend::ManagerBase> FRegisters<M> {
-    /// Allocate a new floating-point registers state.
-    pub fn new(manager: &mut M) -> Self
-    where
-        M: backend::ManagerAlloc,
-    {
-        Self {
-            registers: backend::Cells::new(manager),
-        }
-    }
-
     /// Bind the floating-point register space to the allocated space.
     pub fn bind(space: backend::AllocatedOf<FRegistersLayout, M>) -> Self {
         FRegisters { registers: space }
@@ -659,6 +649,17 @@ impl<M: backend::ManagerBase> FRegisters<M> {
     }
 }
 
+impl<M: backend::ManagerBase> NewState<M> for FRegisters<M> {
+    fn new() -> Self
+    where
+        M: backend::ManagerAlloc,
+    {
+        Self {
+            registers: backend::Cells::new(),
+        }
+    }
+}
+
 impl<M: backend::ManagerClone> Clone for FRegisters<M> {
     fn clone(&self) -> Self {
         Self {
@@ -677,7 +678,7 @@ mod tests {
     use crate::state_backend::ManagerRead;
 
     backend_test!(test_zero, F, {
-        let mut registers = XRegisters::new(&mut F::manager());
+        let mut registers = XRegisters::<F>::new();
 
         // x0 should always read 0.
         assert_eq!(registers.read(x0), 0);
@@ -693,7 +694,7 @@ mod tests {
     ];
 
     backend_test!(test_arbitrary_register, F, {
-        let mut registers = XRegisters::new(&mut F::manager());
+        let mut registers = XRegisters::<F>::new();
 
         // Initialise the registers with something.
         for reg in NONZERO_REGISTERS {
@@ -719,7 +720,7 @@ mod tests {
     });
 
     backend_test!(test_try_read_u32, F, {
-        let mut registers = XRegisters::new(&mut F::manager());
+        let mut registers = XRegisters::<F>::new();
 
         // Reading an integer that is too large should fail
         registers.write(x1, 1 << 32);
@@ -777,7 +778,7 @@ mod tests {
 
     #[test]
     fn test_xregister_offsets() {
-        let registers = XRegisters::new(&mut Owned);
+        let registers = XRegisters::<Owned>::new();
         let registers_ptr = (&registers) as *const XRegisters<Owned>;
 
         for reg in NonZeroXRegister::iter() {

--- a/src/riscv/lib/src/machine_state/reservation_set.rs
+++ b/src/riscv/lib/src/machine_state/reservation_set.rs
@@ -106,12 +106,12 @@ impl<M: backend::ManagerBase> ReservationSet<M> {
 }
 
 impl<M: backend::ManagerBase> NewState<M> for ReservationSet<M> {
-    fn new(manager: &mut M) -> Self
+    fn new() -> Self
     where
         M: backend::ManagerAlloc,
     {
         ReservationSet {
-            start_addr: Cell::new(manager),
+            start_addr: Cell::new(),
         }
     }
 }

--- a/src/riscv/lib/src/pvm/linux.rs
+++ b/src/riscv/lib/src/pvm/linux.rs
@@ -468,17 +468,17 @@ pub struct SupervisorState<M: ManagerBase> {
 
 impl<M: ManagerBase> SupervisorState<M> {
     /// Allocate a new supervisor state.
-    pub fn new(manager: &mut M) -> Self
+    pub fn new() -> Self
     where
         M: ManagerAlloc,
     {
         SupervisorState {
-            tid_address: Cell::new(manager),
+            tid_address: Cell::new(),
             exited: false,
             exit_code: 0,
-            program: Cell::new(manager),
-            heap: Cell::new(manager),
-            stack_guard: Cell::new(manager),
+            program: Cell::new(),
+            heap: Cell::new(),
+            stack_guard: Cell::new(),
         }
     }
 
@@ -1170,13 +1170,11 @@ mod tests {
         type MemLayout = M4K;
         const MEM_BYTES: usize = MemLayout::TOTAL_BYTES;
 
-        let mut manager = F::manager();
         let mut machine_state =
-            MachineState::<MemLayout, DefaultCacheConfig, Interpreted<MemLayout, _>, _>::new(
-                &mut manager,
+            MachineState::<MemLayout, DefaultCacheConfig, Interpreted<MemLayout, F>, F>::new(
                 InterpretedBlockBuilder,
             );
-        let mut supervisor_state = SupervisorState::new(&mut manager);
+        let mut supervisor_state = SupervisorState::<F>::new();
 
         machine_state
             .core
@@ -1205,10 +1203,8 @@ mod tests {
     backend_test!(ppoll_init_fds, F, {
         type MemLayout = M4K;
 
-        let mut manager = F::manager();
         let mut machine_state =
-            MachineState::<MemLayout, DefaultCacheConfig, Interpreted<MemLayout, _>, _>::new(
-                &mut manager,
+            MachineState::<MemLayout, DefaultCacheConfig, Interpreted<MemLayout, F>, F>::new(
                 InterpretedBlockBuilder,
             );
         machine_state.reset();
@@ -1221,7 +1217,7 @@ mod tests {
             .unwrap();
 
         for fd in [0i32, 1, 2] {
-            let mut supervisor_state = SupervisorState::new(&mut manager);
+            let mut supervisor_state = SupervisorState::<F>::new();
 
             let base_address = 0x10;
             machine_state
@@ -1277,10 +1273,8 @@ mod tests {
     backend_test!(rt_sigaction_no_handler, F, {
         type MemLayout = M4K;
 
-        let mut manager = F::manager();
         let mut machine_state =
-            MachineState::<MemLayout, DefaultCacheConfig, Interpreted<MemLayout, _>, _>::new(
-                &mut manager,
+            MachineState::<MemLayout, DefaultCacheConfig, Interpreted<MemLayout, F>, F>::new(
                 InterpretedBlockBuilder,
             );
         machine_state.reset();
@@ -1292,7 +1286,7 @@ mod tests {
             .protect_pages(0, MemLayout::TOTAL_BYTES, Permissions::READ_WRITE)
             .unwrap();
 
-        let mut supervisor_state = SupervisorState::new(&mut manager);
+        let mut supervisor_state = SupervisorState::<F>::new();
 
         // System call number
         machine_state
@@ -1351,13 +1345,11 @@ mod tests {
     backend_test!(sigaltstack_zero_parameter, F, {
         type MemLayout = M4K;
 
-        let mut manager = F::manager();
         let mut machine_state =
-            MachineState::<MemLayout, DefaultCacheConfig, Interpreted<MemLayout, _>, _>::new(
-                &mut manager,
+            MachineState::<MemLayout, DefaultCacheConfig, Interpreted<MemLayout, F>, F>::new(
                 InterpretedBlockBuilder,
             );
-        let mut supervisor_state = SupervisorState::new(&mut manager);
+        let mut supervisor_state = SupervisorState::<F>::new();
 
         // System call number
         machine_state
@@ -1386,13 +1378,11 @@ mod tests {
     backend_test!(sched_getaffinity_set_sizes, F, {
         type MemLayout = M4K;
 
-        let mut manager = F::manager();
         let mut machine_state =
-            MachineState::<MemLayout, DefaultCacheConfig, Interpreted<MemLayout, _>, _>::new(
-                &mut manager,
+            MachineState::<MemLayout, DefaultCacheConfig, Interpreted<MemLayout, F>, F>::new(
                 InterpretedBlockBuilder,
             );
-        let mut supervisor_state = SupervisorState::new(&mut manager);
+        let mut supervisor_state = SupervisorState::<F>::new();
 
         // Make sure everything is readable and writable. Otherwise, we'd get access faults.
         machine_state
@@ -1473,13 +1463,11 @@ mod tests {
     backend_test!(sched_getaffinity_zero_set_size, F, {
         type MemLayout = M4K;
 
-        let mut manager = F::manager();
         let mut machine_state =
-            MachineState::<MemLayout, DefaultCacheConfig, Interpreted<MemLayout, _>, _>::new(
-                &mut manager,
+            MachineState::<MemLayout, DefaultCacheConfig, Interpreted<MemLayout, F>, F>::new(
                 InterpretedBlockBuilder,
             );
-        let mut supervisor_state = SupervisorState::new(&mut manager);
+        let mut supervisor_state = SupervisorState::new();
 
         // Mask pointer (must be non-zero)
         let mask_address = VirtAddr::new(0x100);
@@ -1527,13 +1515,11 @@ mod tests {
     backend_test!(sched_getaffinity_unreasonable_set_size, F, {
         type MemLayout = M4K;
 
-        let mut manager = F::manager();
         let mut machine_state =
-            MachineState::<MemLayout, DefaultCacheConfig, Interpreted<MemLayout, _>, _>::new(
-                &mut manager,
+            MachineState::<MemLayout, DefaultCacheConfig, Interpreted<MemLayout, F>, F>::new(
                 InterpretedBlockBuilder,
             );
-        let mut supervisor_state = SupervisorState::new(&mut manager);
+        let mut supervisor_state = SupervisorState::new();
 
         // Mask pointer (must be non-zero)
         let mask_address = VirtAddr::new(0x100);
@@ -1599,13 +1585,11 @@ mod tests {
     backend_test!(rt_sigaction_zero_parameter, F, {
         type MemLayout = M4K;
 
-        let mut manager = F::manager();
         let mut machine_state =
-            MachineState::<MemLayout, DefaultCacheConfig, Interpreted<MemLayout, _>, _>::new(
-                &mut manager,
+            MachineState::<MemLayout, DefaultCacheConfig, Interpreted<MemLayout, F>, F>::new(
                 InterpretedBlockBuilder,
             );
-        let mut supervisor_state = SupervisorState::new(&mut manager);
+        let mut supervisor_state = SupervisorState::new();
 
         // System call number
         machine_state
@@ -1653,13 +1637,11 @@ mod tests {
     backend_test!(rt_sigprocmask_zero_parameter, F, {
         type MemLayout = M4K;
 
-        let mut manager = F::manager();
         let mut machine_state =
-            MachineState::<MemLayout, DefaultCacheConfig, Interpreted<MemLayout, _>, _>::new(
-                &mut manager,
+            MachineState::<MemLayout, DefaultCacheConfig, Interpreted<MemLayout, F>, F>::new(
                 InterpretedBlockBuilder,
             );
-        let mut supervisor_state = SupervisorState::new(&mut manager);
+        let mut supervisor_state = SupervisorState::new();
 
         // System call number
         machine_state
@@ -1707,10 +1689,8 @@ mod tests {
     backend_test!(clock_gettime_fills_with_zeros, F, {
         type MemLayout = M4K;
 
-        let mut manager = F::manager();
         let mut machine_state =
-            MachineState::<MemLayout, DefaultCacheConfig, Interpreted<MemLayout, _>, _>::new(
-                &mut manager,
+            MachineState::<MemLayout, DefaultCacheConfig, Interpreted<MemLayout, F>, F>::new(
                 InterpretedBlockBuilder,
             );
         machine_state.reset();
@@ -1722,7 +1702,7 @@ mod tests {
             .protect_pages(0, MemLayout::TOTAL_BYTES, Permissions::READ_WRITE)
             .unwrap();
 
-        let mut supervisor_state = SupervisorState::new(&mut manager);
+        let mut supervisor_state = SupervisorState::new();
 
         // System call number
         machine_state
@@ -1779,10 +1759,8 @@ mod tests {
     backend_test!(gettimeofday_fills_with_zeros, F, {
         type MemLayout = M4K;
 
-        let mut manager = F::manager();
         let mut machine_state =
-            MachineState::<MemLayout, DefaultCacheConfig, Interpreted<MemLayout, _>, _>::new(
-                &mut manager,
+            MachineState::<MemLayout, DefaultCacheConfig, Interpreted<MemLayout, F>, F>::new(
                 InterpretedBlockBuilder,
             );
         machine_state.reset();
@@ -1794,7 +1772,7 @@ mod tests {
             .protect_pages(0, MemLayout::TOTAL_BYTES, Permissions::READ_WRITE)
             .unwrap();
 
-        let mut supervisor_state = SupervisorState::new(&mut manager);
+        let mut supervisor_state = SupervisorState::new();
 
         // System call number
         machine_state
@@ -1868,10 +1846,8 @@ mod tests {
     backend_test!(mmap_returns_enomem_when_allocation_fails, F, {
         type MemLayout = M4K;
 
-        let mut manager = F::manager();
         let mut machine_state =
-            MachineState::<MemLayout, DefaultCacheConfig, Interpreted<MemLayout, _>, _>::new(
-                &mut manager,
+            MachineState::<MemLayout, DefaultCacheConfig, Interpreted<MemLayout, F>, F>::new(
                 InterpretedBlockBuilder,
             );
         machine_state.reset();
@@ -1888,7 +1864,7 @@ mod tests {
             )
             .unwrap();
 
-        let mut supervisor_state = SupervisorState::new(&mut manager);
+        let mut supervisor_state = SupervisorState::new();
 
         // Set up necessary registers for mmap
         machine_state

--- a/src/riscv/lib/src/pvm/node_pvm.rs
+++ b/src/riscv/lib/src/pvm/node_pvm.rs
@@ -165,7 +165,7 @@ impl<M: state_backend::ManagerBase> NodePvm<M> {
 impl NodePvm {
     /// Construct an empty PVM state.
     pub fn empty() -> Self {
-        Self::new(&mut Owned)
+        Self::new()
     }
 
     /// Compute the root hash of the PVM state.
@@ -261,12 +261,12 @@ impl PartialEq for NodePvm {
 impl Eq for NodePvm {}
 
 impl<M: state_backend::ManagerBase> NewState<M> for NodePvm<M> {
-    fn new(manager: &mut M) -> Self
+    fn new() -> Self
     where
         M: state_backend::ManagerAlloc,
     {
         Self {
-            state: Box::new(NodePvmState::<M>::new(manager, InterpretedBlockBuilder)),
+            state: Box::new(NodePvmState::<M>::new(InterpretedBlockBuilder)),
         }
     }
 }

--- a/src/riscv/lib/src/pvm/reveals.rs
+++ b/src/riscv/lib/src/pvm/reveals.rs
@@ -60,13 +60,13 @@ impl<M: ManagerBase> RevealRequest<M> {
 }
 
 impl<M: ManagerBase> NewState<M> for RevealRequest<M> {
-    fn new(manager: &mut M) -> Self
+    fn new() -> Self
     where
         M: ManagerAlloc,
     {
         Self {
-            bytes: DynCells::new(manager),
-            size: Cell::new(manager),
+            bytes: DynCells::new(),
+            size: Cell::new(),
         }
     }
 }

--- a/src/riscv/lib/src/state.rs
+++ b/src/riscv/lib/src/state.rs
@@ -11,17 +11,17 @@ use crate::state_backend::ManagerBase;
 /// Methods for creating a new state without additional information
 pub trait NewState<M: ManagerBase> {
     /// Create a new state.
-    fn new(manager: &mut M) -> Self
+    fn new() -> Self
     where
         M: ManagerAlloc;
 }
 
 impl<T: NewState<M>, const LEN: usize, M: ManagerBase> NewState<M> for [T; LEN] {
-    fn new(manager: &mut M) -> Self
+    fn new() -> Self
     where
         M: ManagerAlloc,
     {
-        array::from_fn(|_| T::new(manager))
+        array::from_fn(|_| T::new())
     }
 }
 
@@ -36,10 +36,10 @@ impl<T: NewState<M>, const LEN: usize, M: ManagerBase> NewState<M> for [T; LEN] 
 // This comes with a small trade-off, we loose out on the `Box<_>` implementation of `NewState`.
 // However, this is not a problem since we can always use `Box::new` independently.
 impl<T: NewState<M>, const LEN: usize, M: ManagerBase> NewState<M> for Box<[T; LEN]> {
-    fn new(manager: &mut M) -> Self
+    fn new() -> Self
     where
         M: ManagerAlloc,
     {
-        boxed_from_fn(|| T::new(manager))
+        boxed_from_fn(|| T::new())
     }
 }

--- a/src/riscv/lib/src/state_backend.rs
+++ b/src/riscv/lib/src/state_backend.rs
@@ -156,13 +156,10 @@ pub trait ManagerBase: Sized {
 /// since the manager creates the values on the first allocation.
 pub trait ManagerAlloc: 'static + ManagerReadWrite {
     /// Allocate a region in the state storage.
-    fn allocate_region<E, const LEN: usize>(
-        &mut self,
-        init_value: [E; LEN],
-    ) -> Self::Region<E, LEN>;
+    fn allocate_region<E, const LEN: usize>(init_value: [E; LEN]) -> Self::Region<E, LEN>;
 
     /// Allocate a dynamic region in the state storage.
-    fn allocate_dyn_region<const LEN: usize>(&mut self) -> Self::DynRegion<LEN>;
+    fn allocate_dyn_region<const LEN: usize>() -> Self::DynRegion<LEN>;
 }
 
 /// Manager with read capabilities

--- a/src/riscv/lib/src/state_backend.rs
+++ b/src/riscv/lib/src/state_backend.rs
@@ -404,6 +404,8 @@ pub type RefVerifierAlloc<'a, L> = AllocatedOf<L, Ref<'a, verify_backend::Verifi
 
 #[cfg(test)]
 pub(crate) mod test_helpers {
+    use trait_set::trait_set;
+
     use super::AllocatedOf;
     use super::Layout;
     use super::ManagerAlloc;
@@ -424,23 +426,21 @@ pub(crate) mod test_helpers {
                     $expr
                 }
 
-                inner::<$crate::state_backend::owned_backend::test_helpers::OwnedTestBackendFactory>();
+                inner::<$crate::state_backend::owned_backend::Owned>();
             }
         };
     }
 
-    /// This lets you construct backends for any layout.
-    pub trait TestBackendFactory {
-        /// Manager used in testing
-        type Manager: ManagerReadWrite
-            + ManagerSerialise
-            + ManagerDeserialise
-            + ManagerClone
-            + ManagerAlloc
-            + JitStateAccess;
-
-        /// Construct a manager.
-        fn manager() -> Self::Manager;
+    trait_set! {
+        /// This lets you construct backends for any layout.
+        ///
+        /// Used for testing.
+        pub trait TestBackendFactory = ManagerReadWrite
+        + ManagerSerialise
+        + ManagerDeserialise
+        + ManagerClone
+        + ManagerAlloc
+        + JitStateAccess;
     }
 
     /// Copy the allocated space by serialising and deserialising it.
@@ -494,10 +494,9 @@ mod tests {
         let first_value: u64 = rand::random();
         let second_value: [u32; 4] = rand::random();
 
-        let mut manager = F::manager();
-        let mut instance = Example {
-            first: Cell::new(&mut manager),
-            second: Cells::new(&mut manager),
+        let mut instance: Example<F> = Example {
+            first: Cell::new(),
+            second: Cells::new(),
         };
 
         instance.first.write(first_value);

--- a/src/riscv/lib/src/state_backend/effects.rs
+++ b/src/riscv/lib/src/state_backend/effects.rs
@@ -81,12 +81,12 @@ impl<T: Copy, EG: EffectGetter, M: ManagerBase> EffectCell<T, EG, M> {
 }
 
 impl<T: ConstDefault, EG, M: ManagerBase> NewState<M> for EffectCell<T, EG, M> {
-    fn new(manager: &mut M) -> Self
+    fn new() -> Self
     where
         M: ManagerAlloc,
     {
         Self {
-            inner: Cell::new(manager),
+            inner: Cell::new(),
             _pd: PhantomData,
         }
     }

--- a/src/riscv/lib/src/state_backend/layout.rs
+++ b/src/riscv/lib/src/state_backend/layout.rs
@@ -328,16 +328,13 @@ mod tests {
 
     // Test that the Atom layout initialises the underlying Cell correctly.
     backend_test!(test_cell_init, F, {
-        assert_eq!(
-            Cell::<MyFoo, _>::new(&mut F::manager()).read(),
-            MyFoo::DEFAULT
-        );
+        assert_eq!(Cell::<MyFoo, F>::new().read(), MyFoo::DEFAULT);
     });
 
     // Test that the Array layout initialises the underlying Cells correctly.
     backend_test!(test_cells_init, F, {
         assert_eq!(
-            Cells::<MyFoo, 1337, _>::new(&mut F::manager()).read_all(),
+            Cells::<MyFoo, 1337, F>::new().read_all(),
             [MyFoo::DEFAULT; 1337]
         );
     });
@@ -353,8 +350,8 @@ mod tests {
 
         fn inner(bar: u64, qux: [u8; 64]) {
             let mut foo = AllocatedOf::<Foo, Owned> {
-                bar: Cell::new(&mut Owned),
-                qux: Cells::new(&mut Owned),
+                bar: Cell::new(),
+                qux: Cells::new(),
             };
 
             foo.bar.write(bar);

--- a/src/riscv/lib/src/state_backend/owned_backend.rs
+++ b/src/riscv/lib/src/state_backend/owned_backend.rs
@@ -351,18 +351,6 @@ pub(crate) mod test_helpers {
     use crate::state_backend::proof_backend::ProofDynRegion;
     use crate::state_backend::proof_backend::ProofGen;
     use crate::state_backend::proof_backend::ProofRegion;
-    use crate::state_backend::test_helpers::TestBackendFactory;
-
-    /// Test backend factory for the owned state manager
-    pub struct OwnedTestBackendFactory;
-
-    impl TestBackendFactory for OwnedTestBackendFactory {
-        type Manager = Owned;
-
-        fn manager() -> Self::Manager {
-            Owned
-        }
-    }
 
     /// Ensure [`Cell`] can be serialised and deserialised in a consistent way.
     #[test]

--- a/src/riscv/lib/src/state_backend/owned_backend.rs
+++ b/src/riscv/lib/src/state_backend/owned_backend.rs
@@ -58,14 +58,11 @@ impl ManagerBase for Owned {
 }
 
 impl ManagerAlloc for Owned {
-    fn allocate_region<E: 'static, const LEN: usize>(
-        &mut self,
-        value: [E; LEN],
-    ) -> Self::Region<E, LEN> {
+    fn allocate_region<E: 'static, const LEN: usize>(value: [E; LEN]) -> Self::Region<E, LEN> {
         value
     }
 
-    fn allocate_dyn_region<const LEN: usize>(&mut self) -> Self::DynRegion<LEN> {
+    fn allocate_dyn_region<const LEN: usize>() -> Self::DynRegion<LEN> {
         unsafe {
             let layout = std::alloc::Layout::new::<[u8; LEN]>()
                 .align_to(4096)
@@ -533,7 +530,7 @@ pub(crate) mod test_helpers {
     #[test]
     fn region_init() {
         proptest::proptest!(|(init_value: [u64; 17])| {
-            let region = Owned.allocate_region(init_value);
+            let region = Owned::allocate_region(init_value);
             proptest::prop_assert_eq!(region, init_value);
         });
     }

--- a/src/riscv/lib/src/state_backend/region.rs
+++ b/src/riscv/lib/src/state_backend/region.rs
@@ -35,12 +35,12 @@ pub struct EnrichedCell<V: EnrichedValue, M: ManagerBase> {
 
 impl<V: EnrichedValue, M: ManagerBase> EnrichedCell<V, M> {
     /// Allocate a new enriched cell with the given value.
-    pub fn new_with(manager: &mut M, value: V::E) -> Self
+    pub fn new_with(_manager: &mut M, value: V::E) -> Self
     where
         M: ManagerAlloc,
         V: EnrichedValueLinked,
     {
-        let region = manager.allocate_region([value]);
+        let region = M::allocate_region([value]);
         let cell = M::enrich_cell(region);
         Self { cell }
     }
@@ -151,11 +151,11 @@ pub struct Cell<E: 'static, M: ManagerBase> {
 
 impl<E: 'static, M: ManagerBase> Cell<E, M> {
     /// Allocate a new cell with the given value.
-    pub fn new_with(manager: &mut M, value: E) -> Self
+    pub fn new_with(_manager: &mut M, value: E) -> Self
     where
         M: ManagerAlloc,
     {
-        let region = manager.allocate_region([value]);
+        let region = M::allocate_region([value]);
         Self {
             region: Cells::bind(region),
         }
@@ -295,11 +295,11 @@ pub struct Cells<E: 'static, const LEN: usize, M: ManagerBase> {
 
 impl<E: 'static, const LEN: usize, M: ManagerBase> Cells<E, LEN, M> {
     /// Allocate new cells with the given values.
-    pub fn new_with(manager: &mut M, values: [E; LEN]) -> Self
+    pub fn new_with(_manager: &mut M, values: [E; LEN]) -> Self
     where
         M: ManagerAlloc,
     {
-        let region = manager.allocate_region(values);
+        let region = M::allocate_region(values);
         Self { region }
     }
 
@@ -541,11 +541,11 @@ impl<const LEN: usize, M: ManagerBase> DynCells<LEN, M> {
 }
 
 impl<const LEN: usize, M: ManagerBase> NewState<M> for DynCells<LEN, M> {
-    fn new(manager: &mut M) -> Self
+    fn new(_manager: &mut M) -> Self
     where
         M: ManagerAlloc,
     {
-        let region = manager.allocate_dyn_region();
+        let region = M::allocate_dyn_region();
         Self { region }
     }
 }

--- a/src/riscv/lib/src/stepper/test.rs
+++ b/src/riscv/lib/src/stepper/test.rs
@@ -117,8 +117,8 @@ impl<MC: MemoryConfig, B: Block<MC, Owned>> TestStepper<MC, TestCacheConfig, B> 
         block_builder: B::BlockBuilder,
     ) -> Result<(Self, BTreeMap<u64, String>), TestStepperError> {
         let mut stepper = Self {
-            posix_state: PosixState::new(&mut Owned),
-            machine_state: MachineState::new(&mut Owned, block_builder),
+            posix_state: PosixState::<Owned>::new(),
+            machine_state: MachineState::new(block_builder),
         };
 
         // The interpreter needs a program to run.

--- a/src/riscv/lib/src/stepper/test/posix.rs
+++ b/src/riscv/lib/src/stepper/test/posix.rs
@@ -83,13 +83,13 @@ impl<M: ManagerBase> PosixState<M> {
 }
 
 impl<M: ManagerBase> NewState<M> for PosixState<M> {
-    fn new(manager: &mut M) -> Self
+    fn new() -> Self
     where
         M: ManagerAlloc,
     {
         PosixState {
-            code: Cell::new(manager),
-            exited: Cell::new(manager),
+            code: Cell::new(),
+            exited: Cell::new(),
         }
     }
 }


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

Part of RV-311

# What

<!--
    Summarise the changes in this MR.
-->

* Remove the `&mut self` argument for `ManagerAlloc` functions.
* Remove the `manager: &mut M` argument from `new()` methods of the PVM structures.



# Why

<!-- 
    Explain why this MR is needed.
-->


In order to have `ProofGen<Owned>` be able to allocate regions, `ManagerAlloc::allocate_region(&mut self)` would need to call the nested `Owned::allocate_region` which requires an instance of `&mut Owned`. However, turns out there is no `self` context needed when allocating regions since moving to self-owning regions (before we had the pointer arithmetic over a contiguous byte-array)

# How

<!--
    Explain how the MR achieves its goal. If this is trivial or if the code speaks for itself, you
    can omit this.
-->

Eliminate the actually unused `manager` arguments in the `ManagerAlloc::allocate_regions / ManagerAlloc::allocate_dyn_region` & `new()` methods from the PVM structure hierarchy.

# Manually Testing

```
make -C src/riscv all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
