### PR TITLE
Use `mmap` to allocate dynamic regions

### DIFF
--- a/src/riscv/Cargo.lock
+++ b/src/riscv/Cargo.lock
@@ -1274,6 +1274,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
+name = "memmap2"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1396,6 +1405,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "libsecp256k1",
+ "memmap2",
  "num_enum",
  "paste",
  "proptest",

--- a/src/riscv/Cargo.toml
+++ b/src/riscv/Cargo.toml
@@ -52,6 +52,7 @@ goldenfile = "1.8.0"
 arbitrary-int = "1.3.0"
 range-collections = "0.4.5"
 capstone = "0.13"
+memmap2 = "0.9.5"
 
 [workspace.dependencies.tezos-smart-rollup-constants]
 git = "https://gitlab.com/tezos/tezos.git"

--- a/src/riscv/lib/Cargo.toml
+++ b/src/riscv/lib/Cargo.toml
@@ -39,6 +39,7 @@ itertools.workspace = true
 range-collections.workspace = true
 elf.workspace = true
 trait-set.workspace = true
+memmap2.workspace = true
 
 [dependencies.__tracing_do_not_use_directly]
 workspace = true


### PR DESCRIPTION
Closes RV-710

# What

Replaces the boxed array, which previously backed dynamic regions, with an `mmap`-ing. The `MmapMut` is effectively a handle to an `mmapped` area of virtual memory.

# Why

`mmap` lazily instantiates the physical memory that would back our virtual memory (and virtual-virtual memory ;)).
This helps us save on memory which we don't use, as well as start-up costs for our Sandbox.

The benefits of this for our Rollup Node PVM are likely minimal, as it gets copied, which will likely instantiate all pages. There are things we can do to avoid that as well, but we'll do them when we get to those problems.

# Manually Testing

```
make -C src/riscv all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
