### PR TITLE
Improve how values are accessed in dynamic regions

### DIFF
--- a/src/riscv/lib/src/interpreter/common_memory.rs
+++ b/src/riscv/lib/src/interpreter/common_memory.rs
@@ -16,7 +16,7 @@ where
     MC: memory::MemoryConfig,
     M: backend::ManagerReadWrite,
 {
-    /// Generic read function for loading `mem::size_of<T>` bytes from `address`
+    /// Generic read function for loading `T::STORED_SIZE` bytes from `address`
     pub(super) fn read_from_address<T: backend::Elem>(
         &mut self,
         address: u64,
@@ -26,7 +26,7 @@ where
             .map_err(|_: BadMemoryAccess| Exception::LoadAccessFault(address))
     }
 
-    /// Generic read function for loading `mem::size_of<T>` bytes from address val(rs1) + imm
+    /// Generic read function for loading `T::STORED_SIZE` bytes from address val(rs1) + imm
     pub(super) fn read_from_bus<T: backend::Elem>(
         &mut self,
         imm: i64,
@@ -36,7 +36,7 @@ where
         self.read_from_address(address)
     }
 
-    /// Generic store-operation for writing `mem::size_of<T>` bytes starting at `address`
+    /// Generic store-operation for writing `T::STORED_SIZE` bytes starting at `address`
     pub(super) fn write_to_address<T: backend::Elem>(
         &mut self,
         address: u64,
@@ -47,7 +47,7 @@ where
             .map_err(|_: BadMemoryAccess| Exception::StoreAMOAccessFault(address))
     }
 
-    /// Generic store operation for writing `mem::size_of<T>` bytes starting at address val(rs1) + imm
+    /// Generic store operation for writing `T::STORED_SIZE` bytes starting at address val(rs1) + imm
     pub(super) fn write_to_bus<T: backend::Elem>(
         &mut self,
         imm: i64,

--- a/src/riscv/lib/src/machine_state/memory.rs
+++ b/src/riscv/lib/src/machine_state/memory.rs
@@ -220,7 +220,7 @@ pub trait Memory<M: ManagerBase>: NewState<M> + Sized {
     /// Update multiple elements in the region. `address` is in bytes.
     fn write_all<E>(&mut self, address: Address, values: &[E]) -> Result<(), BadMemoryAccess>
     where
-        E: Elem,
+        E: Elem + Copy,
         M: ManagerReadWrite;
 
     /// Clone all memory.

--- a/src/riscv/lib/src/state_backend.rs
+++ b/src/riscv/lib/src/state_backend.rs
@@ -227,7 +227,7 @@ pub trait ManagerWrite: ManagerBase<ManagerRoot = Self> {
     );
 
     /// Update multiple elements in the region. `address` is in bytes.
-    fn dyn_region_write_all<E: Elem, const LEN: usize>(
+    fn dyn_region_write_all<E: Elem + Copy, const LEN: usize>(
         region: &mut Self::DynRegion<LEN>,
         address: usize,
         values: &[E],


### PR DESCRIPTION
Closes RV-711

Closes RV-713

# What

This changes how values are accessed in dynamic regions to allow decoupling of the value's representation in the dynamic region from the Rust representation.

# Why

Relying on the Rust representation is not always safe.

For instance, in the case of floating-point numbers, we need to convert to and from an integer for the dynamic region representation to be happy. This allows us to keep the soft-float instance, but store the bit representation (`u64`) - thereby decoupling the representations in the Rust space and the dynamic region (see RV-712).

# Manually Testing

```
make -C src/riscv all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [ ] Add tests for bugs that have been fixed.
  - We currently don't have the infrastructure to test endian variants.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
