### PR TITLE
Run sandbox binary by default with `cargo run`

### DIFF
--- a/src/riscv/sandbox/Cargo.toml
+++ b/src/riscv/sandbox/Cargo.toml
@@ -2,6 +2,7 @@
 name = "riscv-sandbox"
 version = "0.0.0"
 edition = "2024"
+default-run = "riscv-sandbox"
 
 [[bin]]
 name = "riscv-sandbox"


### PR DESCRIPTION
# What

With the addition of the `analyse-jit-functions` binary, `cargo run` no longer runs the sandbox by default. This PR specifies a default via the `default-run` field, which seems to work across packages in the same workspace.

# Why

If we can pick a default, the sandbox will probably remain more used than the JIT function analyser. 

# Manually Testing

Check that `cargo run` picks the sandbox binary without an explicit `--bin`, for example:

```
cargo run -- run --input etherlink/target/riscv64gc-unknown-linux-musl/release/etherlink --address sr163Lv22CdE8QagCwf48PWDTquk6isQwv57 --inbox-file assets/etherlink-sample-inbox.json
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
