### PR TITLE
Make JIT exclusive to Owned backend

### DIFF
--- a/src/riscv/lib/src/jit/builder/arithmetic.rs
+++ b/src/riscv/lib/src/jit/builder/arithmetic.rs
@@ -12,50 +12,49 @@ use crate::instruction_context::Shift;
 use crate::instruction_context::arithmetic::Arithmetic;
 use crate::jit::builder::instruction::InstructionBuilder;
 use crate::machine_state::memory::MemoryConfig;
-use crate::state_backend::ManagerBase;
 
-impl<MC: MemoryConfig, M: ManagerBase> Arithmetic<InstructionBuilder<'_, '_, MC, M>> for X64 {
-    fn add(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+impl<MC: MemoryConfig> Arithmetic<InstructionBuilder<'_, '_, MC>> for X64 {
+    fn add(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         let res = builder.ins().iadd(self.0, other.0);
         X64(res)
     }
 
-    fn sub(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn sub(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         let res = builder.ins().isub(self.0, other.0);
         X64(res)
     }
 
-    fn and(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn and(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         let res = builder.ins().band(self.0, other.0);
         X64(res)
     }
 
-    fn or(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn or(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         let res = builder.ins().bor(self.0, other.0);
         X64(res)
     }
 
-    fn xor(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn xor(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         let res = builder.ins().bxor(self.0, other.0);
         X64(res)
     }
 
-    fn mul(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn mul(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         let res = builder.ins().imul(self.0, other.0);
         X64(res)
     }
 
-    fn div_unsigned(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn div_unsigned(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         let res = builder.ins().udiv(self.0, other.0);
         X64(res)
     }
 
-    fn div_signed(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn div_signed(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         let res = builder.ins().sdiv(self.0, other.0);
         X64(res)
     }
 
-    fn negate(self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn negate(self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         X64(builder.ins().ineg(self.0))
     }
 
@@ -63,7 +62,7 @@ impl<MC: MemoryConfig, M: ManagerBase> Arithmetic<InstructionBuilder<'_, '_, MC,
         self,
         shift: Shift,
         amount: Self,
-        builder: &mut InstructionBuilder<'_, '_, MC, M>,
+        builder: &mut InstructionBuilder<'_, '_, MC>,
     ) -> Self {
         match shift {
             Shift::Left => X64(builder.ins().ishl(self.0, amount.0)),
@@ -72,77 +71,73 @@ impl<MC: MemoryConfig, M: ManagerBase> Arithmetic<InstructionBuilder<'_, '_, MC,
         }
     }
 
-    fn modulus_unsigned(
-        self,
-        other: Self,
-        builder: &mut InstructionBuilder<'_, '_, MC, M>,
-    ) -> Self {
+    fn modulus_unsigned(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         X64(builder.ins().urem(self.0, other.0))
     }
 
-    fn modulus_signed(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn modulus_signed(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         X64(builder.ins().srem(self.0, other.0))
     }
 
-    fn min_signed(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn min_signed(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         X64(builder.ins().smin(self.0, other.0))
     }
 
-    fn min_unsigned(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn min_unsigned(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         X64(builder.ins().umin(self.0, other.0))
     }
 
-    fn max_signed(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn max_signed(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         X64(builder.ins().smax(self.0, other.0))
     }
 
-    fn max_unsigned(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn max_unsigned(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         X64(builder.ins().umax(self.0, other.0))
     }
 }
 
-impl<MC: MemoryConfig, M: ManagerBase> Arithmetic<InstructionBuilder<'_, '_, MC, M>> for X32 {
-    fn add(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+impl<MC: MemoryConfig> Arithmetic<InstructionBuilder<'_, '_, MC>> for X32 {
+    fn add(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         let res = builder.ins().iadd(self.0, other.0);
         X32(res)
     }
 
-    fn sub(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn sub(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         let res = builder.ins().isub(self.0, other.0);
         X32(res)
     }
 
-    fn and(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn and(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         let res = builder.ins().band(self.0, other.0);
         X32(res)
     }
 
-    fn or(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn or(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         let res = builder.ins().bor(self.0, other.0);
         X32(res)
     }
 
-    fn xor(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn xor(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         let res = builder.ins().bxor(self.0, other.0);
         X32(res)
     }
 
-    fn mul(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn mul(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         let res = builder.ins().imul(self.0, other.0);
         X32(res)
     }
 
-    fn div_unsigned(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn div_unsigned(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         let res = builder.ins().udiv(self.0, other.0);
         X32(res)
     }
 
-    fn div_signed(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn div_signed(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         let res = builder.ins().sdiv(self.0, other.0);
         X32(res)
     }
 
-    fn negate(self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn negate(self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         X32(builder.ins().ineg(self.0))
     }
 
@@ -150,7 +145,7 @@ impl<MC: MemoryConfig, M: ManagerBase> Arithmetic<InstructionBuilder<'_, '_, MC,
         self,
         shift: Shift,
         amount: Self,
-        builder: &mut InstructionBuilder<'_, '_, MC, M>,
+        builder: &mut InstructionBuilder<'_, '_, MC>,
     ) -> Self {
         match shift {
             Shift::Left => X32(builder.ins().ishl(self.0, amount.0)),
@@ -159,31 +154,27 @@ impl<MC: MemoryConfig, M: ManagerBase> Arithmetic<InstructionBuilder<'_, '_, MC,
         }
     }
 
-    fn modulus_unsigned(
-        self,
-        other: Self,
-        builder: &mut InstructionBuilder<'_, '_, MC, M>,
-    ) -> Self {
+    fn modulus_unsigned(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         X32(builder.ins().urem(self.0, other.0))
     }
 
-    fn modulus_signed(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn modulus_signed(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         X32(builder.ins().srem(self.0, other.0))
     }
 
-    fn min_signed(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn min_signed(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         X32(builder.ins().smin(self.0, other.0))
     }
 
-    fn min_unsigned(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn min_unsigned(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         X32(builder.ins().umin(self.0, other.0))
     }
 
-    fn max_signed(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn max_signed(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         X32(builder.ins().smax(self.0, other.0))
     }
 
-    fn max_unsigned(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC, M>) -> Self {
+    fn max_unsigned(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
         X32(builder.ins().umax(self.0, other.0))
     }
 }

--- a/src/riscv/lib/src/jit/builder/comparable.rs
+++ b/src/riscv/lib/src/jit/builder/comparable.rs
@@ -13,9 +13,8 @@ use crate::jit::builder::X32;
 use crate::jit::builder::X64;
 use crate::jit::builder::instruction::InstructionBuilder;
 use crate::machine_state::memory::MemoryConfig;
-use crate::state_backend::ManagerBase;
 
-impl<MC: MemoryConfig, M: ManagerBase> Comparable<InstructionBuilder<'_, '_, MC, M>> for X64 {
+impl<MC: MemoryConfig> Comparable<InstructionBuilder<'_, '_, MC>> for X64 {
     type Result = Value;
 
     // icmp returns 1 if the condition holds, 0 if it does not.
@@ -30,13 +29,13 @@ impl<MC: MemoryConfig, M: ManagerBase> Comparable<InstructionBuilder<'_, '_, MC,
         self,
         other: Self,
         comparison: Predicate,
-        builder: &mut InstructionBuilder<'_, '_, MC, M>,
+        builder: &mut InstructionBuilder<'_, '_, MC>,
     ) -> Value {
         builder.ins().icmp(comparison, self.0, other.0)
     }
 }
 
-impl<MC: MemoryConfig, M: ManagerBase> Comparable<InstructionBuilder<'_, '_, MC, M>> for X32 {
+impl<MC: MemoryConfig> Comparable<InstructionBuilder<'_, '_, MC>> for X32 {
     type Result = Value;
 
     // icmp returns 1 if the condition holds, 0 if it does not.
@@ -51,7 +50,7 @@ impl<MC: MemoryConfig, M: ManagerBase> Comparable<InstructionBuilder<'_, '_, MC,
         self,
         other: Self,
         comparison: Predicate,
-        builder: &mut InstructionBuilder<'_, '_, MC, M>,
+        builder: &mut InstructionBuilder<'_, '_, MC>,
     ) -> Value {
         builder.ins().icmp(comparison, self.0, other.0)
     }

--- a/src/riscv/lib/src/jit/state_access/stack.rs
+++ b/src/riscv/lib/src/jit/state_access/stack.rs
@@ -10,21 +10,18 @@
 //! See for example [`handle_exception`]:
 //!
 //! ```ignore
-//! use crate::state_backend::ManagerBase;
 //! use crate::machine_state::MachineCoreState;
 //! use crate::machine_state::memory::Address;
 //! use crate::machine_state::memory::MemoryConfig;
 //! use crate::traps::EnvironException;
 //! use crate::traps::Exception;
 //!
-//! trait JitStateAccess: ManagerBase {
-//!     extern "C" fn handle_exception<MC: MemoryConfig>(
-//!         core: &mut MachineCoreState<MC, Self>,
-//!         current_pc: &mut Address,
-//!         exception: &Option<Exception>,
-//!         result: &mut Result<(), EnvironException>,
-//!     ) -> bool;
-//! }
+//! extern "C" fn handle_exception<MC: MemoryConfig>(
+//!     core: &mut MachineCoreState<MC, Owned>,
+//!     current_pc: &mut Address,
+//!     exception: &Option<Exception>,
+//!     result: &mut Result<(), EnvironException>,
+//! ) -> bool;
 //! ```
 //!
 //! The boolean return indicates whether the function has failed. If it has, then an exception will

--- a/src/riscv/lib/src/state_backend.rs
+++ b/src/riscv/lib/src/state_backend.rs
@@ -413,7 +413,6 @@ pub(crate) mod test_helpers {
     use super::ManagerDeserialise;
     use super::ManagerReadWrite;
     use super::ManagerSerialise;
-    use crate::jit::state_access::JitStateAccess;
 
     /// Generate a test against all test backends.
     #[macro_export]
@@ -436,11 +435,10 @@ pub(crate) mod test_helpers {
         ///
         /// Used for testing.
         pub trait TestBackendFactory = ManagerReadWrite
-        + ManagerSerialise
-        + ManagerDeserialise
-        + ManagerClone
-        + ManagerAlloc
-        + JitStateAccess;
+            + ManagerSerialise
+            + ManagerDeserialise
+            + ManagerClone
+            + ManagerAlloc;
     }
 
     /// Copy the allocated space by serialising and deserialising it.

--- a/src/riscv/lib/src/stepper/test/interpreter.rs
+++ b/src/riscv/lib/src/stepper/test/interpreter.rs
@@ -92,7 +92,7 @@ fn interpret_test_with_check(path: &str, check_xregs: &[(XRegister, u64)]) {
 /// For the JIT, we run it twice - the first run to build up the blocks, and the
 /// second to run with these blocks already compiled (so that we actually use them).
 fn inline_jit_test_with_check(path: &str, check_xregs: &[(XRegister, u64)]) {
-    type BlockImpl = Jitted<InlineCompiler<M1M, Owned>, M1M, Owned>;
+    type BlockImpl = Jitted<InlineCompiler<M1M>, M1M>;
 
     let block_builder = Default::default();
     let block_builder = run_test_with_check::<BlockImpl>(path, check_xregs, block_builder);

--- a/src/riscv/lib/tests/test_regression.rs
+++ b/src/riscv/lib/tests/test_regression.rs
@@ -89,8 +89,8 @@ fn test_regression(
 
     // This needs to run *after* the previous *interpreted* test. Otherwise, we run into trouble when
     // checking and updating the golden files.
-    test_regression_for_block::<Jitted<_, _, _>>(
-        OutlineCompiler::<M64M, Owned>::default(),
+    test_regression_for_block::<Jitted<_, _>>(
+        OutlineCompiler::<M64M>::default(),
         &golden_dir,
         &kernel_path,
         &inbox_path,

--- a/src/riscv/sandbox/src/commands/run.rs
+++ b/src/riscv/sandbox/src/commands/run.rs
@@ -31,14 +31,10 @@ cfg_if::cfg_if! {
         type BlockImplInner = block::Interpreted<M1G, Owned>;
     } else if #[cfg(feature = "inline-jit")] {
         /// Inner execution strategy for blocks.
-        type BlockImplInner = block::Jitted<octez_riscv::machine_state::block_cache::block::InlineCompiler<M1G, Owned>, M1G, Owned>;
+        type BlockImplInner = block::Jitted<octez_riscv::machine_state::block_cache::block::InlineCompiler<M1G>, M1G>;
     } else {
         /// Inner execution strategy for blocks.
-        type BlockImplInner = block::Jitted<
-            octez_riscv::machine_state::block_cache::block::OutlineCompiler<M1G, Owned>,
-            M1G,
-            Owned,
-        >;
+        type BlockImplInner = block::Jitted<octez_riscv::machine_state::block_cache::block::OutlineCompiler<M1G>, M1G>;
     }
 }
 


### PR DESCRIPTION
Closes RV-714

# What

Makes the JIT compiler exclusive to the `Owned` backend.

# Why

We only need JIT during normal operations as other backends are for 1-step interactions. See RV-714.

# Manually Testing

```
make -C src/riscv all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
