### PR TITLE
Make JIT IR values strongly typed

### DIFF
--- a/src/riscv/lib/src/jit/builder.rs
+++ b/src/riscv/lib/src/jit/builder.rs
@@ -11,8 +11,8 @@ pub(super) mod comparable;
 pub(super) mod errno;
 pub(crate) mod instruction;
 pub(crate) mod sequence;
+pub(crate) mod typed;
 
-use cranelift::codegen::ir::Value;
 use cranelift::codegen::ir::condcodes::IntCC;
 use cranelift::prelude::FunctionBuilder;
 use cranelift::prelude::InstBuilder;
@@ -20,20 +20,13 @@ use cranelift::prelude::MemFlags;
 use cranelift::prelude::types::I64;
 
 use crate::instruction_context::Predicate;
+use crate::jit::builder::typed::Pointer;
+use crate::jit::builder::typed::Value;
+use crate::machine_state::MachineCoreState;
 use crate::machine_state::memory::MemoryConfig;
+use crate::machine_state::registers::XValue;
+use crate::state_backend::owned_backend::Owned;
 use crate::state_context::projection::MachineCoreProjection;
-
-/// A newtype for wrapping [`Value`], representing a 64-bit value in the JIT context.
-#[derive(Copy, Clone, Debug)]
-pub struct X64(pub Value);
-
-/// A newtype for wrapping [`Value`], representing a 32-bit value in the JIT context.
-#[derive(Copy, Clone, Debug)]
-pub struct X32(pub Value);
-
-/// A newtype for wrapping [`Value`], representing a 64-bit floating-point value in the JIT context.
-#[derive(Copy, Clone, Debug)]
-pub struct F64(pub Value);
 
 impl From<Predicate> for IntCC {
     fn from(value: Predicate) -> Self {
@@ -52,7 +45,11 @@ impl From<Predicate> for IntCC {
 
 /// Reusable implementation of [`crate::state_context::StateContext::read_proj`] for
 /// the sequencer and instruction builder
-fn read_proj<MC, P>(builder: &mut FunctionBuilder, core_param: Value, param: P::Parameter) -> X64
+fn read_proj<MC, P>(
+    builder: &mut FunctionBuilder,
+    core_param: Pointer<MachineCoreState<MC, Owned>>,
+    param: P::Parameter,
+) -> Value<XValue>
 where
     MC: MemoryConfig,
     P: MachineCoreProjection<Target = u64>,
@@ -65,18 +62,19 @@ where
     // hence we use `MemFlags::trusted()`.
     let val = builder
         .ins()
-        .load(I64, MemFlags::trusted(), core_param, offset);
+        .load(I64, MemFlags::trusted(), core_param.to_value(), offset);
 
-    X64(val)
+    // SAFETY: If the projection is correct, then it should resolve to a value of type `XValue`.
+    unsafe { Value::<XValue>::from_raw(val) }
 }
 
 /// Reusable implementation of [`crate::state_context::StateContext::write_proj`] for
 /// the sequencer and instruction builder
 fn write_proj<MC, P>(
     builder: &mut FunctionBuilder,
-    core_param: Value,
+    core_param: Pointer<MachineCoreState<MC, Owned>>,
     param: P::Parameter,
-    value: X64,
+    value: Value<XValue>,
 ) where
     MC: MemoryConfig,
     P: MachineCoreProjection<Target = u64>,
@@ -87,7 +85,10 @@ fn write_proj<MC, P>(
     // `MachineCoreState`. Additionally, the offset produced by `P::owned_pointer_offset` must
     // result in a valid pointer when applied to `core`. We trust that both properties are upheld,
     // hence we use `MemFlags::trusted()`.
-    builder
-        .ins()
-        .store(MemFlags::trusted(), value.0, core_param, offset);
+    builder.ins().store(
+        MemFlags::trusted(),
+        value.to_value(),
+        core_param.to_value(),
+        offset,
+    );
 }

--- a/src/riscv/lib/src/jit/builder/arithmetic.rs
+++ b/src/riscv/lib/src/jit/builder/arithmetic.rs
@@ -6,56 +6,56 @@
 
 use cranelift::codegen::ir::InstBuilder;
 
-use super::X32;
-use super::X64;
 use crate::instruction_context::Shift;
 use crate::instruction_context::arithmetic::Arithmetic;
 use crate::jit::builder::instruction::InstructionBuilder;
+use crate::jit::builder::typed::Value;
 use crate::machine_state::memory::MemoryConfig;
 
-impl<MC: MemoryConfig> Arithmetic<InstructionBuilder<'_, '_, MC>> for X64 {
+impl<T, MC: MemoryConfig> Arithmetic<InstructionBuilder<'_, '_, MC>> for Value<T> {
     fn add(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        let res = builder.ins().iadd(self.0, other.0);
-        X64(res)
+        // SAFETY: `iadd` operation preserves the value type.
+        unsafe { self.lift_binary(|lhs, rhs| builder.ins().iadd(lhs, rhs), other) }
     }
 
     fn sub(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        let res = builder.ins().isub(self.0, other.0);
-        X64(res)
+        // SAFETY: `isub` operation preserves the value type.
+        unsafe { self.lift_binary(|lhs, rhs| builder.ins().isub(lhs, rhs), other) }
     }
 
     fn and(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        let res = builder.ins().band(self.0, other.0);
-        X64(res)
+        // SAFETY: `band` operation preserves the value type.
+        unsafe { self.lift_binary(|lhs, rhs| builder.ins().band(lhs, rhs), other) }
     }
 
     fn or(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        let res = builder.ins().bor(self.0, other.0);
-        X64(res)
+        // SAFETY: `bor` operation preserves the value type.
+        unsafe { self.lift_binary(|lhs, rhs| builder.ins().bor(lhs, rhs), other) }
     }
 
     fn xor(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        let res = builder.ins().bxor(self.0, other.0);
-        X64(res)
+        // SAFETY: `bxor` operation preserves the value type.
+        unsafe { self.lift_binary(|lhs, rhs| builder.ins().bxor(lhs, rhs), other) }
     }
 
     fn mul(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        let res = builder.ins().imul(self.0, other.0);
-        X64(res)
+        // SAFETY: `imul` operation preserves the value type.
+        unsafe { self.lift_binary(|lhs, rhs| builder.ins().imul(lhs, rhs), other) }
     }
 
     fn div_unsigned(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        let res = builder.ins().udiv(self.0, other.0);
-        X64(res)
+        // SAFETY: `udiv` operation preserves the value type.
+        unsafe { self.lift_binary(|lhs, rhs| builder.ins().udiv(lhs, rhs), other) }
     }
 
     fn div_signed(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        let res = builder.ins().sdiv(self.0, other.0);
-        X64(res)
+        // SAFETY: `sdiv` operation preserves the value type.
+        unsafe { self.lift_binary(|lhs, rhs| builder.ins().sdiv(lhs, rhs), other) }
     }
 
     fn negate(self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        X64(builder.ins().ineg(self.0))
+        // SAFETY: `ineg` operation preserves the value type.
+        unsafe { self.lift_unary(|value| builder.ins().ineg(value)) }
     }
 
     fn shift(
@@ -65,116 +65,47 @@ impl<MC: MemoryConfig> Arithmetic<InstructionBuilder<'_, '_, MC>> for X64 {
         builder: &mut InstructionBuilder<'_, '_, MC>,
     ) -> Self {
         match shift {
-            Shift::Left => X64(builder.ins().ishl(self.0, amount.0)),
-            Shift::RightUnsigned => X64(builder.ins().ushr(self.0, amount.0)),
-            Shift::RightSigned => X64(builder.ins().sshr(self.0, amount.0)),
+            Shift::Left =>
+            // SAFETY: `ishl` operation preserves the value type.
+            unsafe { self.lift_binary(|lhs, rhs| builder.ins().ishl(lhs, rhs), amount) },
+
+            Shift::RightUnsigned =>
+            // SAFETY: `ushr` operation preserves the value type.
+            unsafe { self.lift_binary(|lhs, rhs| builder.ins().ushr(lhs, rhs), amount) },
+
+            Shift::RightSigned =>
+            // SAFETY: `sshr` operation preserves the value type.
+            unsafe { self.lift_binary(|lhs, rhs| builder.ins().sshr(lhs, rhs), amount) },
         }
     }
 
     fn modulus_unsigned(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        X64(builder.ins().urem(self.0, other.0))
+        // SAFETY: `urem` operation preserves the value type.
+        unsafe { self.lift_binary(|lhs, rhs| builder.ins().urem(lhs, rhs), other) }
     }
 
     fn modulus_signed(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        X64(builder.ins().srem(self.0, other.0))
+        // SAFETY: `srem` operation preserves the value type.
+        unsafe { self.lift_binary(|lhs, rhs| builder.ins().srem(lhs, rhs), other) }
     }
 
     fn min_signed(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        X64(builder.ins().smin(self.0, other.0))
+        // SAFETY: `smin` operation preserves the value type.
+        unsafe { self.lift_binary(|lhs, rhs| builder.ins().smin(lhs, rhs), other) }
     }
 
     fn min_unsigned(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        X64(builder.ins().umin(self.0, other.0))
+        // SAFETY: `umin` operation preserves the value type.
+        unsafe { self.lift_binary(|lhs, rhs| builder.ins().umin(lhs, rhs), other) }
     }
 
     fn max_signed(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        X64(builder.ins().smax(self.0, other.0))
+        // SAFETY: `smax` operation preserves the value type.
+        unsafe { self.lift_binary(|lhs, rhs| builder.ins().smax(lhs, rhs), other) }
     }
 
     fn max_unsigned(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        X64(builder.ins().umax(self.0, other.0))
-    }
-}
-
-impl<MC: MemoryConfig> Arithmetic<InstructionBuilder<'_, '_, MC>> for X32 {
-    fn add(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        let res = builder.ins().iadd(self.0, other.0);
-        X32(res)
-    }
-
-    fn sub(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        let res = builder.ins().isub(self.0, other.0);
-        X32(res)
-    }
-
-    fn and(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        let res = builder.ins().band(self.0, other.0);
-        X32(res)
-    }
-
-    fn or(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        let res = builder.ins().bor(self.0, other.0);
-        X32(res)
-    }
-
-    fn xor(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        let res = builder.ins().bxor(self.0, other.0);
-        X32(res)
-    }
-
-    fn mul(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        let res = builder.ins().imul(self.0, other.0);
-        X32(res)
-    }
-
-    fn div_unsigned(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        let res = builder.ins().udiv(self.0, other.0);
-        X32(res)
-    }
-
-    fn div_signed(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        let res = builder.ins().sdiv(self.0, other.0);
-        X32(res)
-    }
-
-    fn negate(self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        X32(builder.ins().ineg(self.0))
-    }
-
-    fn shift(
-        self,
-        shift: Shift,
-        amount: Self,
-        builder: &mut InstructionBuilder<'_, '_, MC>,
-    ) -> Self {
-        match shift {
-            Shift::Left => X32(builder.ins().ishl(self.0, amount.0)),
-            Shift::RightUnsigned => X32(builder.ins().ushr(self.0, amount.0)),
-            Shift::RightSigned => X32(builder.ins().sshr(self.0, amount.0)),
-        }
-    }
-
-    fn modulus_unsigned(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        X32(builder.ins().urem(self.0, other.0))
-    }
-
-    fn modulus_signed(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        X32(builder.ins().srem(self.0, other.0))
-    }
-
-    fn min_signed(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        X32(builder.ins().smin(self.0, other.0))
-    }
-
-    fn min_unsigned(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        X32(builder.ins().umin(self.0, other.0))
-    }
-
-    fn max_signed(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        X32(builder.ins().smax(self.0, other.0))
-    }
-
-    fn max_unsigned(self, other: Self, builder: &mut InstructionBuilder<'_, '_, MC>) -> Self {
-        X32(builder.ins().umax(self.0, other.0))
+        // SAFETY: `umax` operation preserves the value type.
+        unsafe { self.lift_binary(|lhs, rhs| builder.ins().umax(lhs, rhs), other) }
     }
 }

--- a/src/riscv/lib/src/jit/builder/comparable.rs
+++ b/src/riscv/lib/src/jit/builder/comparable.rs
@@ -5,38 +5,44 @@
 //! Implementation of comparison operations in JIT mode.
 
 use cranelift::codegen::ir::InstBuilder;
-use cranelift::prelude::Value;
 
 use crate::instruction_context::Predicate;
 use crate::instruction_context::comparable::Comparable;
-use crate::jit::builder::X32;
-use crate::jit::builder::X64;
 use crate::jit::builder::instruction::InstructionBuilder;
+use crate::jit::builder::typed::Value;
 use crate::machine_state::memory::MemoryConfig;
 
-impl<MC: MemoryConfig> Comparable<InstructionBuilder<'_, '_, MC>> for X64 {
-    type Result = Value;
+mod seal {
+    /// Seal trait to prevent comparisons on non-integer types
+    pub trait ComparableInteger {}
 
-    // icmp returns 1 if the condition holds, 0 if it does not.
-    //
-    // This matches the required semantics of bool - namely that it coerces to XValue with
-    // - true => 1
-    // - false => 0
-    //
-    // See
-    // <https://docs.rs/cranelift-codegen/0.117.2/cranelift_codegen/ir/trait.InstBuilder.html#method.icmp>
-    fn compare(
-        self,
-        other: Self,
-        comparison: Predicate,
-        builder: &mut InstructionBuilder<'_, '_, MC>,
-    ) -> Value {
-        builder.ins().icmp(comparison, self.0, other.0)
-    }
+    impl ComparableInteger for u8 {}
+
+    impl ComparableInteger for i8 {}
+
+    impl ComparableInteger for u16 {}
+
+    impl ComparableInteger for i16 {}
+
+    impl ComparableInteger for u32 {}
+
+    impl ComparableInteger for i32 {}
+
+    impl ComparableInteger for u64 {}
+
+    impl ComparableInteger for i64 {}
+
+    impl ComparableInteger for u128 {}
+
+    impl ComparableInteger for i128 {}
+
+    impl<T> ComparableInteger for std::ptr::NonNull<T> {}
 }
 
-impl<MC: MemoryConfig> Comparable<InstructionBuilder<'_, '_, MC>> for X32 {
-    type Result = Value;
+impl<T: seal::ComparableInteger, MC: MemoryConfig> Comparable<InstructionBuilder<'_, '_, MC>>
+    for Value<T>
+{
+    type Result = Value<bool>;
 
     // icmp returns 1 if the condition holds, 0 if it does not.
     //
@@ -51,7 +57,13 @@ impl<MC: MemoryConfig> Comparable<InstructionBuilder<'_, '_, MC>> for X32 {
         other: Self,
         comparison: Predicate,
         builder: &mut InstructionBuilder<'_, '_, MC>,
-    ) -> Value {
-        builder.ins().icmp(comparison, self.0, other.0)
+    ) -> Self::Result {
+        let raw = builder
+            .ins()
+            .icmp(comparison, self.to_value(), other.to_value());
+
+        // SAFETY: Integer comparison operations return a `0` or `1` value as `I8`. We enforce that
+        // `icmp` only compares integers using the `ComparableInteger` constraint on `T`.
+        unsafe { Value::<bool>::from_raw(raw) }
     }
 }

--- a/src/riscv/lib/src/jit/builder/typed.rs
+++ b/src/riscv/lib/src/jit/builder/typed.rs
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: 2025 TriliTech <contact@trili.tech>
+//
+// SPDX-License-Identifier: MIT
+
+//! Strongly-typed wrapper around Cranelift IR values
+//!
+//! This module provides a [`Value`] type that wraps Cranelift's untyped IR values with
+//! compile-time type information. This enables type-safe operations on IR values while maintaining
+//! the flexibility of the underlying Cranelift infrastructure.
+//!
+//! The main type [`Value`] is a zero-cost abstraction that carries type information
+//! in the type system without runtime overhead. It provides safe conversion functions
+//! and operations that preserve type safety across IR transformations.
+
+use std::cmp::Ordering;
+use std::marker::PhantomData;
+use std::ptr::NonNull;
+
+use cranelift::codegen::ir::Value as CraneliftValue;
+
+/// Strongly-typed IR value
+#[derive(Debug)]
+pub struct Value<T> {
+    /// Underlying Cranelift value
+    value: CraneliftValue,
+
+    _pd: PhantomData<T>,
+}
+
+impl<T> Value<T> {
+    /// Enhance a raw Canelift value with a type.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure the type `T` is correct for the given Cranelift value.
+    pub unsafe fn from_raw(value: CraneliftValue) -> Self {
+        Value {
+            value,
+            _pd: PhantomData,
+        }
+    }
+
+    /// Extract the raw Cranelift value from this typed value.
+    pub fn to_value(self) -> CraneliftValue {
+        self.value
+    }
+
+    /// Lift a unary operation on a Cranelift value to a typed value.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the function `f` produces a Cranelift value that represents the
+    /// type `T`.
+    pub unsafe fn lift_unary(self, f: impl FnOnce(CraneliftValue) -> CraneliftValue) -> Value<T> {
+        let raw = f(self.to_value());
+
+        // SAFETY: `f` must produce a Cranelift value of type `T`.
+        unsafe { Value::<T>::from_raw(raw) }
+    }
+
+    /// Lift a binary operation on two Cranelift values to typed values.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the function `f` produces a Cranelift value that represents the
+    /// type `T`.
+    pub unsafe fn lift_binary(
+        self,
+        f: impl FnOnce(CraneliftValue, CraneliftValue) -> CraneliftValue,
+        rhs: Value<T>,
+    ) -> Value<T> {
+        let raw = f(self.to_value(), rhs.to_value());
+
+        // SAFETY: `f` must produce a Cranelift value of type `T`.
+        unsafe { Value::<T>::from_raw(raw) }
+    }
+}
+
+// The deriver macro imposes `T: Copy` on `Value<T>`. We don't want that, so we write our own impl.
+impl<T> Copy for Value<T> {}
+
+// See `impl Copy` for why we hand-write this impl.
+impl<T> Clone for Value<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+// See `impl Copy` for why we hand-write this impl.
+impl<T> PartialEq for Value<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.value.eq(&other.value)
+    }
+}
+
+// See `impl Copy` for why we hand-write this impl.
+impl<T> Eq for Value<T> {}
+
+// See `impl Copy` for why we hand-write this impl.
+impl<T> PartialOrd for Value<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+// See `impl Copy` for why we hand-write this impl.
+impl<T> Ord for Value<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.value.cmp(&other.value)
+    }
+}
+
+/// IR pointer to a value of type `T`
+pub type Pointer<T> = Value<NonNull<T>>;


### PR DESCRIPTION
Closes RV-719

# What

Replaces Cranelift's `Value` with our variant (see `typed` module), which carries the type it represents at the Rust type level. 

# Why

Statically typing IR values improves safety by preventing us from misusing seemingly incompatible values, or at least forces us to think about the compatibility of types.

Using indexed types also enables future improvements (some of which are stacked on this PR):
- Type-safe external function calls
  - We don't enforce that the target C function matches the types of values we pass along. With the indexed types, we can make sure the callee type matches what we pass in terms of values.
- `MaybeUninit` wrapping for stack slots
  - Stack slots can only be created for a type `MaybeUninit<T>` to avoid passing pointers to `T` to an external function, which may treat the pointee as initialised.
  - The `MaybeUninit` wrapper would not be effective without strongly-typed values.

# Manually Testing

```
make -C src/riscv all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
