### PR TITLE
Remove usage of Cranelift F-types, and add floating-point types/operations check

### DIFF
--- a/src/riscv/lib/src/jit.rs
+++ b/src/riscv/lib/src/jit.rs
@@ -264,6 +264,42 @@ impl<MC: MemoryConfig> JIT<MC> {
             "Defined function"
         );
 
+        // Check during test if the compiled function contains any unsafe cranelift IR type/operation.
+        if cfg!(test) {
+            let function_detail_string = self.ctx.func.display().to_string();
+
+            // List of unsafe cranelift IR types/operations.
+            let unsafe_ir_type_and_operation = [
+                "f128",
+                "f64",
+                "f32",
+                "f16",
+                "fcmp",
+                "fadd",
+                "fsub",
+                "fmul",
+                "fdiv",
+                "fma",
+                "fneg",
+                "fabs",
+                "fcopysign",
+                "fmin",
+                "fmax",
+                "ceil",
+                "floor",
+                "trunc",
+                "nearest",
+            ];
+            for word in &unsafe_ir_type_and_operation {
+                assert!(
+                    !function_detail_string.contains(word),
+                    "Compiled function contains unsafe type/operation: {}. Full function detail: {}.",
+                    word,
+                    function_detail_string
+                );
+            }
+        }
+
         self.clear();
 
         // SAFETY: the signature of a JitFn matches exactly the abi we specified in the

--- a/src/riscv/lib/src/jit/state_access/abi.rs
+++ b/src/riscv/lib/src/jit/state_access/abi.rs
@@ -12,7 +12,6 @@ use cranelift::codegen::ir::types::I16;
 use cranelift::codegen::ir::types::I32;
 use cranelift::codegen::ir::types::I64;
 use cranelift::prelude::isa::CallConv;
-use cranelift::prelude::types::F64;
 use cranelift_jit::JITModule;
 use cranelift_module::FuncId;
 use cranelift_module::Linkage;
@@ -162,7 +161,7 @@ impl ToCraneliftRepr for FRegister {
 }
 
 impl ToCraneliftRepr for f64 {
-    const CRANELIFT_TYPE: CraneliftRepr = CraneliftRepr::Value(F64);
+    const CRANELIFT_TYPE: CraneliftRepr = CraneliftRepr::Value(I64);
 }
 
 /// A valid return type for an external function call.

--- a/src/riscv/lib/src/jit/state_access/stack.rs
+++ b/src/riscv/lib/src/jit/state_access/stack.rs
@@ -47,7 +47,6 @@ use cranelift::codegen::ir::Type;
 use cranelift::codegen::ir::Value;
 use cranelift::codegen::ir::types::I64;
 use cranelift::frontend::FunctionBuilder;
-use cranelift::prelude::types::F64;
 use cranelift::prelude::types::I8;
 use cranelift::prelude::types::I16;
 use cranelift::prelude::types::I32;
@@ -143,7 +142,7 @@ impl StackAddressable for f64 {
 }
 
 impl Stackable for f64 {
-    const IR_TYPE: Type = F64;
+    const IR_TYPE: Type = I64;
 }
 
 /// Dedicated space on the stack to store a value of the underlying type.


### PR DESCRIPTION
# What

Remove usage of Cranelift F-types, and add checks to prevent future inclusion of floating-point types/operations.

# Why

Currently the the jit compiler uses Floating point types in cranelift. This is unsafe because:
- Signalling NaNs may actually crash the process the PVM runs in
- Floats may be normalised, causing indeterministic behaviour

# How

There are 2 places where Cranelift F-types are used. They are updated to use an I64:
- Cranelift representation of f64
- Cranelift representation of f64 in stack slots

The challenging part of the MR is in add checks to prevent future inclusion of floating-point. Cranelift hasn't implement disabling of floating point instructions that we can use out of the box([link](https://docs.wasmtime.dev/api/cranelift/prelude/settings/struct.Flags.html#method.enable_float)). Also, checking for floating point type/operation at run-time would be expensive and should be avoided.

The workaround that I use is to introduce checks on compiled function in unit tests, and since our `jit.rs` test covers all lowered opcodes, we have a good safeguard against generating floating point operations with cranelift.

The function being compiled is read as a string and its content is checked against a list of unsafe type/instructions(This solution is a bit hack-ish, but I haven't found a better implementation so far).

# Manually Testing

```
make -C src/riscv all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
