### PR TITLE
Remove ManagerDeserialise & ManagerSerialise requirement for backend_test!

### DIFF
--- a/src/riscv/lib/src/jit.rs
+++ b/src/riscv/lib/src/jit.rs
@@ -320,7 +320,6 @@ mod tests {
     use crate::state::NewState;
     use crate::state_backend::FnManagerIdent;
     use crate::state_backend::ManagerRead;
-    use crate::state_backend::test_helpers::assert_eq_struct;
 
     fn instructions<MC: MemoryConfig, M>(block: &Interpreted<MC, M>) -> Vec<Instruction>
     where
@@ -410,9 +409,9 @@ mod tests {
                 interpreted_res.steps
             );
 
-            assert_eq_struct(
-                &interpreted.struct_ref::<FnManagerIdent>(),
-                &jitted.struct_ref::<FnManagerIdent>(),
+            assert!(
+                interpreted.struct_ref::<FnManagerIdent>() == jitted.struct_ref::<FnManagerIdent>(),
+                "Interpreted and Jitted states should be equal"
             );
 
             // Only check steps against one state, as we know both interpreted/jit steps are equal.

--- a/src/riscv/lib/src/machine_state.rs
+++ b/src/riscv/lib/src/machine_state.rs
@@ -637,7 +637,6 @@ mod tests {
     use crate::parser::parse_block;
     use crate::state_backend::CloneLayout;
     use crate::state_backend::FnManagerIdent;
-    use crate::state_backend::test_helpers::assert_eq_struct;
     use crate::traps::EnvironException;
 
     backend_test!(test_step, F, {
@@ -858,9 +857,9 @@ mod tests {
             alt_state.core.hart.xregisters.read(t2)
         );
 
-        assert_eq_struct(
-            &state.struct_ref::<FnManagerIdent>(),
-            &alt_state.struct_ref::<FnManagerIdent>(),
+        assert!(
+            state.struct_ref::<FnManagerIdent>() == alt_state.struct_ref::<FnManagerIdent>(),
+            "State equality expected"
         );
     });
 
@@ -872,9 +871,9 @@ mod tests {
 
         let second = state.clone();
 
-        assert_eq_struct(
-            &state.struct_ref::<FnManagerIdent>(),
-            &second.struct_ref::<FnManagerIdent>(),
+        assert!(
+            state.struct_ref::<FnManagerIdent>() == second.struct_ref::<FnManagerIdent>(),
+            "State equality expected"
         );
     });
 

--- a/src/riscv/lib/src/machine_state.rs
+++ b/src/riscv/lib/src/machine_state.rs
@@ -635,9 +635,9 @@ mod tests {
     use crate::parser::instruction::SBTypeArgs;
     use crate::parser::instruction::SplitITypeArgs;
     use crate::parser::parse_block;
+    use crate::state_backend::CloneLayout;
     use crate::state_backend::FnManagerIdent;
     use crate::state_backend::test_helpers::assert_eq_struct;
-    use crate::state_backend::test_helpers::copy_via_serde;
     use crate::traps::EnvironException;
 
     backend_test!(test_step, F, {
@@ -815,7 +815,9 @@ mod tests {
         // Perform 2 steps consecutively in one backend.
         let state = {
             let mut state = LocalMachineState::<F>::bind(
-                copy_via_serde::<LocalLayout, _, _>(&base_state.struct_ref::<FnManagerIdent>()),
+                <LocalLayout as CloneLayout>::clone_allocated(
+                    base_state.struct_ref::<FnManagerIdent>(),
+                ),
                 InterpretedBlockBuilder,
             );
 
@@ -829,7 +831,9 @@ mod tests {
         let alt_state = {
             let alt_state = {
                 let mut state = LocalMachineState::<F>::bind(
-                    copy_via_serde::<LocalLayout, _, _>(&base_state.struct_ref::<FnManagerIdent>()),
+                    <LocalLayout as CloneLayout>::clone_allocated(
+                        base_state.struct_ref::<FnManagerIdent>(),
+                    ),
                     InterpretedBlockBuilder,
                 );
                 state.step().unwrap();
@@ -838,7 +842,9 @@ mod tests {
 
             {
                 let mut state = LocalMachineState::<F>::bind(
-                    copy_via_serde::<LocalLayout, _, _>(&alt_state.struct_ref::<FnManagerIdent>()),
+                    <LocalLayout as CloneLayout>::clone_allocated(
+                        alt_state.struct_ref::<FnManagerIdent>(),
+                    ),
                     InterpretedBlockBuilder,
                 );
                 state.step().unwrap();

--- a/src/riscv/lib/src/machine_state/memory/buddy.rs
+++ b/src/riscv/lib/src/machine_state/memory/buddy.rs
@@ -25,6 +25,7 @@ mod proxy;
 pub use proxy::BuddyLayoutProxy;
 
 use crate::state::NewState;
+use crate::state_backend::CloneLayout;
 use crate::state_backend::CommitmentLayout;
 use crate::state_backend::FnManager;
 use crate::state_backend::ManagerBase;
@@ -35,7 +36,7 @@ use crate::state_backend::ProofLayout;
 use crate::state_backend::Ref;
 
 /// Layout for a Buddy-style memory manager
-pub trait BuddyLayout: CommitmentLayout + ProofLayout {
+pub trait BuddyLayout: CommitmentLayout + ProofLayout + CloneLayout {
     /// Buddy-style memory manager implementation
     type Buddy<M: ManagerBase>: Buddy<M>;
 

--- a/src/riscv/lib/src/machine_state/memory/buddy/branch_combinations.rs
+++ b/src/riscv/lib/src/machine_state/memory/buddy/branch_combinations.rs
@@ -16,6 +16,7 @@ use super::branch::BuddyBranch2;
 use super::branch::BuddyBranch2Layout;
 use crate::state::NewState;
 use crate::state_backend::AllocatedOf;
+use crate::state_backend::CloneLayout;
 use crate::state_backend::CommitmentLayout;
 use crate::state_backend::FnManager;
 use crate::state_backend::Layout;
@@ -127,6 +128,13 @@ macro_rules! combined_buddy_branch {
                     proof: ProofTree,
                 ) -> Result<Hash, PartialHashError> {
                     <[<$buddy1 Layout>]<[<$buddy2 Layout>]<B>>>::partial_state_hash(state.0, proof)
+                }
+            }
+
+            impl<B: CloneLayout> CloneLayout for [<$name Layout>]<B> {
+                fn clone_allocated<M: ManagerClone>(space: Self::Allocated<Ref<'_, M>>) -> Self::Allocated<M> {
+                    let inner = <[<$buddy1 Layout>]<[<$buddy2 Layout>]<B>>>::clone_allocated(space.0);
+                    [<$name Alloc>](inner)
                 }
             }
 

--- a/src/riscv/lib/src/machine_state/memory/buddy/branch_combinations.rs
+++ b/src/riscv/lib/src/machine_state/memory/buddy/branch_combinations.rs
@@ -52,7 +52,7 @@ macro_rules! combined_buddy_branch {
             impl<B, M> PartialEq for [<$name Alloc>]<B, M>
             where
                 B: Layout,
-                M: ManagerSerialise,
+                M: ManagerRead,
                 AllocatedOf<[<$buddy1 Layout>]<[<$buddy2 Layout>]<B>>, M>: PartialEq,
             {
                 fn eq(&self, other: &Self) -> bool {
@@ -100,7 +100,6 @@ macro_rules! combined_buddy_branch {
 
             impl<B: Layout> Layout for [<$name Layout>]<B> {
                 type Allocated<M: ManagerBase> = [<$name Alloc>]<B, M>;
-
             }
 
             impl<B: CommitmentLayout> CommitmentLayout for [<$name Layout>]<B> {

--- a/src/riscv/lib/src/machine_state/memory/buddy/leaf.rs
+++ b/src/riscv/lib/src/machine_state/memory/buddy/leaf.rs
@@ -14,6 +14,7 @@ use crate::state::NewState;
 use crate::state_backend::AllocatedOf;
 use crate::state_backend::Atom;
 use crate::state_backend::Cell;
+use crate::state_backend::CloneLayout;
 use crate::state_backend::CommitmentLayout;
 use crate::state_backend::FnManager;
 use crate::state_backend::Layout;
@@ -67,6 +68,15 @@ impl<const PAGES: u64> ProofLayout for BuddyLeafLayout<PAGES> {
         proof: ProofTree,
     ) -> Result<Hash, PartialHashError> {
         Atom::partial_state_hash(state.set, proof)
+    }
+}
+
+impl<const PAGES: u64> CloneLayout for BuddyLeafLayout<PAGES> {
+    fn clone_allocated<M: ManagerClone>(space: Self::Allocated<Ref<'_, M>>) -> Self::Allocated<M> {
+        let region = space.set.into_region();
+        let region = M::clone_region(region);
+        let set = Cell::bind(region);
+        BuddyLeaf { set }
     }
 }
 

--- a/src/riscv/lib/src/machine_state/memory/buddy/proxy.rs
+++ b/src/riscv/lib/src/machine_state/memory/buddy/proxy.rs
@@ -13,6 +13,7 @@ use super::leaf::BuddyLeafLayout;
 use crate::machine_state::memory::buddy::branch_combinations::BuddyBranch8Layout;
 use crate::machine_state::memory::buddy::branch_combinations::BuddyBranch32Layout;
 use crate::state_backend::AllocatedOf;
+use crate::state_backend::CloneLayout;
 use crate::state_backend::CommitmentLayout;
 use crate::state_backend::FnManager;
 use crate::state_backend::Layout;
@@ -68,6 +69,17 @@ where
         proof: ProofTree,
     ) -> Result<Hash, PartialHashError> {
         <PickLayout<PAGES> as ProofLayout>::partial_state_hash(state, proof)
+    }
+}
+
+impl<const PAGES: usize> CloneLayout for BuddyLayoutProxy<PAGES>
+where
+    (): BuddyLayoutMatch<PAGES>,
+{
+    fn clone_allocated<M: crate::state_backend::ManagerClone>(
+        space: Self::Allocated<Ref<'_, M>>,
+    ) -> Self::Allocated<M> {
+        <PickLayout<PAGES> as CloneLayout>::clone_allocated(space)
     }
 }
 

--- a/src/riscv/lib/src/state_backend.rs
+++ b/src/riscv/lib/src/state_backend.rs
@@ -468,13 +468,11 @@ impl<E: 'static, const LEN: usize> Projection for RegionProj<E, LEN> {
 pub(crate) mod test_helpers {
     use trait_set::trait_set;
 
-    use super::AllocatedOf;
-    use super::Layout;
     use super::ManagerAlloc;
     use super::ManagerClone;
-    use super::ManagerDeserialise;
     use super::ManagerReadWrite;
     use super::ManagerSerialise;
+    use crate::state_backend::ManagerDeserialise;
 
     /// Generate a test against all test backends.
     #[macro_export]
@@ -501,19 +499,6 @@ pub(crate) mod test_helpers {
             + ManagerDeserialise
             + ManagerClone
             + ManagerAlloc;
-    }
-
-    /// Copy the allocated space by serialising and deserialising it.
-    pub fn copy_via_serde<L, N, M>(refs: &AllocatedOf<L, N>) -> AllocatedOf<L, M>
-    where
-        L: Layout,
-        N: ManagerSerialise,
-        AllocatedOf<L, N>: serde::Serialize,
-        M: ManagerDeserialise,
-        AllocatedOf<L, M>: serde::de::DeserializeOwned,
-    {
-        let data = crate::storage::binary::serialise(refs).unwrap();
-        crate::storage::binary::deserialise(&data).unwrap()
     }
 
     /// Assert that two values are different. If they differ, offer a command to run that shows the

--- a/src/riscv/lib/src/state_backend.rs
+++ b/src/riscv/lib/src/state_backend.rs
@@ -70,6 +70,7 @@
 //! [Verifier]: verify_backend::Verifier
 //! [ProofGen]: proof_backend::ProofGen
 
+pub mod clone_layout;
 mod commitment_layout;
 mod effects;
 mod elems;
@@ -84,6 +85,7 @@ pub mod verify_backend;
 
 use std::marker::PhantomData;
 
+pub use clone_layout::*;
 pub use commitment_layout::*;
 pub use effects::*;
 pub use elems::*;

--- a/src/riscv/lib/src/state_backend/clone_layout.rs
+++ b/src/riscv/lib/src/state_backend/clone_layout.rs
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2025 TriliTech <contact@trili.tech>
+//
+// SPDX-License-Identifier: MIT
+
+//! This module defines the [`CloneLayout`] trait and its implementations.
+
+use crate::state_backend::Array;
+use crate::state_backend::Atom;
+use crate::state_backend::Cell;
+use crate::state_backend::Cells;
+use crate::state_backend::DynArray;
+use crate::state_backend::DynCells;
+use crate::state_backend::Layout;
+use crate::state_backend::ManagerClone;
+use crate::state_backend::Many;
+use crate::state_backend::Ref;
+
+/// [`Layout`] which can be cloned.
+pub trait CloneLayout: Layout {
+    /// Clone the allocated space of this layout behind a [`Ref`].
+    fn clone_allocated<M: ManagerClone>(space: Self::Allocated<Ref<'_, M>>) -> Self::Allocated<M>;
+}
+
+impl<E: Clone + 'static> CloneLayout for Atom<E> {
+    fn clone_allocated<M: ManagerClone>(space: Self::Allocated<Ref<'_, M>>) -> Self::Allocated<M> {
+        let region = space.into_region();
+        let region = M::clone_region(region);
+        Cell::bind(region)
+    }
+}
+
+impl<E: Clone + 'static, const LEN: usize> CloneLayout for Array<E, LEN> {
+    fn clone_allocated<M: ManagerClone>(space: Self::Allocated<Ref<'_, M>>) -> Self::Allocated<M> {
+        let region = space.into_region();
+        let region = M::clone_region(region);
+        Cells::bind(region)
+    }
+}
+
+impl<A: CloneLayout, B: CloneLayout> CloneLayout for (A, B) {
+    fn clone_allocated<M: ManagerClone>(space: Self::Allocated<Ref<'_, M>>) -> Self::Allocated<M> {
+        let a = A::clone_allocated(space.0);
+        let b = B::clone_allocated(space.1);
+        (a, b)
+    }
+}
+
+impl<A: CloneLayout, B: CloneLayout, C: CloneLayout> CloneLayout for (A, B, C) {
+    fn clone_allocated<M: ManagerClone>(space: Self::Allocated<Ref<'_, M>>) -> Self::Allocated<M> {
+        let a = A::clone_allocated(space.0);
+        let b = B::clone_allocated(space.1);
+        let c = C::clone_allocated(space.2);
+        (a, b, c)
+    }
+}
+
+impl<A: CloneLayout, B: CloneLayout, C: CloneLayout, D: CloneLayout> CloneLayout for (A, B, C, D) {
+    fn clone_allocated<M: ManagerClone>(space: Self::Allocated<Ref<'_, M>>) -> Self::Allocated<M> {
+        let a = A::clone_allocated(space.0);
+        let b = B::clone_allocated(space.1);
+        let c = C::clone_allocated(space.2);
+        let d = D::clone_allocated(space.3);
+        (a, b, c, d)
+    }
+}
+
+impl<A: CloneLayout, B: CloneLayout, C: CloneLayout, D: CloneLayout, E: CloneLayout> CloneLayout
+    for (A, B, C, D, E)
+{
+    fn clone_allocated<M: ManagerClone>(space: Self::Allocated<Ref<'_, M>>) -> Self::Allocated<M> {
+        let a = A::clone_allocated(space.0);
+        let b = B::clone_allocated(space.1);
+        let c = C::clone_allocated(space.2);
+        let d = D::clone_allocated(space.3);
+        let e = E::clone_allocated(space.4);
+        (a, b, c, d, e)
+    }
+}
+
+impl<const LEN: usize> CloneLayout for DynArray<LEN> {
+    fn clone_allocated<M: ManagerClone>(space: Self::Allocated<Ref<'_, M>>) -> Self::Allocated<M> {
+        let region = space.region_ref();
+        let region = M::clone_dyn_region(region);
+        DynCells::bind(region)
+    }
+}
+
+impl<L: CloneLayout, const LEN: usize> CloneLayout for [L; LEN] {
+    fn clone_allocated<M: ManagerClone>(space: Self::Allocated<Ref<'_, M>>) -> Self::Allocated<M> {
+        space.map(L::clone_allocated)
+    }
+}
+
+impl<L: CloneLayout, const LEN: usize> CloneLayout for Many<L, LEN> {
+    fn clone_allocated<M: ManagerClone>(space: Self::Allocated<Ref<'_, M>>) -> Self::Allocated<M> {
+        space.into_iter().map(L::clone_allocated).collect()
+    }
+}
+
+impl<L: CloneLayout> CloneLayout for Box<L> {
+    fn clone_allocated<M: ManagerClone>(space: Self::Allocated<Ref<'_, M>>) -> Self::Allocated<M> {
+        Box::new(L::clone_allocated(*space))
+    }
+}

--- a/src/riscv/lib/src/state_backend/layout.rs
+++ b/src/riscv/lib/src/state_backend/layout.rs
@@ -213,6 +213,27 @@ macro_rules! struct_layout {
                     $crate::state_backend::combine_partial_hashes([$($field_name),+], proof_hash)
                 }
             }
+
+            impl <
+                $(
+                    [<$field_name:camel>]: $crate::state_backend::CloneLayout
+                ),+
+            > $crate::state_backend::CloneLayout for [<$layout_t F>]<
+                $(
+                    [<$field_name:camel>]
+                ),+
+            >
+            {
+                fn clone_allocated<M: $crate::state_backend::ManagerClone>(
+                    space: $crate::state_backend::AllocatedOf<Self, $crate::state_backend::Ref<'_, M>>
+                ) -> $crate::state_backend::AllocatedOf<Self, M> {
+                    [<$layout_t F>] {
+                        $(
+                            $field_name: [<$field_name:camel>]::clone_allocated(space.$field_name),
+                        )+
+                    }
+                }
+            }
         }
     };
 }

--- a/src/riscv/lib/src/state_backend/region.rs
+++ b/src/riscv/lib/src/state_backend/region.rs
@@ -704,7 +704,6 @@ pub(crate) mod tests {
     use crate::state_backend::Cells;
     use crate::state_backend::DynCells;
     use crate::state_backend::Elem;
-    use crate::state_backend::FnManagerIdent;
 
     /// Dummy type that helps us implement custom normalisation via [`Elem`]
     #[repr(C, packed)]
@@ -863,41 +862,5 @@ pub(crate) mod tests {
 
         let buffer = region.read::<[u8; 8]>(0);
         assert_eq!(buffer, [22, 11, 24, 13, 26, 15, 28, 17]);
-    });
-
-    backend_test!(test_region_stored_format, F, {
-        // Writing to one item of the region must convert to stored format.
-        let mut region = Cells::<Flipper, 4, F>::new();
-
-        region.write(0, Flipper { a: 13, b: 37 });
-        assert_eq!(region.read(0), Flipper { a: 13, b: 37 });
-
-        let buffer = bincode::serialize(&region.struct_ref::<FnManagerIdent>()).unwrap();
-        assert_eq!(buffer[..2], [37, 13]);
-
-        // Replacing a value in the region must convert to and from stored format.
-        let old = region.replace(0, Flipper { a: 26, b: 74 });
-        assert_eq!(old, Flipper { a: 13, b: 37 });
-
-        let buffer = bincode::serialize(&region.struct_ref::<FnManagerIdent>()).unwrap();
-        assert_eq!(buffer[..2], [74, 26]);
-
-        // Writing to the entire region must convert properly to stored format.
-        region.write_all(&[
-            Flipper { a: 11, b: 22 },
-            Flipper { a: 13, b: 24 },
-            Flipper { a: 15, b: 26 },
-            Flipper { a: 17, b: 28 },
-        ]);
-
-        assert_eq!(region.read_all(), [
-            Flipper { a: 11, b: 22 },
-            Flipper { a: 13, b: 24 },
-            Flipper { a: 15, b: 26 },
-            Flipper { a: 17, b: 28 },
-        ]);
-
-        let buffer = bincode::serialize(&region.struct_ref::<FnManagerIdent>()).unwrap();
-        assert_eq!(buffer[..8], [22, 11, 24, 13, 26, 15, 28, 17]);
     });
 }

--- a/src/riscv/lib/src/stepper/pvm.rs
+++ b/src/riscv/lib/src/stepper/pvm.rs
@@ -35,12 +35,14 @@ use crate::range_utils::bound_saturating_sub;
 use crate::state_backend::AllocatedOf;
 use crate::state_backend::FnManagerIdent;
 use crate::state_backend::ManagerBase;
+use crate::state_backend::ManagerClone;
 use crate::state_backend::ManagerReadWrite;
 use crate::state_backend::OwnedProofPart;
 use crate::state_backend::ProofLayout;
 use crate::state_backend::ProofPart;
 use crate::state_backend::ProofTree;
 use crate::state_backend::Ref;
+use crate::state_backend::clone_layout::CloneLayout;
 use crate::state_backend::hash::Hash;
 use crate::state_backend::owned_backend::Owned;
 use crate::state_backend::proof_backend::ProofGen;
@@ -247,6 +249,17 @@ impl<H: PvmHooks, MC: MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: M
             binary::deserialise(&data).unwrap()
         };
 
+        self.pvm = Pvm::bind(space, block_builder);
+    }
+
+    /// Re-bind the PVM type by cloning the underlying regions.
+    pub fn rebind_via_clone(&mut self, block_builder: B::BlockBuilder)
+    where
+        PvmLayout<MC, BCC>: CloneLayout,
+        M: ManagerClone,
+    {
+        let refs = self.pvm.struct_ref::<FnManagerIdent>();
+        let space = PvmLayout::<MC, BCC>::clone_allocated(refs);
         self.pvm = Pvm::bind(space, block_builder);
     }
 }

--- a/src/riscv/lib/tests/test_determinism.rs
+++ b/src/riscv/lib/tests/test_determinism.rs
@@ -83,7 +83,7 @@ fn run_steps_ladder<F>(
         assert_eq_struct(&stepper_lhs.struct_ref(), &stepper_rhs.struct_ref());
 
         let block_builder = InterpretedBlockBuilder;
-        stepper_lhs.rebind_via_serde(block_builder);
+        stepper_lhs.rebind_via_clone(block_builder);
     }
 
     assert_eq_struct_wrapper(stepper_lhs.struct_ref(), expected_refs);


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

Closes RV-709

Relates to RV-699

# What

Remove `ManagerDeserialise` & `ManagerSerialise` requirement for the `backend_test!` macro. 

<!--
    Summarise the changes in this MR.
-->

# Why

Will enable adding the `Verify` backend in the `backend_test!` macro which increases test coverage for this backend.

<!-- 
    Explain why this MR is needed.
-->

# How

* Add `FnManagerDerefClone` transformation for regions and 
* Remove printing the actual state data in `assert_eq_struct` to avoid needing to introduce the `Debug` trait over the associated type `ManagerBase::Region`. Would introduce too much noise in the code for not much gain.

<!--
    Explain how the MR achieves its goal. If this is trivial or if the code speaks for itself, you
    can omit this.
-->

# Manually Testing

```
make -C src/riscv all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
