### PR TITLE
Add `Verifier` to backend_test! macro

### DIFF
--- a/src/riscv/lib/src/machine_state.rs
+++ b/src/riscv/lib/src/machine_state.rs
@@ -615,6 +615,7 @@ pub(crate) mod test_helpers {
     use crate::state_backend::ManagerBase;
     use crate::state_backend::owned_backend::Owned;
     use crate::state_backend::proof_backend::ProofGen;
+    use crate::state_backend::verify_backend::Verifier;
 
     /// A wrapper to use a type `T` from either a mutable reference or an owned value.
     pub enum RefMutOrOwned<'a, T> {
@@ -685,10 +686,18 @@ pub(crate) mod test_helpers {
             RefMutOrOwned::RefMut(dirty_state)
         }
     }
+
     impl ReinitMachine<ProofGen<Owned>> for TestMachineOf<ProofGen<Owned>> {
         fn reinit_machine_state(_dirty_state: RefMut<Self>) -> RefMutOrOwned<Self> {
             let new_state = MachineState::new(InterpretedBlockBuilder);
             RefMutOrOwned::Owned(new_state)
+        }
+    }
+
+    impl ReinitMachine<Verifier> for TestMachineOf<Verifier> {
+        fn reinit_machine_state(mut dirty_state: RefMut<Self>) -> RefMutOrOwned<Self> {
+            dirty_state.reset();
+            RefMutOrOwned::RefMut(dirty_state)
         }
     }
 }

--- a/src/riscv/lib/src/state_backend.rs
+++ b/src/riscv/lib/src/state_backend.rs
@@ -482,6 +482,7 @@ pub(crate) mod test_helpers {
             fn $name() {
                 use $crate::state_backend::owned_backend::Owned;
                 use $crate::state_backend::proof_backend::ProofGen;
+                use $crate::state_backend::verify_backend::Verifier;
                 use $crate::state_backend::test_helpers::TestBackendFactory;
 
                 fn inner<$fac_name: TestBackendFactory>() {
@@ -490,6 +491,7 @@ pub(crate) mod test_helpers {
 
                 inner::<Owned>();
                 inner::<ProofGen<Owned>>();
+                inner::<Verifier>();
             }
         };
     }

--- a/src/riscv/lib/src/state_backend/region.rs
+++ b/src/riscv/lib/src/state_backend/region.rs
@@ -823,7 +823,7 @@ pub(crate) mod tests {
         test_dynregion_oob_2,
         F,
         {
-            const LEN: usize = 8;
+            const LEN: usize = 4096;
 
             let mut state = DynCells::<LEN, F>::new();
 
@@ -835,7 +835,7 @@ pub(crate) mod tests {
 
     backend_test!(test_dynregion_stored_format, F, {
         // Writing to one item of the region must convert to stored format.
-        let mut region = DynCells::<1024, F>::new();
+        let mut region = DynCells::<4096, F>::new();
 
         region.write(0, Flipper { a: 13, b: 37 });
         assert_eq!(region.read::<Flipper>(0), Flipper { a: 13, b: 37 });


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

Closes RV-699

# What

Add `Verify` backend to the `backend_test!` macro.

<!--
    Summarise the changes in this MR.
-->

# Why

Better test coverage for the `Verifier` backend.

<!-- 
    Explain why this MR is needed.
-->

# How

* Implemented `ManagerAlloc` for `Verifier` and updated the `backend_test!` macro.
* Had to change the size of dynamic regions in 2 tests in order to pass the compile time check for number of bytes being a multiple of the leaf size of a merkle tree. This check is done for the dynamic regions of the `Verify` backend [here](https://github.com/tezos/riscv-pvm/blob/main/src/riscv/lib/src/state_backend/verify_backend.rs#L446).

<!--
    Explain how the MR achieves its goal. If this is trivial or if the code speaks for itself, you
    can omit this.
-->

# Manually Testing

```
make -C src/riscv all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
