### PR TITLE
Track initialisation status of stack slots and values

### DIFF
--- a/src/riscv/lib/src/jit/builder/errno.rs
+++ b/src/riscv/lib/src/jit/builder/errno.rs
@@ -10,6 +10,8 @@
 //! Any returned values are written via 'out-pointers' - and should only be
 //! loaded on success.
 
+use std::mem::MaybeUninit;
+
 use cranelift::frontend::FunctionBuilder;
 
 use crate::jit::builder::typed::Pointer;
@@ -31,7 +33,7 @@ where
     pub(crate) is_exception: Value<bool>,
 
     /// Pointer to the exception in memory, if an exception occurred
-    pub(crate) exception_ptr: Pointer<Exception>,
+    pub(crate) exception_ptr: Pointer<MaybeUninit<Exception>>,
 
     /// Retrieve the result in case of success
     pub(crate) on_ok: F,
@@ -44,7 +46,7 @@ where
     /// Construct a new `Errno` that must be handled.
     pub(crate) fn new(
         is_exception: Value<bool>,
-        exception_ptr: Pointer<Exception>,
+        exception_ptr: Pointer<MaybeUninit<Exception>>,
         on_ok: F,
     ) -> Self {
         Self {

--- a/src/riscv/lib/src/jit/builder/instruction.rs
+++ b/src/riscv/lib/src/jit/builder/instruction.rs
@@ -543,7 +543,13 @@ impl<MC: MemoryConfig> ICB for InstructionBuilder<'_, '_, MC> {
         // Code for when the store failed
         {
             self.builder.switch_to_block(exception_block);
-            self.handle_exception::<()>(errno.exception_ptr);
+
+            // SAFETY: When the memory store external function call encounters an error, it will
+            // write to the exception pointer. This block handles such a failure case, so we can
+            // assume that the pointee is initialised.
+            let exception_ptr = unsafe { errno.exception_ptr.assume_init() };
+
+            self.handle_exception::<()>(exception_ptr);
         }
 
         // Code for when the store succeeded
@@ -580,7 +586,13 @@ impl<MC: MemoryConfig> ICB for InstructionBuilder<'_, '_, MC> {
         // Code for when the load failed
         {
             self.builder.switch_to_block(exception_block);
-            self.handle_exception::<()>(errno.exception_ptr);
+
+            // SAFETY: When the memory load external function call encounters an error, it will
+            // write to the exception pointer. This block handles such a failure case, so we can
+            // assume that the pointee is initialised.
+            let exception_ptr = unsafe { errno.exception_ptr.assume_init() };
+
+            self.handle_exception::<()>(exception_ptr);
         }
 
         // Code for when the load succeeded
@@ -646,7 +658,13 @@ impl<MC: MemoryConfig> ICB for InstructionBuilder<'_, '_, MC> {
         // Code for when an exception was raised.
         {
             self.builder.switch_to_block(exception_block);
-            self.handle_exception::<()>(errno.exception_ptr);
+
+            // SAFETY: When the external function call encounters an error, it will write to the
+            // exception pointer. This block handles such a failure case, so we can assume that the
+            // pointee is initialised.
+            let exception_ptr = unsafe { errno.exception_ptr.assume_init() };
+
+            self.handle_exception::<()>(exception_ptr);
         }
 
         // Code for when the conversion succeeded.

--- a/src/riscv/lib/src/jit/builder/typed.rs
+++ b/src/riscv/lib/src/jit/builder/typed.rs
@@ -14,6 +14,7 @@
 
 use std::cmp::Ordering;
 use std::marker::PhantomData;
+use std::mem::MaybeUninit;
 use std::ptr::NonNull;
 
 use cranelift::codegen::ir::Value as CraneliftValue;
@@ -73,6 +74,20 @@ impl<T> Value<T> {
 
         // SAFETY: `f` must produce a Cranelift value of type `T`.
         unsafe { Value::<T>::from_raw(raw) }
+    }
+}
+
+impl<T> Value<NonNull<MaybeUninit<T>>> {
+    /// Treat the pointee `T` as initialised.
+    ///
+    /// # Safety
+    ///
+    /// You must ensure that the pointee is indeed initialised before using it.
+    pub unsafe fn assume_init(self) -> Value<NonNull<T>> {
+        Value {
+            value: self.value,
+            _pd: PhantomData,
+        }
     }
 }
 


### PR DESCRIPTION
Closes RV-735

# What

This change tweaks the stack slot mechanism to track whether it has been initialised or not.

You can use `Slot::init` to initialise a slot proactively. Or, you can use `Slot::assume_init` to declare a slot as initialised after it has been written to by an external function. There is also `Pointer::assume_init` to obtain pointers to uninitialised slots and interpret them as initialised later - i.e. in case of branches where only one side may treat the pointee as initialised.

# Why

Tighter integration with typed IR values. Memory safety when calling Rust functions (via C ABI) that deal with references or pointers to un-/initialised memory.

I have prepared a follow-up PR that introduces some tweaks to the external function call framework, which harnesses this to enforce initialisation contracts across the external function barrier.

# Manually Testing

```
make -C src/riscv all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
