### PR TITLE
Replace f64 with soft floats represented as u64

### DIFF
--- a/src/riscv/lib/src/jit/builder/instruction.rs
+++ b/src/riscv/lib/src/jit/builder/instruction.rs
@@ -48,6 +48,7 @@ use crate::machine_state::ProgramCounterUpdate;
 use crate::machine_state::memory::Address;
 use crate::machine_state::memory::MemoryConfig;
 use crate::machine_state::registers::FRegister;
+use crate::machine_state::registers::FValue;
 use crate::machine_state::registers::XValue;
 use crate::machine_state::registers::XValue32;
 use crate::parser::instruction::InstrWidth;
@@ -283,7 +284,7 @@ impl<MC: MemoryConfig> ICB for InstructionBuilder<'_, '_, MC> {
 
     type XValue32 = Value<XValue32>;
 
-    type FValue = Value<f64>;
+    type FValue = Value<FValue>;
 
     type Bool = Value<bool>;
 

--- a/src/riscv/lib/src/jit/state_access.rs
+++ b/src/riscv/lib/src/jit/state_access.rs
@@ -60,6 +60,7 @@ use crate::machine_state::memory::BadMemoryAccess;
 use crate::machine_state::memory::Memory;
 use crate::machine_state::memory::MemoryConfig;
 use crate::machine_state::registers::FRegister;
+use crate::machine_state::registers::FValue;
 use crate::machine_state::registers::XValue;
 use crate::state_backend::Elem;
 use crate::state_backend::owned_backend::Owned;
@@ -153,19 +154,17 @@ register_jsa_functions!(
 extern "C" fn fregister_read<MC: MemoryConfig>(
     core: &mut MachineCoreState<MC, Owned>,
     reg: FRegister,
-) -> f64 {
-    let fval = core.hart.fregisters.read(reg);
-    fval.bits()
+) -> FValue {
+    core.hart.fregisters.read(reg)
 }
 
 /// Write the given value to the given [`FRegister`].
 extern "C" fn fregister_write<MC: MemoryConfig>(
     core: &mut MachineCoreState<MC, Owned>,
     reg: FRegister,
-    val: f64,
+    val: FValue,
 ) {
-    let fval = val.to_bits();
-    core.hart.fregisters.write(reg, fval.into())
+    core.hart.fregisters.write(reg, val)
 }
 
 /// Handle an [`Exception`].
@@ -292,12 +291,11 @@ extern "C" fn f64_from_x64_unsigned_dynamic<MC: MemoryConfig>(
     core: &mut MachineCoreState<MC, Owned>,
     exception_out: &mut MaybeUninit<Exception>,
     xval: XValue,
-    f64_out: &mut MaybeUninit<f64>,
+    fvalue_out: &mut MaybeUninit<FValue>,
 ) -> bool {
     match MachineCoreState::f64_from_x64_unsigned_dynamic(core, xval) {
         Ok(fval) => {
-            let f64val = fval.bits();
-            f64_out.write(f64val);
+            fvalue_out.write(fval);
             false
         }
         Err(e) => {
@@ -311,9 +309,8 @@ extern "C" fn f64_from_x64_unsigned_dynamic<MC: MemoryConfig>(
 extern "C" fn f64_from_x64_unsigned_static<RM: StaticRoundingMode, MC: MemoryConfig>(
     core: &mut MachineCoreState<MC, Owned>,
     xval: XValue,
-) -> f64 {
-    let fval = MachineCoreState::f64_from_x64_unsigned_static(core, xval, RM::ROUND);
-    fval.bits()
+) -> FValue {
+    MachineCoreState::f64_from_x64_unsigned_static(core, xval, RM::ROUND)
 }
 
 /// References to locally imported state access methods, used to directly call these accessor
@@ -353,7 +350,7 @@ pub struct JsaCalls<'a, MC: MemoryConfig> {
     pc_slot: Option<stack::Slot<MaybeUninit<Address>>>,
 
     /// Reusable stack slot for an FValue.
-    f64_ptr_slot: Option<stack::Slot<MaybeUninit<f64>>>,
+    fvalue_ptr_slot: Option<stack::Slot<MaybeUninit<FValue>>>,
 
     _pd: PhantomData<MC>,
 }
@@ -377,8 +374,11 @@ impl<'a, MC: MemoryConfig> JsaCalls<'a, MC> {
     }
 
     /// Get the stack slot for an FValue.
-    fn f64_ptr_slot(&mut self, builder: &mut FunctionBuilder) -> stack::Slot<MaybeUninit<f64>> {
-        self.f64_ptr_slot
+    fn fvalue_ptr_slot(
+        &mut self,
+        builder: &mut FunctionBuilder,
+    ) -> stack::Slot<MaybeUninit<FValue>> {
+        self.fvalue_ptr_slot
             .get_or_insert_with(|| stack::Slot::new(self.ptr_type, builder))
             .clone()
     }
@@ -415,7 +415,7 @@ impl<'a, MC: MemoryConfig> JsaCalls<'a, MC> {
             f64_from_x64_unsigned_static: None,
             exception_ptr_slot: None,
             pc_slot: None,
-            f64_ptr_slot: None,
+            fvalue_ptr_slot: None,
             _pd: PhantomData,
         }
     }
@@ -676,18 +676,19 @@ impl<'a, MC: MemoryConfig> JsaCalls<'a, MC> {
 
     /// Emit the required IR to call `f64_from_x64_unsigned_dynamic`.
     ///
-    /// Returns `errno` - on success, the new F64 value is returned.
+    /// Returns `errno` - on success, the new FValue is returned.
     pub(super) fn f64_from_x64_unsigned_dynamic(
         &mut self,
         builder: &mut FunctionBuilder,
         core_ptr: Pointer<MachineCoreState<MC, Owned>>,
         xval: Value<XValue>,
-    ) -> ErrnoImpl<Value<f64>, impl FnOnce(&mut FunctionBuilder) -> Value<f64> + 'static> {
+    ) -> ErrnoImpl<Value<FValue>, impl FnOnce(&mut FunctionBuilder) -> Value<FValue> + 'static>
+    {
         let exception_slot = self.exception_ptr_slot(builder);
         let exception_ptr = exception_slot.ptr(builder);
 
-        let f64_slot = self.f64_ptr_slot(builder);
-        let f64_ptr = f64_slot.ptr(builder);
+        let fvalue_slot = self.fvalue_ptr_slot(builder);
+        let fvalue_ptr = fvalue_slot.ptr(builder);
 
         let new_f64_from_x64_unsigned_dynamic =
             self.f64_from_x64_unsigned_dynamic.get_or_insert_with(|| {
@@ -699,28 +700,28 @@ impl<'a, MC: MemoryConfig> JsaCalls<'a, MC> {
             core_ptr.to_value(),
             exception_ptr.to_value(),
             xval.to_value(),
-            f64_ptr.to_value(),
+            fvalue_ptr.to_value(),
         ]);
 
         // SAFETY: [`self::f64_from_x64_unsigned_dynamic`] returns a `bool`.
         let is_exception = unsafe { Value::<bool>::from_raw(builder.inst_results(call)[0]) };
 
         ErrnoImpl::new(is_exception, exception_ptr, move |builder| {
-            // SAFETY: This closure runs after the success case of the call, where the f64_slot
-            // is guaranteed to have been initialised with an f64 value.
-            unsafe { f64_slot.assume_init().load(builder) }
+            // SAFETY: This closure runs after the success case of the call, where the fvalue_slot
+            // is guaranteed to have been initialised with an fvalue.
+            unsafe { fvalue_slot.assume_init().load(builder) }
         })
     }
 
     /// Emit the required IR to call `f64_from_x64_unsigned_static`.
-    /// The converted value is returned as `F64`.
+    /// The converted value is returned as `FValue`.
     pub(super) fn f64_from_x64_unsigned_static(
         &mut self,
         builder: &mut FunctionBuilder,
         core_ptr: Pointer<MachineCoreState<MC, Owned>>,
         xval: Value<XValue>,
         rm: RoundingMode,
-    ) -> Value<f64> {
+    ) -> Value<FValue> {
         let new_f64_from_x64_unsigned_static =
             self.f64_from_x64_unsigned_static.get_or_insert_with(|| {
                 let rm_func_id = match rm {
@@ -738,8 +739,8 @@ impl<'a, MC: MemoryConfig> JsaCalls<'a, MC> {
             xval.to_value(),
         ]);
 
-        // SAFETY: [`self::f64_from_x64_unsigned_static`] returns a `f64`.
-        unsafe { Value::<f64>::from_raw(builder.inst_results(call)[0]) }
+        // SAFETY: [`self::f64_from_x64_unsigned_static`] returns a `FValue`.
+        unsafe { Value::<FValue>::from_raw(builder.inst_results(call)[0]) }
     }
 
     /// Emit the required IR to read the value from the given fregister.
@@ -748,7 +749,7 @@ impl<'a, MC: MemoryConfig> JsaCalls<'a, MC> {
         builder: &mut FunctionBuilder,
         core_ptr: Pointer<MachineCoreState<MC, Owned>>,
         reg: FRegister,
-    ) -> Value<f64> {
+    ) -> Value<FValue> {
         let freg_read = self.freg_read.get_or_insert_with(|| {
             self.module
                 .declare_func_in_func(self.imports.freg_read, builder.func)
@@ -756,8 +757,8 @@ impl<'a, MC: MemoryConfig> JsaCalls<'a, MC> {
         let reg = builder.ins().iconst(I8, reg as i64);
         let call = builder.ins().call(*freg_read, &[core_ptr.to_value(), reg]);
 
-        // SAFETY: [`self::fregister_read`] returns a `f64`.
-        unsafe { Value::<f64>::from_raw(builder.inst_results(call)[0]) }
+        // SAFETY: [`self::fregister_read`] returns a `FValue`.
+        unsafe { Value::<FValue>::from_raw(builder.inst_results(call)[0]) }
     }
 
     /// Emit the required IR to write the value to the given fregister.
@@ -766,7 +767,7 @@ impl<'a, MC: MemoryConfig> JsaCalls<'a, MC> {
         builder: &mut FunctionBuilder,
         core_ptr: Pointer<MachineCoreState<MC, Owned>>,
         reg: FRegister,
-        value: Value<f64>,
+        value: Value<FValue>,
     ) {
         let freg_write = self.freg_write.get_or_insert_with(|| {
             self.module

--- a/src/riscv/lib/src/jit/state_access/abi.rs
+++ b/src/riscv/lib/src/jit/state_access/abi.rs
@@ -12,7 +12,6 @@ use cranelift::codegen::ir::types::I16;
 use cranelift::codegen::ir::types::I32;
 use cranelift::codegen::ir::types::I64;
 use cranelift::prelude::isa::CallConv;
-use cranelift::prelude::types::F64;
 use cranelift_jit::JITModule;
 use cranelift_module::FuncId;
 use cranelift_module::Linkage;
@@ -20,6 +19,7 @@ use cranelift_module::Module;
 use cranelift_module::ModuleResult;
 
 use crate::machine_state::registers::FRegister;
+use crate::machine_state::registers::FValue;
 use crate::machine_state::registers::NonZeroXRegister;
 
 /// This struct is used to produce and declare function signatures for external function calls.
@@ -161,8 +161,8 @@ impl ToCraneliftRepr for FRegister {
     const CRANELIFT_TYPE: CraneliftRepr = CraneliftRepr::Value(I8);
 }
 
-impl ToCraneliftRepr for f64 {
-    const CRANELIFT_TYPE: CraneliftRepr = CraneliftRepr::Value(F64);
+impl ToCraneliftRepr for FValue {
+    const CRANELIFT_TYPE: CraneliftRepr = CraneliftRepr::Value(I64);
 }
 
 /// A valid return type for an external function call.

--- a/src/riscv/lib/src/jit/state_access/stack.rs
+++ b/src/riscv/lib/src/jit/state_access/stack.rs
@@ -48,13 +48,13 @@ use cranelift::codegen::ir::StackSlotKind;
 use cranelift::codegen::ir::Type;
 use cranelift::codegen::ir::types::I64;
 use cranelift::frontend::FunctionBuilder;
-use cranelift::prelude::types::F64;
 use cranelift::prelude::types::I8;
 use cranelift::prelude::types::I16;
 use cranelift::prelude::types::I32;
 
 use crate::jit::builder::typed::Pointer;
 use crate::jit::builder::typed::Value;
+use crate::machine_state::registers::FValue;
 use crate::traps::Exception;
 
 /// Any value of type `T: StackAddressable` may be placed on the stack, and
@@ -134,12 +134,12 @@ impl_stackable_int!(16);
 impl_stackable_int!(32);
 impl_stackable_int!(64);
 
-impl StackAddressable for f64 {
-    type Underlying = f64;
+impl StackAddressable for FValue {
+    type Underlying = FValue;
 }
 
-impl Stackable for f64 {
-    const IR_TYPE: Type = F64;
+impl Stackable for FValue {
+    const IR_TYPE: Type = I64;
 }
 
 /// Dedicated space on the stack to store a value of the underlying type.

--- a/src/riscv/lib/src/machine_state/registers.rs
+++ b/src/riscv/lib/src/machine_state/registers.rs
@@ -580,9 +580,9 @@ impl ConstDefault for FValue {
 }
 
 impl FValue {
-    /// Convert to [`f64`] bitwise.
-    pub(crate) fn bits(self) -> f64 {
-        f64::from_bits(self.0)
+    /// Extract the raw bits of FValue to [`u64`].
+    pub(crate) fn bits(self) -> u64 {
+        self.0
     }
 }
 


### PR DESCRIPTION
Closes RV-712

Closes RV-718

# What

This MR removes the use of f64 in both interpreted and jit mode of the RISC-V pvm

# Why

Currently the the riscv-pvm uses Floating point types, including rust f64 and Cranelift F64. This is unsafe because:

- Signalling NaNs may actually crash the process the PVM runs in

- Floats may be normalised, causing indeterministic behaviour

Therefore, all floating point type usage needs to be removed 

# How

This MR replaces all f64 usage with u64. The u64 stores the bit value of the `rustc_apfloat` representation of the f64.

For the external functions reading/writing f64 values, `FValue`(which contains the u64) is passed across extern "C" boundaries.

The stored floating point value can be accessed by first casting to u128 and then calling `Double::from_u128_r(input, round)`

# Manually Testing

```
make -C src/riscv all
```

There are currently no tests that checks for floating point usage. 

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
