### PR TITLE
Etherlink: Benchmarks for natively compiled kernel

### DIFF
--- a/scripts/etherlink-bench.sh
+++ b/scripts/etherlink-bench.sh
@@ -7,32 +7,105 @@
 
 set -e
 
+USAGE="Usage: [ -s: static inbox ] [ -n: run natively ]"
+
 TX="15"
 SANDBOX_BIN="riscv-sandbox"
 DEFAULT_ROLLUP_ADDRESS="sr163Lv22CdE8QagCwf48PWDTquk6isQwv57"
 ETHERLINK_SANDBOX_PARAMS=("--input" "etherlink/target/riscv64gc-unknown-linux-musl/release/etherlink")
 INBOX_FILE="assets/etherlink-erc20-inbox.json"
+STATIC_INBOX=""
+NATIVE=""
 
 CURR=$(pwd)
 RISCV_DIR=$(dirname "$0")/..
 cd "$RISCV_DIR/src/riscv"
 
+while getopts "sn" OPTION; do
+  case "$OPTION" in
+  s)
+    STATIC_INBOX="y"
+    ;;
+  n)
+    NATIVE=$(make --silent -C jstz print-native-target | grep -wv make)
+    ;;
+  *)
+    echo "$USAGE"
+    exit 1
+    ;;
+  esac
+done
+
+if [ -n "$NATIVE" ] && [ -z "$STATIC_INBOX" ]; then
+  echo "Native compilation without static inbox unsupported"
+  echo "$USAGE"
+  exit 1
+fi
+
+##########
+# RISC-V #
+##########
+build_etherlink_riscv() {
+  if [ "$STATIC_INBOX" = "y" ]; then
+    INBOX_FILE="../../../$INBOX_FILE" make -C etherlink build-kernel-static &> /dev/null
+  else
+    make -C etherlink build-kernel &> /dev/null
+  fi
+}
+
+run_etherlink_riscv() {
+  LOG="$DATA_DIR/etherlink.log"
+  "./$SANDBOX_BIN" run \
+    "${ETHERLINK_SANDBOX_PARAMS[@]}" \
+    --inbox-file "$INBOX_FILE" \
+    --address "$DEFAULT_ROLLUP_ADDRESS" \
+    --timings > "$LOG"
+}
+
+##########
+# Native #
+##########
+build_etherlink_native() {
+  INBOX_FILE="../../../$INBOX_FILE" make -C etherlink build-kernel-native
+}
+
+run_etherlink_native() {
+  LOG="$DATA_DIR/etherlink.log"
+  ./etherlink/target/"$NATIVE"/release/etherlink \
+    --timings > "$LOG" 2> /dev/null
+}
+
 echo "[INFO]: Building RISC-V sandbox"
 make "$SANDBOX_BIN" &> /dev/null
 echo "[INFO]: Building bench tool"
 make -C etherlink inbox-bench &> /dev/null
-echo "[INFO]: Building Etherlink kernel (riscv)"
-make -C etherlink build-kernel &> /dev/null
+
+#########
+# Build #
+#########
+echo "[INFO]: Building Etherlink kernel"
+
+if [ -z "$NATIVE" ]; then
+  build_etherlink_riscv
+else
+  build_etherlink_native
+fi
+
+#######
+# Run #
+#######
+run_etherlink() {
+  if [ -z "$NATIVE" ]; then
+    echo "[INFO]: running $TX transfers (riscv) "
+    run_etherlink_riscv
+  else
+    echo "[INFO]: running $TX transfers ($NATIVE) "
+    run_etherlink_native
+  fi
+}
 
 DATA_DIR=${DATA_DIR:=$(mktemp -d)}
-LOG="$DATA_DIR/etherlink.log"
-
-echo "[INFO]: Running $TX transfers (riscv) "
-"./$SANDBOX_BIN" run \
-  "${ETHERLINK_SANDBOX_PARAMS[@]}" \
-  --inbox-file "$INBOX_FILE" \
-  --address "$DEFAULT_ROLLUP_ADDRESS" \
-  --timings > "$LOG"
+run_etherlink
 
 echo -e "\033[1m"
 ./etherlink/inbox-bench results \

--- a/src/riscv/etherlink/Cargo.lock
+++ b/src/riscv/etherlink/Cargo.lock
@@ -1256,7 +1256,7 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.39.1"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "auto_impl",
  "ethereum",
@@ -1272,7 +1272,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.39.0"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "primitive-types",
 ]
@@ -1280,7 +1280,7 @@ dependencies = [
 [[package]]
 name = "evm-execution-latest"
 version = "0.1.0"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "alloy-primitives 0.7.7",
  "alloy-sol-types 0.7.7",
@@ -1316,7 +1316,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.39.0"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "evm-core",
  "evm-runtime",
@@ -1326,7 +1326,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.39.0"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "auto_impl",
  "evm-core",
@@ -1337,7 +1337,7 @@ dependencies = [
 [[package]]
 name = "evm_kernel"
 version = "0.1.0"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "alloy-sol-types 0.7.7",
  "anyhow",
@@ -1920,7 +1920,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "mir"
 version = "0.1.0"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "base58",
  "bitvec",
@@ -2112,6 +2112,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2236,6 +2248,15 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve 0.13.8",
+]
 
 [[package]]
 name = "primitive-types"
@@ -2521,9 +2542,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "revm"
-version = "25.0.0"
+version = "27.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08fd78df29217546ddfd587fe313aff2bf86e57cfe0f18d16cb326d9f50ba54d"
+checksum = "70a84455f03d3480d4ed2e7271c15f2ec95b758e86d57cb8d258a8ff1c22e9a4"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -2540,9 +2561,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "4.1.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942fe4724cf552fd28db6b0a2ca5b79e884d40dd8288a4027ed1e9090e0c6f49"
+checksum = "7a685758a4f375ae9392b571014b9779cfa63f0d8eb91afb4626ddd958b23615"
 dependencies = [
  "bitvec",
  "once_cell",
@@ -2551,9 +2572,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "6.0.0"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190f211f04c8030f5393cfcfa1569b88d5649f0f266bf4291981ba879fa6c5d1"
+checksum = "a990abf66b47895ca3e915d5f3652bb7c6a4cff6e5351fdf0fc2795171fd411c"
 dependencies = [
  "cfg-if",
  "derive-where",
@@ -2566,9 +2587,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "6.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b7e7ff1154e6460cec025fe20dfe45f3325bbb905718643b6d053ec49da6e8"
+checksum = "a303a93102fceccec628265efd550ce49f2817b38ac3a492c53f7d524f18a1ca"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -2581,9 +2602,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "5.0.0"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9456d5cb165fef91c8b538d0115de50059d1cf352d160a1396894eac017a2a34"
+checksum = "7db360729b61cc347f9c2f12adb9b5e14413aea58778cf9a3b7676c6a4afa115"
 dependencies = [
  "revm-bytecode",
  "revm-database-interface",
@@ -2593,11 +2614,12 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "5.0.0"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaeb608de31bfd0e64bf9b5b18ee70ac70094c8c045b28ae8ae8701608d17d34"
+checksum = "b8500194cad0b9b1f0567d72370795fd1a5e0de9ec719b1607fa1566a23f039a"
 dependencies = [
  "auto_impl",
+ "either",
  "revm-primitives",
  "revm-state",
 ]
@@ -2605,14 +2627,16 @@ dependencies = [
 [[package]]
 name = "revm-etherlink"
 version = "0.1.0"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
+ "alloy-primitives 1.2.1",
  "alloy-sol-types 1.2.1",
  "format_no_std",
  "hex",
  "num-bigint",
  "primitive-types",
  "revm",
+ "rlp",
  "tezos-evm-logging-latest",
  "tezos-evm-runtime-latest",
  "tezos-smart-rollup-encoding",
@@ -2626,11 +2650,12 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "6.0.0"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfeaecd909e6be655c36d21032ca932b347e60ec5849ee29e670d63aa97b6adb"
+checksum = "03c35a17a38203976f97109e20eccf6732447ce6c9c42973bae42732b2e957ff"
 dependencies = [
  "auto_impl",
+ "derive-where",
  "revm-bytecode",
  "revm-context",
  "revm-context-interface",
@@ -2643,11 +2668,12 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "6.0.0"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de1c6cddc7d62364dc9fa2f405c2c4637c933c5591addf09977ec8a156e4b23"
+checksum = "e69abf6a076741bd5cd87b7d6c1b48be2821acc58932f284572323e81a8d4179"
 dependencies = [
  "auto_impl",
+ "either",
  "revm-context",
  "revm-database-interface",
  "revm-handler",
@@ -2658,9 +2684,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "21.0.0"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c3ca670eee335d9268a9100932ec1e09638bdd9b31eac9e22dec4de00f2cba"
+checksum = "d95c4a9a1662d10b689b66b536ddc2eb1e89f5debfcabc1a2d7b8417a2fa47cd"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -2669,19 +2695,21 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "22.0.0"
+version = "24.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4330c6982a2ef1d318cb10ce7e726a64e11e44fe1eac29d055de849a5e1e080e"
+checksum = "b68d54a4733ac36bd29ee645c3c2e5e782fb63f199088d49e2c48c64a9fedc15"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
  "ark-ec",
  "ark-ff",
  "ark-serialize",
+ "arrayref",
  "aurora-engine-modexp",
  "cfg-if",
  "k256",
  "once_cell",
+ "p256 0.13.2",
  "revm-primitives",
  "ripemd",
  "sha2 0.10.9",
@@ -2689,9 +2717,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "19.2.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c1588093530ec4442461163be49c433c07a3235d1ca6f6799fef338dacc50d3"
+checksum = "52cdf897b3418f2ee05bcade64985e5faed2dbaa349b2b5f27d3d6bfd10fff2a"
 dependencies = [
  "alloy-primitives 1.2.1",
  "num_enum",
@@ -2699,9 +2727,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "5.0.0"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44320ccf53067136a83cdbc54f4b7529e8f61497666f31d6f5cfd9035a1cc08f"
+checksum = "106fec5c634420118c7d07a6c37110186ae7f23025ceac3a5dbe182eea548363"
 dependencies = [
  "bitflags",
  "revm-bytecode",
@@ -3146,7 +3174,7 @@ dependencies = [
 [[package]]
 name = "tezos-evm-logging-latest"
 version = "0.1.0"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "num-derive",
  "num-traits",
@@ -3156,7 +3184,7 @@ dependencies = [
 [[package]]
 name = "tezos-evm-runtime-latest"
 version = "0.1.0"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "sha3",
  "tezos-evm-logging-latest",
@@ -3170,7 +3198,7 @@ dependencies = [
 [[package]]
 name = "tezos-execution-latest"
 version = "0.1.0"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "anyhow",
  "hex",
@@ -3193,7 +3221,7 @@ dependencies = [
 [[package]]
 name = "tezos-indexable-storage-latest"
 version = "0.1.0"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "rlp",
  "tezos-evm-logging-latest",
@@ -3208,7 +3236,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "hex",
  "serde_json",
@@ -3229,7 +3257,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-build-utils"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3239,12 +3267,12 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-constants"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 
 [[package]]
 name = "tezos-smart-rollup-core"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "tezos-smart-rollup-build-utils",
  "tezos-smart-rollup-constants",
@@ -3253,7 +3281,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-debug"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "tezos-smart-rollup-core",
  "tezos-smart-rollup-host",
@@ -3262,7 +3290,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-encoding"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "hex",
  "nom",
@@ -3281,7 +3309,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-entrypoint"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "cfg-if",
  "dlmalloc",
@@ -3297,7 +3325,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-host"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "tezos-smart-rollup-build-utils",
  "tezos-smart-rollup-core",
@@ -3309,7 +3337,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-installer-config"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "hex",
  "nom",
@@ -3326,7 +3354,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-macros"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "proc-macro-error2",
  "quote",
@@ -3338,7 +3366,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-mock"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "hex",
  "tezos-smart-rollup-core",
@@ -3351,7 +3379,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-panic-hook"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "rustversion",
  "tezos-smart-rollup-build-utils",
@@ -3361,7 +3389,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-storage"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "tezos-smart-rollup-core",
  "tezos-smart-rollup-debug",
@@ -3373,7 +3401,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-utils"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "clap",
  "hex",
@@ -3390,7 +3418,7 @@ dependencies = [
 [[package]]
 name = "tezos-storage-latest"
 version = "0.1.0"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "anyhow",
  "hex",
@@ -3410,7 +3438,7 @@ dependencies = [
 [[package]]
 name = "tezos_crypto_rs"
 version = "0.6.0"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "anyhow",
  "bs58",
@@ -3422,7 +3450,7 @@ dependencies = [
  "nom",
  "num-bigint",
  "num-traits",
- "p256",
+ "p256 0.9.0",
  "rand 0.7.3",
  "serde",
  "strum 0.20.0",
@@ -3435,7 +3463,7 @@ dependencies = [
 [[package]]
 name = "tezos_data_encoding"
 version = "0.6.0"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "bit-vec 0.6.3",
  "bitvec",
@@ -3452,7 +3480,7 @@ dependencies = [
 [[package]]
 name = "tezos_data_encoding_derive"
 version = "0.6.0"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "lazy_static",
  "once_cell",
@@ -3465,7 +3493,7 @@ dependencies = [
 [[package]]
 name = "tezos_ethereum_latest"
 version = "0.1.0"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3484,7 +3512,7 @@ dependencies = [
 [[package]]
 name = "tezos_tezlink_latest"
 version = "0.1.0"
-source = "git+https://gitlab.com/tezos/tezos.git#396e474115786da1229665bf3ec4c7d976db8ec3"
+source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
 dependencies = [
  "hex",
  "mir",
@@ -3495,6 +3523,7 @@ dependencies = [
  "tezos-smart-rollup",
  "tezos_crypto_rs",
  "tezos_data_encoding",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/src/riscv/etherlink/Makefile
+++ b/src/riscv/etherlink/Makefile
@@ -8,6 +8,8 @@ ifneq ($(NATIVE_TARGET),)
 NATIVE_OPT := --target "$(NATIVE_TARGET)"
 endif
 
+INBOX_FILE ?= "../../../assets/etherlink-erc20-inbox.json"
+
 .PHONY: all
 all: build check test inbox-bench
 
@@ -24,16 +26,25 @@ build: build-kernel inbox-bench
 build-kernel:
 	@cargo build -p etherlink --release
 
+.PHONY: build-kernel-static
+build-kernel-static:
+	@INBOX_FILE=$(INBOX_FILE) cargo build -p etherlink --release --features static-inbox
+
+.PHONY: build-kernel-native
+build-kernel-native:
+	@INBOX_FILE=$(INBOX_FILE) cargo build -p etherlink --release --features static-inbox $(NATIVE_OPT)
+
 .PHONY: test
-test:
+test: build-kernel build-kernel-native
 	@../../../scripts/etherlink-bench.sh
+	@../../../scripts/etherlink-bench.sh -sn
 
 .PHONY: check
 check:
 	@exec ../../../scripts/format.sh --check
-	@cargo check --workspace --locked
-	@cargo clippy -- --deny warnings
-	@cargo doc --all-features --document-private-items --no-deps
+	@INBOX_FILE=$(INBOX_FILE) cargo check --all-features --workspace --locked
+	@INBOX_FILE=$(INBOX_FILE) cargo clippy --all-features -- --deny warnings
+	@INBOX_FILE=$(INBOX_FILE) cargo doc --all-features --document-private-items --no-deps
 
 .PHONY: inbox-bench
 inbox-bench:

--- a/src/riscv/etherlink/kernel/Cargo.toml
+++ b/src/riscv/etherlink/kernel/Cargo.toml
@@ -10,3 +10,11 @@ tezos-smart-rollup.workspace = true
 [dependencies.evm_kernel]
 workspace = true
 features = ["debug"]
+
+[target.'cfg(not(target_arch = "riscv64"))'.dependencies.evm_kernel]
+workspace = true
+features = ["debug", "dummy-store-get-hash"]
+
+[features]
+default = []
+static-inbox = []

--- a/src/riscv/etherlink/kernel/build.rs
+++ b/src/riscv/etherlink/kernel/build.rs
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2024 TriliTech <contact@trili.tech>
+//
+// SPDX-License-Identifier: MIT
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=INBOX_FILE");
+}

--- a/src/riscv/etherlink/kernel/src/main.rs
+++ b/src/riscv/etherlink/kernel/src/main.rs
@@ -35,6 +35,10 @@ const VALUES: [(&str, &str); 6] = [
 ];
 
 #[entrypoint::main]
+#[cfg_attr(
+    feature = "static-inbox",
+    entrypoint::runtime(static_inbox = "$INBOX_FILE")
+)]
 pub fn entry(host: &mut impl Runtime) {
     static ONCE: Once = Once::new();
 


### PR DESCRIPTION
Closes RV-739.

# What

Introduce benchmarks for the Etherlink kernel compiled to the native target.

# Why

To be able to monitor the relative performance of the RISC-V interpreter to native when executing the Etherlink kernel.

# How

Similar to the corresponding jstz benchmarks. 

Compiling Etherlink to a target different from `riscv64` requires enabling the `dummy-store-get-hash` feature, which compiles with same implementation for the Etherlink-specific `__internal_store_get_hash` runtime function as for the `riscv64`-compiled kernel.

# Manually Testing

```
make -C src/riscv/etherlink test

[INFO]: Building RISC-V sandbox
[INFO]: Building bench tool
[INFO]: Building Etherlink kernel
[INFO]: running 15 transfers (riscv)


| Run | Transfers |     Duration |     TPS |
|-----|-----------|--------------|---------|
| 1   | 15        | 109.035186ms | 137.570 |

[INFO]: Building RISC-V sandbox
[INFO]: Building bench tool
[INFO]: Building Etherlink kernel
[INFO]: running 15 transfers (aarch64-apple-darwin)


| Run | Transfers |   Duration |      TPS |
|-----|-----------|------------|----------|
| 1   | 15        | 3.981064ms | 3767.837 |
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
