### PR TITLE
Load values from memory using external function framework

### DIFF
--- a/src/riscv/lib/src/jit/builder/typed.rs
+++ b/src/riscv/lib/src/jit/builder/typed.rs
@@ -47,7 +47,7 @@ impl Type {
 }
 
 /// Trait for types that can be represented in Cranelift IR
-pub trait Typed {
+pub trait Typed: Sized {
     const TYPE: Type;
 }
 
@@ -154,6 +154,18 @@ impl<T> Value<T> {
 
         // SAFETY: `f` must produce a Cranelift value of type `T`.
         unsafe { Value::<T>::from_raw(raw) }
+    }
+
+    /// Cast this value to a different type `U`.
+    ///
+    /// # Safety
+    ///
+    /// You must ensure that the type `U` is compatible with the underlying Cranelift value.
+    pub unsafe fn cast<U>(self) -> Value<U> {
+        Value {
+            value: self.value,
+            _pd: PhantomData,
+        }
     }
 }
 


### PR DESCRIPTION
Part of RV-738

# What

Invoke the external function loading values from memory using the new framework.

# Why

Ensure type safety as per RV-738.

# Manually Testing

```
make -C src/riscv all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
