### PR TITLE
RISC-V: Rename `Signal`

### DIFF
--- a/src/riscv/lib/src/pvm/linux.rs
+++ b/src/riscv/lib/src/pvm/linux.rs
@@ -851,7 +851,7 @@ impl<M: ManagerBase> SupervisorState<M> {
     fn handle_tkill(
         &mut self,
         _: parameters::MainThreadId,
-        signal: signals::Signal,
+        signal: signals::TkillSignal,
     ) -> Result<parameters::SystemCallResultExecution, Infallible>
     where
         M: ManagerReadWrite,

--- a/src/riscv/lib/src/pvm/linux/signals.rs
+++ b/src/riscv/lib/src/pvm/linux/signals.rs
@@ -25,9 +25,9 @@ pub const SIGSET_SIZE: u64 = 8;
 
 /// A signal passed to a thread, see `tkill(2)`
 #[derive(Debug, Clone, Copy)]
-pub struct Signal(u7);
+pub struct TkillSignal(u7);
 
-impl Signal {
+impl TkillSignal {
     /// Extract the exit code from the signal stored in this type
     pub fn exit_code(&self) -> u64 {
         // Setting bit 2^7 of the exit code indicates that the process was killed by a signal
@@ -37,11 +37,11 @@ impl Signal {
     }
 }
 
-impl TryFrom<u64> for Signal {
+impl TryFrom<u64> for TkillSignal {
     type Error = Error;
 
     fn try_from(value: u64) -> Result<Self, Self::Error> {
-        Ok(Signal(u7::try_new(value.try_into()?)?))
+        Ok(TkillSignal(u7::try_new(value.try_into()?)?))
     }
 }
 


### PR DESCRIPTION
Closes RV-724

# What
As support for POSIX signals is added, the `Signal` used by the current implementation of `handle_tkill` is a name collision.

`handle_tkill` will later have to be updated to allow generating signals of any kind (not just `SIGKILL`) but work that blocks this requires implementing signal parsing, so this type is temporarily renamed.

# Why

Needed as part of POSIX signal support


# Manually Testing

```
make -C src/riscv all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
