### PR TITLE
Migrate F-register accessors to new external function framework

### DIFF
--- a/src/riscv/lib/src/jit/builder/ext_calls.rs
+++ b/src/riscv/lib/src/jit/builder/ext_calls.rs
@@ -120,6 +120,16 @@ fn call_raw<A: ArgumentsTyped, R: ReturnTyped>(
     R::from_return_values(ret_values)
 }
 
+/// Call an external function with 1 argument.
+pub fn call1<A0: Typed, R: ReturnTyped>(
+    target_config: &TargetFrontendConfig,
+    builder: &mut FunctionBuilder,
+    callee: extern "C" fn(A0) -> R,
+    arg0: Value<A0>,
+) -> R::Value {
+    call_raw::<(A0,), R>(target_config, builder, callee as usize, &[arg0.to_value()])
+}
+
 /// Call an external function with 2 arguments.
 pub fn call2<A0: Typed, A1: Typed, R: ReturnTyped>(
     target_config: &TargetFrontendConfig,
@@ -133,14 +143,21 @@ pub fn call2<A0: Typed, A1: Typed, R: ReturnTyped>(
         arg1.to_value(),
     ])
 }
-/// Call an external function with 1 argument.
-pub fn call1<A0: Typed, R: ReturnTyped>(
+
+/// Call an external function with 3 arguments.
+pub fn call3<A0: Typed, A1: Typed, A2: Typed, R: ReturnTyped>(
     target_config: &TargetFrontendConfig,
     builder: &mut FunctionBuilder,
-    callee: extern "C" fn(A0) -> R,
+    callee: extern "C" fn(A0, A1, A2) -> R,
     arg0: Value<A0>,
+    arg1: Value<A1>,
+    arg2: Value<A2>,
 ) -> R::Value {
-    call_raw::<(A0,), R>(target_config, builder, callee as usize, &[arg0.to_value()])
+    call_raw::<(A0, A1, A2), R>(target_config, builder, callee as usize, &[
+        arg0.to_value(),
+        arg1.to_value(),
+        arg2.to_value(),
+    ])
 }
 
 /// Call an external function with 4 arguments.

--- a/src/riscv/lib/src/jit/builder/typed.rs
+++ b/src/riscv/lib/src/jit/builder/typed.rs
@@ -19,6 +19,8 @@ use std::ptr::NonNull;
 
 use cranelift::codegen::ir::Type as CraneliftType;
 use cranelift::codegen::ir::Value as CraneliftValue;
+use cranelift::prelude::FunctionBuilder;
+use cranelift::prelude::InstBuilder;
 use cranelift::prelude::isa::TargetFrontendConfig;
 use cranelift::prelude::types::I8;
 use cranelift::prelude::types::I16;
@@ -115,6 +117,28 @@ impl<T> Value<T> {
     ///
     /// The caller must ensure the type `T` is correct for the given Cranelift value.
     pub unsafe fn from_raw(value: CraneliftValue) -> Self {
+        Value {
+            value,
+            _pd: PhantomData,
+        }
+    }
+
+    /// Construct a new typed value for an enum from its discriminant.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the discriminant corresponds to a valid variant of the enum.
+    pub unsafe fn from_discriminant(
+        target_config: &TargetFrontendConfig,
+        builder: &mut FunctionBuilder,
+        discriminant: i64,
+    ) -> Self
+    where
+        T: Typed,
+    {
+        let value = builder
+            .ins()
+            .iconst(T::TYPE.to_type(target_config), discriminant);
         Value {
             value,
             _pd: PhantomData,

--- a/src/riscv/lib/src/jit/state_access.rs
+++ b/src/riscv/lib/src/jit/state_access.rs
@@ -30,7 +30,6 @@ use abi::AbiCall;
 use cranelift::codegen::ir::FuncRef;
 use cranelift::codegen::ir::InstBuilder;
 use cranelift::codegen::ir::Type;
-use cranelift::codegen::ir::types::I8;
 use cranelift::frontend::FunctionBuilder;
 use cranelift::prelude::isa::TargetFrontendConfig;
 use cranelift_jit::JITBuilder;
@@ -105,8 +104,6 @@ macro_rules! register_jsa_functions {
 }
 
 register_jsa_functions!(
-    freg_read => (fregister_read::<MC>, AbiCall<2>::args),
-    freg_write => (fregister_write::<MC>, AbiCall<3>::args),
     f64_from_x64_unsigned_dynamic => (
         f64_from_x64_unsigned_dynamic::<MC>,
         AbiCall<4>::args
@@ -135,7 +132,7 @@ register_jsa_functions!(
 
 /// Read the value of the given [`FRegister`].
 extern "C" fn fregister_read<MC: MemoryConfig>(
-    core: &mut MachineCoreState<MC, Owned>,
+    core: &MachineCoreState<MC, Owned>,
     reg: FRegister,
 ) -> FValue {
     core.hart.fregisters.read(reg)
@@ -295,8 +292,6 @@ pub struct JsaCalls<'a, MC: MemoryConfig> {
     module: &'a mut JITModule,
     imports: &'a JsaImports<MC>,
     ptr_type: Type,
-    freg_read: Option<FuncRef>,
-    freg_write: Option<FuncRef>,
     f64_from_x64_unsigned_dynamic: Option<FuncRef>,
     f64_from_x64_unsigned_static: Option<FuncRef>,
 
@@ -351,8 +346,6 @@ impl<'a, MC: MemoryConfig> JsaCalls<'a, MC> {
             module,
             imports,
             ptr_type,
-            freg_read: None,
-            freg_write: None,
             f64_from_x64_unsigned_dynamic: None,
             f64_from_x64_unsigned_static: None,
             exception_ptr_slot: None,
@@ -614,15 +607,21 @@ impl<'a, MC: MemoryConfig> JsaCalls<'a, MC> {
         core_ptr: Pointer<MachineCoreState<MC, Owned>>,
         reg: FRegister,
     ) -> Value<FValue> {
-        let freg_read = self.freg_read.get_or_insert_with(|| {
-            self.module
-                .declare_func_in_func(self.imports.freg_read, builder.func)
-        });
-        let reg = builder.ins().iconst(I8, reg as i64);
-        let call = builder.ins().call(*freg_read, &[core_ptr.to_value(), reg]);
+        // SAFETY: We construct the typed value from the `FRegister`, thereby ensuring the use of
+        // the right discriminant.
+        let reg_value = unsafe {
+            Value::<FRegister>::from_discriminant(&self.target_config, builder, reg as u8 as i64)
+        };
 
-        // SAFETY: [`self::fregister_read`] returns a `FValue`.
-        unsafe { Value::<FValue>::from_raw(builder.inst_results(call)[0]) }
+        // SAFETY: The `core_ptr` is a JIT function argument which means the reference through it
+        // will be valid for the duration of the call.
+        ext_calls::call2(
+            &self.target_config,
+            builder,
+            self::fregister_read,
+            unsafe { core_ptr.as_ref() },
+            reg_value,
+        )
     }
 
     /// Emit the required IR to write the value to the given fregister.
@@ -633,14 +632,22 @@ impl<'a, MC: MemoryConfig> JsaCalls<'a, MC> {
         reg: FRegister,
         value: Value<FValue>,
     ) {
-        let freg_write = self.freg_write.get_or_insert_with(|| {
-            self.module
-                .declare_func_in_func(self.imports.freg_write, builder.func)
-        });
-        let reg = builder.ins().iconst(I8, reg as i64);
-        builder
-            .ins()
-            .call(*freg_write, &[core_ptr.to_value(), reg, value.to_value()]);
+        // SAFETY: We construct the typed value from the `FRegister`, thereby ensuring the use of
+        // the right discriminant.
+        let reg_value = unsafe {
+            Value::<FRegister>::from_discriminant(&self.target_config, builder, reg as u8 as i64)
+        };
+
+        // SAFETY: The `core_ptr` is a JIT function argument which means the reference through it
+        // will be valid for the duration of the call.
+        ext_calls::call3(
+            &self.target_config,
+            builder,
+            self::fregister_write,
+            unsafe { core_ptr.as_mut() },
+            reg_value,
+            value,
+        );
     }
 }
 

--- a/src/riscv/lib/src/jit/state_access/abi.rs
+++ b/src/riscv/lib/src/jit/state_access/abi.rs
@@ -83,10 +83,6 @@ impl AbiCall<2> {
     impl_abicall!(A1, A2);
 }
 
-impl AbiCall<3> {
-    impl_abicall!(A1, A2, A3);
-}
-
 impl AbiCall<4> {
     impl_abicall!(A1, A2, A3, A4);
 }


### PR DESCRIPTION
Part of RV-738

# What

Migrate accessor functions for F-registers to the external function framework.

# Why

Ensures type safety when calling external functions.

# Manually Testing

```
make -C src/riscv all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
