### PR TITLE
Update CI benchmark to run 20 transactions and 20 iterations

### DIFF
--- a/scripts/ci-bench.sh
+++ b/scripts/ci-bench.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+NUM_TXS=20
+NUM_ITERS=20
+
 # Git ref to checkout
 ref=""
 
@@ -46,18 +49,18 @@ nix develop --command make -C src/riscv/jstz build-kernel &>/dev/null
 
 # Generate inbox file for benchmark runs
 inbox_file=$(mktemp)
-nix develop --command cargo run --quiet --manifest-path src/riscv/jstz/Cargo.toml --bin inbox-bench -- generate --transfers 15 --inbox-file "$inbox_file"
+nix develop --command cargo run --quiet --manifest-path src/riscv/jstz/Cargo.toml --bin inbox-bench -- generate --transfers "$NUM_TXS" --inbox-file "$inbox_file"
 
 # Run the benchmark
 result_dir=$(mktemp -d)
 result_args=()
-for i in $(seq 1 10); do 
+for i in $(seq 1 $NUM_ITERS); do 
   nix develop --command cargo run --release --quiet --manifest-path src/riscv/Cargo.toml --bin riscv-sandbox -- run --input src/riscv/jstz/target/riscv64gc-unknown-linux-musl/release/jstz --inbox-file "$inbox_file" --timings > $result_dir/$i.json
   result_args+=("--log-file=$result_dir/$i.json")
 done
 
 # Collect results and display them
-nix develop --command cargo run --quiet --manifest-path src/riscv/jstz/Cargo.toml --bin inbox-bench -- results --inbox-file "$inbox_file" --expected-transfers 15 "${result_args[@]}"
+nix develop --command cargo run --quiet --manifest-path src/riscv/jstz/Cargo.toml --bin inbox-bench -- results --inbox-file "$inbox_file" --expected-transfers "$NUM_TXS" "${result_args[@]}"
 
 # Clean up
 rm -rf "$inbox_file" "$dir" "$result_dir"


### PR DESCRIPTION
Update CI benchmark to run 20 transactions and 20 iterations. Hopefully we can reign in the increased flakiness of the benchmark.