### PR TITLE
RISC-V: Support doc comments for `struct_layout`

### DIFF
--- a/src/riscv/lib/src/state_backend/layout.rs
+++ b/src/riscv/lib/src/state_backend/layout.rs
@@ -67,6 +67,9 @@ impl<const LEN: usize> Layout for DynArray<LEN> {
 #[macro_export]
 macro_rules! struct_layout {
     (
+        $(
+            #[$attributes:meta]
+        )*
         $vis:vis struct $layout_t:ident $(< $($param:ident),+ >)? {
             $($field_vis:vis $field_name:ident: $cell_repr:ty),+
             $(,)?
@@ -74,6 +77,9 @@ macro_rules! struct_layout {
     ) => {
         paste::paste! {
             #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, PartialEq, Eq)]
+            $(
+                #[$attributes]
+            )*
             $vis struct [<$layout_t F>]<
                 $(
                     [<$field_name:camel>]


### PR DESCRIPTION
Closes RV-743

# What
Documentation comments are syntactic sugar for a `#[doc]` attribute. By passing on any attributes in the `struct_layout` macro, we can pass on documentation comments - and potentially any other attribute.

I don't think it's necessary to update the example.

See also:

https://rust-lang.github.io/api-guidelines/macros.html#item-macros-compose-well-with-attributes-c-macro-attr

# Why
I'm trying to write documentation for something using `struct_layout` and don't want to use `//`

# How

Reproducing any attributes inside the macro

# Manually Testing

```
make -C src/riscv all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
