### PR TITLE
CI: PR benchmark comment displays full results in collapsed section

### DIFF
--- a/kernels/jstz/bench/src/main.rs
+++ b/kernels/jstz/bench/src/main.rs
@@ -53,6 +53,8 @@ enum Commands {
         log_file: Vec<Box<Path>>,
         #[arg(long)]
         expected_transfers: usize,
+        #[arg(long)]
+        collapsible_results: bool,
     },
 }
 
@@ -72,7 +74,13 @@ fn main() -> Result<()> {
             inbox_file,
             log_file,
             expected_transfers,
-        } => handle_results(inbox_file, log_file, expected_transfers)?,
+            collapsible_results,
+        } => handle_results(
+            inbox_file,
+            log_file,
+            expected_transfers,
+            collapsible_results,
+        )?,
     }
 
     Ok(())

--- a/kernels/jstz/bench/src/results.rs
+++ b/kernels/jstz/bench/src/results.rs
@@ -27,6 +27,7 @@ pub fn handle_results(
     inbox: Box<Path>,
     all_logs: Vec<Box<Path>>,
     expected_transfers: usize,
+    collapsible_results: bool,
 ) -> Result<()> {
     let inbox = InboxFile::load(&inbox)?;
 
@@ -85,9 +86,6 @@ pub fn handle_results(
         ]);
     }
 
-    println!();
-    println!("{all_results}");
-
     if all_metrics.len() > 1 {
         let mut aggregate_result = comfy_table::Table::new();
         aggregate_result.load_preset(comfy_table::presets::ASCII_MARKDOWN);
@@ -131,6 +129,20 @@ pub fn handle_results(
 
         println!();
         println!("{aggregate_result}");
+    }
+
+    println!();
+
+    if collapsible_results {
+        println!("<details>");
+        println!("<summary>Full results</summary>");
+        println!()
+    }
+
+    println!("{all_results}");
+
+    if collapsible_results {
+        println!("</details>");
     }
 
     Ok(())

--- a/scripts/ci-bench.sh
+++ b/scripts/ci-bench.sh
@@ -54,13 +54,13 @@ nix develop --command cargo run --quiet --manifest-path kernels/jstz/Cargo.toml 
 # Run the benchmark
 result_dir=$(mktemp -d)
 result_args=()
-for i in $(seq 1 $NUM_ITERS); do 
+for i in $(seq 1 $NUM_ITERS); do
   nix develop --command cargo run --release --quiet --manifest-path src/riscv/Cargo.toml --bin riscv-sandbox -- run --input kernels/jstz/target/riscv64gc-unknown-linux-musl/release/jstz --inbox-file "$inbox_file" --timings > $result_dir/$i.json
   result_args+=("--log-file=$result_dir/$i.json")
 done
 
 # Collect results and display them
-nix develop --command cargo run --quiet --manifest-path kernels/jstz/Cargo.toml --bin inbox-bench -- results --inbox-file "$inbox_file" --expected-transfers "$NUM_TXS" "${result_args[@]}"
+nix develop --command cargo run --quiet --manifest-path kernels/jstz/Cargo.toml --bin inbox-bench -- results --collapsible-results --inbox-file "$inbox_file" --expected-transfers "$NUM_TXS" "${result_args[@]}"
 
 # Clean up
 rm -rf "$inbox_file" "$dir" "$result_dir"


### PR DESCRIPTION
# What

The benchmark results run in CI contain both a table with aggregated stats over all iterations and a table with the individual results for each iteration, which is quite large (currently 20 lines). This PR wraps the latter in a collapsed section.

# Why

The stats table usually contains enough information to understand the impact a PR has on performance. This is a small improvement meant to declutter PRs.

# Manually Testing

See the benchmark results comment on this PR.

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
