### PR TITLE
Exceptions without pointers

### DIFF
--- a/src/riscv/lib/src/instruction_context.rs
+++ b/src/riscv/lib/src/instruction_context.rs
@@ -326,7 +326,7 @@ impl<MC: MemoryConfig, M: ManagerReadWrite> ICB for MachineCoreState<MC, M> {
             if let ReservationSetOption::Reset = reservation_set_option {
                 reset_reservation_set(self);
             }
-            Err(Exception::StoreAMOAccessFault(address))
+            Err(Exception::StoreAMOAccessFault)
         } else {
             Ok(())
         }
@@ -372,7 +372,7 @@ impl<MC: MemoryConfig, M: ManagerReadWrite> ICB for MachineCoreState<MC, M> {
     ) -> Self::IResult<()> {
         self.main_memory
             .write(address, V::from_xvalue(value))
-            .map_err(|_: BadMemoryAccess| Exception::StoreAMOAccessFault(address))
+            .map_err(|_: BadMemoryAccess| Exception::StoreAMOAccessFault)
     }
 
     #[inline(always)]
@@ -383,7 +383,7 @@ impl<MC: MemoryConfig, M: ManagerReadWrite> ICB for MachineCoreState<MC, M> {
         self.main_memory
             .read(address)
             .map(V::to_xvalue)
-            .map_err(|_: BadMemoryAccess| Exception::LoadAccessFault(address))
+            .map_err(|_: BadMemoryAccess| Exception::LoadAccessFault)
     }
 
     fn f64_from_x64_unsigned_static(

--- a/src/riscv/lib/src/interpreter/common_memory.rs
+++ b/src/riscv/lib/src/interpreter/common_memory.rs
@@ -23,7 +23,7 @@ where
     ) -> Result<T, Exception> {
         self.main_memory
             .read(address)
-            .map_err(|_: BadMemoryAccess| Exception::LoadAccessFault(address))
+            .map_err(|_: BadMemoryAccess| Exception::LoadAccessFault)
     }
 
     /// Generic read function for loading `T::STORED_SIZE` bytes from address val(rs1) + imm
@@ -44,7 +44,7 @@ where
     ) -> Result<(), Exception> {
         self.main_memory
             .write(address, value)
-            .map_err(|_: BadMemoryAccess| Exception::StoreAMOAccessFault(address))
+            .map_err(|_: BadMemoryAccess| Exception::StoreAMOAccessFault)
     }
 
     /// Generic store operation for writing `T::STORED_SIZE` bytes starting at address val(rs1) + imm

--- a/src/riscv/lib/src/interpreter/load_store.rs
+++ b/src/riscv/lib/src/interpreter/load_store.rs
@@ -205,7 +205,7 @@ mod test {
 
             // Out of bounds loads / stores
             prop_assert!(perform_test(invalid_offset, true).is_err_and(|e|
-                matches!(e, Exception::StoreAMOAccessFault(_))
+                matches!(e, Exception::StoreAMOAccessFault)
             ));
             // Aligned loads / stores
             prop_assert!(perform_test(aligned_offset, true).is_ok());
@@ -214,7 +214,7 @@ mod test {
 
             // Out of bounds loads / stores
             prop_assert!(perform_test(invalid_offset, false).is_err_and(|e|
-                matches!(e, Exception::StoreAMOAccessFault(_))
+                matches!(e, Exception::StoreAMOAccessFault)
             ));
             // Aligned loads / stores
             prop_assert!(perform_test(aligned_offset, false).is_ok());

--- a/src/riscv/lib/src/interpreter/rv64d.rs
+++ b/src/riscv/lib/src/interpreter/rv64d.rs
@@ -542,7 +542,7 @@ mod tests {
 
             // Out of bounds loads / stores
             prop_assert!(perform_test(invalid_offset).is_err_and(|e|
-                matches!(e, Exception::StoreAMOAccessFault(_))
+                matches!(e, Exception::StoreAMOAccessFault)
             ));
             // Aligned loads / stores
             prop_assert!(perform_test(aligned_offset).is_ok());
@@ -551,7 +551,7 @@ mod tests {
 
             // Out of bounds loads / stores
             prop_assert!(perform_test(invalid_offset).is_err_and(|e|
-                matches!(e, Exception::StoreAMOAccessFault(_))
+                matches!(e, Exception::StoreAMOAccessFault)
             ));
             // Aligned loads / stores
             prop_assert!(perform_test(aligned_offset).is_ok());

--- a/src/riscv/lib/src/interpreter/rv64dc.rs
+++ b/src/riscv/lib/src/interpreter/rv64dc.rs
@@ -122,7 +122,7 @@ mod test {
 
             // Out of bounds loads / stores
             prop_assert!(perform_test(OUT_OF_BOUNDS_OFFSET).is_err_and(|e|
-                matches!(e, Exception::StoreAMOAccessFault(_))
+                matches!(e, Exception::StoreAMOAccessFault)
             ));
         });
     });
@@ -157,7 +157,7 @@ mod test {
 
             // Out of bounds loads / stores
             prop_assert!(perform_test(OUT_OF_BOUNDS_OFFSET).is_err_and(|e|
-                matches!(e, Exception::StoreAMOAccessFault(_))
+                matches!(e, Exception::StoreAMOAccessFault)
             ));
         });
     });

--- a/src/riscv/lib/src/interpreter/rv64f.rs
+++ b/src/riscv/lib/src/interpreter/rv64f.rs
@@ -579,7 +579,7 @@ mod tests {
 
             // Out of bounds loads / stores
             prop_assert!(perform_test(invalid_offset).is_err_and(|e|
-                matches!(e, Exception::StoreAMOAccessFault(_))
+                matches!(e, Exception::StoreAMOAccessFault)
             ));
             // Aligned loads / stores
             prop_assert!(perform_test(aligned_offset).is_ok());
@@ -588,7 +588,7 @@ mod tests {
 
             // Out of bounds loads / stores
             prop_assert!(perform_test(invalid_offset).is_err_and(|e|
-                matches!(e, Exception::StoreAMOAccessFault(_))
+                matches!(e, Exception::StoreAMOAccessFault)
             ));
             // Aligned loads / stores
             prop_assert!(perform_test(aligned_offset).is_ok());

--- a/src/riscv/lib/src/jit/builder/errno.rs
+++ b/src/riscv/lib/src/jit/builder/errno.rs
@@ -10,30 +10,23 @@
 //! Any returned values are written via 'out-pointers' - and should only be
 //! loaded on success.
 
-use std::mem::MaybeUninit;
-
 use cranelift::frontend::FunctionBuilder;
 
-use crate::jit::builder::typed::Pointer;
 use crate::jit::builder::typed::Value;
-use crate::traps::Exception;
+use crate::jit::state_access::ExceptionCode;
 
 /// Helper type for ensuring fallible operations are handled correctly.
 ///
-/// The errno is constructed out of three pieces:
-/// - whether or not a failure occurred
-/// - if yes, the pointer to the exception in memory that has been written with the failure kind
-/// - if no, a handler to load any state that was returned in `out-params` that is now safe to
-///   access.
+/// The errno is constructed out of two pieces:
+/// - an exception code indicating whether an exception occurred and which type
+/// - a handler to load any state that was returned in `out-params` that is now safe to
+///   access on success.
 pub(crate) struct ErrnoImpl<T, F>
 where
     F: FnOnce(&mut FunctionBuilder) -> T,
 {
-    /// Boolean value indicating whether an exception occurred
-    pub(crate) is_exception: Value<bool>,
-
-    /// Pointer to the exception in memory, if an exception occurred
-    pub(crate) exception_ptr: Pointer<MaybeUninit<Exception>>,
+    /// Exception code, indicates whether an exception occurred and which
+    pub(crate) code: Value<ExceptionCode>,
 
     /// Retrieve the result in case of success
     pub(crate) on_ok: F,
@@ -44,15 +37,7 @@ where
     F: FnOnce(&mut FunctionBuilder) -> T,
 {
     /// Construct a new `Errno` that must be handled.
-    pub(crate) fn new(
-        is_exception: Value<bool>,
-        exception_ptr: Pointer<MaybeUninit<Exception>>,
-        on_ok: F,
-    ) -> Self {
-        Self {
-            is_exception,
-            exception_ptr,
-            on_ok,
-        }
+    pub(crate) fn new(code: Value<ExceptionCode>, on_ok: F) -> Self {
+        Self { code, on_ok }
     }
 }

--- a/src/riscv/lib/src/jit/builder/ext_calls.rs
+++ b/src/riscv/lib/src/jit/builder/ext_calls.rs
@@ -120,16 +120,6 @@ fn call_raw<A: ArgumentsTyped, R: ReturnTyped>(
     R::from_return_values(ret_values)
 }
 
-/// Call an external function with 1 argument.
-pub fn call1<A0: Typed, R: ReturnTyped>(
-    target_config: &TargetFrontendConfig,
-    builder: &mut FunctionBuilder,
-    callee: extern "C" fn(A0) -> R,
-    arg0: Value<A0>,
-) -> R::Value {
-    call_raw::<(A0,), R>(target_config, builder, callee as usize, &[arg0.to_value()])
-}
-
 /// Call an external function with 2 arguments.
 pub fn call2<A0: Typed, A1: Typed, R: ReturnTyped>(
     target_config: &TargetFrontendConfig,

--- a/src/riscv/lib/src/jit/builder/instruction.rs
+++ b/src/riscv/lib/src/jit/builder/instruction.rs
@@ -505,7 +505,7 @@ impl<MC: MemoryConfig> ICB for InstructionBuilder<'_, '_, MC> {
 
             let exception_ptr = self
                 .ext_calls
-                .raise_store_amo_access_fault_exception(self.builder, address);
+                .raise_store_amo_access_fault_exception(self.builder);
             self.handle_exception::<()>(exception_ptr);
         }
 

--- a/src/riscv/lib/src/jit/builder/instruction.rs
+++ b/src/riscv/lib/src/jit/builder/instruction.rs
@@ -42,6 +42,7 @@ use crate::interpreter::atomics::ReservationSetOption;
 use crate::interpreter::float::RoundingMode;
 use crate::jit::builder::typed::Pointer;
 use crate::jit::builder::typed::Value;
+use crate::jit::state_access::ExceptionCode;
 use crate::jit::state_access::JsaCalls;
 use crate::machine_state::MachineCoreState;
 use crate::machine_state::ProgramCounterUpdate;
@@ -56,7 +57,6 @@ use crate::state_backend::owned_backend::Owned;
 use crate::state_context::StateContext;
 use crate::state_context::projection::MachineCoreProjection;
 use crate::traps::EnvironException;
-use crate::traps::Exception;
 
 /// Instruction execution outcome
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
@@ -205,15 +205,12 @@ impl<'seq, 'jit, MC: MemoryConfig> InstructionBuilder<'seq, 'jit, MC> {
     }
 
     /// Handle an exception raised by the instruction.
-    fn handle_exception<Any>(
-        &mut self,
-        exception_ptr: Pointer<Exception>,
-    ) -> InstructionResult<Any> {
+    fn handle_exception<Any>(&mut self, exception: Value<ExceptionCode>) -> InstructionResult<Any> {
         let current_pc = self.pc_read();
         let outcome = self.ext_calls.handle_exception(
             self.builder,
             self.core_param,
-            exception_ptr,
+            exception,
             self.result_param,
             current_pc,
         );
@@ -515,8 +512,8 @@ impl<MC: MemoryConfig> ICB for InstructionBuilder<'_, '_, MC> {
     }
 
     fn ecall(&mut self) -> Self::IResult<ProgramCounterUpdate<Self::XValue>> {
-        let exception_ptr = self.ext_calls.ecall(self.builder);
-        self.handle_exception(exception_ptr)
+        let exception = self.ext_calls.ecall(self.builder);
+        self.handle_exception(exception)
     }
 
     fn main_memory_store<V: StoreLoadInt>(
@@ -531,8 +528,9 @@ impl<MC: MemoryConfig> ICB for InstructionBuilder<'_, '_, MC> {
         let exception_block = self.builder.create_block();
         let success_block = self.builder.create_block();
 
+        let is_exception = errno.code.is_exception(self.builder);
         self.ins().brif(
-            errno.is_exception.to_value(),
+            is_exception.to_value(),
             exception_block,
             [],
             success_block,
@@ -545,13 +543,7 @@ impl<MC: MemoryConfig> ICB for InstructionBuilder<'_, '_, MC> {
         // Code for when the store failed
         {
             self.builder.switch_to_block(exception_block);
-
-            // SAFETY: When the memory store external function call encounters an error, it will
-            // write to the exception pointer. This block handles such a failure case, so we can
-            // assume that the pointee is initialised.
-            let exception_ptr = unsafe { errno.exception_ptr.assume_init() };
-
-            self.handle_exception::<()>(exception_ptr);
+            self.handle_exception::<()>(errno.code);
         }
 
         // Code for when the store succeeded
@@ -574,8 +566,9 @@ impl<MC: MemoryConfig> ICB for InstructionBuilder<'_, '_, MC> {
         let exception_block = self.builder.create_block();
         let success_block = self.builder.create_block();
 
+        let is_exception = errno.code.is_exception(self.builder);
         self.ins().brif(
-            errno.is_exception.to_value(),
+            is_exception.to_value(),
             exception_block,
             [],
             success_block,
@@ -589,12 +582,7 @@ impl<MC: MemoryConfig> ICB for InstructionBuilder<'_, '_, MC> {
         {
             self.builder.switch_to_block(exception_block);
 
-            // SAFETY: When the memory load external function call encounters an error, it will
-            // write to the exception pointer. This block handles such a failure case, so we can
-            // assume that the pointee is initialised.
-            let exception_ptr = unsafe { errno.exception_ptr.assume_init() };
-
-            self.handle_exception::<()>(exception_ptr);
+            self.handle_exception::<()>(errno.code);
         }
 
         // Code for when the load succeeded
@@ -645,8 +633,9 @@ impl<MC: MemoryConfig> ICB for InstructionBuilder<'_, '_, MC> {
         let exception_block = self.builder.create_block();
         let success_block = self.builder.create_block();
 
+        let is_exception = errno.code.is_exception(self.builder);
         self.ins().brif(
-            errno.is_exception.to_value(),
+            is_exception.to_value(),
             exception_block,
             [],
             success_block,
@@ -661,12 +650,7 @@ impl<MC: MemoryConfig> ICB for InstructionBuilder<'_, '_, MC> {
         {
             self.builder.switch_to_block(exception_block);
 
-            // SAFETY: When the external function call encounters an error, it will write to the
-            // exception pointer. This block handles such a failure case, so we can assume that the
-            // pointee is initialised.
-            let exception_ptr = unsafe { errno.exception_ptr.assume_init() };
-
-            self.handle_exception::<()>(exception_ptr);
+            self.handle_exception::<()>(errno.code);
         }
 
         // Code for when the conversion succeeded.

--- a/src/riscv/lib/src/jit/builder/typed.rs
+++ b/src/riscv/lib/src/jit/builder/typed.rs
@@ -14,7 +14,6 @@
 
 use std::cmp::Ordering;
 use std::marker::PhantomData;
-use std::mem::MaybeUninit;
 use std::ptr::NonNull;
 
 use cranelift::codegen::ir::Type as CraneliftType;
@@ -214,20 +213,6 @@ impl<T: Sized> Value<NonNull<T>> {
     ///
     /// You must ensure that the lifetime of the returned reference is valid.
     pub unsafe fn as_mut<'a>(&self) -> Value<&'a mut T> {
-        Value {
-            value: self.value,
-            _pd: PhantomData,
-        }
-    }
-}
-
-impl<T> Value<NonNull<MaybeUninit<T>>> {
-    /// Treat the pointee `T` as initialised.
-    ///
-    /// # Safety
-    ///
-    /// You must ensure that the pointee is indeed initialised before using it.
-    pub unsafe fn assume_init(self) -> Value<NonNull<T>> {
         Value {
             value: self.value,
             _pd: PhantomData,

--- a/src/riscv/lib/src/jit/state_access.rs
+++ b/src/riscv/lib/src/jit/state_access.rs
@@ -105,11 +105,8 @@ extern "C" fn raise_illegal_instruction_exception(exception_out: &mut MaybeUnini
 ///
 /// Writes the instruction to the given exception memory, after which it would be safe to
 /// assume it is initialised.
-extern "C" fn raise_store_amo_access_fault_exception(
-    exception_out: &mut MaybeUninit<Exception>,
-    address: u64,
-) {
-    exception_out.write(Exception::StoreAMOAccessFault(address));
+extern "C" fn raise_store_amo_access_fault_exception(exception_out: &mut MaybeUninit<Exception>) {
+    exception_out.write(Exception::StoreAMOAccessFault);
 }
 
 /// Raise the appropriate environment-call exception given the current machine mode.
@@ -135,7 +132,7 @@ extern "C" fn memory_store<E: Elem, MC: MemoryConfig>(
     match core.main_memory.write(address, value) {
         Ok(()) => false,
         Err(BadMemoryAccess) => {
-            exception_out.write(Exception::StoreAMOAccessFault(address));
+            exception_out.write(Exception::StoreAMOAccessFault);
             true
         }
     }
@@ -161,7 +158,7 @@ extern "C" fn memory_load<E: Elem, MC: MemoryConfig>(
             false
         }
         Err(BadMemoryAccess) => {
-            exception_out.write(Exception::LoadAccessFault(address));
+            exception_out.write(Exception::LoadAccessFault);
             true
         }
     }
@@ -317,19 +314,17 @@ impl<MC: MemoryConfig> JsaCalls<MC> {
     pub(super) fn raise_store_amo_access_fault_exception(
         &mut self,
         builder: &mut FunctionBuilder,
-        address: Value<Address>,
     ) -> Pointer<Exception> {
         let exception_slot = self.exception_ptr_slot(builder);
         let exception_ptr = exception_slot.ptr(builder);
 
         // SAFETY: The exception reference is guaranteed to be valid for the duration of the call as
         // it is scoped to the JIT function.
-        ext_calls::call2(
+        ext_calls::call1(
             &self.target_config,
             builder,
             self::raise_store_amo_access_fault_exception,
             unsafe { exception_ptr.as_mut() },
-            address,
         );
 
         // SAFETY: The `raise_store_amo_access_fault_exception` function writes to the exception

--- a/src/riscv/lib/src/jit/state_access.rs
+++ b/src/riscv/lib/src/jit/state_access.rs
@@ -13,7 +13,10 @@ use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 
 use cranelift::frontend::FunctionBuilder;
+use cranelift::prelude::InstBuilder;
+use cranelift::prelude::IntCC;
 use cranelift::prelude::isa::TargetFrontendConfig;
+use cranelift::prelude::types::I64;
 
 use super::builder::errno::ErrnoImpl;
 use crate::instruction_context::ICB;
@@ -26,6 +29,7 @@ use crate::interpreter::float::RoundRUP;
 use crate::interpreter::float::RoundingMode;
 use crate::interpreter::float::StaticRoundingMode;
 use crate::jit::builder::ext_calls;
+use crate::jit::builder::typed;
 use crate::jit::builder::typed::Pointer;
 use crate::jit::builder::typed::Value;
 use crate::machine_state::MachineCoreState;
@@ -40,6 +44,94 @@ use crate::state_backend::Elem;
 use crate::state_backend::owned_backend::Owned;
 use crate::traps::EnvironException;
 use crate::traps::Exception;
+
+/// Exception codes used for efficient exception handling in JIT-compiled code
+///
+/// This enum represents different types of exceptions that can occur during
+/// instruction execution, encoded as i64 values for easy transmission between
+/// JIT-compiled code and runtime handlers.
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(i64)]
+pub enum ExceptionCode {
+    NoException = 0,
+    InstructionAccessFault = Exception::InstructionAccessFault as i64,
+    IllegalInstruction = Exception::IllegalInstruction as i64,
+    Breakpoint = Exception::Breakpoint as i64,
+    LoadAccessFault = Exception::LoadAccessFault as i64,
+    StoreAMOAccessFault = Exception::StoreAMOAccessFault as i64,
+    EnvCall = Exception::EnvCall as i64,
+    InstructionPageFault = Exception::InstructionPageFault as i64,
+    LoadPageFault = Exception::LoadPageFault as i64,
+    StoreAMOPageFault = Exception::StoreAMOPageFault as i64,
+}
+
+impl ExceptionCode {
+    /// Construct the corresponding exception code.
+    pub fn from_exception(exception: Exception) -> Self {
+        match exception {
+            Exception::InstructionAccessFault => Self::InstructionAccessFault,
+            Exception::IllegalInstruction => Self::IllegalInstruction,
+            Exception::Breakpoint => Self::Breakpoint,
+            Exception::LoadAccessFault => Self::LoadAccessFault,
+            Exception::StoreAMOAccessFault => Self::StoreAMOAccessFault,
+            Exception::EnvCall => Self::EnvCall,
+            Exception::InstructionPageFault => Self::InstructionPageFault,
+            Exception::LoadPageFault => Self::LoadPageFault,
+            Exception::StoreAMOPageFault => Self::StoreAMOPageFault,
+        }
+    }
+
+    /// Convert the exception code back to an [`Exception`].
+    ///
+    /// # Panics
+    ///
+    /// This function panics if called on `NoException`, as it is not a valid exception.
+    pub fn to_exception(self) -> Exception {
+        match self {
+            Self::NoException => unreachable!(),
+            Self::InstructionAccessFault => Exception::InstructionAccessFault,
+            Self::IllegalInstruction => Exception::IllegalInstruction,
+            Self::Breakpoint => Exception::Breakpoint,
+            Self::LoadAccessFault => Exception::LoadAccessFault,
+            Self::StoreAMOAccessFault => Exception::StoreAMOAccessFault,
+            Self::EnvCall => Exception::EnvCall,
+            Self::InstructionPageFault => Exception::InstructionPageFault,
+            Self::LoadPageFault => Exception::LoadPageFault,
+            Self::StoreAMOPageFault => Exception::StoreAMOPageFault,
+        }
+    }
+
+    /// Construct an IR value representing the exception.
+    pub fn build_exception_code(
+        builder: &mut FunctionBuilder,
+        exception: Exception,
+    ) -> Value<ExceptionCode> {
+        let exception_code = Self::from_exception(exception);
+        let raw = builder.ins().iconst(I64, exception_code as i64);
+
+        // SAFETY: The raw value is constructed from a valid discriminant. ExceptionCode is
+        // represented as a `i64`, so we can safely convert it to a `Value<ExceptionCode>`.
+        unsafe { Value::<ExceptionCode>::from_raw(raw) }
+    }
+}
+
+impl Value<ExceptionCode> {
+    /// Does the exception code represent an exception?
+    pub fn is_exception(self, builder: &mut FunctionBuilder) -> Value<bool> {
+        let raw = builder.ins().icmp_imm(
+            IntCC::NotEqual,
+            self.to_value(),
+            ExceptionCode::NoException as i64,
+        );
+
+        // SAFETY: `icmp_imm` returns a boolean.
+        unsafe { Value::<bool>::from_raw(raw) }
+    }
+}
+
+impl typed::Typed for ExceptionCode {
+    const TYPE: typed::Type = typed::Type::Basic(I64);
+}
 
 /// Read the value of the given [`FRegister`].
 extern "C" fn fregister_read<MC: MemoryConfig>(
@@ -58,7 +150,7 @@ extern "C" fn fregister_write<MC: MemoryConfig>(
     core.hart.fregisters.write(reg, val)
 }
 
-/// Handle an [`Exception`].
+/// Handle an [`ExceptionCode`].
 ///
 /// If the exception is succesfully handled, the
 /// `current_pc` is updated to the new value, and returns true. The `current_pc`
@@ -68,24 +160,22 @@ extern "C" fn fregister_write<MC: MemoryConfig>(
 /// `result` is updated with the `EnvironException` and `false` is
 /// returned.
 ///
-/// # Panics
-///
-/// Panics if the exception does not have `Some(_)` value.
-///
 /// See [`MachineCoreState::address_on_exception`].
 extern "C" fn handle_exception<MC: MemoryConfig>(
     core: &mut MachineCoreState<MC, Owned>,
     current_pc: &mut Address,
-    exception: &Exception,
+    exception: ExceptionCode,
     result: &mut Result<(), EnvironException>,
 ) -> bool {
-    let res = core.address_on_exception(*exception, *current_pc);
+    let exception = exception.to_exception();
+    let res = core.address_on_exception(exception, *current_pc);
 
     match res {
         Err(e) => {
             *result = Err(e);
             false
         }
+
         Ok(address) => {
             *current_pc = address;
             true
@@ -93,92 +183,58 @@ extern "C" fn handle_exception<MC: MemoryConfig>(
     }
 }
 
-/// Raise an [`Exception::IllegalInstruction`].
-///
-/// Writes the instruction to the given exception memory, after which it would be safe to
-/// assume it is initialised.
-extern "C" fn raise_illegal_instruction_exception(exception_out: &mut MaybeUninit<Exception>) {
-    exception_out.write(Exception::IllegalInstruction);
-}
-
-/// Raise an [`Exception::StoreAMOAccessFault`].
-///
-/// Writes the instruction to the given exception memory, after which it would be safe to
-/// assume it is initialised.
-extern "C" fn raise_store_amo_access_fault_exception(exception_out: &mut MaybeUninit<Exception>) {
-    exception_out.write(Exception::StoreAMOAccessFault);
-}
-
-/// Raise the appropriate environment-call exception given the current machine mode.
-///
-/// Writes the exception to the given exception memory, after which it would be safe to
-/// assume it is initialised.
-extern "C" fn ecall(exception_out: &mut MaybeUninit<Exception>) {
-    exception_out.write(Exception::EnvCall);
-}
-
 /// Store the lowest `width` bytes of the given value to memory, at the physical address.
 ///
-/// If the store is successful, `false` is returned to indicate no exception handling is necessary.
+/// Returns [`ExceptionCode::NoException`] if the store is successful.
 ///
-/// If the store fails (due to out of bouds etc) then an exception will be written
-/// to `exception_out` and `true` returned to indicate exception handling will be necessary.
+/// If the store fails (due to out of bounds etc) then the appropriate exception code
+/// is returned to indicate the type of failure that occurred.
 extern "C" fn memory_store<E: Elem, MC: MemoryConfig>(
     core: &mut MachineCoreState<MC, Owned>,
     address: u64,
     value: E,
-    exception_out: &mut MaybeUninit<Exception>,
-) -> bool {
+) -> ExceptionCode {
     match core.main_memory.write(address, value) {
-        Ok(()) => false,
-        Err(BadMemoryAccess) => {
-            exception_out.write(Exception::StoreAMOAccessFault);
-            true
-        }
+        Ok(()) => ExceptionCode::NoException,
+        Err(BadMemoryAccess) => ExceptionCode::from_exception(Exception::StoreAMOAccessFault),
     }
 }
 
 /// Load `width` bytes from memory, at the physical address, into lowest `width` bytes of an
 /// `XValue`, with (un)signed extension.
 ///
-/// If the load is successful, `false` is returned to indicate no exception handling is
-/// necessary.
+/// If the load is successful, the value is written to `xval_out` and
+/// [`ExceptionCode::NoException`] is returned.
 ///
-/// If the load fails (due to out of bouds etc) then an exception will be written
-/// to `exception_out` and `true` returned to indicate exception handling will be necessary.
+/// If the load fails (due to out of bounds etc) then the appropriate exception code
+/// is returned to indicate the type of failure that occurred.
 extern "C" fn memory_load<E: Elem, MC: MemoryConfig>(
     core: &MachineCoreState<MC, Owned>,
     address: u64,
     xval_out: &mut MaybeUninit<E>,
-    exception_out: &mut MaybeUninit<Exception>,
-) -> bool {
+) -> ExceptionCode {
     match core.main_memory.read::<E>(address) {
         Ok(value) => {
             xval_out.write(value);
-            false
+            ExceptionCode::NoException
         }
-        Err(BadMemoryAccess) => {
-            exception_out.write(Exception::LoadAccessFault);
-            true
-        }
+
+        Err(BadMemoryAccess) => ExceptionCode::from_exception(Exception::LoadAccessFault),
     }
 }
 
 extern "C" fn f64_from_x64_unsigned_dynamic<MC: MemoryConfig>(
     core: &mut MachineCoreState<MC, Owned>,
-    exception_out: &mut MaybeUninit<Exception>,
     xval: XValue,
     fvalue_out: &mut MaybeUninit<FValue>,
-) -> bool {
+) -> ExceptionCode {
     match MachineCoreState::f64_from_x64_unsigned_dynamic(core, xval) {
         Ok(fval) => {
             fvalue_out.write(fval);
-            false
+            ExceptionCode::NoException
         }
-        Err(e) => {
-            exception_out.write(e);
-            true
-        }
+
+        Err(e) => ExceptionCode::from_exception(e),
     }
 }
 
@@ -196,9 +252,6 @@ pub struct JsaCalls<MC: MemoryConfig> {
     /// pointer type and width
     target_config: TargetFrontendConfig,
 
-    /// Reusable stack slot for the exception pointer
-    exception_ptr_slot: Option<stack::Slot<MaybeUninit<Exception>>>,
-
     /// Reusable stack slot for the PC value
     pc_slot: Option<stack::Slot<MaybeUninit<Address>>>,
 
@@ -209,16 +262,6 @@ pub struct JsaCalls<MC: MemoryConfig> {
 }
 
 impl<MC: MemoryConfig> JsaCalls<MC> {
-    /// Get the stack slot for the exception pointer.
-    fn exception_ptr_slot(
-        &mut self,
-        builder: &mut FunctionBuilder,
-    ) -> stack::Slot<MaybeUninit<Exception>> {
-        self.exception_ptr_slot
-            .get_or_insert_with(|| stack::Slot::new(self.target_config.pointer_type(), builder))
-            .clone()
-    }
-
     /// Get the stack slot for the PC value.
     fn pc_slot(&mut self, builder: &mut FunctionBuilder) -> stack::Slot<MaybeUninit<Address>> {
         self.pc_slot
@@ -240,7 +283,6 @@ impl<MC: MemoryConfig> JsaCalls<MC> {
     pub(super) fn new(target_config: TargetFrontendConfig) -> Self {
         Self {
             target_config,
-            exception_ptr_slot: None,
             pc_slot: None,
             fvalue_ptr_slot: None,
             _pd: PhantomData,
@@ -258,7 +300,7 @@ impl<MC: MemoryConfig> JsaCalls<MC> {
         &mut self,
         builder: &mut FunctionBuilder,
         core_ptr: Pointer<MachineCoreState<MC, Owned>>,
-        exception_ptr: Pointer<Exception>,
+        exception: Value<ExceptionCode>,
         result_ptr: Pointer<Result<(), EnvironException>>,
         current_pc: Value<Address>,
     ) -> ExceptionHandledOutcome {
@@ -268,7 +310,6 @@ impl<MC: MemoryConfig> JsaCalls<MC> {
         // SAFETY: Arguments get cast into references with valid lifetimes.
         // - `core_ptr` is a JIT function argument
         // - `pc_ptr` points to a stack slot which is valid for the duration of the JIT function
-        // - `exception_ptr` points to a stack slot as well (allocated by the caller)
         // - `result_ptr` is a JIT function argument
         let handled = ext_calls::call4(
             &self.target_config,
@@ -276,7 +317,7 @@ impl<MC: MemoryConfig> JsaCalls<MC> {
             self::handle_exception,
             unsafe { core_ptr.as_mut() },
             unsafe { pc_ptr.as_mut() },
-            unsafe { exception_ptr.as_ref() },
+            exception,
             unsafe { result_ptr.as_mut() },
         );
 
@@ -284,70 +325,31 @@ impl<MC: MemoryConfig> JsaCalls<MC> {
         ExceptionHandledOutcome { handled, new_pc }
     }
 
-    /// Emit the required IR to call `raise_illegal_exception`.
+    /// Emit the required IR to create an illegal instruction exception code.
     ///
-    /// This returns an initialised pointer to the exception.
+    /// This returns the exception code value for an illegal instruction.
     pub(super) fn raise_illegal_instruction_exception(
         &mut self,
         builder: &mut FunctionBuilder,
-    ) -> Pointer<Exception> {
-        let exception_slot = self.exception_ptr_slot(builder);
-        let exception_ptr = exception_slot.ptr(builder);
-
-        // SAFETY: The exception pointer reference is scoped to the JIT function. Hence it is safe
-        // to pass it to the external function which is called within the JIT function scope.
-        ext_calls::call1(
-            &self.target_config,
-            builder,
-            self::raise_illegal_instruction_exception,
-            unsafe { exception_ptr.as_mut() },
-        );
-
-        // SAFETY: The `raise_illegal_instruction_exception` function writes to the exception slot
-        // unconditionally.
-        unsafe { exception_slot.assume_init().ptr(builder) }
+    ) -> Value<ExceptionCode> {
+        ExceptionCode::build_exception_code(builder, Exception::IllegalInstruction)
     }
 
-    /// Emit the required IR to call `raise_store_amo_access_fault_exception`.
+    /// Emit the required IR to create a store/AMO access fault exception code.
     ///
-    /// This returns an initialised pointer to the exception.
+    /// This returns the exception code value for a store/AMO access fault.
     pub(super) fn raise_store_amo_access_fault_exception(
         &mut self,
         builder: &mut FunctionBuilder,
-    ) -> Pointer<Exception> {
-        let exception_slot = self.exception_ptr_slot(builder);
-        let exception_ptr = exception_slot.ptr(builder);
-
-        // SAFETY: The exception reference is guaranteed to be valid for the duration of the call as
-        // it is scoped to the JIT function.
-        ext_calls::call1(
-            &self.target_config,
-            builder,
-            self::raise_store_amo_access_fault_exception,
-            unsafe { exception_ptr.as_mut() },
-        );
-
-        // SAFETY: The `raise_store_amo_access_fault_exception` function writes to the exception
-        // slot unconditionally.
-        unsafe { exception_slot.assume_init().ptr(builder) }
+    ) -> Value<ExceptionCode> {
+        ExceptionCode::build_exception_code(builder, Exception::StoreAMOAccessFault)
     }
 
-    /// Emit the required IR to call `ecall`.
+    /// Emit the required IR to create an environment call exception code.
     ///
-    /// This returns an initialised pointer to the appropriate environment
-    /// call exception for the current machine mode.
-    pub(super) fn ecall(&mut self, builder: &mut FunctionBuilder) -> Pointer<Exception> {
-        let exception_slot = self.exception_ptr_slot(builder);
-        let exception_ptr = exception_slot.ptr(builder);
-
-        // SAFETY: The exception reference is guaranteed to be valid for the duration of the call as
-        // it points to a stack slot which is valid for the duration of the JIT function.
-        ext_calls::call1(&self.target_config, builder, self::ecall, unsafe {
-            exception_ptr.as_mut()
-        });
-
-        // SAFETY: The `ecall` function writes to the exception slot unconditionally.
-        unsafe { exception_slot.assume_init().ptr(builder) }
+    /// This returns the exception code value for an environment call.
+    pub(super) fn ecall(&mut self, builder: &mut FunctionBuilder) -> Value<ExceptionCode> {
+        ExceptionCode::build_exception_code(builder, Exception::EnvCall)
     }
 
     /// Emit the required IR to call `memory_store`.
@@ -360,25 +362,20 @@ impl<MC: MemoryConfig> JsaCalls<MC> {
         phys_address: Value<Address>,
         value: Value<XValue>,
     ) -> ErrnoImpl<(), impl FnOnce(&mut FunctionBuilder) + 'static> {
-        let exception_slot = self.exception_ptr_slot(builder);
-        let exception_ptr = exception_slot.ptr(builder);
-
         let value = V::from_xvalue_ir(builder, value);
 
         // SAFETY: The reference argument lifetimes are valid for the duration of the call:
         // - `core_ptr` is a JIT function argument
-        // - `exception_ptr` points to a stack slot within the JIT function
-        let is_exception = ext_calls::call4(
+        let exception = ext_calls::call3(
             &self.target_config,
             builder,
             self::memory_store,
             unsafe { core_ptr.as_mut() },
             phys_address,
             value,
-            unsafe { exception_ptr.as_mut() },
         );
 
-        ErrnoImpl::new(is_exception, exception_ptr, |_| {})
+        ErrnoImpl::new(exception, |_| {})
     }
 
     /// Emit the required IR to call `memory_load`.
@@ -391,9 +388,6 @@ impl<MC: MemoryConfig> JsaCalls<MC> {
         phys_address: Value<Address>,
     ) -> ErrnoImpl<Value<XValue>, impl FnOnce(&mut FunctionBuilder) -> Value<XValue> + 'static>
     {
-        let exception_slot = self.exception_ptr_slot(builder);
-        let exception_ptr = exception_slot.ptr(builder);
-
         let xval_slot =
             stack::Slot::<MaybeUninit<V>>::new(self.target_config.pointer_type(), builder);
         let xval_ptr = xval_slot.ptr(builder);
@@ -401,18 +395,16 @@ impl<MC: MemoryConfig> JsaCalls<MC> {
         // SAFETY: The reference argument lifetimes are valid for the duration of the call:
         // - `core_ptr` is a JIT function argument
         // - `xval_ptr` points to a stack slot which is valid for the duration of the JIT function
-        // - `exception_ptr` points to a stack slot within the JIT function as well
-        let is_exception = ext_calls::call4(
+        let exception = ext_calls::call3(
             &self.target_config,
             builder,
             self::memory_load,
             unsafe { core_ptr.as_ref() },
             phys_address,
             unsafe { xval_ptr.as_mut() },
-            unsafe { exception_ptr.as_mut() },
         );
 
-        ErrnoImpl::new(is_exception, exception_ptr, move |builder| {
+        ErrnoImpl::new(exception, move |builder| {
             // SAFETY: The slot is guaranteed to be initialised at this point as this closure
             // generates IR for the success case when the external function will have written to
             // the stack slot.
@@ -432,27 +424,22 @@ impl<MC: MemoryConfig> JsaCalls<MC> {
         xval: Value<XValue>,
     ) -> ErrnoImpl<Value<FValue>, impl FnOnce(&mut FunctionBuilder) -> Value<FValue> + 'static>
     {
-        let exception_slot = self.exception_ptr_slot(builder);
-        let exception_ptr = exception_slot.ptr(builder);
-
         let fvalue_slot = self.fvalue_ptr_slot(builder);
         let fvalue_ptr = fvalue_slot.ptr(builder);
 
         // SAFETY: The reference argument lifetimes are valid for the duration of the call:
         // - `core_ptr` is a JIT function argument, therefore valid for the entire function
-        // - `exception_ptr` points to a stack slot which is valid for the duration of the function
         // - `fvalue_ptr` also points to a stack slot
-        let is_exception = ext_calls::call4(
+        let exception = ext_calls::call3(
             &self.target_config,
             builder,
             self::f64_from_x64_unsigned_dynamic,
             unsafe { core_ptr.as_mut() },
-            unsafe { exception_ptr.as_mut() },
             xval,
             unsafe { fvalue_ptr.as_mut() },
         );
 
-        ErrnoImpl::new(is_exception, exception_ptr, move |builder| {
+        ErrnoImpl::new(exception, move |builder| {
             // SAFETY: This closure runs after the success case of the call, where the fvalue_slot
             // is guaranteed to have been initialised with an fvalue.
             unsafe { fvalue_slot.assume_init().load(builder) }

--- a/src/riscv/lib/src/machine_state.rs
+++ b/src/riscv/lib/src/machine_state.rs
@@ -334,7 +334,7 @@ impl<MC: memory::MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: backen
         self.core
             .main_memory
             .read_exec(phys_addr)
-            .map_err(|_: BadMemoryAccess| Exception::InstructionAccessFault(phys_addr))
+            .map_err(|_: BadMemoryAccess| Exception::InstructionAccessFault)
     }
 
     /// Fetch instruction from the address given by program counter

--- a/src/riscv/lib/src/traps.rs
+++ b/src/riscv/lib/src/traps.rs
@@ -25,8 +25,6 @@ use std::fmt::Formatter;
 
 use tezos_smart_rollup_constants::riscv::SbiError;
 
-use crate::machine_state::memory::Address;
-
 /// RISC-V Exceptions (also known as synchronous exceptions)
 #[derive(PartialEq, Eq, thiserror::Error, strum::Display, Debug, Clone, Copy)]
 pub enum EnvironException {
@@ -41,12 +39,12 @@ impl TryFrom<&Exception> for EnvironException {
             Exception::EnvCall => Ok(EnvironException::EnvCall),
             Exception::Breakpoint
             | Exception::IllegalInstruction
-            | Exception::InstructionAccessFault(_)
-            | Exception::LoadAccessFault(_)
-            | Exception::StoreAMOAccessFault(_)
-            | Exception::InstructionPageFault(_)
-            | Exception::LoadPageFault(_)
-            | Exception::StoreAMOPageFault(_) => {
+            | Exception::InstructionAccessFault
+            | Exception::LoadAccessFault
+            | Exception::StoreAMOAccessFault
+            | Exception::InstructionPageFault
+            | Exception::LoadPageFault
+            | Exception::StoreAMOPageFault => {
                 Err("Execution environment supports only ecall exceptions")
             }
         }
@@ -56,27 +54,24 @@ impl TryFrom<&Exception> for EnvironException {
 /// RISC-V Exceptions (also known as synchronous exceptions)
 #[derive(PartialEq, Eq, thiserror::Error, strum::Display, Clone, Copy)]
 pub enum Exception {
-    /// `InstructionAccessFault(addr)` where `addr` is the faulting instruction address
-    InstructionAccessFault(Address),
+    InstructionAccessFault,
     IllegalInstruction,
     Breakpoint,
-    /// `LoadAccessFault(addr)` where `addr` is the faulting load address
-    LoadAccessFault(Address),
-    /// `StoreAccessFault(addr)` where `addr` is the faulting store address
-    StoreAMOAccessFault(Address),
+    LoadAccessFault,
+    StoreAMOAccessFault,
     EnvCall,
-    InstructionPageFault(Address),
-    LoadPageFault(Address),
-    StoreAMOPageFault(Address),
+    InstructionPageFault,
+    LoadPageFault,
+    StoreAMOPageFault,
 }
 
 impl core::fmt::Debug for Exception {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            Self::InstructionPageFault(adr) => write!(f, "InstructionPageFault({adr:#X})"),
-            Self::LoadPageFault(adr) => write!(f, "LoadPageFault({adr:#X})"),
-            Self::StoreAMOPageFault(adr) => write!(f, "StoreAMOPageFault({adr:#X})"),
-            Self::LoadAccessFault(adr) => write!(f, "LoadAccessFault({adr:#X})"),
+            Self::InstructionPageFault => write!(f, "InstructionPageFault"),
+            Self::LoadPageFault => write!(f, "LoadPageFault"),
+            Self::StoreAMOPageFault => write!(f, "StoreAMOPageFault"),
+            Self::LoadAccessFault => write!(f, "LoadAccessFault"),
             other => write!(f, "{other}"),
         }
     }
@@ -85,12 +80,12 @@ impl core::fmt::Debug for Exception {
 impl From<Exception> for SbiError {
     fn from(value: Exception) -> Self {
         match value {
-            Exception::InstructionAccessFault(_)
-            | Exception::InstructionPageFault(_)
-            | Exception::LoadAccessFault(_)
-            | Exception::LoadPageFault(_)
-            | Exception::StoreAMOAccessFault(_)
-            | Exception::StoreAMOPageFault(_) => SbiError::InvalidAddress,
+            Exception::InstructionAccessFault
+            | Exception::InstructionPageFault
+            | Exception::LoadAccessFault
+            | Exception::LoadPageFault
+            | Exception::StoreAMOAccessFault
+            | Exception::StoreAMOPageFault => SbiError::InvalidAddress,
             Exception::IllegalInstruction | Exception::Breakpoint | Exception::EnvCall => {
                 SbiError::Failed
             }

--- a/src/riscv/lib/src/traps.rs
+++ b/src/riscv/lib/src/traps.rs
@@ -53,8 +53,9 @@ impl TryFrom<&Exception> for EnvironException {
 
 /// RISC-V Exceptions (also known as synchronous exceptions)
 #[derive(PartialEq, Eq, thiserror::Error, strum::Display, Clone, Copy)]
+#[repr(i64)]
 pub enum Exception {
-    InstructionAccessFault,
+    InstructionAccessFault = 1,
     IllegalInstruction,
     Breakpoint,
     LoadAccessFault,


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

# What

Changes to passing exceptions by value instead of via a pointer.

# Why

This makes passing exceptions around more straightforward. It also allows us to avoid allocating a stack slot for exceptions.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
