### PR TITLE
Use the kernel sdk constants in defining ethereum crypto sys-calls

### DIFF
--- a/src/riscv/lib/src/pvm/tezos.rs
+++ b/src/riscv/lib/src/pvm/tezos.rs
@@ -22,18 +22,11 @@ use tezos_smart_rollup_constants::riscv::SBI_TEZOS_BLAKE2B_HASH256;
 use tezos_smart_rollup_constants::riscv::SBI_TEZOS_ED25519_SIGN;
 use tezos_smart_rollup_constants::riscv::SBI_TEZOS_ED25519_VERIFY;
 use tezos_smart_rollup_constants::riscv::SBI_TEZOS_INBOX_NEXT;
+use tezos_smart_rollup_constants::riscv::SBI_TEZOS_KECCAK256_HASH;
 use tezos_smart_rollup_constants::riscv::SBI_TEZOS_REVEAL;
+use tezos_smart_rollup_constants::riscv::SBI_TEZOS_SECP256K1_VERIFY;
 use tezos_smart_rollup_constants::riscv::SbiError;
 
-// TODO: RV-691: Move constant to kernel_sdk
-/// Function ID for `sbi_tezos_secp256k1_verify`
-pub const SBI_TEZOS_SECP256K1_VERIFY: u64 = 0x0a;
-
-// TODO: RV-691: Move constant to kernel_sdk
-/// Function ID for `sbi_tezos_keccak_hash256`
-pub const SBI_TEZOS_KECCAK256_HASH: u64 = 0x0b;
-
-// TODO: RV-691: Move constant to kernel_sdk
 /// Maximum size of pvm memory access by a host function in bytes
 /// To limit size of proofs in refutation games
 pub const MAX_PVM_MEMORY_ACCESS: usize = 4096;


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->
 Relates to RV-691
# What
Use kernel sdk constants, instead of locally defined copies. Introduced in this [MR](https://gitlab.com/tezos/tezos/-/merge_requests/18732/)
<!--
    Summarise the changes in this MR.
-->

# Why
To not duplicate the system call constants
<!-- 
    Explain why this MR is needed.
-->

# How
Import kernel sdk constants instead of redefining. Note that I have removed the linear issue link from the field `MAX_PVM_MEMORY_ACCESS` as I thought that's not actually a hard constraint part of the SDK, but a soft constraint used for this particular hashing system call.

<!--
    Explain how the MR achieves its goal. If this is trivial or if the code speaks for itself, you
    can omit this.
-->

# Manually Testing
Not applicable
```
make -C src/riscv all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
