### PR TITLE
Add `RunDeserialiser` trait

### DIFF
--- a/src/riscv/lib/src/pvm/common.rs
+++ b/src/riscv/lib/src/pvm/common.rs
@@ -42,7 +42,8 @@ use crate::state_backend::proof_backend::ProofGen;
 use crate::state_backend::proof_backend::ProofWrapper;
 use crate::state_backend::proof_backend::proof::MerkleProof;
 use crate::state_backend::proof_backend::proof::Proof;
-use crate::state_backend::proof_backend::proof::deserialise_owned;
+use crate::state_backend::proof_backend::proof::deserialise_owned::ProofTreeDeserialiser;
+use crate::state_backend::proof_backend::proof::deserialiser::RunDeserialiser;
 use crate::state_backend::verify_backend::Verifier;
 use crate::storage::Hash;
 use crate::storage::HashError;
@@ -455,9 +456,11 @@ impl<MC: MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, Verifier>> Pvm<MC, BC
     where
         AllocatedOf<BCC::Layout, Verifier>: 'static,
     {
-        let space = deserialise_owned::deserialise::<PvmLayout<MC, BCC>>(ProofTree::Present(proof))
-            .ok()?
-            .0;
+        let (space, _proof_tree) =
+            ProofTreeDeserialiser::into_verifier_alloc::<PvmLayout<MC, BCC>>(ProofTree::Present(
+                proof,
+            ))
+            .ok()?;
         Some(Self::bind(space, block_builder))
     }
 }

--- a/src/riscv/lib/src/state_backend/layout.rs
+++ b/src/riscv/lib/src/state_backend/layout.rs
@@ -343,7 +343,8 @@ mod tests {
     use crate::state_backend::ProofPart;
     use crate::state_backend::owned_backend::Owned;
     use crate::state_backend::proof_backend::ProofWrapper;
-    use crate::state_backend::proof_backend::proof::deserialise_owned;
+    use crate::state_backend::proof_backend::proof::deserialise_owned::ProofTreeDeserialiser;
+    use crate::state_backend::proof_backend::proof::deserialiser::RunDeserialiser;
     use crate::state_backend::verify_backend::handle_stepper_panics;
 
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -437,7 +438,7 @@ mod tests {
             // Verify the proof and check the final hash
             handle_stepper_panics(|| {
                 let mut verify_foo =
-                    deserialise_owned::deserialise::<Foo>(ProofPart::Present(&proof))
+                    ProofTreeDeserialiser::into_verifier_alloc::<Foo>(ProofPart::Present(&proof))
                         .unwrap()
                         .0;
                 assert_eq!(bar, verify_foo.bar.read());

--- a/src/riscv/lib/src/state_backend/proof_backend/proof.rs
+++ b/src/riscv/lib/src/state_backend/proof_backend/proof.rs
@@ -25,6 +25,8 @@ use crate::pvm::node_pvm::NodePvmLayout;
 use crate::state_backend::OwnedProofPart;
 use crate::state_backend::ProofLayoutError;
 use crate::state_backend::hash::Hash;
+use crate::state_backend::proof_backend::proof::deserialise_stream::StreamDeserialiser;
+use crate::state_backend::proof_backend::proof::deserialiser::RunDeserialiser;
 use crate::state_backend::verify_backend::Verifier;
 use crate::storage::DIGEST_SIZE;
 use crate::storage::HashError;
@@ -320,8 +322,9 @@ pub fn deserialise_proof<I: Iterator<Item = u8>>(
     let final_state_hash = deserialise_final_hash(&mut bytes)
         .map_err(|e| ProofLayoutError::TagDeserialise(e.into()))?;
 
-    let (space, proof_tree) =
-        deserialise_stream::deserialise::<NodePvmLayout>(bytes.collect::<Vec<u8>>().as_slice())?;
+    let (space, proof_tree) = StreamDeserialiser::into_verifier_alloc::<NodePvmLayout>(
+        bytes.collect::<Vec<u8>>().as_slice(),
+    )?;
 
     let merkle_tree = match proof_tree {
         OwnedProofPart::Absent => return Err(ProofLayoutError::AbsentProof.into()),

--- a/src/riscv/lib/src/state_backend/proof_backend/proof/deserialise_owned.rs
+++ b/src/riscv/lib/src/state_backend/proof_backend/proof/deserialise_owned.rs
@@ -12,17 +12,14 @@ use super::deserialiser::DeserialiserNode;
 use super::deserialiser::Partial;
 use super::deserialiser::ProofLayoutResult;
 use super::deserialiser::Suspended;
-use crate::state_backend::AllocatedOf;
-use crate::state_backend::OwnedProofPart;
-use crate::state_backend::ProofLayout;
 use crate::state_backend::ProofLayoutError;
 use crate::state_backend::ProofPart;
 use crate::state_backend::ProofTree;
 use crate::state_backend::proof_backend::proof::MerkleProofLeaf;
 use crate::state_backend::proof_backend::proof::deserialiser;
 use crate::state_backend::proof_backend::proof::deserialiser::ProofParseResult;
+use crate::state_backend::proof_backend::proof::deserialiser::RunDeserialiser;
 use crate::state_backend::proof_backend::tree::Tree;
-use crate::state_backend::verify_backend::Verifier;
 use crate::storage::binary;
 
 /// Deserialiser for [`Deserialiser`] which owns the data.
@@ -236,10 +233,16 @@ impl<R> OwnedParserComb<'_, R> {
     }
 }
 
-/// Given a [`ProofTree`] deserialise it into an allocated [`Verifier`] backend.
-pub fn deserialise<L: ProofLayout>(
-    proof: ProofTree,
-) -> deserialiser::Result<(AllocatedOf<L, Verifier>, OwnedProofPart)> {
-    let comp_fn = L::into_verifier_alloc::<ProofTreeDeserialiser>(proof.into())?;
-    Ok(comp_fn.into_result()?)
+impl<'t> RunDeserialiser for ProofTreeDeserialiser<'t> {
+    type Data = ProofTree<'t>;
+
+    fn run<R>(
+        input_data: Self::Data,
+        deser_fn: impl FnOnce(Self) -> ProofLayoutResult<<Self as Deserialiser>::Suspended<R>>,
+    ) -> deserialiser::Result<R> {
+        let proof_tree = ProofTreeDeserialiser(input_data);
+        deser_fn(proof_tree)?
+            .into_result()
+            .map_err(deserialiser::Error::ParseProof)
+    }
 }

--- a/src/riscv/lib/src/state_backend/proof_backend/proof/deserialise_stream.rs
+++ b/src/riscv/lib/src/state_backend/proof_backend/proof/deserialise_stream.rs
@@ -17,9 +17,6 @@ use super::deserialiser::DeserialiserNode;
 use super::deserialiser::Partial;
 use super::deserialiser::ProofLayoutResult;
 use super::deserialiser::Suspended;
-use crate::state_backend::AllocatedOf;
-use crate::state_backend::OwnedProofPart;
-use crate::state_backend::ProofLayout;
 use crate::state_backend::ProofLayoutError;
 use crate::state_backend::ProofParseError;
 use crate::state_backend::TagError;
@@ -27,7 +24,7 @@ use crate::state_backend::proof_backend::proof::InvalidTagError;
 use crate::state_backend::proof_backend::proof::NotEnoughBytesError;
 use crate::state_backend::proof_backend::proof::deserialiser;
 use crate::state_backend::proof_backend::proof::deserialiser::ProofParseResult;
-use crate::state_backend::verify_backend::Verifier;
+use crate::state_backend::proof_backend::proof::deserialiser::RunDeserialiser;
 use crate::storage::Hash;
 
 /// Wrapper type over the raw byte data to parse tags.
@@ -328,16 +325,20 @@ impl<R> StreamParserComb<'_, R> {
     }
 }
 
-/// Deserialise raw bytes into a [`Verifier`] backend and the partial state hash helper [`OwnedProofPart`].
-///
-/// Convenience function to bundle deserialisation and execution of the suspended function for the owned deserialisation.
-pub fn deserialise<L: ProofLayout>(
-    proof_tree_raw_bytes: &[u8],
-) -> deserialiser::Result<(AllocatedOf<L, Verifier>, OwnedProofPart)> {
-    let tags_rc = Rc::new(RefCell::new(TagIter::new(proof_tree_raw_bytes)));
-    let comp_fn = L::into_verifier_alloc(StreamDeserialiser::new_present(tags_rc.clone()))?;
+impl<'t> RunDeserialiser for StreamDeserialiser<'t> {
+    type Data = &'t [u8];
 
-    // SAFETY: The `Deserialiser` trait provided to the `FromProof` implementation of T
-    // can not execute the suspended computation, it can only compose them due to encapsulation
-    Ok(comp_fn.into_result(&mut tags_rc.borrow_mut().remaining_to_stream_input())?)
+    fn run<R>(
+        input_data: Self::Data,
+        deser_fn: impl FnOnce(Self) -> ProofLayoutResult<<Self as Deserialiser>::Suspended<R>>,
+    ) -> deserialiser::Result<R> {
+        let tags = Rc::new(RefCell::new(TagIter::new(input_data)));
+        let comp_fn = deser_fn(StreamDeserialiser::new_present(tags.clone()))?;
+
+        // SAFETY: The `Deserialiser` trait provided to the `FromProof` implementation of T
+        // can not execute the suspended computation, it can only compose them due to encapsulation
+        comp_fn
+            .into_result(&mut tags.borrow_mut().remaining_to_stream_input())
+            .map_err(deserialiser::Error::ParseProof)
+    }
 }

--- a/src/riscv/lib/src/state_backend/proof_backend/proof/deserialiser.rs
+++ b/src/riscv/lib/src/state_backend/proof_backend/proof/deserialiser.rs
@@ -15,11 +15,14 @@
 
 use bincode::Decode;
 
+use crate::state_backend::AllocatedOf;
 use crate::state_backend::OwnedProofPart;
+use crate::state_backend::ProofLayout;
 use crate::state_backend::ProofLayoutError;
 use crate::state_backend::ProofParseError;
 use crate::state_backend::hash::Hash;
 use crate::state_backend::proof_backend::merkle::MERKLE_LEAF_SIZE;
+use crate::state_backend::verify_backend::Verifier;
 
 /// Result type used when deserialising with [`Deserialiser`] traits.
 pub(in crate::state_backend) type ProofLayoutResult<R, E = ProofLayoutError> =
@@ -186,6 +189,25 @@ pub trait Suspended {
     ) -> <Self::Parent as Deserialiser>::Suspended<T>
     where
         Self::Output: 'static;
+}
+
+/// Trait for common deserialisation functionality abstracting over the deserialiser type.
+pub trait RunDeserialiser: Deserialiser + Sized {
+    /// Data type consumed by the deserialiser.
+    type Data;
+
+    /// Run the deserialiser and obtain the result of the computation.
+    fn run<R>(
+        input_data: Self::Data,
+        deser_fn: impl FnOnce(Self) -> ProofLayoutResult<<Self as Deserialiser>::Suspended<R>>,
+    ) -> Result<R>;
+
+    /// Based on a [`ProofLayout`] obtain the corresponding [`AllocatedOf`] and [`OwnedProofPart`].
+    fn into_verifier_alloc<L: ProofLayout>(
+        input_data: Self::Data,
+    ) -> Result<(AllocatedOf<L, Verifier>, OwnedProofPart)> {
+        Self::run(input_data, L::into_verifier_alloc)
+    }
 }
 
 #[cfg(test)]

--- a/src/riscv/lib/src/state_backend/proof_layout.rs
+++ b/src/riscv/lib/src/state_backend/proof_layout.rs
@@ -1204,7 +1204,8 @@ mod tests {
     use crate::state_backend::ManagerWrite;
     use crate::state_backend::proof_backend::ProofGen;
     use crate::state_backend::proof_backend::ProofRegion;
-    use crate::state_backend::proof_backend::proof::deserialise_owned;
+    use crate::state_backend::proof_backend::proof::deserialise_owned::ProofTreeDeserialiser;
+    use crate::state_backend::proof_backend::proof::deserialiser::RunDeserialiser;
 
     const CELLS_SIZE: usize = 32;
 
@@ -1240,7 +1241,7 @@ mod tests {
                 .to_merkle_proof()
                 .unwrap();
 
-            let verifier_state = deserialise_owned::deserialise::<TestLayout>(
+            let verifier_state = ProofTreeDeserialiser::into_verifier_alloc::<TestLayout>(
                 ProofTree::Present(&merkle_proof)
             ).unwrap();
 

--- a/src/riscv/lib/src/stepper/pvm.rs
+++ b/src/riscv/lib/src/stepper/pvm.rs
@@ -45,8 +45,9 @@ use crate::state_backend::hash::Hash;
 use crate::state_backend::owned_backend::Owned;
 use crate::state_backend::proof_backend::ProofGen;
 use crate::state_backend::proof_backend::proof::Proof;
-use crate::state_backend::proof_backend::proof::deserialise_owned;
-use crate::state_backend::proof_backend::proof::deserialise_stream::{self};
+use crate::state_backend::proof_backend::proof::deserialise_owned::ProofTreeDeserialiser;
+use crate::state_backend::proof_backend::proof::deserialise_stream::StreamDeserialiser;
+use crate::state_backend::proof_backend::proof::deserialiser::RunDeserialiser;
 use crate::state_backend::proof_backend::proof::serialise_merkle_tree;
 use crate::state_backend::verify_backend::ProofVerificationFailure;
 use crate::state_backend::verify_backend::Verifier;
@@ -270,7 +271,7 @@ impl<H, MC: MemoryConfig, BCC: BlockCacheConfig, M: ManagerReadWrite> PvmStepper
     {
         let tree_serialisation: Box<[u8]> = serialise_merkle_tree(proof.tree()).collect();
         let (space, merkle_tree) =
-            deserialise_stream::deserialise::<PvmLayout<MC, BCC>>(&tree_serialisation)
+            StreamDeserialiser::into_verifier_alloc::<PvmLayout<MC, BCC>>(&tree_serialisation)
                 .map_err(ProofVerificationFailure::BadDeserialisation)?;
 
         let deserialised_proof_tree = match merkle_tree {
@@ -295,7 +296,7 @@ impl<H, MC: MemoryConfig, BCC: BlockCacheConfig, M: ManagerReadWrite> PvmStepper
     {
         let proof_tree = ProofTree::Present(proof.tree());
         let (space, deserialised_proof_tree) =
-            deserialise_owned::deserialise::<PvmLayout<MC, BCC>>(proof_tree)
+            ProofTreeDeserialiser::into_verifier_alloc::<PvmLayout<MC, BCC>>(proof_tree)
                 .map_err(ProofVerificationFailure::BadDeserialisation)?;
 
         let deserialised_proof_tree = match deserialised_proof_tree {


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

Related to RV-629

# What

<!--
    Summarise the changes in this MR.
-->

Introduce `RunDeserialiser` trait for common functionality over the two deserialisers that we have (owned / streaming)

# Why

A follow up to #186, reduce duplicated code.

<!-- 
    Explain why this MR is needed.
-->

# How

Introduce a trait for abstracting away the internals of how to run the deserialisation, requiring just a `run` function to be implemented for each deserialiser.

Based on the `run` function we can have a default implementation for deserialising into a verifier with `RunDeserialiser::into_verifier_alloc`

<!--
    Explain how the MR achieves its goal. If this is trivial or if the code speaks for itself, you
    can omit this.
-->

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
