### PR TITLE
Only allow read/write of CSR values as u64

### DIFF
--- a/src/riscv/lib/src/bits.rs
+++ b/src/riscv/lib/src/bits.rs
@@ -3,8 +3,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-use std::fmt;
-
 macro_rules! bits_builtin {
     ($t:tt, $size:expr) => {
         #[allow(clippy::allow_attributes, reason = "As the macro generates methods regardless of whether they're used or not, we need to be able to silence some warnings")]
@@ -32,6 +30,7 @@ macro_rules! bits_builtin {
             }
 
             /// Returns the [bit] of `v` as a boolean.
+            #[allow(dead_code, reason = "This is generated in a macro and is not guaranteed to be used")]
             #[inline(always)]
             pub const fn bit(v: $t, bit: usize) -> bool {
                 ((v >> bit) & 1) != 0
@@ -39,6 +38,7 @@ macro_rules! bits_builtin {
 
             /// Returns a strict subset of bits of `v`.
             /// Panics if the range covers the whole value.
+            #[allow(dead_code, reason = "This is generated in a macro and is not guaranteed to be used")]
             #[inline(always)]
             pub const fn bits_subset(v: $t, start: usize, end: usize) -> $t {
                 (v & mask_subset(start, end)) >> end
@@ -67,97 +67,6 @@ macro_rules! bits_builtin {
 
 bits_builtin!(u16, 16);
 bits_builtin!(u64, 64);
-
-/// Implementations can be converted to and from a binary [prim@u64] representation
-pub trait Bits64 {
-    const WIDTH: usize;
-
-    /// Convert from the [prim@u64] binary representation.
-    fn from_bits(value: u64) -> Self;
-
-    /// Serialise to the [prim@u64] binary representation.
-    fn to_bits(&self) -> u64;
-}
-
-impl Bits64 for bool {
-    const WIDTH: usize = 1;
-
-    #[inline(always)]
-    fn from_bits(value: u64) -> Self {
-        u64::bit(value, 0)
-    }
-
-    #[inline(always)]
-    fn to_bits(&self) -> u64 {
-        if *self { 1 } else { 0 }
-    }
-}
-
-macro_rules! bits64_builtin {
-    ( $t:ty ) => {
-        impl Bits64 for $t {
-            const WIDTH: usize = { <$t>::BITS as usize };
-
-            #[inline(always)]
-            fn from_bits(value: u64) -> Self {
-                value as $t
-            }
-
-            #[inline(always)]
-            fn to_bits(&self) -> u64 {
-                *self as u64
-            }
-        }
-    };
-}
-
-bits64_builtin!(u8);
-bits64_builtin!(u16);
-bits64_builtin!(u32);
-bits64_builtin!(u64);
-
-bits64_builtin!(i8);
-bits64_builtin!(i16);
-bits64_builtin!(i32);
-bits64_builtin!(i64);
-
-/// Helper type for [Bits64] that always inhabits a default value of `WIDTH` bits
-#[derive(Copy, Clone)]
-pub struct ConstantBits<const WIDTH: usize, const VALUE: u64 = 0>;
-
-impl<const WIDTH: usize, const VALUE: u64> Bits64 for ConstantBits<WIDTH, VALUE> {
-    const WIDTH: usize = WIDTH;
-
-    fn from_bits(_value: u64) -> Self {
-        Self
-    }
-
-    fn to_bits(&self) -> u64 {
-        VALUE
-    }
-}
-
-impl<const WIDTH: usize, const VALUE: u64> fmt::Debug for ConstantBits<WIDTH, VALUE> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "0b{VALUE:b}/0x{VALUE:x}")
-    }
-}
-
-/// Like [prim@u64] but limited in width
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct FixedWidthBits<const WIDTH: usize>(u64);
-
-impl<const WIDTH: usize> Bits64 for FixedWidthBits<WIDTH> {
-    const WIDTH: usize = WIDTH;
-
-    fn from_bits(value: u64) -> Self {
-        Self(u64::bits_subset(value, WIDTH - 1, 0))
-    }
-
-    fn to_bits(&self) -> u64 {
-        u64::bits_subset(self.0, WIDTH - 1, 0)
-    }
-}
 
 /// Get the bitmask formed of `n` ones.
 pub const fn ones(n: u64) -> u64 {

--- a/src/riscv/lib/src/instruction_context.rs
+++ b/src/riscv/lib/src/instruction_context.rs
@@ -25,7 +25,6 @@ use crate::interpreter::atomics::reset_reservation_set;
 use crate::interpreter::float::RoundingMode;
 use crate::machine_state::MachineCoreState;
 use crate::machine_state::ProgramCounterUpdate;
-use crate::machine_state::csregisters::CSRRepr;
 use crate::machine_state::csregisters::CSRegister;
 use crate::machine_state::instruction::Args;
 use crate::machine_state::memory::Address;
@@ -405,11 +404,7 @@ impl<MC: MemoryConfig, M: ManagerReadWrite> ICB for MachineCoreState<MC, M> {
 
     fn f64_from_x64_unsigned_dynamic(&mut self, xval: Self::XValue) -> Self::IResult<Self::FValue> {
         let extended = xval as u128;
-        let rm: RoundingMode = self
-            .hart
-            .csregisters
-            .read::<CSRRepr>(CSRegister::frm)
-            .try_into()?;
+        let rm: RoundingMode = self.hart.csregisters.read(CSRegister::frm).try_into()?;
 
         let StatusAnd { status, value } = Double::from_u128_r(extended, rm.into());
 

--- a/src/riscv/lib/src/interpreter/float.rs
+++ b/src/riscv/lib/src/interpreter/float.rs
@@ -463,10 +463,7 @@ where
     pub(crate) fn f_rounding_mode(&self, rm: InstrRoundingMode) -> Result<Round, Exception> {
         let rm = match rm {
             InstrRoundingMode::Static(rm) => rm,
-            InstrRoundingMode::Dynamic => self
-                .csregisters
-                .read::<CSRRepr>(CSRegister::frm)
-                .try_into()?,
+            InstrRoundingMode::Dynamic => self.csregisters.read(CSRegister::frm).try_into()?,
         };
 
         Ok(rm.into())
@@ -728,7 +725,7 @@ mod test {
             let fval = match rm {
                 InstrRoundingMode::Static(rm) => Double::from_u128_r(r1_val as u128, rm.into()),
                 InstrRoundingMode::Dynamic => {
-                    let rm: RoundingMode = state.hart.csregisters.read::<CSRRepr>(CSRegister::frm).try_into()?;
+                    let rm: RoundingMode = state.hart.csregisters.read(CSRegister::frm).try_into()?;
                     Double::from_u128_r(r1_val as u128, rm.into())
                 }
             };

--- a/src/riscv/lib/src/machine_state/csregisters.rs
+++ b/src/riscv/lib/src/machine_state/csregisters.rs
@@ -9,7 +9,6 @@ use std::ops::Shr;
 
 use num_enum::TryFromPrimitive;
 
-use crate::bits::Bits64;
 use crate::state::NewState;
 use crate::state_backend as backend;
 use crate::state_backend::Atom;
@@ -178,26 +177,26 @@ pub struct CSRegisters<M: backend::ManagerBase> {
 impl<M: backend::ManagerBase> CSRegisters<M> {
     /// Write to a CSR.
     #[inline]
-    pub fn write<V: Bits64>(&mut self, reg: CSRegister, value: V)
+    pub fn write(&mut self, reg: CSRegister, value: CSRRepr)
     where
         M: backend::ManagerWrite,
     {
         match reg {
             CSRegister::fflags => {
-                let fflags = value.to_bits().bitand(FFLAGS_MASK) as u8;
+                let fflags = value.bitand(FFLAGS_MASK) as u8;
                 self.fflags.write(fflags);
             }
 
             CSRegister::frm => {
-                let frm = value.to_bits().bitand(FRM_MASK) as u8;
+                let frm = value.bitand(FRM_MASK) as u8;
                 self.frm.write(frm);
             }
 
             CSRegister::fcsr => {
-                let fflags = value.to_bits().bitand(FFLAGS_MASK) as u8;
+                let fflags = value.bitand(FFLAGS_MASK) as u8;
                 self.fflags.write(fflags);
 
-                let frm = value.to_bits().shr(FRM_SHIFT).bitand(FRM_MASK) as u8;
+                let frm = value.shr(FRM_SHIFT).bitand(FRM_MASK) as u8;
                 self.frm.write(frm);
             }
 
@@ -240,31 +239,24 @@ impl<M: backend::ManagerBase> CSRegisters<M> {
 
     /// Read from a CSR.
     #[inline]
-    pub fn read<V: Bits64>(&self, reg: CSRegister) -> V
+    pub fn read(&self, reg: CSRegister) -> CSRRepr
     where
         M: backend::ManagerRead,
     {
         match reg {
-            CSRegister::fflags => {
-                let fflags = self.fflags.read() as u64;
-                V::from_bits(fflags)
-            }
+            CSRegister::fflags => self.fflags.read() as u64,
 
-            CSRegister::frm => {
-                let frm = self.frm.read() as u64;
-                V::from_bits(frm)
-            }
+            CSRegister::frm => self.frm.read() as u64,
 
             CSRegister::fcsr => {
                 let fflags = self.fflags.read() as u64;
                 let frm = self.frm.read() as u64;
-                let fcsr = frm.shl(FRM_SHIFT).bitor(fflags);
-                V::from_bits(fcsr)
+                frm.shl(FRM_SHIFT).bitor(fflags)
             }
 
             CSRegister::cycle | CSRegister::time | CSRegister::instret => {
                 // We don't count those at the moment.
-                V::from_bits(0)
+                0
             }
 
             CSRegister::hpmcounter3
@@ -298,18 +290,18 @@ impl<M: backend::ManagerBase> CSRegisters<M> {
             | CSRegister::hpmcounter31 => {
                 // We assume that the M-level counters are all not enabled. There is no M-level, so
                 // we get to decide.
-                V::from_bits(0)
+                0
             }
         }
     }
 
     /// Replace the CSR value, returning the previous value.
     #[inline]
-    pub fn replace<V: Bits64>(&mut self, reg: CSRegister, value: V) -> V
+    pub fn replace(&mut self, reg: CSRegister, value: CSRRepr) -> CSRRepr
     where
         M: backend::ManagerReadWrite,
     {
-        let old = self.read::<V>(reg);
+        let old = self.read(reg);
         self.write(reg, value);
         old
     }
@@ -396,7 +388,6 @@ mod tests {
     use strum::IntoEnumIterator;
 
     use crate::backend_test;
-    use crate::machine_state::csregisters::CSRRepr;
     use crate::machine_state::csregisters::CSRegister;
     use crate::machine_state::csregisters::CSRegisters;
     use crate::machine_state::csregisters::Exception;
@@ -428,29 +419,29 @@ mod tests {
         let mut csrs = CSRegisters::<F>::new();
 
         // check starting values
-        assert_eq!(0, csrs.read::<CSRRepr>(CSRegister::fcsr));
-        assert_eq!(0, csrs.read::<CSRRepr>(CSRegister::frm));
-        assert_eq!(0, csrs.read::<CSRRepr>(CSRegister::fflags));
+        assert_eq!(0, csrs.read(CSRegister::fcsr));
+        assert_eq!(0, csrs.read(CSRegister::frm));
+        assert_eq!(0, csrs.read(CSRegister::fflags));
 
         // writing to fcsr is reflected in frm/fflags
         csrs.write(CSRegister::fcsr, 0b111_11111);
 
-        assert_eq!(0b111_11111, csrs.read::<CSRRepr>(CSRegister::fcsr));
-        assert_eq!(0b111, csrs.read::<CSRRepr>(CSRegister::frm));
-        assert_eq!(0b11111, csrs.read::<CSRRepr>(CSRegister::fflags));
+        assert_eq!(0b111_11111, csrs.read(CSRegister::fcsr));
+        assert_eq!(0b111, csrs.read(CSRegister::frm));
+        assert_eq!(0b11111, csrs.read(CSRegister::fflags));
 
         // writing to frm is reflected in fcsr
         csrs.write(CSRegister::frm, 0b010);
 
-        assert_eq!(0b010_11111, csrs.read::<CSRRepr>(CSRegister::fcsr));
-        assert_eq!(0b010, csrs.read::<CSRRepr>(CSRegister::frm));
-        assert_eq!(0b11111, csrs.read::<CSRRepr>(CSRegister::fflags));
+        assert_eq!(0b010_11111, csrs.read(CSRegister::fcsr));
+        assert_eq!(0b010, csrs.read(CSRegister::frm));
+        assert_eq!(0b11111, csrs.read(CSRegister::fflags));
 
         // writing to fflags is reflected in fcsr
         csrs.write(CSRegister::fflags, 0b01010);
 
-        assert_eq!(0b010_01010, csrs.read::<CSRRepr>(CSRegister::fcsr));
-        assert_eq!(0b010, csrs.read::<CSRRepr>(CSRegister::frm));
-        assert_eq!(0b01010, csrs.read::<CSRRepr>(CSRegister::fflags));
+        assert_eq!(0b010_01010, csrs.read(CSRegister::fcsr));
+        assert_eq!(0b010, csrs.read(CSRegister::frm));
+        assert_eq!(0b01010, csrs.read(CSRegister::fflags));
     });
 }

--- a/src/riscv/lib/src/pvm/common.rs
+++ b/src/riscv/lib/src/pvm/common.rs
@@ -225,7 +225,7 @@ impl<MC: MemoryConfig, BCC: BlockCacheConfig, B: block::Block<MC, M>, M: state_b
         let csregs = &mut self.machine_state.core.hart.csregisters;
 
         // `fflags` is a writable CSR
-        let fflags = csregs.read::<u64>(CSRegister::fflags);
+        let fflags = csregs.read(CSRegister::fflags);
         csregs.write(CSRegister::fflags, fflags + 1);
     }
 


### PR DESCRIPTION
Part of RV-747

# What

You could read CSR values as any type that implements `Bits64`. However, this is no longer utilised. Hence, I remove these bits.

# Why

Cleaning this up makes subsequent changes related to RV-747 easier. It primarily removes an unused feature.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
