### PR TITLE
Remove ad-hoc exception construction functions from ICB

### DIFF
--- a/src/riscv/lib/src/instruction_context.rs
+++ b/src/riscv/lib/src/instruction_context.rs
@@ -148,8 +148,8 @@ pub(crate) trait ICB: StateContext<X64 = Self::XValue> {
     /// Wrap a value as a fallible value.
     fn ok<Value>(&mut self, val: Value) -> Self::IResult<Value>;
 
-    /// Raise an [`Exception::IllegalInstruction`] error.
-    fn err_illegal_instruction<In>(&mut self) -> Self::IResult<In>;
+    /// Raise an exception, returning a fallible value.
+    fn raise_exception<In>(&mut self, exception: Exception) -> Self::IResult<In>;
 
     /// Raise an [`Exception::StoreAMOAccessFault`] error if `address` is not
     /// aligned to the given [`LoadStoreWidth`].
@@ -168,9 +168,6 @@ pub(crate) trait ICB: StateContext<X64 = Self::XValue> {
     fn and_then<Value, Next, F>(res: Self::IResult<Value>, f: F) -> Self::IResult<Next>
     where
         F: FnOnce(Value) -> Self::IResult<Next>;
-
-    /// Exception to perform an ECall at the current mode
-    fn ecall(&mut self) -> Self::IResult<ProgramCounterUpdate<Self::XValue>>;
 
     /// Write value to main memory, at the given address.
     ///
@@ -338,9 +335,9 @@ impl<MC: MemoryConfig, M: ManagerReadWrite> ICB for MachineCoreState<MC, M> {
         Ok(val)
     }
 
-    #[inline(always)]
-    fn err_illegal_instruction<In>(&mut self) -> Self::IResult<In> {
-        Err(Exception::IllegalInstruction)
+    #[inline]
+    fn raise_exception<In>(&mut self, exception: Exception) -> Self::IResult<In> {
+        Err(exception)
     }
 
     #[inline(always)]
@@ -357,10 +354,6 @@ impl<MC: MemoryConfig, M: ManagerReadWrite> ICB for MachineCoreState<MC, M> {
         F: FnOnce(In) -> Self::IResult<Out>,
     {
         res.and_then(f)
-    }
-
-    fn ecall(&mut self) -> Self::IResult<ProgramCounterUpdate<Self::XValue>> {
-        Err(Exception::EnvCall)
     }
 
     #[inline(always)]

--- a/src/riscv/lib/src/jit/builder/instruction.rs
+++ b/src/riscv/lib/src/jit/builder/instruction.rs
@@ -57,6 +57,7 @@ use crate::state_backend::owned_backend::Owned;
 use crate::state_context::StateContext;
 use crate::state_context::projection::MachineCoreProjection;
 use crate::traps::EnvironException;
+use crate::traps::Exception;
 
 /// Instruction execution outcome
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
@@ -500,20 +501,12 @@ impl<MC: MemoryConfig> ICB for InstructionBuilder<'_, '_, MC> {
                 atomics::reset_reservation_set(self);
             }
 
-            let exception_ptr = self
-                .ext_calls
-                .raise_store_amo_access_fault_exception(self.builder);
-            self.handle_exception::<()>(exception_ptr);
+            self.raise_exception::<()>(Exception::StoreAMOAccessFault);
         }
 
         self.builder.switch_to_block(success_block);
 
         InstructionResult::HasNext(())
-    }
-
-    fn ecall(&mut self) -> Self::IResult<ProgramCounterUpdate<Self::XValue>> {
-        let exception = self.ext_calls.ecall(self.builder);
-        self.handle_exception(exception)
     }
 
     fn main_memory_store<V: StoreLoadInt>(
@@ -598,11 +591,9 @@ impl<MC: MemoryConfig> ICB for InstructionBuilder<'_, '_, MC> {
         InstructionResult::HasNext(val)
     }
 
-    fn err_illegal_instruction<In>(&mut self) -> Self::IResult<In> {
-        let exception_ptr = self
-            .ext_calls
-            .raise_illegal_instruction_exception(self.builder);
-        self.handle_exception(exception_ptr)
+    fn raise_exception<In>(&mut self, exception: Exception) -> Self::IResult<In> {
+        let code = ExceptionCode::build_exception_code(self.builder, exception);
+        self.handle_exception(code)
     }
 
     fn map<Value, Next, F>(res: Self::IResult<Value>, f: F) -> Self::IResult<Next>

--- a/src/riscv/lib/src/jit/state_access.rs
+++ b/src/riscv/lib/src/jit/state_access.rs
@@ -325,33 +325,6 @@ impl<MC: MemoryConfig> JsaCalls<MC> {
         ExceptionHandledOutcome { handled, new_pc }
     }
 
-    /// Emit the required IR to create an illegal instruction exception code.
-    ///
-    /// This returns the exception code value for an illegal instruction.
-    pub(super) fn raise_illegal_instruction_exception(
-        &mut self,
-        builder: &mut FunctionBuilder,
-    ) -> Value<ExceptionCode> {
-        ExceptionCode::build_exception_code(builder, Exception::IllegalInstruction)
-    }
-
-    /// Emit the required IR to create a store/AMO access fault exception code.
-    ///
-    /// This returns the exception code value for a store/AMO access fault.
-    pub(super) fn raise_store_amo_access_fault_exception(
-        &mut self,
-        builder: &mut FunctionBuilder,
-    ) -> Value<ExceptionCode> {
-        ExceptionCode::build_exception_code(builder, Exception::StoreAMOAccessFault)
-    }
-
-    /// Emit the required IR to create an environment call exception code.
-    ///
-    /// This returns the exception code value for an environment call.
-    pub(super) fn ecall(&mut self, builder: &mut FunctionBuilder) -> Value<ExceptionCode> {
-        ExceptionCode::build_exception_code(builder, Exception::EnvCall)
-    }
-
     /// Emit the required IR to call `memory_store`.
     ///
     /// Returns `errno` - on success, no additional values are returned.

--- a/src/riscv/lib/src/machine_state/instruction.rs
+++ b/src/riscv/lib/src/machine_state/instruction.rs
@@ -1494,7 +1494,7 @@ impl Args {
     }
 
     fn run_ecall<I: ICB>(&self, icb: &mut I) -> IcbFnResult<I> {
-        icb.ecall()
+        icb.raise_exception(Exception::EnvCall)
     }
 
     // RV64C compressed instructions
@@ -1505,7 +1505,7 @@ impl Args {
 
     // Unknown
     fn run_illegal<I: ICB>(&self, icb: &mut I) -> IcbFnResult<I> {
-        icb.err_illegal_instruction()
+        icb.raise_exception(Exception::IllegalInstruction)
     }
 }
 


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

# What

Replace the ad-hoc exception-raising mechanism in the ICB with a generic one. 

# Why

This means you can raise any exception through the ICB.

Using this, we can implement fault guards such as the one for Atomics generically. See #210.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
