### PR TITLE
Don't impose `Result` on `Hash::combine` which can't fail

### DIFF
--- a/src/riscv/lib/src/state_backend/commitment_layout.rs
+++ b/src/riscv/lib/src/state_backend/commitment_layout.rs
@@ -70,7 +70,7 @@ where
 {
     fn state_hash<M: ManagerSerialise>(state: AllocatedOf<Self, M>) -> Result<Hash, HashError> {
         let hashes = [A::state_hash(state.0)?, B::state_hash(state.1)?];
-        Hash::combine(&hashes)
+        Ok(Hash::combine(hashes))
     }
 }
 
@@ -86,7 +86,7 @@ where
             B::state_hash(state.1)?,
             C::state_hash(state.2)?,
         ];
-        Hash::combine(&hashes)
+        Ok(Hash::combine(hashes))
     }
 }
 
@@ -104,7 +104,7 @@ where
             C::state_hash(state.2)?,
             D::state_hash(state.3)?,
         ];
-        Hash::combine(&hashes)
+        Ok(Hash::combine(hashes))
     }
 }
 
@@ -124,7 +124,7 @@ where
             D::state_hash(state.3)?,
             E::state_hash(state.4)?,
         ];
-        Hash::combine(&hashes)
+        Ok(Hash::combine(hashes))
     }
 }
 
@@ -146,7 +146,7 @@ where
             E::state_hash(state.4)?,
             F::state_hash(state.5)?,
         ];
-        Hash::combine(&hashes)
+        Ok(Hash::combine(hashes))
     }
 }
 
@@ -159,7 +159,7 @@ where
             .into_iter()
             .map(T::state_hash)
             .collect::<Result<Vec<_>, _>>()?;
-        Hash::combine(&hashes)
+        Ok(Hash::combine(hashes))
     }
 }
 

--- a/src/riscv/lib/src/state_backend/hash.rs
+++ b/src/riscv/lib/src/state_backend/hash.rs
@@ -5,6 +5,7 @@
 
 //! Common type for hashes
 
+use std::borrow::Borrow;
 use std::num::NonZeroUsize;
 
 use bincode::Decode;
@@ -62,15 +63,16 @@ impl Hash {
     /// The hashes are combined by concatenating them, then hashing the result.
     /// Pre-image resistance is not compromised because the concatenation is not
     /// ambiguous, with hashes having a fixed size ([`DIGEST_SIZE`]).
-    pub fn combine(hashes: &[Hash]) -> Result<Hash, HashError> {
+    pub fn combine<H: Borrow<Hash>, HS: IntoIterator<Item = H>>(hashes: HS) -> Hash {
         let mut hasher = blake3::Hasher::new();
 
         for hash in hashes {
+            let hash: &Hash = hash.borrow();
             hasher.update(hash.as_ref());
         }
 
         let digest = hasher.finalize().into();
-        Ok(Hash { digest })
+        Hash { digest }
     }
 }
 
@@ -204,7 +206,7 @@ pub(crate) fn build_custom_merkle_hash(
     while nodes.len() > 1 {
         // Group the nodes into chunks of size `arity` and hash each chunk.
         for chunk in nodes.chunks(arity) {
-            next_level.push(Hash::combine(chunk)?)
+            next_level.push(Hash::combine(chunk))
         }
 
         std::mem::swap(&mut nodes, &mut next_level);

--- a/src/riscv/lib/src/state_backend/layout.rs
+++ b/src/riscv/lib/src/state_backend/layout.rs
@@ -146,11 +146,11 @@ macro_rules! struct_layout {
                 fn state_hash<M: $crate::state_backend::ManagerRead + $crate::state_backend::ManagerSerialise>(
                     state: $crate::state_backend::AllocatedOf<Self, M>
                 ) -> std::result::Result<$crate::storage::Hash, $crate::storage::HashError> {
-                    $crate::storage::Hash::combine(&[
+                    Ok($crate::storage::Hash::combine([
                         $(
                             [<$field_name:camel>]::state_hash(state.$field_name)?
                         ),+
-                    ])
+                    ]))
                 }
             }
 
@@ -172,13 +172,13 @@ macro_rules! struct_layout {
                 fn to_merkle_tree(
                     state: $crate::state_backend::RefProofGenOwnedAlloc<Self>,
                 ) -> std::result::Result<$crate::state_backend::proof_backend::merkle::MerkleTree, $crate::storage::HashError> {
-                    $crate::state_backend::proof_backend::merkle::MerkleTree::make_merkle_node(
+                    Ok($crate::state_backend::proof_backend::merkle::MerkleTree::make_merkle_node(
                         vec![
                             $(
                                 [<$field_name:camel>]::to_merkle_tree(state.$field_name)?
                             ),+
                         ]
-                    )
+                    ))
                 }
 
                 #[inline]

--- a/src/riscv/lib/src/state_backend/proof_backend/merkle.rs
+++ b/src/riscv/lib/src/state_backend/proof_backend/merkle.rs
@@ -56,10 +56,10 @@ impl MerkleTree {
 
     /// Make a Merkle tree consisting of a node which combines the given
     /// child trees.
-    pub fn make_merkle_node(children: Vec<Self>) -> Result<Self, HashError> {
-        let children_hashes: Vec<Hash> = children.iter().map(|t| t.root_hash()).collect();
-        let node_hash = Hash::combine(children_hashes.as_slice())?;
-        Ok(MerkleTree::Node(node_hash, children))
+    pub fn make_merkle_node(children: Vec<Self>) -> Self {
+        let children_hashes = children.iter().map(|t| t.root_hash());
+        let node_hash = Hash::combine(children_hashes);
+        MerkleTree::Node(node_hash, children)
     }
 
     /// Compress into a [`CompressedMerkleTree`].
@@ -103,7 +103,7 @@ impl MerkleTree {
                     .flatten();
 
                 let compressed_tree = match compression {
-                    Some(access) => CompresedLeaf(Hash::combine(hashes.as_slice())?, access),
+                    Some(access) => CompresedLeaf(Hash::combine(hashes), access),
                     None => CompresedNode(hash, compact_children),
                 };
 
@@ -354,7 +354,7 @@ impl MerkleTree {
                         })
                         .collect();
 
-                    Hash::combine(&children_hashes).is_ok_and(|h| h == *hash)
+                    &Hash::combine(children_hashes) == hash
                 }
             };
             if !is_valid_hash {
@@ -379,7 +379,7 @@ pub(crate) fn build_custom_merkle_tree(
 
     while nodes.len() > 1 {
         for chunk in nodes.chunks(arity) {
-            next_level.push(MerkleTree::make_merkle_node(chunk.to_vec())?)
+            next_level.push(MerkleTree::make_merkle_node(chunk.to_vec()))
         }
 
         std::mem::swap(&mut nodes, &mut next_level);
@@ -435,15 +435,11 @@ mod tests {
                         }
                     },
                     Self::Node(hash, children) => {
-                        let children_hashes: Vec<Hash> = children
-                            .iter()
-                            .map(|child| {
-                                deque.push_back(child);
-                                child.root_hash()
-                            })
-                            .collect();
-
-                        Hash::combine(&children_hashes).is_ok_and(|h| h == *hash)
+                        let children_hashes = children.iter().map(|child| {
+                            deque.push_back(child);
+                            child.root_hash()
+                        });
+                        &Hash::combine(children_hashes) == hash
                     }
                 };
                 if !is_valid_hash {
@@ -459,7 +455,7 @@ mod tests {
         Ok(MerkleTree::Leaf(hash, access, data.to_vec()))
     }
 
-    fn m_t(left: MerkleTree, right: MerkleTree) -> Result<MerkleTree, HashError> {
+    fn m_t(left: MerkleTree, right: MerkleTree) -> MerkleTree {
         MerkleTree::make_merkle_node(vec![left, right])
     }
 
@@ -467,27 +463,24 @@ mod tests {
     fn test_compression() {
         let test = |l: Vec<Vec<u8>>| -> Result<_, HashError> {
             // The LHS leaf will be blinded
-            let single_leaves_t = m_t(m_l(&l[0], false)?, m_l(&l[1], true)?)?;
+            let single_leaves_t = m_t(m_l(&l[0], false)?, m_l(&l[1], true)?);
 
             // The whole subtree will be blinded and compressed
             let no_access_t = m_t(
                 m_l(&l[2], false)?,
-                m_t(m_l(&l[3], false)?, m_l(&l[4], false)?)?,
-            )?;
+                m_t(m_l(&l[3], false)?, m_l(&l[4], false)?),
+            );
 
             // No leaf will be blinded, the tree will not be compressed
-            let read_write_3_t = m_t(
-                m_t(m_l(&l[5], true)?, m_l(&l[6], true)?)?,
-                m_l(&l[7], true)?,
-            )?;
+            let read_write_3_t = m_t(m_t(m_l(&l[5], true)?, m_l(&l[6], true)?), m_l(&l[7], true)?);
 
             // No leaf will be blinded, the tree will not be compressed
             let read_write_4_t = m_t(
-                m_t(m_l(&l[8], true)?, m_l(&l[9], true)?)?,
-                m_t(m_l(&l[10], true)?, m_l(&l[11], true)?)?,
-            )?;
+                m_t(m_l(&l[8], true)?, m_l(&l[9], true)?),
+                m_t(m_l(&l[10], true)?, m_l(&l[11], true)?),
+            );
 
-            let combine_isolated_t = m_t(m_t(no_access_t, read_write_3_t)?, read_write_4_t)?;
+            let combine_isolated_t = m_t(m_t(no_access_t, read_write_3_t), read_write_4_t);
 
             let mix_t = m_t(
                 // The whole subtree will be compressed
@@ -495,20 +488,20 @@ mod tests {
                     m_l(&l[12], false)?,
                     m_t(
                         m_l(&l[13], false)?,
-                        m_t(m_l(&l[14], false)?, m_l(&l[15], false)?)?,
-                    )?,
-                )?,
+                        m_t(m_l(&l[14], false)?, m_l(&l[15], false)?),
+                    ),
+                ),
                 m_t(
                     m_t(
                         m_l(&l[16], true)?,
                         // Only the non-accessed leaves will be compressed
-                        m_t(m_l(&l[17], false)?, m_l(&l[18], false)?)?,
-                    )?,
+                        m_t(m_l(&l[17], false)?, m_l(&l[18], false)?),
+                    ),
                     m_l(&l[19], true)?,
-                )?,
-            )?;
+                ),
+            );
 
-            let merkle_tree = m_t(single_leaves_t, m_t(combine_isolated_t, mix_t)?)?;
+            let merkle_tree = m_t(single_leaves_t, m_t(combine_isolated_t, mix_t));
 
             let merkle_proof_leaf =
                 |data: &Vec<u8>, access: bool| -> Result<MerkleProof, HashError> {
@@ -526,13 +519,13 @@ mod tests {
             ]);
 
             // The structure of the original subtree is compressed into a single leaf.
-            let proof_no_access = MerkleProof::Leaf(MerkleProofLeaf::Blind(Hash::combine(&[
+            let proof_no_access = MerkleProof::Leaf(MerkleProofLeaf::Blind(Hash::combine([
                 Hash::blake3_hash_bytes(&l[2])?,
-                Hash::combine(&[
+                Hash::combine([
                     Hash::blake3_hash_bytes(&l[3])?,
                     Hash::blake3_hash_bytes(&l[4])?,
-                ])?,
-            ])?));
+                ]),
+            ])));
 
             let proof_read_write_3 = MerkleProof::Node(vec![
                 MerkleProof::Node(vec![
@@ -560,23 +553,23 @@ mod tests {
 
             let proof_mix = MerkleProof::Node(vec![
                 // The structure of the original subtree is compressed into a single leaf.
-                MerkleProof::Leaf(MerkleProofLeaf::Blind(Hash::combine(&[
+                MerkleProof::Leaf(MerkleProofLeaf::Blind(Hash::combine([
                     Hash::blake3_hash_bytes(&l[12])?,
-                    Hash::combine(&[
+                    Hash::combine([
                         Hash::blake3_hash_bytes(&l[13])?,
-                        Hash::combine(&[
+                        Hash::combine([
                             Hash::blake3_hash_bytes(&l[14])?,
                             Hash::blake3_hash_bytes(&l[15])?,
-                        ])?,
-                    ])?,
-                ])?)),
+                        ]),
+                    ]),
+                ]))),
                 MerkleProof::Node(vec![
                     MerkleProof::Node(vec![
                         merkle_proof_leaf(&l[16], true)?,
-                        MerkleProof::Leaf(MerkleProofLeaf::Blind(Hash::combine(&[
+                        MerkleProof::Leaf(MerkleProofLeaf::Blind(Hash::combine([
                             Hash::blake3_hash_bytes(&l[17])?,
                             Hash::blake3_hash_bytes(&l[18])?,
-                        ])?)),
+                        ]))),
                     ]),
                     merkle_proof_leaf(&l[19], true)?,
                 ]),

--- a/src/riscv/lib/src/state_backend/proof_backend/proof.rs
+++ b/src/riscv/lib/src/state_backend/proof_backend/proof.rs
@@ -144,7 +144,7 @@ impl MerkleProof {
                 MerkleProofLeaf::Blind(hash) => Ok(*hash),
                 MerkleProofLeaf::Read(data) => Hash::blake3_hash_bytes(data.as_slice()),
             },
-            |(), leaves| Hash::combine(&leaves),
+            |(), leaves| Ok(Hash::combine(leaves)),
         )
     }
 }

--- a/src/riscv/lib/src/state_backend/proof_layout.rs
+++ b/src/riscv/lib/src/state_backend/proof_layout.rs
@@ -646,7 +646,7 @@ where
 {
     fn to_merkle_tree(state: RefProofGenOwnedAlloc<Self>) -> Result<MerkleTree, HashError> {
         let children = vec![A::to_merkle_tree(state.0)?, B::to_merkle_tree(state.1)?];
-        MerkleTree::make_merkle_node(children)
+        Ok(MerkleTree::make_merkle_node(children))
     }
 
     fn into_verifier_alloc<De: Deserialiser>(proof: De) -> VerifierAllocResult<De, Self> {
@@ -683,7 +683,7 @@ where
             B::to_merkle_tree(state.1)?,
             C::to_merkle_tree(state.2)?,
         ];
-        MerkleTree::make_merkle_node(children)
+        Ok(MerkleTree::make_merkle_node(children))
     }
 
     fn into_verifier_alloc<De: Deserialiser>(proof: De) -> VerifierAllocResult<De, Self> {
@@ -724,7 +724,7 @@ where
             C::to_merkle_tree(state.2)?,
             D::to_merkle_tree(state.3)?,
         ];
-        MerkleTree::make_merkle_node(children)
+        Ok(MerkleTree::make_merkle_node(children))
     }
 
     fn into_verifier_alloc<De: Deserialiser>(proof: De) -> VerifierAllocResult<De, Self> {
@@ -769,7 +769,7 @@ where
             D::to_merkle_tree(state.3)?,
             E::to_merkle_tree(state.4)?,
         ];
-        MerkleTree::make_merkle_node(children)
+        Ok(MerkleTree::make_merkle_node(children))
     }
 
     fn into_verifier_alloc<De: Deserialiser>(proof: De) -> VerifierAllocResult<De, Self> {
@@ -817,7 +817,7 @@ where
             E::to_merkle_tree(state.4)?,
             F::to_merkle_tree(state.5)?,
         ];
-        MerkleTree::make_merkle_node(children)
+        Ok(MerkleTree::make_merkle_node(children))
     }
 
     fn into_verifier_alloc<De: Deserialiser>(proof: De) -> VerifierAllocResult<De, Self> {
@@ -854,7 +854,7 @@ where
             .map(T::to_merkle_tree)
             .collect::<Result<Vec<_>, _>>()?;
 
-        MerkleTree::make_merkle_node(children)
+        Ok(MerkleTree::make_merkle_node(children))
     }
 
     fn into_verifier_alloc<D: Deserialiser>(proof: D) -> VerifierAllocResult<D, Self> {
@@ -1080,7 +1080,7 @@ pub fn combine_partial_hashes(
 ) -> Result<Hash, PartialHashError> {
     let hash_results = hash_results.as_ref();
     if hash_results.is_empty() {
-        return Ok(Hash::combine(&[])?);
+        return Ok(Hash::combine::<Hash, _>([]));
     }
 
     // If the first result is a hash, all results need to be a hash in order to
@@ -1105,7 +1105,7 @@ pub fn combine_partial_hashes(
 
     if expect_ok {
         debug_assert_eq!(hashes.len(), hash_results_len);
-        return Ok(Hash::combine(hashes.as_slice())?);
+        return Ok(Hash::combine(hashes));
     };
 
     proof_hash.ok_or(PartialHashError::PotentiallyRecoverable)


### PR DESCRIPTION
# What

This removes the `Result` from `Hash::combine`'s return type, as it cannot fail.

Additionally, it accepts any iterator for the input parameter instead of a slice. 

# Why

This is primarily a quality-of-life change. It makes types a bit more accurate.

Accepting iterators over slices makes it possible to avoid intermediary allocation via `collect` in some places. However, we rarely combine many hashes. Hence, this won't result in a visible performance improvement.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
