### PR TITLE
Access F-registers via projections

### DIFF
--- a/src/riscv/lib/src/instruction_context.rs
+++ b/src/riscv/lib/src/instruction_context.rs
@@ -28,7 +28,6 @@ use crate::machine_state::instruction::Args;
 use crate::machine_state::memory::BadMemoryAccess;
 use crate::machine_state::memory::Memory;
 use crate::machine_state::memory::MemoryConfig;
-use crate::machine_state::registers::FRegister;
 use crate::machine_state::registers::FValue;
 use crate::machine_state::registers::XValue;
 use crate::machine_state::registers::XValue32;
@@ -91,12 +90,6 @@ where
 
     /// Construct an [`ICB::XValue32`] from an `imm: i32`.
     fn xvalue32_of_imm(&mut self, imm: i32) -> Self::XValue32;
-
-    #[expect(unused, reason = "Will Be Used Soon™")]
-    fn fregister_read(&mut self, reg: FRegister) -> Self::FValue;
-
-    /// Perform a write to a [`FRegister`], with the given value.
-    fn fregister_write(&mut self, reg: FRegister, value: Self::FValue);
 
     /// Perform a read of the program counter.
     fn pc_read(&mut self) -> Self::XValue;
@@ -240,16 +233,6 @@ impl<MC: MemoryConfig, M: ManagerReadWrite> ICB for MachineCoreState<MC, M> {
 
     fn xvalue32_of_imm(&mut self, imm: i32) -> Self::XValue32 {
         imm as u32
-    }
-
-    #[inline(always)]
-    fn fregister_read(&mut self, reg: FRegister) -> Self::FValue {
-        self.hart.fregisters.read(reg)
-    }
-
-    #[inline(always)]
-    fn fregister_write(&mut self, reg: FRegister, value: Self::FValue) {
-        self.hart.fregisters.write(reg, value)
     }
 
     #[inline(always)]

--- a/src/riscv/lib/src/interpreter/float.rs
+++ b/src/riscv/lib/src/interpreter/float.rs
@@ -26,6 +26,7 @@ use crate::machine_state::registers::FRegister;
 use crate::machine_state::registers::FValue;
 use crate::machine_state::registers::XRegister;
 use crate::machine_state::registers::read_xregister;
+use crate::machine_state::registers::write_fregister;
 use crate::parser::instruction::InstrRoundingMode;
 use crate::state_backend as backend;
 
@@ -676,7 +677,7 @@ pub fn run_f64_from_x64_unsigned<I: ICB>(
         InstrRoundingMode::Static(rm) => icb.f64_from_x64_unsigned_static(xval, rm),
         InstrRoundingMode::Dynamic => icb.f64_from_x64_unsigned_dynamic(xval),
     };
-    icb.fregister_write(rd, fval);
+    write_fregister(icb, rd, fval);
 }
 
 #[cfg(test)]

--- a/src/riscv/lib/src/jit/builder/instruction.rs
+++ b/src/riscv/lib/src/jit/builder/instruction.rs
@@ -46,7 +46,6 @@ use crate::machine_state::ProgramCounterUpdate;
 use crate::machine_state::csregisters::CSRegister;
 use crate::machine_state::memory::Address;
 use crate::machine_state::memory::MemoryConfig;
-use crate::machine_state::registers::FRegister;
 use crate::machine_state::registers::FValue;
 use crate::machine_state::registers::XValue;
 use crate::machine_state::registers::XValue32;
@@ -314,17 +313,6 @@ impl<MC: MemoryConfig> ICB for InstructionBuilder<'_, '_, MC> {
         // SAFETY: The value returned by `uextend` is of type `I64` which matches the representation
         // of `XValue`.
         unsafe { Value::<XValue>::from_raw(raw) }
-    }
-
-    fn fregister_read(&mut self, reg: FRegister) -> Self::FValue {
-        self.ext_calls
-            .ir_freg_read(self.builder, self.core_param, reg)
-    }
-
-    fn fregister_write(&mut self, reg: FRegister, value: Self::FValue) {
-        // The value contained must be a floating-point type.
-        self.ext_calls
-            .ir_freg_write(self.builder, self.core_param, reg, value)
     }
 
     fn pc_read(&mut self) -> Self::XValue {

--- a/src/riscv/lib/src/jit/state_access.rs
+++ b/src/riscv/lib/src/jit/state_access.rs
@@ -38,7 +38,6 @@ use crate::machine_state::memory::Address;
 use crate::machine_state::memory::BadMemoryAccess;
 use crate::machine_state::memory::Memory;
 use crate::machine_state::memory::MemoryConfig;
-use crate::machine_state::registers::FRegister;
 use crate::machine_state::registers::FValue;
 use crate::machine_state::registers::XValue;
 use crate::state_backend::Elem;
@@ -132,23 +131,6 @@ impl Value<ExceptionCode> {
 
 impl typed::Typed for ExceptionCode {
     const TYPE: typed::Type = typed::Type::Basic(I64);
-}
-
-/// Read the value of the given [`FRegister`].
-extern "C" fn fregister_read<MC: MemoryConfig>(
-    core: &MachineCoreState<MC, Owned>,
-    reg: FRegister,
-) -> FValue {
-    core.hart.fregisters.read(reg)
-}
-
-/// Write the given value to the given [`FRegister`].
-extern "C" fn fregister_write<MC: MemoryConfig>(
-    core: &mut MachineCoreState<MC, Owned>,
-    reg: FRegister,
-    val: FValue,
-) {
-    core.hart.fregisters.write(reg, val)
 }
 
 /// Handle an [`ExceptionCode`].
@@ -429,56 +411,6 @@ impl<MC: MemoryConfig> JsaCalls<MC> {
             unsafe { core_ptr.as_mut() },
             xval,
         )
-    }
-
-    /// Emit the required IR to read the value from the given fregister.
-    pub(super) fn ir_freg_read(
-        &mut self,
-        builder: &mut FunctionBuilder,
-        core_ptr: Pointer<MachineCoreState<MC, Owned>>,
-        reg: FRegister,
-    ) -> Value<FValue> {
-        // SAFETY: We construct the typed value from the `FRegister`, thereby ensuring the use of
-        // the right discriminant.
-        let reg_value = unsafe {
-            Value::<FRegister>::from_discriminant(&self.target_config, builder, reg as u8 as i64)
-        };
-
-        // SAFETY: The `core_ptr` is a JIT function argument which means the reference through it
-        // will be valid for the duration of the call.
-        ext_calls::call2(
-            &self.target_config,
-            builder,
-            self::fregister_read,
-            unsafe { core_ptr.as_ref() },
-            reg_value,
-        )
-    }
-
-    /// Emit the required IR to write the value to the given fregister.
-    pub(super) fn ir_freg_write(
-        &mut self,
-        builder: &mut FunctionBuilder,
-        core_ptr: Pointer<MachineCoreState<MC, Owned>>,
-        reg: FRegister,
-        value: Value<FValue>,
-    ) {
-        // SAFETY: We construct the typed value from the `FRegister`, thereby ensuring the use of
-        // the right discriminant.
-        let reg_value = unsafe {
-            Value::<FRegister>::from_discriminant(&self.target_config, builder, reg as u8 as i64)
-        };
-
-        // SAFETY: The `core_ptr` is a JIT function argument which means the reference through it
-        // will be valid for the duration of the call.
-        ext_calls::call3(
-            &self.target_config,
-            builder,
-            self::fregister_write,
-            unsafe { core_ptr.as_mut() },
-            reg_value,
-            value,
-        );
     }
 
     /// Write to a Control and Status register.

--- a/src/riscv/lib/src/machine_state/registers.rs
+++ b/src/riscv/lib/src/machine_state/registers.rs
@@ -703,6 +703,26 @@ pub fn write_xregister<I: ICB + ?Sized>(icb: &mut I, reg: XRegister, value: I::X
     icb.write_proj::<XRegisterProj>((reg as usize,), value)
 }
 
+impl_projection! {
+    projection FRegisterProj {
+        subject = MachineCoreCons,
+        target_projection = CellsProj<FValue, 32>,
+        path = hart.fregisters.registers,
+    }
+}
+
+/// Read from a floating-point number register.
+#[inline]
+pub fn read_fregister<I: ICB>(icb: &mut I, reg: FRegister) -> I::FValue {
+    icb.read_proj::<FRegisterProj>((reg as usize,))
+}
+
+/// Write to a floating-point number register.
+#[inline]
+pub fn write_fregister<I: ICB>(icb: &mut I, reg: FRegister, value: I::FValue) {
+    icb.write_proj::<FRegisterProj>((reg as usize,), value)
+}
+
 #[cfg(test)]
 mod tests {
     use arbitrary_int::Number;


### PR DESCRIPTION
# What

Replaces the ICB methods for accessing floating-point registers with projection methods.

# Why

This lets us remove ICB methods and replace them with a more versatile access method via projections. It consolidates the access patterns for registers.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
