### PR TITLE
Support projections on arbitrary types

### DIFF
--- a/src/riscv/lib/src/instruction_context.rs
+++ b/src/riscv/lib/src/instruction_context.rs
@@ -47,7 +47,34 @@ pub type IcbFnResult<I> = <I as ICB>::IResult<ProgramCounterUpdate<<I as ICB>::X
 /// Instruction Context Builder contains operations required to
 /// execute RISC-V instructions.
 #[expect(clippy::upper_case_acronyms, reason = "ICB looks cooler than Icb")]
-pub(crate) trait ICB: StateContext<X64 = Self::XValue> {
+pub(crate) trait ICB
+where
+    // These contraints let us tie a type-equality knot.
+    //
+    // We want to allow handling of arbitrary value types via [`StateContext`]'s associated type
+    // `Value`, whilst adding functionality on a subset of those values (e.g. 64-bit and 32-bit
+    // integers, and floating-point numbers).
+    //
+    // There are two ways one can achieve this:
+    //
+    // 1. Define associated types with those additional constraints (those bring the additional
+    //    functionality into scope). Then force each specific `Self::Value<_>` to be equal to the
+    //    new associated types.
+    //
+    // 2. Constrain the instantiated `Self::Value<_>` directly.
+    //
+    // The second approach would be nicer, if it weren't for Rust's inability to express constraints
+    // on associated types like super-trait relationships. This means, if you use `ICB` as a
+    // constraint, you also need to express all its inherited constraints on the associated types
+    // of `StateContext` in the trait bounds. This results in massive amount of boilerplate being
+    // added everywhere. Imagine how many ICB-style instruction implementations there are that
+    // mention `ICB` in their trait bounds.
+    // Because of this, we use the first approach, which is more verbose with respect to the number
+    // of types being declared, but is equally as powerful.
+    Self: StateContext<Value<u64> = Self::XValue>
+        + StateContext<Value<u32> = Self::XValue32>
+        + StateContext<Value<FValue> = Self::FValue>,
+{
     /// A 64-bit value stored in [`XRegisters`].
     ///
     /// [`XRegisters`]: crate::machine_state::registers::XRegisters

--- a/src/riscv/lib/src/interpreter/atomics.rs
+++ b/src/riscv/lib/src/interpreter/atomics.rs
@@ -671,12 +671,12 @@ impl_projection! {
 }
 
 /// Read the reservation set address from the machine state.
-pub(crate) fn read_reservation_set<SC: StateContext>(state: &mut SC) -> SC::X64 {
+pub(crate) fn read_reservation_set<SC: StateContext>(state: &mut SC) -> SC::Value<u64> {
     state.read_proj::<ReservationSetProj>(())
 }
 
 /// Write to the reservation set address in the machine state.
-pub(crate) fn write_reservation_set<SC: StateContext>(state: &mut SC, value: SC::X64) {
+pub(crate) fn write_reservation_set<SC: StateContext>(state: &mut SC, value: SC::Value<u64>) {
     state.write_proj::<ReservationSetProj>((), value);
 }
 

--- a/src/riscv/lib/src/jit/builder.rs
+++ b/src/riscv/lib/src/jit/builder.rs
@@ -18,14 +18,13 @@ use cranelift::codegen::ir::condcodes::IntCC;
 use cranelift::prelude::FunctionBuilder;
 use cranelift::prelude::InstBuilder;
 use cranelift::prelude::MemFlags;
-use cranelift::prelude::types::I64;
+use cranelift::prelude::isa::TargetFrontendConfig;
 
 use crate::instruction_context::Predicate;
 use crate::jit::builder::typed::Pointer;
 use crate::jit::builder::typed::Value;
 use crate::machine_state::MachineCoreState;
 use crate::machine_state::memory::MemoryConfig;
-use crate::machine_state::registers::XValue;
 use crate::state_backend::owned_backend::Owned;
 use crate::state_context::projection::MachineCoreProjection;
 
@@ -47,13 +46,15 @@ impl From<Predicate> for IntCC {
 /// Reusable implementation of [`crate::state_context::StateContext::read_proj`] for
 /// the sequencer and instruction builder
 fn read_proj<MC, P>(
+    target_config: &TargetFrontendConfig,
     builder: &mut FunctionBuilder,
     core_param: Pointer<MachineCoreState<MC, Owned>>,
     param: P::Parameter,
-) -> Value<XValue>
+) -> Value<P::Target>
 where
     MC: MemoryConfig,
-    P: MachineCoreProjection<Target = u64>,
+    P: MachineCoreProjection,
+    P::Target: typed::Typed,
 {
     let offset = P::owned_pointer_offset::<MC>(param);
 
@@ -61,12 +62,15 @@ where
     // `MachineCoreState`. Additionally, the offset produced by `P::owned_pointer_offset` must
     // result in a valid pointer when applied to `core`. We trust that both properties are upheld,
     // hence we use `MemFlags::trusted()`.
-    let val = builder
-        .ins()
-        .load(I64, MemFlags::trusted(), core_param.to_value(), offset);
+    let val = builder.ins().load(
+        <P::Target as typed::Typed>::TYPE.to_type(target_config),
+        MemFlags::trusted(),
+        core_param.to_value(),
+        offset,
+    );
 
     // SAFETY: If the projection is correct, then it should resolve to a value of type `XValue`.
-    unsafe { Value::<XValue>::from_raw(val) }
+    unsafe { Value::<P::Target>::from_raw(val) }
 }
 
 /// Reusable implementation of [`crate::state_context::StateContext::write_proj`] for
@@ -75,10 +79,10 @@ fn write_proj<MC, P>(
     builder: &mut FunctionBuilder,
     core_param: Pointer<MachineCoreState<MC, Owned>>,
     param: P::Parameter,
-    value: Value<XValue>,
+    value: Value<P::Target>,
 ) where
     MC: MemoryConfig,
-    P: MachineCoreProjection<Target = u64>,
+    P: MachineCoreProjection,
 {
     let offset = P::owned_pointer_offset::<MC>(param);
 

--- a/src/riscv/lib/src/jit/builder/instruction.rs
+++ b/src/riscv/lib/src/jit/builder/instruction.rs
@@ -26,6 +26,7 @@ use cranelift::codegen::ir::BlockArg;
 use cranelift::prelude::Block;
 use cranelift::prelude::FunctionBuilder;
 use cranelift::prelude::InstBuilder;
+use cranelift::prelude::isa::TargetFrontendConfig;
 use cranelift::prelude::types::I32;
 use cranelift::prelude::types::I64;
 use cranelift::prelude::types::I128;
@@ -36,6 +37,7 @@ use crate::instruction_context::StoreLoadInt;
 use crate::instruction_context::value::PhiValue;
 use crate::interpreter::float::RoundingMode;
 use crate::jit::builder::typed::Pointer;
+use crate::jit::builder::typed::Typed;
 use crate::jit::builder::typed::Value;
 use crate::jit::state_access::ExceptionCode;
 use crate::jit::state_access::JsaCalls;
@@ -130,6 +132,9 @@ pub enum InstructionResult<T> {
 
 /// Builder for a single RISC-V instruction
 pub struct InstructionBuilder<'seq, 'jit, MC: MemoryConfig> {
+    /// Target configuration for the JIT module
+    target_config: TargetFrontendConfig,
+
     /// IR builder
     builder: &'seq mut FunctionBuilder<'jit>,
 
@@ -155,6 +160,7 @@ pub struct InstructionBuilder<'seq, 'jit, MC: MemoryConfig> {
 impl<'seq, 'jit, MC: MemoryConfig> InstructionBuilder<'seq, 'jit, MC> {
     /// Create a new instruction builder.
     pub(super) fn new(
+        target_config: TargetFrontendConfig,
         builder: &'seq mut FunctionBuilder<'jit>,
         ext_calls: &'seq mut JsaCalls<MC>,
         entry_block: Block,
@@ -163,6 +169,7 @@ impl<'seq, 'jit, MC: MemoryConfig> InstructionBuilder<'seq, 'jit, MC> {
         result_param: Pointer<Result<(), EnvironException>>,
     ) -> Self {
         Self {
+            target_config,
             builder,
             ext_calls,
             entry_block,
@@ -604,18 +611,19 @@ impl<MC: MemoryConfig> ICB for InstructionBuilder<'_, '_, MC> {
 }
 
 impl<MC: MemoryConfig> StateContext for InstructionBuilder<'_, '_, MC> {
-    type X64 = Value<XValue>;
+    type Value<R> = Value<R>;
 
-    fn read_proj<P>(&mut self, param: P::Parameter) -> Self::X64
+    fn read_proj<P>(&mut self, param: P::Parameter) -> Self::Value<P::Target>
     where
-        P: MachineCoreProjection<Target = u64>,
+        P: MachineCoreProjection,
+        P::Target: Typed,
     {
-        super::read_proj::<MC, P>(self.builder, self.core_param, param)
+        super::read_proj::<MC, P>(&self.target_config, self.builder, self.core_param, param)
     }
 
-    fn write_proj<P>(&mut self, param: P::Parameter, value: Self::X64)
+    fn write_proj<P>(&mut self, param: P::Parameter, value: Self::Value<P::Target>)
     where
-        P: MachineCoreProjection<Target = u64>,
+        P: MachineCoreProjection,
     {
         super::write_proj::<MC, P>(self.builder, self.core_param, param, value)
     }

--- a/src/riscv/lib/src/jit/builder/sequence.rs
+++ b/src/riscv/lib/src/jit/builder/sequence.rs
@@ -19,6 +19,7 @@ use cranelift::prelude::Block;
 use cranelift::prelude::FunctionBuilder;
 use cranelift::prelude::FunctionBuilderContext;
 use cranelift::prelude::InstBuilder;
+use cranelift::prelude::isa::TargetFrontendConfig;
 use cranelift::prelude::types::I64;
 use cranelift_jit::JITModule;
 use cranelift_module::Module;
@@ -27,13 +28,13 @@ use super::instruction::Outcome;
 use crate::jit::builder::instruction::InstructionBuilder;
 use crate::jit::builder::instruction::LoweredInstruction;
 use crate::jit::builder::typed::Pointer;
+use crate::jit::builder::typed::Typed;
 use crate::jit::builder::typed::Value;
 use crate::jit::state_access::JsaCalls;
 use crate::machine_state::MachineCoreState;
 use crate::machine_state::hart_state::write_pc;
 use crate::machine_state::memory::Address;
 use crate::machine_state::memory::MemoryConfig;
-use crate::machine_state::registers::XValue;
 use crate::parser::instruction::InstrWidth;
 use crate::state_backend::owned_backend::Owned;
 use crate::state_context::StateContext;
@@ -42,6 +43,9 @@ use crate::traps::EnvironException;
 
 /// Builder for an instruction sequence
 pub struct SequenceBuilder<'jit, MC: MemoryConfig> {
+    /// Target configuration for the JIT module
+    target_config: TargetFrontendConfig,
+
     /// IR builder
     builder: FunctionBuilder<'jit>,
 
@@ -134,7 +138,10 @@ impl<'jit, MC: MemoryConfig> SequenceBuilder<'jit, MC> {
         let entry_block = builder.create_block();
         builder.ins().jump(entry_block, []);
 
+        let target_config = module.target_config();
+
         Self {
+            target_config,
             builder,
             ext_calls,
             entry_block,
@@ -186,6 +193,7 @@ impl<'jit, MC: MemoryConfig> SequenceBuilder<'jit, MC> {
         };
 
         let instr_builder = InstructionBuilder::new(
+            self.target_config,
             &mut self.builder,
             &mut self.ext_calls,
             entry_block,
@@ -331,18 +339,24 @@ impl<'jit, MC: MemoryConfig> SequenceBuilder<'jit, MC> {
 }
 
 impl<MC: MemoryConfig> StateContext for SequenceBuilder<'_, MC> {
-    type X64 = Value<XValue>;
+    type Value<R> = Value<R>;
 
-    fn read_proj<P>(&mut self, param: P::Parameter) -> Self::X64
+    fn read_proj<P>(&mut self, param: P::Parameter) -> Self::Value<P::Target>
     where
-        P: MachineCoreProjection<Target = u64>,
+        P: MachineCoreProjection,
+        P::Target: Typed,
     {
-        super::read_proj::<MC, P>(&mut self.builder, self.core_param, param)
+        super::read_proj::<MC, P>(
+            &self.target_config,
+            &mut self.builder,
+            self.core_param,
+            param,
+        )
     }
 
-    fn write_proj<P>(&mut self, param: P::Parameter, value: Self::X64)
+    fn write_proj<P>(&mut self, param: P::Parameter, value: Self::Value<P::Target>)
     where
-        P: MachineCoreProjection<Target = u64>,
+        P: MachineCoreProjection,
     {
         super::write_proj::<MC, P>(&mut self.builder, self.core_param, param, value)
     }

--- a/src/riscv/lib/src/machine_state/hart_state.rs
+++ b/src/riscv/lib/src/machine_state/hart_state.rs
@@ -121,6 +121,6 @@ impl_projection! {
 
 /// Update the program counter in the given state context.
 #[inline]
-pub(crate) fn write_pc<SC: StateContext + ?Sized>(state: &mut SC, value: SC::X64) {
+pub(crate) fn write_pc<SC: StateContext + ?Sized>(state: &mut SC, value: SC::Value<XValue>) {
     state.write_proj::<ProgramCounterProj>((), value);
 }

--- a/src/riscv/lib/src/machine_state/registers.rs
+++ b/src/riscv/lib/src/machine_state/registers.rs
@@ -682,7 +682,7 @@ impl_projection! {
 pub fn read_xregister_nz<SC: StateContext + ?Sized>(
     state: &mut SC,
     reg: NonZeroXRegister,
-) -> SC::X64 {
+) -> SC::Value<XValue> {
     state.read_proj::<XRegisterProj>((reg as usize,))
 }
 
@@ -691,7 +691,7 @@ pub fn read_xregister_nz<SC: StateContext + ?Sized>(
 pub fn write_xregister_nz<SC: StateContext + ?Sized>(
     state: &mut SC,
     reg: NonZeroXRegister,
-    value: SC::X64,
+    value: SC::Value<XValue>,
 ) {
     state.write_proj::<XRegisterProj>((reg as usize,), value)
 }

--- a/src/riscv/lib/src/state_context.rs
+++ b/src/riscv/lib/src/state_context.rs
@@ -14,6 +14,7 @@
 
 pub(crate) mod projection;
 
+use crate::jit::builder::typed::Typed;
 use crate::machine_state::MachineCoreState;
 use crate::machine_state::memory::MemoryConfig;
 use crate::state_backend::ManagerReadWrite;
@@ -21,35 +22,37 @@ use crate::state_context::projection::MachineCoreProjection;
 
 /// Context for accessing parts of the PVM state
 pub trait StateContext {
-    /// 64-bit integer type
-    type X64;
+    /// Value type for this context
+    type Value<R>;
 
     /// Read from a region of the machine core state.
-    fn read_proj<P>(&mut self, param: P::Parameter) -> Self::X64
+    fn read_proj<P>(&mut self, param: P::Parameter) -> Self::Value<P::Target>
     where
-        P: MachineCoreProjection<Target = u64>;
+        P: MachineCoreProjection,
+        P::Target: Copy + Typed;
 
     /// Write to a region of the machine core state.
-    fn write_proj<P>(&mut self, param: P::Parameter, value: Self::X64)
+    fn write_proj<P>(&mut self, param: P::Parameter, value: Self::Value<P::Target>)
     where
-        P: MachineCoreProjection<Target = u64>;
+        P: MachineCoreProjection;
 }
 
 impl<MC: MemoryConfig, M: ManagerReadWrite> StateContext for MachineCoreState<MC, M> {
-    type X64 = u64;
+    type Value<R> = R;
 
     #[inline]
-    fn read_proj<P>(&mut self, param: P::Parameter) -> Self::X64
+    fn read_proj<P>(&mut self, param: P::Parameter) -> Self::Value<P::Target>
     where
-        P: MachineCoreProjection<Target = u64>,
+        P: MachineCoreProjection,
+        P::Target: Copy,
     {
         P::project_read(self, param)
     }
 
     #[inline]
-    fn write_proj<P>(&mut self, param: P::Parameter, value: Self::X64)
+    fn write_proj<P>(&mut self, param: P::Parameter, value: Self::Value<P::Target>)
     where
-        P: MachineCoreProjection<Target = u64>,
+        P: MachineCoreProjection,
     {
         P::project_write(self, param, value);
     }


### PR DESCRIPTION
# What

Previously, we would only allow projections on 64-bit integer types. This PR enables projections for arbitrary target values types.

# Why

This lets use projections for more parts of the state. Accesses through projections can be lowered to Cranelift IR fairly simply. This makes them ideal for state accesses in the JIT context. When generating code, we save the cost of calling a C function and can instead access the memory directly.

See https://github.com/tezos/riscv-pvm/pull/218/commits/5f31f02e0c2ae36979551b4d0b13ab91adefd7e5 of #218 for an example of how these projections can be used to access F-register value.

The main performance boost will come from translating memory accesses into lowerable functions. This PR unblocks progress in that direction.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
