### PR TITLE
Remove redundant constraint on Arithmetic trait implementation

### DIFF
--- a/src/riscv/lib/src/instruction_context/arithmetic.rs
+++ b/src/riscv/lib/src/instruction_context/arithmetic.rs
@@ -2,14 +2,13 @@
 //
 // SPDX-License-Identifier: MIT
 
-//! Arithmetic operations required in the [`ICB`], including implementations for interpreted mode.
+//! Arithmetic operations required in the [`super::ICB`], including implementations for interpreted mode.
 
-use super::ICB;
 use super::Shift;
 use crate::machine_state::registers::XValue;
 use crate::machine_state::registers::XValue32;
 
-/// Trait for arithmetic operations on **XValues** used in the [`ICB`].
+/// Trait for arithmetic operations on **XValues** used in the [`super::ICB`].
 pub trait Arithmetic<I: ?Sized>: Copy {
     /// Perform a wrapping add of two **XValues**, returning the new value.
     ///
@@ -71,7 +70,7 @@ pub trait Arithmetic<I: ?Sized>: Copy {
     fn max_unsigned(self, other: Self, icb: &mut I) -> Self;
 }
 
-impl<I: ICB> Arithmetic<I> for XValue {
+impl<I: ?Sized> Arithmetic<I> for XValue {
     fn add(self, other: Self, _: &mut I) -> Self {
         self.wrapping_add(other)
     }
@@ -141,7 +140,7 @@ impl<I: ICB> Arithmetic<I> for XValue {
     }
 }
 
-impl<I: ICB> Arithmetic<I> for XValue32 {
+impl<I: ?Sized> Arithmetic<I> for XValue32 {
     fn add(self, other: Self, _: &mut I) -> Self {
         self.wrapping_add(other)
     }


### PR DESCRIPTION
# What

Removes a redundant trait bound on the implementation of `Arithmetic` for `XValue` and `XValue32`.

# Why

The trait bound serves no purpose.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
