### PR TITLE
projection: eliminate potential negative offsets

### DIFF
--- a/src/riscv/lib/src/state_backend.rs
+++ b/src/riscv/lib/src/state_backend.rs
@@ -103,6 +103,7 @@ pub use trans::*;
 use crate::machine_state::memory::MemoryConfig;
 use crate::state_context::projection::ApplyCons;
 use crate::state_context::projection::Projection;
+use crate::state_context::projection::ProjectionOffset;
 use crate::state_context::projection::RegionCons;
 
 /// An enriched value may be stored in a [`ManagerBase::EnrichedCell`].
@@ -451,17 +452,18 @@ impl<E: 'static, const LEN: usize> Projection for RegionProj<E, LEN> {
         M::region_write(state, param.0, value);
     }
 
-    fn owned_pointer_offset<MC: MemoryConfig>(param: Self::Parameter) -> i32 {
+    fn owned_pointer_offset<MC: MemoryConfig>(param: Self::Parameter) -> ProjectionOffset {
         assert!(
             param.0 < LEN,
             "Region index out of bounds: {} >= {}",
             param.0,
             LEN
         );
-        std::mem::size_of::<E>()
-            .wrapping_mul(param.0)
-            .try_into()
-            .expect("Region offset exceeds i32 range")
+        let offset = std::mem::size_of::<E>()
+            .checked_mul(param.0)
+            .expect("Region offset exceeds usize range");
+
+        ProjectionOffset::new(offset)
     }
 }
 

--- a/src/riscv/lib/src/state_backend/region.rs
+++ b/src/riscv/lib/src/state_backend/region.rs
@@ -38,6 +38,7 @@ use crate::state_context::projection::ApplyCons;
 use crate::state_context::projection::CellCons;
 use crate::state_context::projection::CellsCons;
 use crate::state_context::projection::Projection;
+use crate::state_context::projection::ProjectionOffset;
 
 /// Link a stored value directly with a derived value -
 /// that would either be expensive to compute each time, or cannot
@@ -354,11 +355,10 @@ impl<E: 'static> Projection for CellProj<E> {
         state.write(value);
     }
 
-    fn owned_pointer_offset<MC: MemoryConfig>(_param: Self::Parameter) -> i32 {
-        let field_offset: i32 = std::mem::offset_of!(Cell<E, Owned>, region.region)
-            .try_into()
-            .expect("Field offset exceeds i32 range");
-        field_offset + RegionProj::<E, 1>::owned_pointer_offset::<MC>((0,))
+    fn owned_pointer_offset<MC: MemoryConfig>(_param: Self::Parameter) -> ProjectionOffset {
+        let field_offset = std::mem::offset_of!(Cell<E, Owned>, region.region);
+
+        RegionProj::<E, 1>::owned_pointer_offset::<MC>((0,)) + field_offset
     }
 }
 
@@ -543,11 +543,10 @@ impl<E: 'static, const LEN: usize> Projection for CellsProj<E, LEN> {
         RegionProj::<E, LEN>::project_write::<MC, M>(&mut state.region, param, value);
     }
 
-    fn owned_pointer_offset<MC: MemoryConfig>(param: Self::Parameter) -> i32 {
-        let field_offset: i32 = std::mem::offset_of!(Cells<E, LEN, Owned>, region)
-            .try_into()
-            .expect("Field offset exceeds i32 range");
-        field_offset + RegionProj::<E, LEN>::owned_pointer_offset::<MC>(param)
+    fn owned_pointer_offset<MC: MemoryConfig>(param: Self::Parameter) -> ProjectionOffset {
+        let field_offset = std::mem::offset_of!(Cells<E, LEN, Owned>, region);
+
+        RegionProj::<E, LEN>::owned_pointer_offset::<MC>(param) + field_offset
     }
 }
 

--- a/src/riscv/lib/src/state_context/projection.rs
+++ b/src/riscv/lib/src/state_context/projection.rs
@@ -68,6 +68,64 @@ impl TypeCons for MachineCoreCons {
     type Applied<MC: MemoryConfig, M: ManagerBase> = MachineCoreState<MC, M>;
 }
 
+/// Offset from a base pointer to a [projection's] subject, within the owned backend.
+///
+/// Additional offsets may be added to an existing one, to build up offsets within
+/// layered projections. All such additions will panic on overflowing the `i32` range.
+///
+/// [projection's]: Projection
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ProjectionOffset {
+    offset: i32,
+}
+
+impl ProjectionOffset {
+    /// Create a new projection offset from the given offset.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the offset overflows the `i32` range.
+    pub fn new(offset: usize) -> Self {
+        Self {
+            offset: offset.try_into().expect("offset overflows i32 range"),
+        }
+    }
+}
+
+impl std::ops::Add<usize> for ProjectionOffset {
+    type Output = Self;
+
+    fn add(self, other: usize) -> Self {
+        let other: i32 = other.try_into().expect("offset overflows i32 range");
+
+        Self {
+            offset: self
+                .offset
+                .checked_add(other)
+                .expect("offset overflows i32 range on addition"),
+        }
+    }
+}
+
+impl std::ops::Add for ProjectionOffset {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        Self {
+            offset: self
+                .offset
+                .checked_add(other.offset)
+                .expect("offset overflows i32 range on addition"),
+        }
+    }
+}
+
+impl From<ProjectionOffset> for cranelift::codegen::ir::immediates::Offset32 {
+    fn from(value: ProjectionOffset) -> Self {
+        Self::new(value.offset)
+    }
+}
+
 /// Projections give you access to a value of the target type within the value of a subject type.
 pub trait Projection {
     /// Subject that contains the target value
@@ -108,7 +166,7 @@ pub trait Projection {
     /// offset to an address of the subject value that would give you the address of the target
     /// value. This is exclusive to the [`crate::state_backend::owned_backend::Owned`] state
     /// backend.
-    fn owned_pointer_offset<MC: MemoryConfig>(param: Self::Parameter) -> i32;
+    fn owned_pointer_offset<MC: MemoryConfig>(param: Self::Parameter) -> ProjectionOffset;
 }
 
 /// Implement a projection by pre-composing a field access to an existing projection.
@@ -178,16 +236,17 @@ macro_rules! impl_projection {
 
             fn owned_pointer_offset<MC: $crate::machine_state::memory::MemoryConfig>(
                 param: Self::Parameter
-            ) -> i32 {
-                let field_offset: i32 = std::mem::offset_of!(
+            ) -> $crate::state_context::projection::ProjectionOffset {
+                let field_offset = std::mem::offset_of!(
                     $crate::state_context::projection::ApplyCons<
                         $subject,
                         MC,
                         $crate::state_backend::owned_backend::Owned
                     >,
                     $($field).+
-                ).try_into().expect("Field offset exceeds i32 range");
-                field_offset + <$target>::owned_pointer_offset::<MC>(param)
+                );
+
+                <$target>::owned_pointer_offset::<MC>(param) + field_offset
             }
         }
     };


### PR DESCRIPTION
# What

Eliminate _potential_ source of undefined/incorrect behaviour w.r.t. offsets:
- offsets incorrectly use `wrapping` arithmetic, rather than saturating/checked

# Why

Offset usage in the JIT must be correct and point to the exact place in memory. Since all offsets are part of _projections_, they can only ever be positive (ie looking _inside_ a larger structure) and we should ensure this is the case.

While this currently is not encountered by existing code, it would be a potential 'gotcha' when dealing with larger structures in memory (e.g. indexing into main memory, which can be extremely large depending on the configuration)

# How

Use `usize` for calculating all offsets, with checked arithmetic to avoid overflow. When using an offset, care can be taken at the _usage_ site to ensure the offset is indeed valid.

While not strictly necessary for this PR, switching to `usize` emphasises the non-negative requirement, and will be needed when indexing into potentially large arrays in future (particularly main memory)

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
