### PR TITLE
Move exception handling code out of JIT function

### DIFF
--- a/src/riscv/lib/src/jit.rs
+++ b/src/riscv/lib/src/jit.rs
@@ -1664,7 +1664,10 @@ mod tests {
     #[test]
     fn test_unknown() {
         let scenarios: &[Scenario] = &[ScenarioBuilder::default()
-            .set_expected_steps(2)
+            .set_expected_steps(
+                // The unknown instruction raises an exception. This does not count as a full step.
+                1,
+            )
             .set_instructions(&[
                 I::new_nop(Uncompressed),
                 I::new_unknown(Compressed),
@@ -2147,7 +2150,10 @@ mod tests {
                     I::new_nop(InstrWidth::Compressed),
                 ])
                 // the load will fail due to being out of bounds
-                .set_expected_steps(3)
+                .set_expected_steps(
+                    // A failed store does not count as a full step
+                    2,
+                )
                 .set_assert_hook(assert_hook!(|core| {
                     let value: u64 = core.main_memory.read(MEMORY_SIZE - 8).unwrap();
 
@@ -2225,7 +2231,10 @@ mod tests {
                     I::new_nop(InstrWidth::Compressed),
                 ])
                 // the load will fail due to being out of bounds
-                .set_expected_steps(2)
+                .set_expected_steps(
+                    // A failed load does not count as a full step
+                    1,
+                )
                 .set_assert_hook(assert_hook!(|core| {
                     let value: u64 = core.hart.xregisters.read(x2);
                     assert_eq!(value, 0, "Found {value:x}, but expected load to fail");
@@ -2419,7 +2428,10 @@ mod tests {
                     constructor(x3, x1, x2, false, false, InstrWidth::Uncompressed),
                     I::new_nop(InstrWidth::Compressed),
                 ])
-                .set_expected_steps(3)
+                .set_expected_steps(
+                    // A failed atomic operation does not count as a full step
+                    2,
+                )
                 .set_assert_hook(assert_hook!(|core| {
                     let value: u64 = core.hart.xregisters.read(x3);
                     assert_eq!(value as i64, 0);
@@ -2452,7 +2464,10 @@ mod tests {
                     constructor(x3, x1, x2, false, false, InstrWidth::Uncompressed),
                     I::new_nop(InstrWidth::Compressed),
                 ])
-                .set_expected_steps(3)
+                .set_expected_steps(
+                    // A failed atomic operation does not count as a full step
+                    2,
+                )
                 .set_assert_hook(assert_hook!(|core| {
                     let value: u64 = core.hart.xregisters.read(x3);
                     assert_eq!(value, 0);
@@ -2645,7 +2660,10 @@ mod tests {
                     I::new_x32_atomic_load(x3, x1, false, false, InstrWidth::Uncompressed),
                     I::new_nop(InstrWidth::Compressed),
                 ])
-                .set_expected_steps(2)
+                .set_expected_steps(
+                    // A failed atomic load does not count as a full step
+                    1,
+                )
                 .set_assert_hook(assert_hook!(|core| {
                     let value: u64 = core.hart.xregisters.read(x3);
                     assert_eq!(value, 0);
@@ -2669,7 +2687,10 @@ mod tests {
                     I::new_x32_atomic_store(x3, x4, x2, false, false, InstrWidth::Uncompressed),
                     I::new_nop(InstrWidth::Compressed),
                 ])
-                .set_expected_steps(5)
+                .set_expected_steps(
+                    // The failed atomic operation does not count as a full step
+                    4,
+                )
                 .set_assert_hook(assert_hook!(|core| {
                     // Failure due to unaligned address should not modify the value in `rd`.
                     let value: u64 = core.hart.xregisters.read(x3);
@@ -2792,7 +2813,10 @@ mod tests {
                     I::new_x64_atomic_load(x3, x1, false, false, InstrWidth::Uncompressed),
                     I::new_nop(InstrWidth::Compressed),
                 ])
-                .set_expected_steps(2)
+                .set_expected_steps(
+                    // A failed atomic load does not count as a full step
+                    1,
+                )
                 .set_assert_hook(assert_hook!(|core| {
                     let value: u64 = core.hart.xregisters.read(x3);
                     assert_eq!(value, 0);
@@ -2816,7 +2840,10 @@ mod tests {
                     I::new_x64_atomic_store(x3, x4, x2, false, false, InstrWidth::Uncompressed),
                     I::new_nop(InstrWidth::Compressed),
                 ])
-                .set_expected_steps(5)
+                .set_expected_steps(
+                    // The failed atomic operation does not count as a full step
+                    4,
+                )
                 .set_assert_hook(assert_hook!(|core| {
                     // Failure due to unaligned address should not modify the value in `rd`.
                     let value: u64 = core.hart.xregisters.read(x3);
@@ -3167,7 +3194,10 @@ mod tests {
                     constructor(x3, x1, x2, false, false, InstrWidth::Uncompressed),
                     I::new_nop(InstrWidth::Compressed),
                 ])
-                .set_expected_steps(3)
+                .set_expected_steps(
+                    // A failed atomic operation does not count as a full step
+                    2,
+                )
                 .set_assert_hook(assert_hook!(|core| {
                     let value = core.hart.xregisters.read(x3);
                     assert_eq!(value, 0);

--- a/src/riscv/lib/src/jit.rs
+++ b/src/riscv/lib/src/jit.rs
@@ -22,6 +22,7 @@ use cranelift_module::ModuleError;
 use thiserror::Error;
 
 use crate::jit::builder::sequence::SequenceBuilder;
+use crate::jit::state_access::ExceptionCode;
 use crate::log;
 use crate::machine_state::MachineCoreState;
 use crate::machine_state::block_cache::metrics::block_metrics;
@@ -29,7 +30,6 @@ use crate::machine_state::instruction::Instruction;
 use crate::machine_state::memory::MemoryConfig;
 use crate::state_backend::hash::Hash;
 use crate::state_backend::owned_backend::Owned;
-use crate::traps::EnvironException;
 
 /// Alias for the function signature produced by the JIT compilation.
 ///
@@ -50,7 +50,7 @@ pub type JitFn<MC> = unsafe extern "C" fn(
     &mut MachineCoreState<MC, Owned>,
     u64,
     usize,
-    &mut Result<(), EnvironException>,
+    &mut ExceptionCode,
     // ignored
     *const c_void,
 ) -> usize;
@@ -374,7 +374,7 @@ mod tests {
                 block.run_block(&mut interpreted, initial_pc, max_steps, interpreted_bb)
             };
 
-            let mut jitted_res = Ok(());
+            let mut jitted_err = ExceptionCode::NoException;
             let jitted_steps = unsafe {
                 // # Safety - the block builder is alive for at least
                 //            the duration of the `run` function.
@@ -383,13 +383,13 @@ mod tests {
                     &mut jitted,
                     initial_pc,
                     max_steps,
-                    &mut jitted_res,
+                    &mut jitted_err,
                     null(),
                 )
             };
             let jitted_res = StepManyResult {
                 steps: jitted_steps,
-                error: jitted_res.err(),
+                error: jitted_err.to_exception(),
             };
 
             // Assert state equality.
@@ -1749,7 +1749,7 @@ mod tests {
                 .compile(instructions(&block).as_slice())
                 .expect("Compilation of subsequent functions should succeed");
 
-            let mut jitted_res = Ok(());
+            let mut jitted_err = ExceptionCode::NoException;
             let max_steps = usize::MAX;
             let jitted_steps = unsafe {
                 // # Safety - the jit is not dropped until after we
@@ -1759,12 +1759,12 @@ mod tests {
                     &mut jitted,
                     initial_pc,
                     max_steps,
-                    &mut jitted_res,
+                    &mut jitted_err,
                     null(),
                 )
             };
 
-            assert!(jitted_res.is_ok());
+            assert_eq!(jitted_err, ExceptionCode::NoException);
             assert_eq!(jitted_steps, success.len());
         }
     }

--- a/src/riscv/lib/src/jit/builder/ext_calls.rs
+++ b/src/riscv/lib/src/jit/builder/ext_calls.rs
@@ -149,21 +149,3 @@ pub fn call3<A0: Typed, A1: Typed, A2: Typed, R: ReturnTyped>(
         arg2.to_value(),
     ])
 }
-
-/// Call an external function with 4 arguments.
-pub fn call4<A0: Typed, A1: Typed, A2: Typed, A3: Typed, R: ReturnTyped>(
-    target_config: &TargetFrontendConfig,
-    builder: &mut FunctionBuilder,
-    callee: extern "C" fn(A0, A1, A2, A3) -> R,
-    arg0: Value<A0>,
-    arg1: Value<A1>,
-    arg2: Value<A2>,
-    arg3: Value<A3>,
-) -> R::Value {
-    call_raw::<(A0, A1, A2, A3), R>(target_config, builder, callee as usize, &[
-        arg0.to_value(),
-        arg1.to_value(),
-        arg2.to_value(),
-        arg3.to_value(),
-    ])
-}

--- a/src/riscv/lib/src/jit/builder/instruction.rs
+++ b/src/riscv/lib/src/jit/builder/instruction.rs
@@ -53,7 +53,6 @@ use crate::parser::instruction::InstrWidth;
 use crate::state_backend::owned_backend::Owned;
 use crate::state_context::StateContext;
 use crate::state_context::projection::MachineCoreProjection;
-use crate::traps::EnvironException;
 use crate::traps::Exception;
 
 /// Instruction execution outcome
@@ -151,7 +150,7 @@ pub struct InstructionBuilder<'seq, 'jit, MC: MemoryConfig> {
     core_param: Pointer<MachineCoreState<MC, Owned>>,
 
     /// Parameter pointing to the sequence result
-    result_param: Pointer<Result<(), EnvironException>>,
+    result_param: Pointer<ExceptionCode>,
 
     /// Execution outcomes of the instruction
     outcomes: Vec<Outcome>,
@@ -166,7 +165,7 @@ impl<'seq, 'jit, MC: MemoryConfig> InstructionBuilder<'seq, 'jit, MC> {
         entry_block: Block,
         instruction_pc: Value<Address>,
         core_param: Pointer<MachineCoreState<MC, Owned>>,
-        result_param: Pointer<Result<(), EnvironException>>,
+        result_param: Pointer<ExceptionCode>,
     ) -> Self {
         Self {
             target_config,
@@ -199,39 +198,12 @@ impl<'seq, 'jit, MC: MemoryConfig> InstructionBuilder<'seq, 'jit, MC> {
         hook
     }
 
-    /// Allocate an outcome block for an unknown branch.
-    fn create_unknown_branch_outcome(&mut self, destination: Value<Address>) -> Block {
-        let hook = self.builder.create_block();
-        self.outcomes
-            .push(Outcome::UnknownBranch { destination, hook });
-        hook
-    }
-
     /// Handle an exception raised by the instruction.
     fn handle_exception<Any>(&mut self, exception: Value<ExceptionCode>) -> InstructionResult<Any> {
-        let current_pc = self.pc_read();
-        let outcome = self.ext_calls.handle_exception(
-            self.builder,
-            self.core_param,
-            exception,
-            self.result_param,
-            current_pc,
-        );
+        self.result_param.write(self.builder, exception);
 
         let exception_block = self.create_exception_outcome();
-        let unknown_branch_block = self.create_unknown_branch_outcome(outcome.new_pc);
-
-        self.ins().brif(
-            outcome.handled.to_value(),
-            unknown_branch_block,
-            [],
-            exception_block,
-            [],
-        );
-
-        // The predecessors of either block are now known
-        self.builder.seal_block(exception_block);
-        self.builder.seal_block(unknown_branch_block);
+        self.builder.ins().jump(exception_block, []);
 
         InstructionResult::NoNext
     }

--- a/src/riscv/lib/src/jit/builder/sequence.rs
+++ b/src/riscv/lib/src/jit/builder/sequence.rs
@@ -32,6 +32,7 @@ use crate::jit::builder::instruction::LoweredInstruction;
 use crate::jit::builder::typed::Pointer;
 use crate::jit::builder::typed::Typed;
 use crate::jit::builder::typed::Value;
+use crate::jit::state_access::ExceptionCode;
 use crate::jit::state_access::JsaCalls;
 use crate::machine_state::MachineCoreState;
 use crate::machine_state::hart_state::write_pc;
@@ -41,7 +42,6 @@ use crate::parser::instruction::InstrWidth;
 use crate::state_backend::owned_backend::Owned;
 use crate::state_context::StateContext;
 use crate::state_context::projection::MachineCoreProjection;
-use crate::traps::EnvironException;
 
 const STEPS_REMAINING_VAR_ID: usize = 0;
 
@@ -72,7 +72,7 @@ pub struct SequenceBuilder<'jit, MC: MemoryConfig> {
     max_steps_param: Value<usize>,
 
     /// Parameter pointing to the sequence result
-    result_param: Pointer<Result<(), EnvironException>>,
+    result_param: Pointer<ExceptionCode>,
 
     /// Variable storing the maximum number of steps that can be executed in the sequence.
     steps_remaining: Variable,
@@ -144,10 +144,10 @@ impl<'jit, MC: MemoryConfig> SequenceBuilder<'jit, MC> {
             Value::<usize>::from_raw(raw_value)
         };
 
-        // SAFETY: `JitFn` accepts a `&mut Result<(), EnvironException>` as the 5th parameter.
+        // SAFETY: `JitFn` accepts a `&mut ExceptionCode` as the 5th parameter.
         let result_param = unsafe {
             let raw_value = builder.block_params(param_block)[4];
-            Pointer::<Result<(), EnvironException>>::from_raw(raw_value)
+            Pointer::<ExceptionCode>::from_raw(raw_value)
         };
 
         let steps_remaining = Variable::new(STEPS_REMAINING_VAR_ID);

--- a/src/riscv/lib/src/jit/builder/typed.rs
+++ b/src/riscv/lib/src/jit/builder/typed.rs
@@ -15,6 +15,7 @@
 use std::marker::PhantomData;
 use std::ptr::NonNull;
 
+use cranelift::codegen::ir::MemFlags;
 use cranelift::codegen::ir::Type as CraneliftType;
 use cranelift::codegen::ir::Value as CraneliftValue;
 use cranelift::prelude::FunctionBuilder;
@@ -217,6 +218,13 @@ impl<T: Sized> Value<NonNull<T>> {
             value: self.value,
             _pd: PhantomData,
         }
+    }
+
+    /// Write a value to the memory location pointed to by this pointer.
+    pub fn write(self, builder: &mut FunctionBuilder, value: Value<T>) {
+        builder
+            .ins()
+            .store(MemFlags::trusted(), value.to_value(), self.to_value(), 0);
     }
 }
 

--- a/src/riscv/lib/src/jit/state_access.rs
+++ b/src/riscv/lib/src/jit/state_access.rs
@@ -42,7 +42,6 @@ use crate::machine_state::registers::FValue;
 use crate::machine_state::registers::XValue;
 use crate::state_backend::Elem;
 use crate::state_backend::owned_backend::Owned;
-use crate::traps::EnvironException;
 use crate::traps::Exception;
 
 /// Exception codes used for efficient exception handling in JIT-compiled code
@@ -50,7 +49,7 @@ use crate::traps::Exception;
 /// This enum represents different types of exceptions that can occur during
 /// instruction execution, encoded as i64 values for easy transmission between
 /// JIT-compiled code and runtime handlers.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(i64)]
 pub enum ExceptionCode {
     NoException = 0,
@@ -81,23 +80,20 @@ impl ExceptionCode {
         }
     }
 
-    /// Convert the exception code back to an [`Exception`].
-    ///
-    /// # Panics
-    ///
-    /// This function panics if called on `NoException`, as it is not a valid exception.
-    pub fn to_exception(self) -> Exception {
+    /// Convert the exception code back to an [`Exception`] if it represents an exception.
+    /// Otherwise it will return `None` for [`ExceptionCode::NoException`].
+    pub fn to_exception(self) -> Option<Exception> {
         match self {
-            Self::NoException => unreachable!(),
-            Self::InstructionAccessFault => Exception::InstructionAccessFault,
-            Self::IllegalInstruction => Exception::IllegalInstruction,
-            Self::Breakpoint => Exception::Breakpoint,
-            Self::LoadAccessFault => Exception::LoadAccessFault,
-            Self::StoreAMOAccessFault => Exception::StoreAMOAccessFault,
-            Self::EnvCall => Exception::EnvCall,
-            Self::InstructionPageFault => Exception::InstructionPageFault,
-            Self::LoadPageFault => Exception::LoadPageFault,
-            Self::StoreAMOPageFault => Exception::StoreAMOPageFault,
+            Self::NoException => None,
+            Self::InstructionAccessFault => Some(Exception::InstructionAccessFault),
+            Self::IllegalInstruction => Some(Exception::IllegalInstruction),
+            Self::Breakpoint => Some(Exception::Breakpoint),
+            Self::LoadAccessFault => Some(Exception::LoadAccessFault),
+            Self::StoreAMOAccessFault => Some(Exception::StoreAMOAccessFault),
+            Self::EnvCall => Some(Exception::EnvCall),
+            Self::InstructionPageFault => Some(Exception::InstructionPageFault),
+            Self::LoadPageFault => Some(Exception::LoadPageFault),
+            Self::StoreAMOPageFault => Some(Exception::StoreAMOPageFault),
         }
     }
 
@@ -131,39 +127,6 @@ impl Value<ExceptionCode> {
 
 impl typed::Typed for ExceptionCode {
     const TYPE: typed::Type = typed::Type::Basic(I64);
-}
-
-/// Handle an [`ExceptionCode`].
-///
-/// If the exception is succesfully handled, the
-/// `current_pc` is updated to the new value, and returns true. The `current_pc`
-/// remains initialised to its previous value otherwise.
-///
-/// If the exception needs to be treated by the execution environment,
-/// `result` is updated with the `EnvironException` and `false` is
-/// returned.
-///
-/// See [`MachineCoreState::address_on_exception`].
-extern "C" fn handle_exception<MC: MemoryConfig>(
-    core: &mut MachineCoreState<MC, Owned>,
-    current_pc: &mut Address,
-    exception: ExceptionCode,
-    result: &mut Result<(), EnvironException>,
-) -> bool {
-    let exception = exception.to_exception();
-    let res = core.address_on_exception(exception, *current_pc);
-
-    match res {
-        Err(e) => {
-            *result = Err(e);
-            false
-        }
-
-        Ok(address) => {
-            *current_pc = address;
-            true
-        }
-    }
 }
 
 /// Store the lowest `width` bytes of the given value to memory, at the physical address.
@@ -244,63 +207,16 @@ pub struct JsaCalls<MC: MemoryConfig> {
     /// pointer type and width
     target_config: TargetFrontendConfig,
 
-    /// Reusable stack slot for the PC value
-    pc_slot: Option<stack::Slot<MaybeUninit<Address>>>,
-
     _pd: PhantomData<MC>,
 }
 
 impl<MC: MemoryConfig> JsaCalls<MC> {
-    /// Get the stack slot for the PC value.
-    fn pc_slot(&mut self, builder: &mut FunctionBuilder) -> stack::Slot<MaybeUninit<Address>> {
-        self.pc_slot
-            .get_or_insert_with(|| stack::Slot::new(self.target_config.pointer_type(), builder))
-            .clone()
-    }
-
     /// Construct a new `JsaCalls` instance with the given target configuration.
     pub(super) fn new(target_config: TargetFrontendConfig) -> Self {
         Self {
             target_config,
-            pc_slot: None,
             _pd: PhantomData,
         }
-    }
-
-    /// Emit the required IR to call `handle_exception`.
-    ///
-    /// # Panics
-    ///
-    /// The call to `handle_exception` will panic (at runtime) if no exception
-    /// has occurred so-far in the JIT-compiled function, if the error-handling
-    /// code is triggerred.
-    pub(super) fn handle_exception(
-        &mut self,
-        builder: &mut FunctionBuilder,
-        core_ptr: Pointer<MachineCoreState<MC, Owned>>,
-        exception: Value<ExceptionCode>,
-        result_ptr: Pointer<Result<(), EnvironException>>,
-        current_pc: Value<Address>,
-    ) -> ExceptionHandledOutcome {
-        let pc_slot = self.pc_slot(builder).init(builder, current_pc);
-        let pc_ptr = pc_slot.ptr(builder);
-
-        // SAFETY: Arguments get cast into references with valid lifetimes.
-        // - `core_ptr` is a JIT function argument
-        // - `pc_ptr` points to a stack slot which is valid for the duration of the JIT function
-        // - `result_ptr` is a JIT function argument
-        let handled = ext_calls::call4(
-            &self.target_config,
-            builder,
-            self::handle_exception,
-            unsafe { core_ptr.as_mut() },
-            unsafe { pc_ptr.as_mut() },
-            exception,
-            unsafe { result_ptr.as_mut() },
-        );
-
-        let new_pc = pc_slot.load(builder);
-        ExceptionHandledOutcome { handled, new_pc }
     }
 
     /// Emit the required IR to call `memory_store`.
@@ -464,17 +380,4 @@ impl<MC: MemoryConfig> JsaCalls<MC> {
             reg_value,
         )
     }
-}
-
-/// Outcome of handling an exception.
-pub(super) struct ExceptionHandledOutcome {
-    /// Whether the exception was succesfully handled.
-    ///
-    /// - If true, the exception was handled and the step is completed.
-    /// - If false, the exception must be instead handled by the environment.
-    ///   The step is not complete.
-    pub handled: Value<bool>,
-
-    /// The new value of the instruction pc, after exception handling.
-    pub new_pc: Value<Address>,
 }

--- a/src/riscv/lib/src/jit/state_access/stack.rs
+++ b/src/riscv/lib/src/jit/state_access/stack.rs
@@ -7,22 +7,7 @@
 //! Certain information is occassionally required to be on the stack, when executing
 //! a JIT-compiled block.
 //!
-//! See for example [`handle_exception`]:
-//!
-//! ```ignore
-//! use crate::machine_state::MachineCoreState;
-//! use crate::machine_state::memory::Address;
-//! use crate::machine_state::memory::MemoryConfig;
-//! use crate::traps::EnvironException;
-//! use crate::traps::Exception;
-//!
-//! extern "C" fn handle_exception<MC: MemoryConfig>(
-//!     core: &mut MachineCoreState<MC, Owned>,
-//!     current_pc: &mut Address,
-//!     exception: &Option<Exception>,
-//!     result: &mut Result<(), EnvironException>,
-//! ) -> bool;
-//! ```
+//! See [`crate::jit::state_access`] for examples.
 //!
 //! The boolean return indicates whether the function has failed. If it has, then an exception will
 //! have been written to the place in memory specified by `exception`. `current_pc` is also an out
@@ -34,8 +19,6 @@
 //! Larger/more complex types cannot be moved between registers and the stack safely. Exceptions
 //! are a good example of this. For now, we choose to pass pointers from values created in rust
 //! code, for safety.
-//!
-//! [`handle_exception`]: super::handle_exception
 
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
@@ -169,18 +152,6 @@ impl<T: StackAddressable> Slot<MaybeUninit<T>> {
     ///
     /// You must ensure the slot is initialised before using it.
     pub(super) unsafe fn assume_init(self) -> Slot<T> {
-        Slot {
-            slot: self.slot,
-            ptr_type: self.ptr_type,
-            _pd: PhantomData,
-        }
-    }
-}
-
-impl<T: Stackable> Slot<MaybeUninit<T>> {
-    /// Emit IR to initialise the stack slot.
-    pub(super) fn init(self, builder: &mut FunctionBuilder, value: Value<T>) -> Slot<T> {
-        builder.ins().stack_store(value.to_value(), self.slot, 0);
         Slot {
             slot: self.slot,
             ptr_type: self.ptr_type,

--- a/src/riscv/lib/src/machine_state.rs
+++ b/src/riscv/lib/src/machine_state.rs
@@ -67,55 +67,18 @@ pub struct MachineCoreState<MC: memory::MemoryConfig, M: backend::ManagerBase> {
 }
 
 impl<MC: memory::MemoryConfig, M: backend::ManagerBase> MachineCoreState<MC, M> {
-    /// Handle an [`Exception`] if one was risen during execution
-    /// of an instruction (also known as synchronous exception) by taking a trap.
-    ///
-    /// Return the new address of the program counter, becoming the address of a trap handler.
-    /// Throw [`EnvironException`] if the exception needs to be treated by the execution enviroment.
-    pub(crate) fn address_on_exception(
-        &mut self,
-        exception: Exception,
-        current_pc: Address,
-    ) -> Result<Address, EnvironException>
-    where
-        M: backend::ManagerReadWrite,
-    {
-        if let Ok(exc) = EnvironException::try_from(&exception) {
-            // We need to commit the PC before returning because the caller (e.g.
-            // [step]) doesn't commit it eagerly.
-            self.hart.pc.write(current_pc);
-
-            return Err(exc);
-        }
-
-        // TODO: RV-653: Traps are no longer supported. In this place we would need to trigger a
-        // signal handler instead.
-        let trap_pc = 0;
-
-        Ok(trap_pc)
-    }
-
     #[inline]
-    fn handle_step_result(
-        &mut self,
-        instr_pc: Address,
-        result: Result<ProgramCounterUpdate<Address>, Exception>,
-    ) -> Result<Address, EnvironException>
+    fn update_pc(&mut self, instr_pc: Address, update: ProgramCounterUpdate<Address>)
     where
-        M: backend::ManagerReadWrite,
+        M: backend::ManagerWrite,
     {
-        let pc = match result {
-            Err(exc) => self.address_on_exception(exc, instr_pc)?,
-            Ok(update) => match update {
-                ProgramCounterUpdate::Set(address) => address,
-                ProgramCounterUpdate::Next(width) => instr_pc.wrapping_add(width as u64),
-                ProgramCounterUpdate::Relative(offset) => instr_pc.wrapping_add_signed(offset),
-            },
+        let pc = match update {
+            ProgramCounterUpdate::Set(address) => address,
+            ProgramCounterUpdate::Next(width) => instr_pc.wrapping_add(width as u64),
+            ProgramCounterUpdate::Relative(offset) => instr_pc.wrapping_add_signed(offset),
         };
 
         self.hart.pc.write(pc);
-
-        Ok(pc)
     }
 
     /// Bind the machine state to the given allocated space.
@@ -429,10 +392,9 @@ impl<MC: memory::MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: backen
     /// Take an interrupt if available, and then
     /// perform precisely one [`Instr`] and handle the traps that may rise as a side-effect.
     ///
-    /// The [`Err`] case represents an [`Exception`] to be handled by
-    /// the execution environment, narrowed down by the type [`EnvironException`].
+    /// The [`Err`] case represents an [`Exception`] that ought to be handled at a higher level.
     #[inline]
-    pub fn step(&mut self) -> Result<(), EnvironException>
+    pub fn step(&mut self) -> Result<(), Exception>
     where
         M: ManagerReadWrite,
     {
@@ -442,18 +404,16 @@ impl<MC: memory::MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: backen
         }
     }
 
-    fn step_max_inner(&mut self, max_steps: usize) -> StepManyResult<EnvironException>
+    fn step_max_inner(&mut self, max_steps: usize) -> StepManyResult<Exception>
     where
         M: backend::ManagerReadWrite,
     {
-        let mut result = StepManyResult::ZERO;
-
-        let current_block_result = self
+        let mut result = self
             .block_cache
             .complete_current_block(&mut self.core, max_steps);
 
         // Executing the current block may fail
-        if result.merge_and_return(current_block_result) {
+        if result.error.is_some() {
             return result;
         }
 
@@ -461,7 +421,7 @@ impl<MC: memory::MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: backen
             // Obtain the pc for the next instruction to be executed
             let instr_pc = self.core.hart.pc.read();
 
-            let res = match self.block_cache.get_block(instr_pc) {
+            match self.block_cache.get_block(instr_pc) {
                 Some(mut block) => {
                     let steps_remaining = max_steps - result.steps;
                     let block_result = block.run_block(
@@ -475,19 +435,20 @@ impl<MC: memory::MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: backen
                     if result.merge_and_return(block_result) {
                         return result;
                     }
-
-                    continue;
                 }
 
-                None => self.run_instr_at(instr_pc),
-            };
+                None => match self.run_instr_at(instr_pc) {
+                    Ok(update) => {
+                        self.core.update_pc(instr_pc, update);
+                        result.steps += 1;
+                    }
 
-            if let Err(error) = self.core.handle_step_result(instr_pc, res) {
-                result.error = Some(error);
-                return result;
+                    Err(exc) => {
+                        result.error = Some(exc);
+                        return result;
+                    }
+                },
             }
-
-            result.steps += 1;
         }
 
         result
@@ -496,7 +457,7 @@ impl<MC: memory::MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: backen
     /// Perform as many steps as the given `max_steps` bound allows. Returns the number of retired
     /// instructions.
     #[inline]
-    pub fn step_max(&mut self, max_steps: Bound<usize>) -> StepManyResult<EnvironException>
+    pub fn step_max(&mut self, max_steps: Bound<usize>) -> StepManyResult<Exception>
     where
         M: backend::ManagerReadWrite,
     {
@@ -543,16 +504,25 @@ impl<MC: memory::MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: backen
                     steps = steps.saturating_add(1);
                     step_bounds = bound_saturating_sub(step_bounds, 1);
 
-                    match handle(self, cause) {
-                        Ok(may_continue) => {
-                            if !may_continue {
-                                break None;
+                    match cause {
+                        Exception::EnvCall => match handle(self, EnvironException::EnvCall) {
+                            Ok(may_continue) => {
+                                if !may_continue {
+                                    break None;
+                                }
                             }
-                        }
 
-                        Err(error) => break Some(error),
+                            Err(error) => break Some(error),
+                        },
+
+                        _exception => {
+                            // TODO: RV-653: We trap to a "known" bad address right now. This will
+                            // change once synchronous signals are implemented.
+                            self.core.hart.pc.write(0);
+                        }
                     }
                 }
+
                 None => break None,
             }
         };
@@ -733,7 +703,7 @@ mod tests {
     use crate::pvm::hooks::StdoutDebugHooks;
     use crate::state_backend::CloneLayout;
     use crate::state_backend::FnManagerIdent;
-    use crate::traps::EnvironException;
+    use crate::traps::Exception;
 
     backend_test!(test_step, F, {
         let state = TestMachineOf::<F>::new(InterpretedBlockBuilder);
@@ -802,20 +772,18 @@ mod tests {
             state.core.main_memory.write_instruction_unchecked(init_pc_addr, ECALL).unwrap();
             let e = state.step()
                 .expect_err("should raise Environment Exception");
-            assert_eq!(e, EnvironException::EnvCall);
+            assert_eq!(e, Exception::EnvCall);
             prop_assert_eq!(state.core.hart.pc.read(), init_pc_addr);
         });
     });
 
-    backend_test!(test_step_exc_us, F, {
+    backend_test!(test_step_access_exception, F, {
         let state = TestMachineOf::<F>::new(InterpretedBlockBuilder);
-
         let state_cell = std::cell::RefCell::new(state);
 
         proptest!(|(
             pc_addr_offset in 0..200_u64,
         )| {
-            // Raise exception, take trap from U-mode to S-mode (test delegation takes place)
             let mut state = <F as ManagerTestInit>::reinit_machine_state(
                 state_cell.borrow_mut(),
             );
@@ -823,8 +791,9 @@ mod tests {
             let bad_address = memory::FIRST_ADDRESS.wrapping_sub((pc_addr_offset + 10) * 4);
             state.core.hart.pc.write(bad_address);
 
-            state.step().expect("should not raise environment exception");
-            assert_eq!(state.core.hart.pc.read(), 0);
+            let result = state.step();
+            assert_eq!(result, Err(Exception::InstructionAccessFault));
+            assert_eq!(state.core.hart.pc.read(), bad_address);
         });
     });
 

--- a/src/riscv/lib/src/machine_state/block_cache.rs
+++ b/src/riscv/lib/src/machine_state/block_cache.rs
@@ -106,7 +106,6 @@ use crate::state_backend::ManagerClone;
 use crate::state_backend::ManagerRead;
 use crate::state_backend::ManagerReadWrite;
 use crate::state_backend::Ref;
-use crate::traps::EnvironException;
 use crate::traps::Exception;
 
 /// The maximum number of instructions that may be contained in a block.
@@ -176,7 +175,7 @@ impl<B: Block<MC, M>, MC: MemoryConfig, M: ManagerReadWrite> BlockCall<'_, B, MC
         block_builder: &mut B::BlockBuilder,
         instr_pc: Address,
         max_steps: usize,
-    ) -> StepManyResult<EnvironException> {
+    ) -> StepManyResult<Exception> {
         if self.entry.block.num_instr() <= max_steps {
             // Safety: the same block builder is passed through every time.
             unsafe {
@@ -248,7 +247,7 @@ pub trait BlockCache<MC: MemoryConfig, B: Block<MC, M>, M: ManagerBase> {
         &mut self,
         core: &mut MachineCoreState<MC, M>,
         max_steps: usize,
-    ) -> StepManyResult<EnvironException>
+    ) -> StepManyResult<Exception>
     where
         M: ManagerReadWrite;
 }

--- a/src/riscv/lib/src/machine_state/block_cache/block.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/block.rs
@@ -35,7 +35,6 @@ use crate::state_backend::ManagerRead;
 use crate::state_backend::ManagerReadWrite;
 use crate::state_backend::ManagerWrite;
 use crate::state_backend::Ref;
-use crate::traps::EnvironException;
 use crate::traps::Exception;
 
 /// State Layout for Blocks
@@ -116,7 +115,7 @@ pub trait Block<MC: MemoryConfig, M: ManagerBase>: NewState<M> {
         instr_pc: Address,
         max_steps: usize,
         block_builder: &mut Self::BlockBuilder,
-    ) -> StepManyResult<EnvironException>
+    ) -> StepManyResult<Exception>
     where
         M: ManagerReadWrite;
 }
@@ -124,7 +123,7 @@ pub trait Block<MC: MemoryConfig, M: ManagerBase>: NewState<M> {
 fn run_block_inner<MC: MemoryConfig, M: ManagerReadWrite>(
     instr: &[EnrichedCell<ICallPlaced<MC, M>, M>],
     core: &mut MachineCoreState<MC, M>,
-    instr_pc: &mut Address,
+    mut instr_pc: Address,
     max_steps: usize,
 ) -> StepManyResult<Exception> {
     let mut result = StepManyResult::ZERO;
@@ -132,30 +131,32 @@ fn run_block_inner<MC: MemoryConfig, M: ManagerReadWrite>(
     for instr in instr.iter().take(max_steps) {
         match run_instr(instr, core) {
             Ok(ProgramCounterUpdate::Next(width)) => {
-                *instr_pc += width as u64;
-                core.hart.pc.write(*instr_pc);
+                instr_pc += width as u64;
+                core.hart.pc.write(instr_pc);
                 result.steps += 1;
             }
 
-            Ok(ProgramCounterUpdate::Set(instr_pc)) => {
-                // Setting the instr_pc implies execution continuing
-                // elsewhere and no longer within the current block, so the
-                // current block instr_pc does not need updating.
-                core.hart.pc.write(instr_pc);
+            Ok(ProgramCounterUpdate::Set(new_instr_pc)) => {
+                // A jump to a new instruction requires us to exit this loop. The targeted
+                // instruction may not be part of the current block, but also we need to ensure we
+                // don't violate the maximum number of steps allowed to run.
+                core.hart.pc.write(new_instr_pc);
                 result.steps += 1;
                 break;
             }
 
             Ok(ProgramCounterUpdate::Relative(offset)) => {
+                // While relative jumps are likely to be in the same block, we don't do step
+                // counting within this function, so we can't respect the maximum number of steps
+                // allowed to run.
                 core.hart.pc.write(instr_pc.wrapping_add_signed(offset));
                 result.steps += 1;
                 break;
             }
 
-            Err(e) => {
-                // Exceptions lead to a new address being set to handle it,
-                // with no guarantee of it being the next instruction.
-                result.error = Some(e);
+            Err(exception) => {
+                // Exceptions are handled outside of block execution. So we exit the loop.
+                result.error = Some(exception);
                 break;
             }
         }

--- a/src/riscv/lib/src/machine_state/block_cache/block/dispatch.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/block/dispatch.rs
@@ -19,12 +19,12 @@ use std::sync::mpsc::Sender;
 use super::Jitted;
 use crate::jit::JIT;
 use crate::jit::JitFn;
+use crate::jit::state_access::ExceptionCode;
 use crate::machine_state::MachineCoreState;
 use crate::machine_state::instruction::Instruction;
 use crate::machine_state::memory::Address;
 use crate::machine_state::memory::MemoryConfig;
 use crate::state_backend::owned_backend::Owned;
-use crate::traps::EnvironException;
 
 /// The function signature for dispatching a block run.
 ///
@@ -37,7 +37,7 @@ pub type DispatchFn<D, MC> = unsafe extern "C" fn(
     &mut MachineCoreState<MC, Owned>,
     Address,
     usize,
-    &mut Result<(), EnvironException>,
+    &mut ExceptionCode,
     &mut D,
 ) -> usize;
 

--- a/src/riscv/lib/src/machine_state/block_cache/block/interpreted.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/block/interpreted.rs
@@ -29,7 +29,7 @@ use crate::state_backend::ManagerRead;
 use crate::state_backend::ManagerReadWrite;
 use crate::state_backend::ManagerWrite;
 use crate::state_backend::Ref;
-use crate::traps::EnvironException;
+use crate::traps::Exception;
 
 /// Interpreted blocks are built automatically, and require no additional context.
 #[derive(Debug, Default)]
@@ -135,30 +135,13 @@ impl<MC: MemoryConfig, M: ManagerBase> Block<MC, M> for Interpreted<MC, M> {
     unsafe fn run_block(
         &mut self,
         core: &mut MachineCoreState<MC, M>,
-        mut instr_pc: Address,
+        instr_pc: Address,
         max_steps: usize,
         _block_builder: &mut Self::BlockBuilder,
-    ) -> StepManyResult<EnvironException>
+    ) -> StepManyResult<Exception>
     where
         M: ManagerReadWrite,
     {
-        let mut result = run_block_inner(self.instr(), core, &mut instr_pc, max_steps);
-
-        if let Some(exc) = result.error {
-            if let Err(err) = core.handle_step_result(instr_pc, Err(exc)) {
-                return StepManyResult {
-                    steps: result.steps,
-                    error: Some(err),
-                };
-            }
-
-            // If we successfully handled an error, need to increment steps one more.
-            result.steps += 1;
-        }
-
-        StepManyResult {
-            steps: result.steps,
-            error: None,
-        }
+        run_block_inner(self.instr(), core, instr_pc, max_steps)
     }
 }

--- a/src/riscv/lib/src/machine_state/block_cache/block/jitted.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/block/jitted.rs
@@ -6,6 +6,7 @@
 //! JIT-compiled blocks of instructions
 
 use super::ICallPlaced;
+use crate::jit::state_access::ExceptionCode;
 use crate::machine_state::MachineCoreState;
 use crate::machine_state::StepManyResult;
 use crate::machine_state::block_cache::block::Block;
@@ -22,7 +23,7 @@ use crate::state_backend::EnrichedCell;
 use crate::state_backend::FnManager;
 use crate::state_backend::Ref;
 use crate::state_backend::owned_backend::Owned;
-use crate::traps::EnvironException;
+use crate::traps::Exception;
 
 /// Blocks that are compiled to native code for execution, when possible.
 ///
@@ -52,7 +53,7 @@ impl<D: DispatchCompiler<MC>, MC: MemoryConfig> Jitted<D, MC> {
         core: &mut MachineCoreState<MC, Owned>,
         instr_pc: Address,
         max_steps: usize,
-        result: &mut Result<(), EnvironException>,
+        result: &mut ExceptionCode,
         block_builder: &mut D,
     ) -> usize {
         if !block_builder.should_compile(&mut self.dispatch) {
@@ -90,7 +91,7 @@ impl<D: DispatchCompiler<MC>, MC: MemoryConfig> Jitted<D, MC> {
         core: &mut MachineCoreState<MC, Owned>,
         instr_pc: Address,
         max_steps: usize,
-        result: &mut Result<(), EnvironException>,
+        result: &mut ExceptionCode,
         _block_builder: &mut D,
     ) -> usize {
         let block_result = unsafe {
@@ -103,10 +104,10 @@ impl<D: DispatchCompiler<MC>, MC: MemoryConfig> Jitted<D, MC> {
             )
         };
 
-        *result = match block_result.error {
-            Some(exc) => Err(exc),
-            None => Ok(()),
-        };
+        *result = block_result
+            .error
+            .map(ExceptionCode::from_exception)
+            .unwrap_or(ExceptionCode::NoException);
 
         block_result.steps
     }
@@ -175,8 +176,8 @@ impl<D: DispatchCompiler<MC>, MC: MemoryConfig> Block<MC, Owned> for Jitted<D, M
         instr_pc: Address,
         max_steps: usize,
         block_builder: &mut Self::BlockBuilder,
-    ) -> StepManyResult<EnvironException> {
-        let mut result = Ok(());
+    ) -> StepManyResult<Exception> {
+        let mut result = ExceptionCode::NoException;
 
         let fun = self.dispatch.get();
 
@@ -186,7 +187,7 @@ impl<D: DispatchCompiler<MC>, MC: MemoryConfig> Block<MC, Owned> for Jitted<D, M
 
         StepManyResult {
             steps,
-            error: result.err(),
+            error: result.to_exception(),
         }
     }
 

--- a/src/riscv/lib/src/machine_state/block_cache/metrics.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/metrics.rs
@@ -42,7 +42,7 @@ use crate::state_backend::ManagerAlloc;
 use crate::state_backend::ManagerBase;
 use crate::state_backend::ManagerRead;
 use crate::storage::Hash;
-use crate::traps::EnvironException;
+use crate::traps::Exception;
 
 #[cfg(feature = "metrics")]
 #[doc(hidden)]
@@ -319,7 +319,7 @@ impl<B: Block<MC, M>, MC: MemoryConfig, M: ManagerBase> Block<MC, M> for BlockMe
         instr_pc: crate::machine_state::memory::Address,
         max_steps: usize,
         block_builder: &mut Self::BlockBuilder,
-    ) -> StepManyResult<EnvironException>
+    ) -> StepManyResult<Exception>
     where
         M: crate::state_backend::ManagerReadWrite,
     {

--- a/src/riscv/lib/src/machine_state/block_cache/state.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/state.rs
@@ -31,7 +31,7 @@ use crate::state_backend::ManagerRead;
 use crate::state_backend::ManagerReadWrite;
 use crate::state_backend::ManagerWrite;
 use crate::state_backend::Ref;
-use crate::traps::EnvironException;
+use crate::traps::Exception;
 
 /// Layout of a partial block.
 pub type PartialBlockLayout = (Atom<Address>, Atom<bool>, Atom<u8>);
@@ -93,7 +93,7 @@ impl<M: ManagerBase> PartialBlock<M> {
         core: &mut MachineCoreState<MC, M>,
         max_steps: usize,
         entry: &mut Cached<MC, B, M>,
-    ) -> StepManyResult<EnvironException>
+    ) -> StepManyResult<Exception>
     where
         M: ManagerReadWrite,
     {
@@ -110,7 +110,7 @@ impl<M: ManagerBase> PartialBlock<M> {
         core: &mut MachineCoreState<MC, M>,
         max_steps: usize,
         entry: &mut Cached<MC, B, M>,
-    ) -> StepManyResult<EnvironException>
+    ) -> StepManyResult<Exception>
     where
         M: ManagerReadWrite,
     {
@@ -157,18 +157,9 @@ impl<M: ManagerBase> PartialBlock<M> {
                     return result;
                 }
 
-                Err(e) => {
+                Err(exc) => {
                     self.reset();
-
-                    // Exceptions lead to a new address being set to handle it,
-                    // with no guarantee of it being the next instruction.
-                    if let Err(error) = core.handle_step_result(instr_pc, Err(e)) {
-                        result.error = Some(error);
-                        return result;
-                    }
-
-                    // If we succesfully handled an error, need to increment steps one more.
-                    result.steps += 1;
+                    result.error = Some(exc);
                     return result;
                 }
             }
@@ -532,7 +523,7 @@ impl<const SIZE: usize, MC: MemoryConfig, B: Block<MC, M>, M: ManagerBase>
         &mut self,
         core: &mut MachineCoreState<MC, M>,
         max_steps: usize,
-    ) -> StepManyResult<EnvironException>
+    ) -> StepManyResult<Exception>
     where
         M: ManagerReadWrite,
     {
@@ -574,7 +565,7 @@ mod tests {
     use crate::parser::instruction::InstrWidth;
     use crate::state::NewState;
     use crate::state_backend::owned_backend::Owned;
-    use crate::traps::EnvironException;
+    use crate::traps::Exception;
 
     type TestState<M> = <TestCacheConfig as BlockCacheConfig>::State<M4K, Interpreted<M4K, M>, M>;
 
@@ -911,7 +902,7 @@ mod tests {
             .unwrap();
 
         let result = state.step();
-        assert_eq!(result, Err(EnvironException::EnvCall));
+        assert_eq!(result, Err(Exception::EnvCall));
     }
 
     /// The initialised block cache has an entry for address 0. The block at address 0 happens to

--- a/src/riscv/lib/src/pvm/common.rs
+++ b/src/riscv/lib/src/pvm/common.rs
@@ -47,7 +47,6 @@ use crate::state_backend::verify_backend::Verifier;
 use crate::storage::Hash;
 use crate::storage::HashError;
 use crate::struct_layout;
-use crate::traps::EnvironException;
 
 /// Type of input that can be passed to the PVM
 pub enum PvmInput<'a> {
@@ -222,22 +221,8 @@ impl<MC: MemoryConfig, BCC: BlockCacheConfig, B: block::Block<MC, M>, M: state_b
         csregs.write(CSRegister::fflags, fflags + 1);
     }
 
-    /// Handle an exception using the defined Execution Environment.
-    fn handle_exception(&mut self, hooks: impl PvmHooks, _exception: EnvironException) -> bool
-    where
-        M: state_backend::ManagerReadWrite,
-    {
-        handle_system_call(
-            &mut self.machine_state,
-            &mut self.system_state,
-            &mut self.status,
-            &mut self.reveal_request,
-            hooks,
-        )
-    }
-
     /// Perform one evaluation step.
-    pub(crate) fn eval_one(&mut self, hooks: impl PvmHooks)
+    pub(crate) fn eval_one(&mut self, mut hooks: impl PvmHooks)
     where
         M: state_backend::ManagerReadWrite,
     {
@@ -248,9 +233,19 @@ impl<MC: MemoryConfig, BCC: BlockCacheConfig, B: block::Block<MC, M>, M: state_b
             return self.provide_reveal_error_response();
         }
 
-        if let Err(exc) = self.machine_state.step() {
-            self.handle_exception(hooks, exc);
-        }
+        self.machine_state.step_max_handle::<Infallible>(
+            Bound::Included(1),
+            |machine_state, _exception| {
+                Ok(handle_system_call(
+                    machine_state,
+                    &mut self.system_state,
+                    &mut self.status,
+                    &mut self.reveal_request,
+                    &mut hooks,
+                ))
+            },
+        );
+
         self.tick.write(self.tick.read().wrapping_add(1u64));
     }
 
@@ -517,6 +512,29 @@ mod tests {
     use crate::pvm::linux;
     use crate::state_backend::owned_backend::Owned;
 
+    impl<
+        MC: MemoryConfig,
+        BCC: BlockCacheConfig,
+        B: block::Block<MC, M>,
+        M: state_backend::ManagerBase,
+    > Pvm<MC, BCC, B, M>
+    {
+        /// Handle an exception using the defined Execution Environment.
+        // The conditional compilation below causes some warnings.
+        fn handle_exception(&mut self, hooks: impl PvmHooks) -> bool
+        where
+            M: state_backend::ManagerReadWrite,
+        {
+            handle_system_call(
+                &mut self.machine_state,
+                &mut self.system_state,
+                &mut self.status,
+                &mut self.reveal_request,
+                hooks,
+            )
+        }
+    }
+
     #[test]
     fn test_read_input() {
         type MC = M1M;
@@ -568,7 +586,7 @@ mod tests {
         assert_eq!(pvm.status(), PvmStatus::Evaluating);
 
         // Handle the ECALL successfully
-        let outcome = pvm.handle_exception(StdoutDebugHooks, EnvironException::EnvCall);
+        let outcome = pvm.handle_exception(StdoutDebugHooks);
         assert!(!outcome);
 
         // After the ECALL we should be waiting for input
@@ -666,7 +684,7 @@ mod tests {
                 .xregisters
                 .write(a2, written.len() as u64);
 
-            pvm.handle_exception(&mut buffer, EnvironException::EnvCall);
+            pvm.handle_exception(&mut buffer);
 
             // Compare what characters have been passed to the hook versus what we
             // intended to write
@@ -713,7 +731,7 @@ mod tests {
         assert_eq!(pvm.status(), PvmStatus::Evaluating);
 
         // Handle the ECALL successfully
-        let outcome = pvm.handle_exception(StdoutDebugHooks, EnvironException::EnvCall);
+        let outcome = pvm.handle_exception(StdoutDebugHooks);
         assert!(!outcome);
 
         // After the ECALL we should be waiting for reveal
@@ -788,7 +806,7 @@ mod tests {
         assert_eq!(pvm.status(), PvmStatus::Evaluating);
 
         // Handle the ECALL successfully
-        let outcome = pvm.handle_exception(StdoutDebugHooks, EnvironException::EnvCall);
+        let outcome = pvm.handle_exception(StdoutDebugHooks);
         assert!(!outcome);
 
         // After the ECALL we should be waiting for reveal


### PR DESCRIPTION
Closes RV-750

# What

This PR moves exception handling out of JIT-produced functions. The generated code (both IR and final assembly) for JIT-compiled sequences of instructions becomes simpler that way.

I had to change a few JIT scenario tests which now perform one fewer step, as the exception handling, which counted as the completion of a step in those cases, is no longer done. This has been split out into a separate commit for your reviewing convenience.

# Why

The changes result in a slight reduction in complexity of the JIT builder. It also results in a ~2.12% performance boost.

# How

Since exceptions are no longer handled, there is no mechanism to update the `Result<(), EnvironmentException>` parameter via its mutable reference.

Strictly speaking, the exception kind is no longer an environment exception, but a regular exception. Changing the out parameter type to `Result<(), Exception>` would require an external function call to convert the `ExceptionCode` as it is raised into an `Exception` and then update the result parameter. To avoid this additional external function call, we change the result parameter to `ExceptionCode`. This means we can directly update the mutable reference as an exception is raised; no conversion needed.

Exception handling is now done in a single place: `Pvm::step_max_handle`.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
