### PR TITLE
Use test cache configs for proof and determinism tests

### DIFF
--- a/src/riscv/lib/tests/common/mod.rs
+++ b/src/riscv/lib/tests/common/mod.rs
@@ -6,15 +6,15 @@ use std::fs;
 
 use octez_riscv::machine_state::block_cache::BlockCacheConfig;
 use octez_riscv::machine_state::block_cache::block::InterpretedBlockBuilder;
-use octez_riscv::machine_state::memory::M64M;
+use octez_riscv::machine_state::memory::MemoryConfig;
 use octez_riscv::pvm::hooks::NoHooks;
 use octez_riscv::stepper::pvm::PvmStepper;
 use rand::Rng;
 use rand::seq::SliceRandom;
 use tezos_smart_rollup_utils::inbox::InboxBuilder;
 
-pub fn make_stepper_factory<BCC: BlockCacheConfig>() -> impl Fn() -> PvmStepper<NoHooks, M64M, BCC>
-{
+pub fn make_stepper_factory<MC: MemoryConfig, BCC: BlockCacheConfig>()
+-> impl Fn() -> PvmStepper<NoHooks, MC, BCC> {
     let program = fs::read("../assets/jstz").unwrap();
 
     let mut inbox = InboxBuilder::new();
@@ -28,7 +28,7 @@ pub fn make_stepper_factory<BCC: BlockCacheConfig>() -> impl Fn() -> PvmStepper<
     move || {
         let block_builder = InterpretedBlockBuilder;
 
-        PvmStepper::<NoHooks, M64M, BCC>::new(
+        PvmStepper::<NoHooks, MC, BCC>::new(
             &program,
             inbox.clone(),
             NoHooks,

--- a/src/riscv/lib/tests/test_determinism.rs
+++ b/src/riscv/lib/tests/test_determinism.rs
@@ -7,11 +7,14 @@ mod common;
 use std::ops::Bound;
 
 use common::*;
-use octez_riscv::machine_state::block_cache::DefaultCacheConfig;
+use octez_riscv::machine_state::block_cache::BlockCacheConfig;
+use octez_riscv::machine_state::block_cache::TestCacheConfig;
 use octez_riscv::machine_state::block_cache::block::InterpretedBlockBuilder;
 use octez_riscv::machine_state::memory::M64M;
+use octez_riscv::machine_state::memory::MemoryConfig;
 use octez_riscv::pvm::PvmLayout;
 use octez_riscv::pvm::hooks::NoHooks;
+use octez_riscv::state_backend::CloneLayout;
 use octez_riscv::state_backend::RefOwnedAlloc;
 use octez_riscv::state_backend::hash;
 use octez_riscv::stepper::Stepper;
@@ -43,16 +46,20 @@ fn test_jstz_determinism() {
 
     // Create multiple series of bisections that we will evaluate.
     let ladder = dissect_steps(steps, 0);
-    run_steps_ladder(&make_stepper, &ladder, &base_refs, base_hash);
+    run_steps_ladder::<M64M, TestCacheConfig, _>(&make_stepper, &ladder, &base_refs, base_hash);
 }
 
-fn run_steps_ladder<F>(
+fn run_steps_ladder<MC, BCC, F>(
     make_stepper: F,
     ladder: &[usize],
-    expected_refs: &RefOwnedAlloc<PvmLayout<M64M, DefaultCacheConfig>>,
+    expected_refs: &RefOwnedAlloc<PvmLayout<MC, BCC>>,
     expected_hash: hash::Hash,
 ) where
-    F: Fn() -> PvmStepper<NoHooks, M64M, DefaultCacheConfig>,
+    MC: MemoryConfig,
+    BCC: BlockCacheConfig,
+    PvmLayout<MC, BCC>: CloneLayout,
+    for<'a> RefOwnedAlloc<'a, PvmLayout<MC, BCC>>: PartialEq,
+    F: Fn() -> PvmStepper<NoHooks, MC, BCC>,
 {
     let expected_steps = ladder.iter().sum::<usize>();
     let mut stepper_lhs = make_stepper();
@@ -93,15 +100,17 @@ fn run_steps_ladder<F>(
         stepper_lhs.rebind_via_clone(block_builder);
     }
 
-    assert_eq_struct_wrapper(stepper_lhs.struct_ref(), expected_refs);
+    assert_eq_struct_wrapper::<MC, BCC>(stepper_lhs.struct_ref(), expected_refs);
     assert_eq!(stepper_lhs.hash(), expected_hash);
     assert_eq!(stepper_rhs.hash(), expected_hash);
 }
 
-fn assert_eq_struct_wrapper<'a, 'regions1, 'regions2>(
-    refs: RefOwnedAlloc<'regions1, PvmLayout<M64M, DefaultCacheConfig>>,
-    expected: &'a RefOwnedAlloc<'regions2, PvmLayout<M64M, DefaultCacheConfig>>,
-) {
+fn assert_eq_struct_wrapper<'a, 'regions1, 'regions2, MC: MemoryConfig, BCC: BlockCacheConfig>(
+    refs: RefOwnedAlloc<'regions1, PvmLayout<MC, BCC>>,
+    expected: &'a RefOwnedAlloc<'regions2, PvmLayout<MC, BCC>>,
+) where
+    RefOwnedAlloc<'regions2, PvmLayout<MC, BCC>>: PartialEq,
+{
     // SAFETY: Rust does not allow us to compare two references with different lifetimes.
     // Theoretically this should be possible and safe thanks to `PartialEq`. However, Rust's
     // subtyping rules seem to influence trait-implementation selection for our `AllocatedOf<...>`
@@ -110,7 +119,6 @@ fn assert_eq_struct_wrapper<'a, 'regions1, 'regions2>(
     // the `==` operator need to be identical in type. This also means lifetimes are forcibly
     // unified. We can work around this by transmuting the references to the same lifetime. This is
     // safe because lifetimes are not violated as dictated by the interface of this function.
-    let refs: RefOwnedAlloc<'regions2, PvmLayout<M64M, DefaultCacheConfig>> =
-        unsafe { std::mem::transmute(refs) };
+    let refs: RefOwnedAlloc<'regions2, PvmLayout<MC, BCC>> = unsafe { std::mem::transmute(refs) };
     assert!(&refs == expected);
 }

--- a/src/riscv/lib/tests/test_proofs.rs
+++ b/src/riscv/lib/tests/test_proofs.rs
@@ -11,7 +11,6 @@ use std::time::Instant;
 
 use common::*;
 use octez_riscv::machine_state::block_cache::BlockCacheConfig;
-use octez_riscv::machine_state::block_cache::DefaultCacheConfig;
 use octez_riscv::machine_state::block_cache::TestCacheConfig;
 use octez_riscv::machine_state::block_cache::block::Interpreted;
 use octez_riscv::machine_state::memory::M64M;
@@ -32,32 +31,32 @@ use rand::Rng;
 #[test]
 #[ignore]
 fn test_jstz_proofs_one_step() {
-    test_jstz_proofs(false, PvmStepper::verify_proof)
+    test_jstz_proofs::<M64M, TestCacheConfig>(false, PvmStepper::verify_proof)
 }
 
 #[test]
 #[ignore]
 fn test_jstz_proofs_one_step_stream() {
-    test_jstz_proofs(false, PvmStepper::verify_proof_using_raw_bytes)
+    test_jstz_proofs::<M64M, TestCacheConfig>(false, PvmStepper::verify_proof_using_raw_bytes)
 }
 
 #[test]
 #[ignore]
 fn test_jstz_proofs_full() {
-    test_jstz_proofs(true, PvmStepper::verify_proof)
+    test_jstz_proofs::<M64M, TestCacheConfig>(true, PvmStepper::verify_proof)
 }
 
 #[test]
 #[ignore]
 fn test_jstz_proofs_full_stream() {
-    test_jstz_proofs(true, PvmStepper::verify_proof_using_raw_bytes)
+    test_jstz_proofs::<M64M, TestCacheConfig>(true, PvmStepper::verify_proof_using_raw_bytes)
 }
 
 #[test]
 fn test_jstz_initial_proof_regression() {
     // Configuring the stepper with `TestCachelayouts` to match the node PVM
     // and make the test run faster.
-    let make_stepper = make_stepper_factory::<TestCacheConfig>();
+    let make_stepper = make_stepper_factory::<M64M, TestCacheConfig>();
     let mut stepper = make_stepper();
 
     eprintln!("> Producing proof ...");
@@ -72,8 +71,12 @@ fn test_jstz_initial_proof_regression() {
     writeln!(proof_capture, "{proof_bytes}").unwrap();
 }
 
-fn test_jstz_proofs(full: bool, verify_fn: StepperVerifyFn<M64M, DefaultCacheConfig, Owned>) {
-    let make_stepper = make_stepper_factory::<DefaultCacheConfig>();
+fn test_jstz_proofs<MC, BCC>(full: bool, verify_fn: StepperVerifyFn<MC, BCC, Owned>)
+where
+    MC: MemoryConfig,
+    BCC: BlockCacheConfig + 'static,
+{
+    let make_stepper = make_stepper_factory::<MC, BCC>();
 
     let mut base_stepper = make_stepper();
     let base_result = base_stepper.step_max(Bound::Unbounded);
@@ -95,13 +98,15 @@ fn test_jstz_proofs(full: bool, verify_fn: StepperVerifyFn<M64M, DefaultCacheCon
     }
 }
 
-fn run_steps_ladder<F>(
+fn run_steps_ladder<MC, BCC, F>(
     make_stepper: F,
     ladder: &[usize],
     expected_hash: Option<hash::Hash>,
-    verify_fn: StepperVerifyFn<M64M, DefaultCacheConfig, Owned>,
+    verify_fn: StepperVerifyFn<MC, BCC, Owned>,
 ) where
-    F: Fn() -> PvmStepper<NoHooks, M64M, DefaultCacheConfig>,
+    MC: MemoryConfig,
+    BCC: BlockCacheConfig + 'static,
+    F: Fn() -> PvmStepper<NoHooks, MC, BCC>,
 {
     let expected_steps = ladder.iter().sum::<usize>();
     let mut stepper = make_stepper();


### PR DESCRIPTION
# What

Configures the proof and determinism tests to use the `TestCacheConfig`.

# Why

Using a smaller block cache speeds up tests dramatically.

The `make test test-long` step in CI is reduced from about 19 mins to about 12 mins.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
