### PR TITLE
Vdum@update etherlink

### DIFF
--- a/kernels/etherlink/Cargo.lock
+++ b/kernels/etherlink/Cargo.lock
@@ -35,7 +35,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b82752a889170df67bbb36d42ca63c531eb16274f0d7299ae2a680facba17bd"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives",
  "alloy-rlp",
 ]
 
@@ -45,7 +45,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d4769c6ffddca380b0070d71c8b7f30bed375543fe76bb2f74ec0acf4b7cd16"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives",
  "alloy-rlp",
  "k256",
  "thiserror 2.0.12",
@@ -53,49 +53,21 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.7.7"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc05b04ac331a9f07e3a4036ef7926e49a8bf84a99a1ccfc7e2ab55a5fcbb372"
+checksum = "459f98c6843f208856f338bfb25e65325467f7aff35dfeb0484d0a76e059134b"
 dependencies = [
- "alloy-primitives 0.7.7",
- "alloy-sol-type-parser 0.7.7",
- "serde",
-]
-
-[[package]]
-name = "alloy-json-abi"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15516116086325c157c18261d768a20677f0f699348000ed391d4ad0dcb82530"
-dependencies = [
- "alloy-primitives 1.2.1",
- "alloy-sol-type-parser 1.2.1",
+ "alloy-primitives",
+ "alloy-sol-type-parser",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-primitives"
-version = "0.7.7"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb3ead547f4532bc8af961649942f0b9c16ee9226e26caa3f38420651cc0bf4"
-dependencies = [
- "bytes",
- "cfg-if",
- "const-hex",
- "derive_more 0.99.20",
- "hex-literal",
- "itoa",
- "ruint",
- "serde",
- "tiny-keccak",
-]
-
-[[package]]
-name = "alloy-primitives"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6177ed26655d4e84e00b65cb494d4e0b8830e7cae7ef5d63087d445a2600fb55"
+checksum = "3cfebde8c581a5d37b678d0a48a32decb51efd7a63a08ce2517ddec26db705c8"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -137,26 +109,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.7.7"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b40397ddcdcc266f59f959770f601ce1280e699a91fc1862f29cef91707cd09"
+checksum = "aedac07a10d4c2027817a43cc1f038313fc53c7ac866f7363239971fd01f9f18"
 dependencies = [
- "alloy-sol-macro-expander 0.7.7",
- "alloy-sol-macro-input 0.7.7",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "alloy-sol-macro"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14f21d053aea4c6630687c2f4ad614bed4c81e14737a9b904798b24f30ea849"
-dependencies = [
- "alloy-sol-macro-expander 1.2.1",
- "alloy-sol-macro-input 1.2.1",
+ "alloy-sol-macro-expander",
+ "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -165,31 +123,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.7.7"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "867a5469d61480fea08c7333ffeca52d5b621f5ca2e44f271b117ec1fc9a0525"
+checksum = "24f9a598f010f048d8b8226492b6401104f5a5c1273c2869b72af29b48bb4ba9"
 dependencies = [
- "alloy-json-abi 0.7.7",
- "alloy-sol-macro-input 0.7.7",
- "const-hex",
- "heck 0.5.0",
- "indexmap",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
- "syn-solidity 0.7.7",
- "tiny-keccak",
-]
-
-[[package]]
-name = "alloy-sol-macro-expander"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d99282e7c9ef14eb62727981a985a01869e586d1dec729d3bb33679094c100"
-dependencies = [
- "alloy-json-abi 1.2.1",
- "alloy-sol-macro-input 1.2.1",
+ "alloy-json-abi",
+ "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
  "indexmap",
@@ -197,34 +136,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
- "syn-solidity 1.2.1",
+ "syn-solidity",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.7.7"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e482dc33a32b6fadbc0f599adea520bd3aaa585c141a80b404d0a3e3fa72528"
+checksum = "f494adf9d60e49aa6ce26dfd42c7417aa6d4343cf2ae621f20e4d92a5ad07d85"
 dependencies = [
- "alloy-json-abi 0.7.7",
- "const-hex",
- "dunce",
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "serde_json",
- "syn 2.0.101",
- "syn-solidity 0.7.7",
-]
-
-[[package]]
-name = "alloy-sol-macro-input"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda029f955b78e493360ee1d7bd11e1ab9f2a220a5715449babc79d6d0a01105"
-dependencies = [
- "alloy-json-abi 1.2.1",
+ "alloy-json-abi",
  "const-hex",
  "dunce",
  "heck 0.5.0",
@@ -233,50 +155,28 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.101",
- "syn-solidity 1.2.1",
+ "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.7.7"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbcba3ca07cf7975f15d871b721fb18031eec8bce51103907f6dcce00b255d98"
+checksum = "52db32fbd35a9c0c0e538b58b81ebbae08a51be029e7ad60e08b60481c2ec6c3"
 dependencies = [
  "serde",
- "winnow 0.6.26",
-]
-
-[[package]]
-name = "alloy-sol-type-parser"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10db1bd7baa35bc8d4a1b07efbf734e73e5ba09f2580fb8cee3483a36087ceb2"
-dependencies = [
- "serde",
- "winnow 0.7.10",
+ "winnow",
 ]
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.7.7"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91ca40fa20793ae9c3841b83e74569d1cc9af29a2f5237314fd3452d51e38c7"
+checksum = "a285b46e3e0c177887028278f04cc8262b76fd3b8e0e20e93cea0a58c35f5ac5"
 dependencies = [
- "alloy-json-abi 0.7.7",
- "alloy-primitives 0.7.7",
- "alloy-sol-macro 0.7.7",
- "const-hex",
-]
-
-[[package]]
-name = "alloy-sol-types"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58377025a47d8b8426b3e4846a251f2c1991033b27f517aade368146f6ab1dfe"
-dependencies = [
- "alloy-json-abi 1.2.1",
- "alloy-primitives 1.2.1",
- "alloy-sol-macro 1.2.1",
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-macro",
 ]
 
 [[package]]
@@ -763,12 +663,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,19 +824,6 @@ checksum = "510c292c8cf384b1a340b816a9a6cf2599eb8f566a44949024af88418000c50b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
  "syn 2.0.101",
 ]
 
@@ -1256,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.39.1"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "auto_impl",
  "ethereum",
@@ -1272,7 +1153,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.39.0"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "primitive-types",
 ]
@@ -1280,10 +1161,10 @@ dependencies = [
 [[package]]
 name = "evm-execution-latest"
 version = "0.1.0"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
- "alloy-primitives 0.7.7",
- "alloy-sol-types 0.7.7",
+ "alloy-primitives",
+ "alloy-sol-types",
  "aurora-engine-modexp",
  "const-decoder",
  "enum_dispatch",
@@ -1316,7 +1197,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.39.0"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "evm-core",
  "evm-runtime",
@@ -1326,7 +1207,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.39.0"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "auto_impl",
  "evm-core",
@@ -1337,9 +1218,9 @@ dependencies = [
 [[package]]
 name = "evm_kernel"
 version = "0.1.0"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
- "alloy-sol-types 0.7.7",
+ "alloy-sol-types",
  "anyhow",
  "bytes",
  "ethbloom",
@@ -1550,12 +1431,6 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "hex-literal"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hmac"
@@ -1920,7 +1795,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "mir"
 version = "0.1.0"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "base58",
  "bitvec",
@@ -2281,30 +2156,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2627,18 +2478,19 @@ dependencies = [
 [[package]]
 name = "revm-etherlink"
 version = "0.1.0"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
- "alloy-primitives 1.2.1",
- "alloy-sol-types 1.2.1",
+ "alloy-sol-types",
  "format_no_std",
  "hex",
+ "nom",
  "num-bigint",
  "primitive-types",
  "revm",
  "rlp",
  "tezos-evm-logging-latest",
  "tezos-evm-runtime-latest",
+ "tezos-indexable-storage-latest",
  "tezos-smart-rollup-encoding",
  "tezos-smart-rollup-host",
  "tezos-smart-rollup-storage",
@@ -2721,7 +2573,7 @@ version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52cdf897b3418f2ee05bcade64985e5faed2dbaa349b2b5f27d3d6bfd10fff2a"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives",
  "num_enum",
 ]
 
@@ -3133,21 +2985,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.7.7"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c837dc8852cb7074e46b444afb81783140dab12c58867b49fb3898fbafedf7ea"
-dependencies = [
- "paste",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "syn-solidity"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ac494e7266fcdd2ad80bf4375d55d27a117ea5c866c26d0e97fe5b3caeeb75"
+checksum = "a7a985ff4ffd7373e10e0fb048110fb11a162e5a4c47f92ddb8787a6f766b769"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -3174,7 +3014,7 @@ dependencies = [
 [[package]]
 name = "tezos-evm-logging-latest"
 version = "0.1.0"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "num-derive",
  "num-traits",
@@ -3184,7 +3024,7 @@ dependencies = [
 [[package]]
 name = "tezos-evm-runtime-latest"
 version = "0.1.0"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "sha3",
  "tezos-evm-logging-latest",
@@ -3198,7 +3038,7 @@ dependencies = [
 [[package]]
 name = "tezos-execution-latest"
 version = "0.1.0"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "anyhow",
  "hex",
@@ -3221,7 +3061,7 @@ dependencies = [
 [[package]]
 name = "tezos-indexable-storage-latest"
 version = "0.1.0"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "rlp",
  "tezos-evm-logging-latest",
@@ -3236,7 +3076,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "hex",
  "serde_json",
@@ -3257,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-build-utils"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3267,12 +3107,12 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-constants"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 
 [[package]]
 name = "tezos-smart-rollup-core"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "tezos-smart-rollup-build-utils",
  "tezos-smart-rollup-constants",
@@ -3281,7 +3121,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-debug"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "tezos-smart-rollup-core",
  "tezos-smart-rollup-host",
@@ -3290,7 +3130,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-encoding"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "hex",
  "nom",
@@ -3309,7 +3149,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-entrypoint"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "cfg-if",
  "dlmalloc",
@@ -3325,7 +3165,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-host"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "tezos-smart-rollup-build-utils",
  "tezos-smart-rollup-core",
@@ -3337,7 +3177,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-installer-config"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "hex",
  "nom",
@@ -3354,7 +3194,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-macros"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "proc-macro-error2",
  "quote",
@@ -3366,7 +3206,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-mock"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "hex",
  "tezos-smart-rollup-core",
@@ -3379,7 +3219,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-panic-hook"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "rustversion",
  "tezos-smart-rollup-build-utils",
@@ -3389,7 +3229,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-storage"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "tezos-smart-rollup-core",
  "tezos-smart-rollup-debug",
@@ -3401,7 +3241,7 @@ dependencies = [
 [[package]]
 name = "tezos-smart-rollup-utils"
 version = "0.2.2"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "clap",
  "hex",
@@ -3418,7 +3258,7 @@ dependencies = [
 [[package]]
 name = "tezos-storage-latest"
 version = "0.1.0"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "anyhow",
  "hex",
@@ -3438,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "tezos_crypto_rs"
 version = "0.6.0"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "anyhow",
  "bs58",
@@ -3463,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "tezos_data_encoding"
 version = "0.6.0"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "bit-vec 0.6.3",
  "bitvec",
@@ -3480,7 +3320,7 @@ dependencies = [
 [[package]]
 name = "tezos_data_encoding_derive"
 version = "0.6.0"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "lazy_static",
  "once_cell",
@@ -3493,7 +3333,7 @@ dependencies = [
 [[package]]
 name = "tezos_ethereum_latest"
 version = "0.1.0"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3502,6 +3342,7 @@ dependencies = [
  "hex",
  "libsecp256k1",
  "primitive-types",
+ "revm",
  "rlp",
  "sha3",
  "tezos-smart-rollup-encoding",
@@ -3512,7 +3353,7 @@ dependencies = [
 [[package]]
 name = "tezos_tezlink_latest"
 version = "0.1.0"
-source = "git+https://gitlab.com/tezos/tezos.git#70187e57c4f994f44f4461f3cb4498d47c426c7d"
+source = "git+https://gitlab.com/tezos/tezos.git#0df690ee24565e0f17dae5759e2c1608bb97f5ec"
 dependencies = [
  "hex",
  "mir",
@@ -3521,6 +3362,7 @@ dependencies = [
  "primitive-types",
  "rlp",
  "tezos-smart-rollup",
+ "tezos-smart-rollup-host",
  "tezos_crypto_rs",
  "tezos_data_encoding",
  "thiserror 1.0.69",
@@ -3635,7 +3477,7 @@ checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow 0.7.10",
+ "winnow",
 ]
 
 [[package]]
@@ -3921,12 +3763,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.6.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
 
 [[package]]
 name = "winnow"

--- a/kernels/etherlink/bench/src/results.rs
+++ b/kernels/etherlink/bench/src/results.rs
@@ -70,24 +70,18 @@ fn extract_transactions_from_log(log: &[LogLine]) -> Result<Vec<Tx>> {
     let mut txs: Vec<Tx> = Vec::new();
     let mut tx_builder: Option<TxBuilder> = None;
     for line in log {
-        if line.message == TX_START_LINE {
+        if line.message.starts_with(TX_OUTCOME_LINE) {
             // If a transaction is already in progress (i.e., this is not
             // the first transaction), build it using the new transaction's
             // start time as its end time.
             if let Some(txb) = tx_builder.take() {
-                txs.push(txb.build(Some(line.elapsed))?);
-            }
-            tx_builder = Some(TxBuilder::new(line.elapsed));
-        }
-
-        if line.message.starts_with(TX_OUTCOME_LINE) {
-            let txb = tx_builder
-                .ok_or("Parsed unexpected transaction outcome: no transaction in progress")?;
+                txs.push(txb.build(Some(line.elapsed))?)
+            };
+            let txb = TxBuilder::new(line.elapsed);
             let tx_outcome = parse_execution_outcome(&line.message)
                 .ok_or("Could not extract transaction execution outcome")?;
             tx_builder = Some(txb.outcome(tx_outcome));
         }
-
         if line.message.starts_with(TX_END_LINE) {
             let txb = tx_builder
                 .ok_or("Parsed unexpected transaction end: no transaction in progress")?;
@@ -421,6 +415,5 @@ fn u64_from_ethereum_u256_bytes(bytes: &[u8]) -> Option<u64> {
     }
 }
 
-const TX_START_LINE: &str = "[Debug] Going to run an Ethereum transaction";
 const TX_OUTCOME_LINE: &str = "[Debug] Transaction executed, outcome:";
 const TX_END_LINE: &str = "[Debug] Applying FeeUpdates";


### PR DESCRIPTION
# What

This MR updates the version of the Etherlink kernel and adjusts the benchmarking tool to work with its log format (transaction start is no longer logged).

# Why

Etherlink has switched to using Revm by default.

# Manually Testing

```
make -C kernels/etherlink test
```


# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
