### PR TITLE
Update Rust toolchain to 1.88.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.88.0"
 components = ["rustfmt", "clippy"]

--- a/src/riscv/lib/Cargo.toml
+++ b/src/riscv/lib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "octez-riscv"
 version = "0.0.0"
 edition = "2024"
-rust-version = "1.86.0"
+rust-version = "1.88.0"
 
 [lints]
 workspace = true

--- a/src/riscv/lib/src/jit.rs
+++ b/src/riscv/lib/src/jit.rs
@@ -68,7 +68,7 @@ pub enum JitError {
     BuilderFailure(#[from] CodegenError),
     /// Unable to register external state access functionality.
     #[error("Unable to register external state access functions: {0}")]
-    JsaRegistration(#[from] ModuleError),
+    JsaRegistration(#[from] Box<ModuleError>),
 }
 
 /// The JIT is responsible for compiling blocks of instructions to machine code,
@@ -181,7 +181,7 @@ impl<MC: MemoryConfig> JIT<MC> {
     }
 
     /// Finalise and cache the function under construction.
-    fn produce_function(&mut self, hash: &Hash) -> cranelift_module::ModuleResult<JitFn<MC>> {
+    fn produce_function(&mut self, hash: &Hash) -> Result<JitFn<MC>, Box<ModuleError>> {
         let name = hex::encode(hash);
 
         let fun = self.finalise(&name)?;
@@ -193,7 +193,7 @@ impl<MC: MemoryConfig> JIT<MC> {
     }
 
     /// Finalise the function currently under construction.
-    fn finalise(&mut self, name: &str) -> cranelift_module::ModuleResult<JitFn<MC>> {
+    fn finalise(&mut self, name: &str) -> Result<JitFn<MC>, Box<ModuleError>> {
         let id = self.module.declare_function(
             name.as_ref(),
             Linkage::Export,

--- a/src/riscv/lib/src/jit.rs
+++ b/src/riscv/lib/src/jit.rs
@@ -3241,7 +3241,7 @@ mod tests {
                     let expected: FValue = (Double::from_u128_r(13872u128, Round::TowardZero))
                         .value
                         .into();
-                    assert_eq!(res, expected, "Expected {:?}, found {:?}", expected, res);
+                    assert_eq!(res, expected, "Expected {expected:?}, found {res:?}");
                 }))
                 .build(),
             ScenarioBuilder::default()
@@ -3261,7 +3261,7 @@ mod tests {
                         (Double::from_u128_r(13872u128, Round::NearestTiesToEven))
                             .value
                             .into();
-                    assert_eq!(res, expected, "Expected {:?}, found {:?}", expected, res);
+                    assert_eq!(res, expected, "Expected {expected:?}, found {res:?}");
                 }))
                 .build(),
         ];

--- a/src/riscv/lib/src/parser.rs
+++ b/src/riscv/lib/src/parser.rs
@@ -1200,7 +1200,7 @@ impl Display for XRegisterParsed {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             XRegisterParsed::X0 => write!(f, "zero"),
-            XRegisterParsed::NonZero(r) => write!(f, "{}", r),
+            XRegisterParsed::NonZero(r) => write!(f, "{r}"),
         }
     }
 }

--- a/src/riscv/lib/src/parser/instruction.rs
+++ b/src/riscv/lib/src/parser/instruction.rs
@@ -1281,7 +1281,7 @@ impl fmt::Display for FenceSet {
         if out.is_empty() {
             write!(f, "unknown")
         } else {
-            write!(f, "{}", out)
+            write!(f, "{out}")
         }
     }
 }
@@ -1532,11 +1532,11 @@ impl fmt::Display for InstrCacheable {
             CFsd(args) => write!(f, "c.fsd {},{}({})", args.rs2, args.imm, args.rs1),
             CFsdsp(args) => cs_instr_sp!(f, "c.fsdsp", args),
 
-            Unknown { instr } => write!(f, "unknown {:x}", instr),
-            UnknownCompressed { instr } => write!(f, "unknown.c {:x}", instr),
+            Unknown { instr } => write!(f, "unknown {instr:x}"),
+            UnknownCompressed { instr } => write!(f, "unknown.c {instr:x}"),
 
-            Hint { instr } => write!(f, "hint {:x}", instr),
-            HintCompressed { instr } => write!(f, "hint.c {:x}", instr),
+            Hint { instr } => write!(f, "hint {instr:x}"),
+            HintCompressed { instr } => write!(f, "hint.c {instr:x}"),
             // Interrupt-management
             Wfi => write!(f, "wfi"),
 

--- a/src/riscv/lib/src/stepper/pvm.rs
+++ b/src/riscv/lib/src/stepper/pvm.rs
@@ -150,7 +150,7 @@ impl<H: PvmHooks, MC: MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: M
                 return StepperStatus::Exited {
                     steps: 0,
                     success: exit_code == 0,
-                    status: format!("Exited with code {}", exit_code),
+                    status: format!("Exited with code {exit_code}"),
                 };
             }
         }

--- a/src/riscv/lib/src/stepper/test/interpreter.rs
+++ b/src/riscv/lib/src/stepper/test/interpreter.rs
@@ -73,11 +73,10 @@ fn run_test_with_check<B: Block<M1M, Owned>>(
             message,
             steps,
         } => match message {
-            Some(message) => panic!(
-                "Unexpected exception after {steps} steps: {message} (caused by {:?})",
-                cause
-            ),
-            None => panic!("Unexpected exception after {steps} steps: {:?}", cause),
+            Some(message) => {
+                panic!("Unexpected exception after {steps} steps: {message} (caused by {cause:?})")
+            }
+            None => panic!("Unexpected exception after {steps} steps: {cause:?}"),
         },
     };
 

--- a/src/riscv/lib/tests/test_determinism.rs
+++ b/src/riscv/lib/tests/test_determinism.rs
@@ -72,7 +72,7 @@ fn run_steps_ladder<MC, BCC, F>(
 
     let mut steps_done = 0;
     for &steps in ladder {
-        eprintln!("> Running {} steps ...", steps);
+        eprintln!("> Running {steps} steps ...");
         let result_lhs = stepper_lhs.step_max(Bound::Included(steps));
         let result_rhs = stepper_rhs.step_max(Bound::Included(steps));
         steps_done += steps;
@@ -92,8 +92,7 @@ fn run_steps_ladder<MC, BCC, F>(
         );
         assert!(
             stepper_lhs.struct_ref() == stepper_rhs.struct_ref(),
-            "Stepper states have diverged after running {} steps",
-            steps
+            "Stepper states have diverged after running {steps} steps"
         );
 
         let block_builder = InterpretedBlockBuilder;

--- a/src/riscv/lib/tests/test_proofs.rs
+++ b/src/riscv/lib/tests/test_proofs.rs
@@ -115,7 +115,7 @@ fn run_steps_ladder<MC, BCC, F>(
     for &steps in ladder {
         // Run one step short of `steps`, then produce a proof of the following step.
         let steps = steps.checked_sub(1).expect("minimum step size is 1");
-        eprintln!("> Running {} steps ...", steps);
+        eprintln!("> Running {steps} steps ...");
         let result = stepper.step_max(Bound::Included(steps));
         steps_done += steps;
 

--- a/src/riscv/lib/tests/test_suite_parser.rs
+++ b/src/riscv/lib/tests/test_suite_parser.rs
@@ -29,23 +29,23 @@ fn transform_objdump_instr<'a>(address: &'a str, instr: &'a str, args: &'a str) 
             let rs2 = args.next().unwrap();
             let branch_address = args.next().unwrap();
             let offset = compute_offset(address, branch_address);
-            format!("{} {},{},{}", op, rs1, rs2, offset)
+            format!("{op} {rs1},{rs2},{offset}")
         }
         "jal" => {
             let mut args = args.split(',');
             let rd = args.next().unwrap();
             let branch_address = args.next().unwrap();
             let offset = compute_offset(address, branch_address);
-            format!("{} {},{}", op, rd, offset)
+            format!("{op} {rd},{offset}")
         }
         "lr.w" | "lr.w.aq" | "lr.w.rl" | "lr.w.aqrl" | "lr.d" | "lr.d.aq" | "lr.d.rl"
         | "lr.d.aqrl" => {
             let args = args.replace(",(", ",zero,(");
-            format!("{} {}", op, args)
+            format!("{op} {args}")
         }
         "c.j" => {
             let offset = compute_offset(address, args);
-            format!("{} {}", op, offset)
+            format!("{op} {offset}")
         }
         "c.addi" => {
             let mut args = args.split(',');
@@ -55,7 +55,7 @@ fn transform_objdump_instr<'a>(address: &'a str, instr: &'a str, args: &'a str) 
                 // objdump seems to treat `c.nop` as a pseudoinstruction, but,
                 // unlike `nop`, the spec defines it as an instruction
                 ("zero", "0") => "c.nop".to_string(),
-                _ => format!("{} {},{}", op, rd_rs1, imm),
+                _ => format!("{op} {rd_rs1},{imm}"),
             }
         }
         "c.beqz" | "c.bnez" => {
@@ -63,13 +63,13 @@ fn transform_objdump_instr<'a>(address: &'a str, instr: &'a str, args: &'a str) 
             let rs1 = args.next().unwrap();
             let branch_address = args.next().unwrap();
             let offset = compute_offset(address, branch_address);
-            format!("{} {},{}", op, rs1, offset)
+            format!("{op} {rs1},{offset}")
         }
         _ => {
             if args.is_empty() {
                 op.to_string()
             } else {
-                format!("{} {}", op, args)
+                format!("{op} {args}")
             }
         }
     }
@@ -134,8 +134,7 @@ fn objdump(file_path: &str, disassembled: bool) -> Vec<(String, Instr, String)> 
     }
     assert!(
         !instructions.is_empty(),
-        "Could not extract any instructions from {}",
-        file_path
+        "Could not extract any instructions from {file_path}"
     );
     instructions
 }
@@ -180,11 +179,7 @@ fn check_instructions(fname: &str, instructions: Vec<(String, Instr, String)>) {
         {
             continue;
         }
-        assert_eq!(
-            printed_instr, objdump_instr,
-            "{} at address {}",
-            fname, address
-        );
+        assert_eq!(printed_instr, objdump_instr, "{fname} at address {address}");
     }
 }
 

--- a/src/riscv/sandbox/src/cli.rs
+++ b/src/riscv/sandbox/src/cli.rs
@@ -198,8 +198,7 @@ impl BenchCompareOptions {
                 if let Some(p) = p.to_str() {
                     Ok(p.to_string())
                 } else {
-                    Err(Box::new(std::io::Error::new(
-                        std::io::ErrorKind::Other,
+                    Err(Box::new(std::io::Error::other(
                         "Invalid path to benchmark file",
                     )))
                 }

--- a/src/riscv/sandbox/src/commands/bench/commands/run.rs
+++ b/src/riscv/sandbox/src/commands/bench/commands/run.rs
@@ -213,9 +213,9 @@ fn run_binary(path: &Path, opts: &BenchRunOptions) -> Result<BenchStats, Box<dyn
         }
     };
     if !warnings.is_empty() {
-        eprintln!("Warning: Binary {:?} exited with:", path);
+        eprintln!("Warning: Binary {path:?} exited with:");
         for w in warnings {
-            eprintln!(" - {}", w);
+            eprintln!(" - {w}");
         }
     }
     Ok(stats)

--- a/src/riscv/sandbox/src/commands/bench/data.rs
+++ b/src/riscv/sandbox/src/commands/bench/data.rs
@@ -62,7 +62,7 @@ impl Display for SimpleBenchData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let f_duration = format!("Bench Duration: {:?}", self.duration);
         let f_steps = format!("Steps:          {}", self.steps);
-        write!(f, "Simple bench data:\n {}\n {}", f_duration, f_steps)
+        write!(f, "Simple bench data:\n {f_duration}\n {f_steps}")
     }
 }
 

--- a/src/riscv/sandbox/src/commands/bench/stats.rs
+++ b/src/riscv/sandbox/src/commands/bench/stats.rs
@@ -205,7 +205,7 @@ impl fmt::Display for BenchStats {
 
         writeln!(f, "Outcome:        {}", self.run_result)?;
         writeln!(f, "Total steps:    {}", self.total_steps)?;
-        writeln!(f, "Speed:          {} instr / s", instr_speed)?;
+        writeln!(f, "Speed:          {instr_speed} instr / s")?;
         writeln!(f)?;
         writeln!(f, " Bench stats:\n{}", self.bench_duration_stats)?;
 
@@ -230,6 +230,6 @@ impl fmt::Display for BenchStats {
                 format!("{summary}\n{instr_data}")
             }
         };
-        write!(f, " Instruction statistics:\n{}", stats)
+        write!(f, " Instruction statistics:\n{stats}")
     }
 }

--- a/src/riscv/sandbox/src/commands/gdb.rs
+++ b/src/riscv/sandbox/src/commands/gdb.rs
@@ -93,19 +93,19 @@ pub fn gdb_server(opts: GdbServerOptions) -> Result<(), Box<dyn Error>> {
 
     let disconnect = debugger.run_blocking::<RiscvEventLoop<_>>(&mut target)?;
 
-    eprintln!("{:?}", disconnect);
+    eprintln!("{disconnect:?}");
     Ok(())
 }
 
 /// Blocks until a GDB client connects via TCP.
 /// i.e: Running `target remote localhost:<port>` from the GDB prompt.
 fn wait_for_gdb_connection(port: u16) -> io::Result<TcpStream> {
-    let sockaddr = format!("localhost:{}", port);
-    eprintln!("Waiting for a GDB connection on {:?}...", sockaddr);
+    let sockaddr = format!("localhost:{port}");
+    eprintln!("Waiting for a GDB connection on {sockaddr:?}...");
     let sock = TcpListener::bind(sockaddr)?;
     let (stream, addr) = sock.accept()?;
 
-    eprintln!("Debugger connected from {}", addr);
+    eprintln!("Debugger connected from {addr}");
     Ok(stream)
 }
 

--- a/src/riscv/sandbox/src/main.rs
+++ b/src/riscv/sandbox/src/main.rs
@@ -24,7 +24,7 @@ fn format_status(result: &StepperStatus) -> String {
             status,
             ..
         } => format!("Ok (status = {status})"),
-        Exited { status, .. } => format!("Exit with exit code = {}", status),
+        Exited { status, .. } => format!("Exit with exit code = {status}"),
         Running { .. } => "Timeout".to_string(),
         Errored { cause, message, .. } => format!("{message}\nCaused by: {cause}"),
     }

--- a/src/riscv/tools/analyse-jit-functions/src/main.rs
+++ b/src/riscv/tools/analyse-jit-functions/src/main.rs
@@ -146,7 +146,7 @@ fn create_type_file(content: &str, func_name: &str, func_addr: u64, type_dir: &P
     let named_base = format!("{func_name}.txt");
     let named_path = by_name_dir.join(&named_base);
     let mut file = File::create(&named_path)?;
-    writeln!(file, "{}", content)?;
+    writeln!(file, "{content}")?;
 
     // Create symlink in by-address directory with hex address
     let addr_base = format!("{func_addr:#x}.txt");
@@ -223,7 +223,7 @@ fn create_function_files(
     let disassembly =
         match disassemble_machine_code(capstone, &func_data.machine_code, func_data.func_addr) {
             Ok(disassembly) => disassembly,
-            Err(e) => format!("Error disassembling: {}", e),
+            Err(e) => format!("Error disassembling: {e}"),
         };
     create_type_file(
         &disassembly,


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

# What

Upgrades the Rust version for our main crate to `1.88.0`.

This includes fixes for new lints which now appear.

# Why

[!18941](https://gitlab.com/tezos/tezos/-/merge_requests/18941) has merged, which upgrades the Rust version used to compile our library to `1.88.0` in the Octez repository. We want to stay aligned with this version.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
