### PR TITLE
Make errors raised by hash functions stricter

### DIFF
--- a/src/riscv/lib/src/state_backend/commitment_layout.rs
+++ b/src/riscv/lib/src/state_backend/commitment_layout.rs
@@ -39,7 +39,7 @@ where
     T: Encode + 'static,
 {
     fn state_hash<M: ManagerSerialise>(state: AllocatedOf<Self, M>) -> Result<Hash, HashError> {
-        Hash::blake3_hash(state)
+        Ok(Hash::blake3_hash(state)?)
     }
 }
 
@@ -48,7 +48,7 @@ where
     T: Encode + 'static,
 {
     fn state_hash<M: ManagerSerialise>(state: AllocatedOf<Self, M>) -> Result<Hash, HashError> {
-        Hash::blake3_hash(state)
+        Ok(Hash::blake3_hash(state)?)
     }
 }
 
@@ -58,7 +58,7 @@ impl<const LEN: usize> CommitmentLayout for DynArray<LEN> {
         chunks_to_writer::<LEN, _, _>(&mut writer, |address| {
             state.read::<[u8; MERKLE_LEAF_SIZE.get()]>(address)
         })?;
-        let hashes = writer.finalise()?;
+        let hashes = writer.finalise();
         hash::build_custom_merkle_hash(MERKLE_ARITY, hashes)
     }
 }

--- a/src/riscv/lib/src/state_backend/hash.rs
+++ b/src/riscv/lib/src/state_backend/hash.rs
@@ -17,14 +17,11 @@ use crate::storage::binary;
 
 #[derive(Error, Debug)]
 pub enum HashError {
-    #[error("Invalid digest size")]
-    InvalidDigestSize,
-
-    #[error("Serialization error: {0}")]
-    SerializationError(#[from] EncodeError),
+    #[error("Encoding error: {0}")]
+    Encode(#[from] EncodeError),
 
     #[error("IO error: {0}")]
-    IoError(#[from] std::io::Error),
+    IO(#[from] std::io::Error),
 
     #[error("The input buffer was expected to be non-empty")]
     NonEmptyBufferExpected,
@@ -44,13 +41,13 @@ pub struct Hash {
 
 impl Hash {
     /// Hash a slice of bytes
-    pub fn blake3_hash_bytes(bytes: &[u8]) -> Result<Self, HashError> {
+    pub fn blake3_hash_bytes(bytes: &[u8]) -> Self {
         let digest = blake3::hash(bytes).into();
-        Ok(Hash { digest })
+        Hash { digest }
     }
 
     /// Get the hash of a value that can be serialised by hashing its serialisation
-    pub fn blake3_hash<T: Encode>(data: T) -> Result<Self, HashError> {
+    pub fn blake3_hash<T: Encode>(data: T) -> Result<Self, EncodeError> {
         let mut hasher = blake3::Hasher::new();
         binary::serialise_into(&data, &mut hasher)?;
 
@@ -85,24 +82,6 @@ impl std::fmt::Display for Hash {
 impl std::fmt::Debug for Hash {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self, f)
-    }
-}
-
-impl TryFrom<&[u8]> for Hash {
-    type Error = HashError;
-
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        let digest: [u8; DIGEST_SIZE] =
-            value.try_into().map_err(|_| HashError::InvalidDigestSize)?;
-        Ok(Hash { digest })
-    }
-}
-
-impl TryFrom<Vec<u8>> for Hash {
-    type Error = HashError;
-
-    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
-        Hash::try_from(value.as_ref())
     }
 }
 
@@ -144,19 +123,19 @@ impl HashWriter {
 
     /// Finalise the writer by hashing any remaining data and returning the vector
     /// of hashes.
-    pub fn finalise(mut self) -> Result<Vec<Hash>, HashError> {
+    pub fn finalise(mut self) -> Vec<Hash> {
         if !self.buffer.is_empty() {
-            self.flush_buffer()?;
+            self.flush_buffer();
         }
-        Ok(self.hashes)
+
+        self.hashes
     }
 
     /// Hash the contents of the buffer.
-    fn flush_buffer(&mut self) -> Result<(), HashError> {
-        let hash = Hash::blake3_hash_bytes(&self.buffer)?;
+    fn flush_buffer(&mut self) {
+        let hash = Hash::blake3_hash_bytes(&self.buffer);
         self.hashes.push(hash);
         self.buffer.clear();
-        Ok(())
     }
 }
 
@@ -174,9 +153,10 @@ impl std::io::Write for HashWriter {
 
             // If the buffer has been completely filled, flush it.
             if rem_buffer_len == new_buf_len {
-                self.flush_buffer().map_err(std::io::Error::other)?;
+                self.flush_buffer();
             }
         }
+
         Ok(consumed)
     }
 

--- a/src/riscv/lib/src/state_backend/proof_backend/merkle.rs
+++ b/src/riscv/lib/src/state_backend/proof_backend/merkle.rs
@@ -49,9 +49,9 @@ impl MerkleTree {
 
     /// Make a Merkle tree consisting of a single leaf; representing
     /// the given data and its access pattern.
-    pub fn make_merkle_leaf(data: Vec<u8>, access_info: bool) -> Result<Self, HashError> {
-        let hash = Hash::blake3_hash_bytes(&data)?;
-        Ok(MerkleTree::Leaf(hash, access_info, data))
+    pub fn make_merkle_leaf(data: Vec<u8>, access_info: bool) -> Self {
+        let hash = Hash::blake3_hash_bytes(&data);
+        MerkleTree::Leaf(hash, access_info, data)
     }
 
     /// Make a Merkle tree consisting of a node which combines the given
@@ -277,7 +277,7 @@ impl MerkleWriter {
 
     /// Commit the leaf corresponding to the contents of the buffer before
     /// clearing it.
-    fn flush_buffer(&mut self) -> Result<(), HashError> {
+    fn flush_buffer(&mut self) {
         let pos = self.leaves.len() * self.leaf_size;
         let range = pos..pos + self.leaf_size;
 
@@ -290,10 +290,8 @@ impl MerkleWriter {
         self.leaves.push(MerkleTree::make_merkle_leaf(
             self.buffer.clone(),
             access_info,
-        )?);
+        ));
         self.buffer.clear();
-
-        Ok(())
     }
 
     /// Finalise the writer by generating the Merkle tree with the configured
@@ -301,7 +299,7 @@ impl MerkleWriter {
     /// a smaller arity.
     pub fn finalise(mut self) -> Result<MerkleTree, HashError> {
         if !self.buffer.is_empty() {
-            self.flush_buffer()?;
+            self.flush_buffer();
         }
 
         build_custom_merkle_tree(self.arity, self.leaves)
@@ -322,7 +320,7 @@ impl std::io::Write for MerkleWriter {
 
             // If the buffer has been completely filled, flush it.
             if rem_buffer_len == new_buf_len {
-                self.flush_buffer().map_err(std::io::Error::other)?;
+                self.flush_buffer();
             }
         }
         Ok(consumed)
@@ -342,9 +340,7 @@ impl MerkleTree {
 
         while let Some(node) = deque.pop_front() {
             let is_valid_hash = match node {
-                Self::Leaf(hash, _, data) => {
-                    Hash::blake3_hash_bytes(data).is_ok_and(|h| h == *hash)
-                }
+                Self::Leaf(hash, _, data) => &Hash::blake3_hash_bytes(data) == hash,
                 Self::Node(hash, children) => {
                     let children_hashes: Vec<Hash> = children
                         .iter()
@@ -431,7 +427,7 @@ mod tests {
                     Self::Leaf(hash, access_info) => match access_info {
                         CompressedAccessInfo::NoAccess => true,
                         CompressedAccessInfo::ReadWrite(data) => {
-                            Hash::blake3_hash_bytes(data).is_ok_and(|h| h == *hash)
+                            &Hash::blake3_hash_bytes(data) == hash
                         }
                     },
                     Self::Node(hash, children) => {
@@ -451,7 +447,7 @@ mod tests {
     }
 
     fn m_l(data: &[u8], access: bool) -> Result<MerkleTree, HashError> {
-        let hash = Hash::blake3_hash_bytes(data)?;
+        let hash = Hash::blake3_hash_bytes(data);
         Ok(MerkleTree::Leaf(hash, access, data.to_vec()))
     }
 
@@ -505,7 +501,7 @@ mod tests {
 
             let merkle_proof_leaf =
                 |data: &Vec<u8>, access: bool| -> Result<MerkleProof, HashError> {
-                    let hash = Hash::blake3_hash_bytes(data)?;
+                    let hash = Hash::blake3_hash_bytes(data);
                     Ok(MerkleProof::Leaf(if access {
                         MerkleProofLeaf::Read(data.clone())
                     } else {
@@ -520,10 +516,10 @@ mod tests {
 
             // The structure of the original subtree is compressed into a single leaf.
             let proof_no_access = MerkleProof::Leaf(MerkleProofLeaf::Blind(Hash::combine([
-                Hash::blake3_hash_bytes(&l[2])?,
+                Hash::blake3_hash_bytes(&l[2]),
                 Hash::combine([
-                    Hash::blake3_hash_bytes(&l[3])?,
-                    Hash::blake3_hash_bytes(&l[4])?,
+                    Hash::blake3_hash_bytes(&l[3]),
+                    Hash::blake3_hash_bytes(&l[4]),
                 ]),
             ])));
 
@@ -554,12 +550,12 @@ mod tests {
             let proof_mix = MerkleProof::Node(vec![
                 // The structure of the original subtree is compressed into a single leaf.
                 MerkleProof::Leaf(MerkleProofLeaf::Blind(Hash::combine([
-                    Hash::blake3_hash_bytes(&l[12])?,
+                    Hash::blake3_hash_bytes(&l[12]),
                     Hash::combine([
-                        Hash::blake3_hash_bytes(&l[13])?,
+                        Hash::blake3_hash_bytes(&l[13]),
                         Hash::combine([
-                            Hash::blake3_hash_bytes(&l[14])?,
-                            Hash::blake3_hash_bytes(&l[15])?,
+                            Hash::blake3_hash_bytes(&l[14]),
+                            Hash::blake3_hash_bytes(&l[15]),
                         ]),
                     ]),
                 ]))),
@@ -567,8 +563,8 @@ mod tests {
                     MerkleProof::Node(vec![
                         merkle_proof_leaf(&l[16], true)?,
                         MerkleProof::Leaf(MerkleProofLeaf::Blind(Hash::combine([
-                            Hash::blake3_hash_bytes(&l[17])?,
-                            Hash::blake3_hash_bytes(&l[18])?,
+                            Hash::blake3_hash_bytes(&l[17]),
+                            Hash::blake3_hash_bytes(&l[18]),
                         ]))),
                     ]),
                     merkle_proof_leaf(&l[19], true)?,
@@ -618,7 +614,7 @@ mod tests {
 
         let gen_hash_data = || {
             let data = rand::random::<[u8; 12]>().to_vec();
-            let hash = Hash::blake3_hash_bytes(&data).unwrap();
+            let hash = Hash::blake3_hash_bytes(&data);
             (data, hash)
         };
 

--- a/src/riscv/lib/src/state_backend/proof_backend/proof.rs
+++ b/src/riscv/lib/src/state_backend/proof_backend/proof.rs
@@ -140,9 +140,11 @@ impl MerkleProof {
                     Tree::Leaf(data) => ModifyResult::LeafStop(data),
                 })
             },
-            |leaf| match leaf {
-                MerkleProofLeaf::Blind(hash) => Ok(*hash),
-                MerkleProofLeaf::Read(data) => Hash::blake3_hash_bytes(data.as_slice()),
+            |leaf| {
+                Ok(match leaf {
+                    MerkleProofLeaf::Blind(hash) => *hash,
+                    MerkleProofLeaf::Read(data) => Hash::blake3_hash_bytes(data.as_slice()),
+                })
             },
             |(), leaves| Ok(Hash::combine(leaves)),
         )
@@ -397,7 +399,7 @@ mod tests {
 
         let mut raw_array = vec![0; length];
         Fill::fill(raw_array.as_mut_slice(), &mut rand::rng());
-        let blind_hash: Hash = Hash::blake3_hash_bytes(&raw_array).unwrap();
+        let blind_hash: Hash = Hash::blake3_hash_bytes(&raw_array);
 
         match is_leaf_read {
             true => MerkleProof::Leaf(MerkleProofLeaf::Read(raw_array)),
@@ -406,7 +408,7 @@ mod tests {
     }
 
     fn check_serialisation(tree: MerkleProof, tree_correct_bytes: &[u8]) {
-        let final_state_hash = Hash::blake3_hash_bytes(&rand::random::<[u8; 10]>()).unwrap();
+        let final_state_hash = Hash::blake3_hash_bytes(&rand::random::<[u8; 10]>());
         let proof = Proof::new(tree, final_state_hash);
 
         let ser_bytes: Vec<u8> = serialise_proof(&proof).collect();
@@ -425,7 +427,7 @@ mod tests {
         let rleaf = MerkleProof::Leaf(MerkleProofLeaf::Read(raw_array.to_vec()));
         check_serialisation(rleaf, &[&[TAG_READ << 6], raw_array.as_slice()].concat());
 
-        let hash = Hash::blake3_hash_bytes(&raw_array).unwrap();
+        let hash = Hash::blake3_hash_bytes(&raw_array);
         check_serialisation(
             MerkleProof::Leaf(MerkleProofLeaf::Blind(hash)),
             &[&[TAG_BLIND << 6], hash.as_ref()].concat(),
@@ -436,8 +438,8 @@ mod tests {
     fn serialise_1_level() {
         // Check serialisation of a node containing some leaves.
 
-        let h1 = Hash::blake3_hash_bytes(&[1, 2, 3]).unwrap();
-        let h2 = Hash::blake3_hash_bytes(&[20, 30, 1, 5, 6]).unwrap();
+        let h1 = Hash::blake3_hash_bytes(&[1, 2, 3]);
+        let h2 = Hash::blake3_hash_bytes(&[20, 30, 1, 5, 6]);
 
         let n1 = MerkleProof::Leaf(MerkleProofLeaf::Read(vec![12, 15, 30, 40]));
         let n2 = MerkleProof::Leaf(MerkleProofLeaf::Blind(h1));
@@ -489,7 +491,7 @@ mod tests {
     }
 
     fn check_bounds(tree: MerkleProof, bound: &SerialisationBound) {
-        let final_state_hash = Hash::blake3_hash_bytes(&rand::random::<[u8; 10]>()).unwrap();
+        let final_state_hash = Hash::blake3_hash_bytes(&rand::random::<[u8; 10]>());
         let proof = Proof::new(tree, final_state_hash);
 
         let serialisation: Vec<_> = super::serialise_proof(&proof).collect();

--- a/src/riscv/lib/src/state_backend/proof_backend/proof/deserialiser.rs
+++ b/src/riscv/lib/src/state_backend/proof_backend/proof/deserialiser.rs
@@ -274,13 +274,8 @@ mod tests {
 
         // We expect to get the Absent case since the father of the nested node is blinded
         let merkle_proof = MerkleProof::Node(vec![
-            MerkleProof::leaf_read(
-                Hash::blake3_hash_bytes(&[0, 1, 2])
-                    .unwrap()
-                    .as_ref()
-                    .to_vec(),
-            ),
-            MerkleProof::leaf_blind(Hash::blake3_hash_bytes(&[3, 4, 5]).unwrap()),
+            MerkleProof::leaf_read(Hash::blake3_hash_bytes(&[0, 1, 2]).as_ref().to_vec()),
+            MerkleProof::leaf_blind(Hash::blake3_hash_bytes(&[3, 4, 5])),
         ]);
         let proof: ProofTreeDeserialiser = ProofTree::Present(&merkle_proof).into();
         let comp_fn = computation(proof).unwrap();
@@ -302,7 +297,7 @@ mod tests {
         // Expect absent case in the computed result
         let tag_bytes = [TAG_NODE << 6 | TAG_READ << 4 | TAG_BLIND << 2];
         let leaf_read: [u8; DIGEST_SIZE] = [12; 32];
-        let leaf_blind: [u8; DIGEST_SIZE] = Hash::blake3_hash_bytes(&[3, 4, 5]).unwrap().into();
+        let leaf_blind: [u8; DIGEST_SIZE] = Hash::blake3_hash_bytes(&[3, 4, 5]).into();
         let proof_bytes = [tag_bytes.as_ref(), leaf_read.as_ref(), leaf_blind.as_ref()].concat();
         let res = run_stream_deserialiser(computation, &proof_bytes);
         assert_eq!(res.unwrap().unwrap(), 0);
@@ -312,10 +307,10 @@ mod tests {
     fn test_blind_computation() {
         // The nested leaf is blinded
         let absent_shape = MerkleProof::Node(vec![
-            MerkleProof::leaf_blind(Hash::blake3_hash_bytes(&[0, 1, 2]).unwrap()),
-            MerkleProof::Node(vec![MerkleProof::leaf_blind(
-                Hash::blake3_hash_bytes(&[0, 1, 2]).unwrap(),
-            )]),
+            MerkleProof::leaf_blind(Hash::blake3_hash_bytes(&[0, 1, 2])),
+            MerkleProof::Node(vec![MerkleProof::leaf_blind(Hash::blake3_hash_bytes(&[
+                0, 1, 2,
+            ]))]),
         ]);
         let comp_fn =
             computation::<ProofTreeDeserialiser>(ProofTree::Present(&absent_shape).into());
@@ -326,7 +321,7 @@ mod tests {
 
         // For computation_2, the provided merkle proof will resolve as blinded
         // since root is blinded
-        let merkle_proof = MerkleProof::leaf_blind(Hash::blake3_hash_bytes(&[6, 7, 8]).unwrap());
+        let merkle_proof = MerkleProof::leaf_blind(Hash::blake3_hash_bytes(&[6, 7, 8]));
         let proof: ProofTreeDeserialiser = ProofTree::Present(&merkle_proof).into();
         let comp_fn = computation_2(proof).unwrap();
         assert_eq!(comp_fn.into_result(), -1);
@@ -340,8 +335,8 @@ mod tests {
     fn test_blind_computation_stream() {
         // The nested leaf is blinded
         let raw_bytes_tags = raw_tags_to_bytes([TAG_NODE, TAG_BLIND, TAG_NODE, TAG_BLIND]);
-        let b1: [u8; DIGEST_SIZE] = Hash::blake3_hash_bytes(&[0, 1, 2]).unwrap().into();
-        let b2: [u8; DIGEST_SIZE] = Hash::blake3_hash_bytes(&[0, 1, 2]).unwrap().into();
+        let b1: [u8; DIGEST_SIZE] = Hash::blake3_hash_bytes(&[0, 1, 2]).into();
+        let b2: [u8; DIGEST_SIZE] = Hash::blake3_hash_bytes(&[0, 1, 2]).into();
         let raw_bytes_content = [raw_bytes_tags.as_ref(), b1.as_ref(), b2.as_ref()].concat();
 
         let rc = Rc::new(RefCell::new(TagIter::new(&raw_bytes_content)));
@@ -358,7 +353,7 @@ mod tests {
 
         // For computation_2, the provided merkle proof will resolve as blinded
         // since root is blinded
-        let merkle_proof = MerkleProof::leaf_blind(Hash::blake3_hash_bytes(&[6, 7, 8]).unwrap());
+        let merkle_proof = MerkleProof::leaf_blind(Hash::blake3_hash_bytes(&[6, 7, 8]));
         let proof: ProofTreeDeserialiser = ProofTree::Present(&merkle_proof).into();
         let comp_fn = computation_2(proof).unwrap();
         assert_eq!(comp_fn.into_result(), -1);
@@ -368,15 +363,15 @@ mod tests {
     fn test_bad_structure() {
         let bad_shape_1 = MerkleProof::Node(vec![]);
         let bad_shape_2 = MerkleProof::Node(vec![
-            MerkleProof::leaf_blind(Hash::blake3_hash_bytes(&[0, 1, 2]).unwrap()),
-            MerkleProof::leaf_blind(Hash::blake3_hash_bytes(&[0, 1, 2]).unwrap()),
+            MerkleProof::leaf_blind(Hash::blake3_hash_bytes(&[0, 1, 2])),
+            MerkleProof::leaf_blind(Hash::blake3_hash_bytes(&[0, 1, 2])),
             MerkleProof::Node(vec![]),
             MerkleProof::Node(vec![]),
             MerkleProof::Node(vec![]),
         ]);
         let bad_shape_3 = MerkleProof::Node(vec![
             MerkleProof::Node(vec![]),
-            MerkleProof::leaf_blind(Hash::blake3_hash_bytes(&[0, 1, 2]).unwrap()),
+            MerkleProof::leaf_blind(Hash::blake3_hash_bytes(&[0, 1, 2])),
         ]);
         let bad_shape_4 = MerkleProof::Node(vec![
             MerkleProof::leaf_read([42_u8; 32].to_vec()),
@@ -410,7 +405,7 @@ mod tests {
 
     #[test]
     fn test_bad_structure_stream() {
-        let hash: [u8; DIGEST_SIZE] = Hash::blake3_hash_bytes(&[0, 1, 2]).unwrap().into();
+        let hash: [u8; DIGEST_SIZE] = Hash::blake3_hash_bytes(&[0, 1, 2]).into();
         // Place an invalid second tag
         let tag_shape_1 = [TAG_NODE << tag_offset(0) | 0b01 << tag_offset(1)];
         let tag_shape_2 =
@@ -457,9 +452,9 @@ mod tests {
     fn test_valid_computation() {
         let merkleproof = MerkleProof::Node(vec![
             MerkleProof::leaf_read(0x140A_0000_i32.to_le_bytes().to_vec()),
-            MerkleProof::leaf_blind(Hash::blake3_hash_bytes(&[3, 4, 5]).unwrap()),
+            MerkleProof::leaf_blind(Hash::blake3_hash_bytes(&[3, 4, 5])),
             MerkleProof::leaf_read(0xC0005_i32.to_le_bytes().to_vec()),
-            MerkleProof::leaf_blind(Hash::blake3_hash_bytes(&[9, 10, 11]).unwrap()),
+            MerkleProof::leaf_blind(Hash::blake3_hash_bytes(&[9, 10, 11])),
         ]);
 
         let proof: ProofTreeDeserialiser = ProofTree::Present(&merkleproof).into();
@@ -470,9 +465,9 @@ mod tests {
     #[test]
     fn test_valid_computation_stream() {
         let h1 = 0x140A_0000_i32.to_le_bytes();
-        let h2: [u8; DIGEST_SIZE] = Hash::blake3_hash_bytes(&[3, 4, 5]).unwrap().into();
+        let h2: [u8; DIGEST_SIZE] = Hash::blake3_hash_bytes(&[3, 4, 5]).into();
         let h3 = 0xC0005_i32.to_le_bytes();
-        let h4: [u8; DIGEST_SIZE] = Hash::blake3_hash_bytes(&[9, 10, 11]).unwrap().into();
+        let h4: [u8; DIGEST_SIZE] = Hash::blake3_hash_bytes(&[9, 10, 11]).into();
 
         let tags = raw_tags_to_bytes([TAG_NODE, TAG_READ, TAG_BLIND, TAG_READ, TAG_BLIND]);
 

--- a/src/riscv/lib/src/state_backend/proof_layout.rs
+++ b/src/riscv/lib/src/state_backend/proof_layout.rs
@@ -8,6 +8,7 @@ use std::collections::VecDeque;
 use bincode::Decode;
 use bincode::Encode;
 use bincode::error::DecodeError;
+use bincode::error::EncodeError;
 use perfect_derive::perfect_derive;
 
 use super::AllocatedOf;
@@ -89,8 +90,10 @@ pub type VerifierAlloc<L> = <L as Layout>::Allocated<verify_backend::Verifier>;
 /// Errors that may occur when hashing a [`verify_backend::Verifier`] state
 #[derive(Debug, thiserror::Error)]
 pub enum PartialHashError {
-    #[error("Error during hashing: {0}")]
-    Hash(#[from] HashError),
+    /// The hash could not be computed because encoding a value to bytes failed. The byte
+    /// representation is used as input to the hash function.
+    #[error("Error while encoding a to-be-hashed value: {0}")]
+    Encode(#[from] EncodeError),
 
     #[error("Error from proof: {0}")]
     FromProof(#[from] FromProofError),
@@ -189,7 +192,7 @@ impl<'a> ProofTree<'a> {
 
         let hash = match leaf {
             MerkleProofLeaf::Blind(hash) => *hash,
-            MerkleProofLeaf::Read(data) => Hash::blake3_hash_bytes(data)?,
+            MerkleProofLeaf::Read(data) => Hash::blake3_hash_bytes(data),
         };
 
         Ok(hash)
@@ -330,7 +333,7 @@ where
         let access_info = region.get_access_info();
         let cell = super::Cell::<T, Ref<'_, Owned>>::bind(region.inner_region_ref());
         let serialised = binary::serialise(&cell)?;
-        MerkleTree::make_merkle_leaf(serialised, access_info)
+        Ok(MerkleTree::make_merkle_leaf(serialised, access_info))
     }
 
     fn into_verifier_alloc<D: Deserialiser>(proof: D) -> VerifierAllocResult<D, Self> {
@@ -366,7 +369,7 @@ where
         let access_info = region.get_access_info();
         let cells = super::Cells::<T, LEN, Ref<'_, Owned>>::bind(region.inner_region_ref());
         let serialised = binary::serialise(&cells)?;
-        MerkleTree::make_merkle_leaf(serialised, access_info)
+        Ok(MerkleTree::make_merkle_leaf(serialised, access_info))
     }
 
     fn into_verifier_alloc<D: Deserialiser>(proof: D) -> VerifierAllocResult<D, Self> {
@@ -510,7 +513,7 @@ impl<const LEN: usize> ProofLayout for DynArray<LEN> {
                         {
                             PartialState::Absent => hashes.push(tree.partial_hash_leaf()),
                             PartialState::Complete(data) => {
-                                hashes.push(Ok(Hash::blake3_hash_bytes(data)?))
+                                hashes.push(Ok(Hash::blake3_hash_bytes(data)))
                             }
                             PartialState::Incomplete => {
                                 return Err(PartialHashError::Fatal);

--- a/src/riscv/lib/src/storage.rs
+++ b/src/riscv/lib/src/storage.rs
@@ -92,7 +92,7 @@ impl Store {
     /// Store data and return its hash. The data is written to disk only if
     /// previously unseen.
     pub fn store(&self, data: &[u8]) -> Result<Hash, StorageError> {
-        let hash = Hash::blake3_hash_bytes(data)?;
+        let hash = Hash::blake3_hash_bytes(data);
         let file_name = self.path_of_hash(&hash);
         self.write_data_if_new(file_name, data)?;
         Ok(hash)


### PR DESCRIPTION
# What

This PR simplifies the error types and function signatures used when hashing data.

- `Hash::blake3_hash_bytes` no longer returns a `Result`.
- `Hash::blake3_hash` returns `EncodeError` instead of `HashError` to better reflect the kind of error that can occur.
- Variant `HashError::InvalidDigestSize` is removed as it would never be instantiated
- Variant `PartialHashError::Hash` is replaced with `Encode` to make the error variant more precise

These changes allow us to remove a lot of `.unwrap()` calls as well as `try` operations via the `?` operator.

# Why

These changes slim down the interfaces and remove redundant code.

Additionally, these changes will simplify future (I have them locally already) parallelised hashing. For example, hashing of dynamic regions does not involve encoding the data. This means, the Merkle-isation can be parallelised without regard for error cases.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
