### PR TITLE
Remove `EnvironException`

### DIFF
--- a/src/riscv/lib/src/machine_state.rs
+++ b/src/riscv/lib/src/machine_state.rs
@@ -40,7 +40,6 @@ use crate::range_utils::unwrap_bound;
 use crate::state::NewState;
 use crate::state_backend as backend;
 use crate::state_backend::ManagerReadWrite;
-use crate::traps::EnvironException;
 use crate::traps::Exception;
 
 /// Layout for the machine 'run state' - which contains everything required for the running of
@@ -448,7 +447,7 @@ impl<MC: memory::MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: backen
     pub fn step_max_handle<E>(
         &mut self,
         mut step_bounds: Bound<usize>,
-        mut handle: impl FnMut(&mut Self, EnvironException) -> Result<bool, E>,
+        mut handle: impl FnMut(&mut Self) -> Result<bool, E>,
     ) -> StepManyResult<E>
     where
         M: backend::ManagerReadWrite,
@@ -470,7 +469,7 @@ impl<MC: memory::MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: backen
                     step_bounds = bound_saturating_sub(step_bounds, 1);
 
                     match cause {
-                        Exception::EnvCall => match handle(self, EnvironException::EnvCall) {
+                        Exception::EnvCall => match handle(self) {
                             Ok(may_continue) => {
                                 if !may_continue {
                                     break None;
@@ -803,28 +802,27 @@ mod tests {
 
             state.setup_linux_process(&program).unwrap();
 
-            let res =
-                state
-                    .machine_state
-                    .step_max_handle::<()>(Bound::Unbounded, |machine, _exc| {
-                        let syscall_number = machine.core.hart.xregisters.read(a7) as i64;
+            let res = state
+                .machine_state
+                .step_max_handle::<()>(Bound::Unbounded, |machine| {
+                    let syscall_number = machine.core.hart.xregisters.read(a7) as i64;
 
-                        // The `block-cache-tester` kernel will issue a system call with number -1
-                        // to indicate that it has reached the signal point. This is our cue that we
-                        // have produced the right "start" state.
-                        if syscall_number == -1 {
-                            return Err(());
-                        }
+                    // The `block-cache-tester` kernel will issue a system call with number -1
+                    // to indicate that it has reached the signal point. This is our cue that we
+                    // have produced the right "start" state.
+                    if syscall_number == -1 {
+                        return Err(());
+                    }
 
-                        let shall_continue = handle_system_call(
-                            machine,
-                            &mut state.system_state,
-                            &mut state.status,
-                            &mut state.reveal_request,
-                            StdoutDebugHooks,
-                        );
-                        Ok(shall_continue)
-                    });
+                    let shall_continue = handle_system_call(
+                        machine,
+                        &mut state.system_state,
+                        &mut state.status,
+                        &mut state.reveal_request,
+                        StdoutDebugHooks,
+                    );
+                    Ok(shall_continue)
+                });
 
             assert_eq!(
                 res.error,

--- a/src/riscv/lib/src/pvm/common.rs
+++ b/src/riscv/lib/src/pvm/common.rs
@@ -233,9 +233,8 @@ impl<MC: MemoryConfig, BCC: BlockCacheConfig, B: block::Block<MC, M>, M: state_b
             return self.provide_reveal_error_response();
         }
 
-        self.machine_state.step_max_handle::<Infallible>(
-            Bound::Included(1),
-            |machine_state, _exception| {
+        self.machine_state
+            .step_max_handle::<Infallible>(Bound::Included(1), |machine_state| {
                 Ok(handle_system_call(
                     machine_state,
                     &mut self.system_state,
@@ -243,8 +242,7 @@ impl<MC: MemoryConfig, BCC: BlockCacheConfig, B: block::Block<MC, M>, M: state_b
                     &mut self.reveal_request,
                     &mut hooks,
                 ))
-            },
-        );
+            });
 
         self.tick.write(self.tick.read().wrapping_add(1u64));
     }
@@ -282,7 +280,7 @@ impl<MC: MemoryConfig, BCC: BlockCacheConfig, B: block::Block<MC, M>, M: state_b
 
         let steps = self
             .machine_state
-            .step_max_handle::<Infallible>(step_bounds, |machine_state, _exception| {
+            .step_max_handle::<Infallible>(step_bounds, |machine_state| {
                 Ok(handle_system_call(
                     machine_state,
                     &mut self.system_state,

--- a/src/riscv/lib/src/stepper/test.rs
+++ b/src/riscv/lib/src/stepper/test.rs
@@ -31,7 +31,7 @@ use crate::machine_state::memory::Permissions;
 use crate::program::Program;
 use crate::state::NewState;
 use crate::state_backend::owned_backend::Owned;
-use crate::traps::EnvironException;
+use crate::traps::Exception;
 
 #[derive(Clone, Debug)]
 pub enum TestStepperResult {
@@ -39,10 +39,10 @@ pub enum TestStepperResult {
     Running { steps: usize },
     /// Program exited. Returns exit code and number of steps executed.
     Exit { code: usize, steps: usize },
-    /// Execution finished because an unhandled environment exception has been thrown.
+    /// Execution finished because an unhandled exception has been thrown.
     /// Returns exception and number of steps executed.
     Exception {
-        cause: EnvironException,
+        cause: Exception,
         steps: usize,
         message: Option<String>,
     },
@@ -57,13 +57,13 @@ impl Default for TestStepperResult {
 impl StepResult for TestStepperResult {
     fn to_stepper_status(&self) -> StepperStatus {
         match self {
-            Running { steps } => StepperStatus::Running { steps: *steps },
-            Exit { code, steps } => StepperStatus::Exited {
+            Self::Running { steps } => StepperStatus::Running { steps: *steps },
+            Self::Exit { code, steps } => StepperStatus::Exited {
                 steps: *steps,
                 success: *code == 0,
                 status: format!("code {code}"),
             },
-            Exception {
+            Self::Exception {
                 cause,
                 steps,
                 message,
@@ -75,8 +75,6 @@ impl StepResult for TestStepperResult {
         }
     }
 }
-
-use TestStepperResult::*;
 
 #[derive(Debug, From, Error, derive_more::Display)]
 pub enum TestStepperError {
@@ -138,7 +136,7 @@ impl<MC: MemoryConfig, B: Block<MC, Owned>> TestStepper<MC, TestCacheConfig, B> 
 
     fn handle_step_result(
         &mut self,
-        result: StepManyResult<(EnvironException, String)>,
+        result: StepManyResult<(Exception, String)>,
     ) -> TestStepperResult {
         match result.error {
             // An error was encountered in the evaluation function.
@@ -152,12 +150,12 @@ impl<MC: MemoryConfig, B: Block<MC, Owned>> TestStepper<MC, TestCacheConfig, B> 
             None => {
                 // Check if the machine has exited.
                 if let Some(code) = self.posix_state.exit_code() {
-                    Exit {
+                    TestStepperResult::Exit {
                         code: code as usize,
                         steps: result.steps,
                     }
                 } else {
-                    Running {
+                    TestStepperResult::Running {
                         steps: result.steps,
                     }
                 }
@@ -181,13 +179,11 @@ impl<MC: MemoryConfig, B: Block<MC, Owned>> Stepper for TestStepper<MC, TestCach
     type StepResult = TestStepperResult;
 
     fn step_max(&mut self, steps: Bound<usize>) -> Self::StepResult {
-        let result = self
-            .machine_state
-            .step_max_handle(steps, |machine_state, exc| {
-                self.posix_state
-                    .handle_call(machine_state)
-                    .map_err(|message| (exc, message))
-            });
+        let result = self.machine_state.step_max_handle(steps, |machine_state| {
+            self.posix_state
+                .handle_call(machine_state)
+                .map_err(|message| (Exception::EnvCall, message))
+        });
         self.handle_step_result(result)
     }
 }

--- a/src/riscv/lib/src/traps.rs
+++ b/src/riscv/lib/src/traps.rs
@@ -26,33 +26,6 @@ use std::fmt::Formatter;
 use tezos_smart_rollup_constants::riscv::SbiError;
 
 /// RISC-V Exceptions (also known as synchronous exceptions)
-#[derive(PartialEq, Eq, thiserror::Error, strum::Display, Debug, Clone, Copy)]
-pub enum EnvironException {
-    EnvCall,
-}
-
-impl TryFrom<&Exception> for EnvironException {
-    type Error = &'static str;
-
-    fn try_from(value: &Exception) -> Result<Self, Self::Error> {
-        match value {
-            Exception::EnvCall => Ok(EnvironException::EnvCall),
-            Exception::FenceI
-            | Exception::Breakpoint
-            | Exception::IllegalInstruction
-            | Exception::InstructionAccessFault
-            | Exception::LoadAccessFault
-            | Exception::StoreAMOAccessFault
-            | Exception::InstructionPageFault
-            | Exception::LoadPageFault
-            | Exception::StoreAMOPageFault => {
-                Err("Execution environment supports only ecall exceptions")
-            }
-        }
-    }
-}
-
-/// RISC-V Exceptions (also known as synchronous exceptions)
 #[derive(PartialEq, Eq, thiserror::Error, strum::Display, Clone, Copy)]
 #[repr(i64)]
 pub enum Exception {


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

# What

Remove the type for environment exceptions. 

# Why

The type doesn't add anything over a unit type. It is entirely redundant, so we can remove it.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
