### PR TITLE
Kernels: Update Rust toolchain to 1.88.0

### DIFF
--- a/kernels/dummy/src/main.rs
+++ b/kernels/dummy/src/main.rs
@@ -65,7 +65,7 @@ pub fn entry(host: &mut impl Runtime) {
     host.write_debug("Reveal metadata...\n");
     let result = host.reveal_metadata();
     host.write_debug("Reveal metadata succeeded, result: \n");
-    host.write_debug(&format!("Rollup address: {:?}\n", result));
+    host.write_debug(&format!("Rollup address: {result:?}\n"));
 
     host.write_debug("Reveal preimage...\n");
 

--- a/kernels/etherlink/bench/src/results.rs
+++ b/kernels/etherlink/bench/src/results.rs
@@ -152,31 +152,23 @@ fn check_transfer(tx: &Tx) -> Result<u64> {
                 .outcome
                 .logs
                 .as_ref()
-                .ok_or(format!(
-                    "Expected this contract call to have a log {:?}",
-                    tx
-                ))?
+                .ok_or(format!("Expected this contract call to have a log {tx:?}"))?
                 .data;
             let amount = u64_from_ethereum_u256_bytes(tx_data.as_slice()).ok_or(format!(
-                "Expected this contract call to have log data {:?}",
-                tx
+                "Expected this contract call to have log data {tx:?}"
             ))?;
             Ok(amount)
         }
-        _ => Err(format!("Expected a successful contract call, got {:?}", tx).into()),
+        _ => Err(format!("Expected a successful contract call, got {tx:?}").into()),
     }
 }
 
 fn check_call_balance_of(tx: &Tx) -> Result<u64> {
     match tx.outcome.result {
-        TxExecutionResult::CallSucceeded { value, .. } => value.ok_or(
-            format!(
-                "Expected this contract call to have a return value {:?}",
-                tx
-            )
-            .into(),
-        ),
-        _ => Err(format!("Expected a successful contract call, got {:?}", tx).into()),
+        TxExecutionResult::CallSucceeded { value, .. } => {
+            value.ok_or(format!("Expected this contract call to have a return value {tx:?}").into())
+        }
+        _ => Err(format!("Expected a successful contract call, got {tx:?}").into()),
     }
 }
 

--- a/kernels/jstz/bench/src/results.rs
+++ b/kernels/jstz/bench/src/results.rs
@@ -313,8 +313,7 @@ fn check_balances(level: &Level, messages: &[Message], num_transfers: usize) -> 
 
     if expected_transfers != num_transfers {
         return Err(format!(
-            "Found {} transfer messages, vs {} transfers completed",
-            num_transfers, expected_transfers
+            "Found {num_transfers} transfer messages, vs {expected_transfers} transfers completed",
         )
         .into());
     }

--- a/kernels/rust-toolchain.toml
+++ b/kernels/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.88.0"
 components = ["rustfmt", "clippy"]
 targets = ["riscv64gc-unknown-linux-musl"]


### PR DESCRIPTION
# What

This PR updates the Rust toolchain in `kernels/` to 1.88.0.

# Why

To bring it in line with the toolchain version used for the other crates and for the latest Etherlink kernel.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
