### PR TITLE
Copy less when combining hashes

### DIFF
--- a/src/riscv/lib/src/state_backend/commitment_layout.rs
+++ b/src/riscv/lib/src/state_backend/commitment_layout.rs
@@ -155,11 +155,7 @@ where
     T: CommitmentLayout,
 {
     fn state_hash<M: ManagerSerialise>(state: AllocatedOf<Self, M>) -> Result<Hash, HashError> {
-        let hashes: Vec<Hash> = state
-            .into_iter()
-            .map(T::state_hash)
-            .collect::<Result<Vec<_>, _>>()?;
-        Ok(Hash::combine(hashes))
+        Hash::try_combine(state.into_iter().map(T::state_hash))
     }
 }
 

--- a/src/riscv/lib/src/state_backend/hash.rs
+++ b/src/riscv/lib/src/state_backend/hash.rs
@@ -34,7 +34,7 @@ pub const DIGEST_SIZE: usize = 32;
 /// produced by a preset hash function, currently BLAKE2b. It can be obtained
 /// by either hashing data directly or after hashing by converting from
 /// a suitably sized byte slice or vector.
-#[derive(Clone, Copy, PartialEq, Eq, Encode, Decode, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, Encode, Decode, Hash, PartialOrd, Ord, derive_more::From)]
 pub struct Hash {
     digest: [u8; DIGEST_SIZE],
 }
@@ -71,6 +71,21 @@ impl Hash {
         let digest = hasher.finalize().into();
         Hash { digest }
     }
+
+    /// Like [`Self::combine`], but the iterator can yield errors.
+    pub fn try_combine<H: Borrow<Hash>, E, HS: IntoIterator<Item = Result<H, E>>>(
+        hashes: HS,
+    ) -> Result<Hash, E> {
+        let mut hasher = blake3::Hasher::new();
+
+        for hash in hashes {
+            let hash = hash?;
+            hasher.update(hash.borrow().as_ref());
+        }
+
+        let digest = hasher.finalize().into();
+        Ok(Hash { digest })
+    }
 }
 
 impl std::fmt::Display for Hash {
@@ -88,12 +103,6 @@ impl std::fmt::Debug for Hash {
 impl From<Hash> for [u8; DIGEST_SIZE] {
     fn from(value: Hash) -> Self {
         value.digest
-    }
-}
-
-impl From<[u8; DIGEST_SIZE]> for Hash {
-    fn from(digest: [u8; DIGEST_SIZE]) -> Self {
-        Hash { digest }
     }
 }
 


### PR DESCRIPTION
# What

This enables a micro-optimisation I found when digging into more efficient proofs some time ago. 

The new `Hash::try_combine` allows you to pass in iterators where the items contain failures. Previously, you had to allocate a vector and `collect` the iterator's items using it. `try_combine` lets you avoid this optimisation.

# Why

I just want to unroll it so it doesn't become stale in my JJ stash. The allocation saved, including a time improvement, is <5% of proof generation. So it is not a significant improvement currently. The complexity of the solution is fortunately low.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers. 