### PR TITLE
jstz/bench: add option for warmup transactions in benchmarking

### DIFF
--- a/kernels/jstz/bench/src/main.rs
+++ b/kernels/jstz/bench/src/main.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 TriliTech <contact@trili.tech>
+// SPDX-FileCopyrightText: 2024-2025 TriliTech <contact@trili.tech>
 //
 // SPDX-License-Identifier: MIT
 
@@ -55,6 +55,8 @@ enum Commands {
         expected_transfers: usize,
         #[arg(long)]
         collapsible_results: bool,
+        #[arg(long)]
+        exclude_warmup_transfers: usize,
     },
 }
 
@@ -75,11 +77,13 @@ fn main() -> Result<()> {
             log_file,
             expected_transfers,
             collapsible_results,
+            exclude_warmup_transfers
         } => handle_results(
             inbox_file,
             log_file,
             expected_transfers,
             collapsible_results,
+            exclude_warmup_transfers
         )?,
     }
 

--- a/kernels/jstz/bench/src/results.rs
+++ b/kernels/jstz/bench/src/results.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 TriliTech <contact@trili.tech>
+// SPDX-FileCopyrightText: 2024-2025 TriliTech <contact@trili.tech>
 //
 // SPDX-License-Identifier: MIT
 
@@ -28,7 +28,13 @@ pub fn handle_results(
     all_logs: Vec<Box<Path>>,
     expected_transfers: usize,
     collapsible_results: bool,
+    exclude_warmup_transfers: usize,
 ) -> Result<()> {
+
+    if expected_transfers <= exclude_warmup_transfers {
+        return Err(format!("Warmup transfers {exclude_warmup_transfers} must be less than total transfers {expected_transfers}").into());
+    }
+
     let inbox = InboxFile::load(&inbox)?;
 
     let all_metrics = all_logs
@@ -54,7 +60,7 @@ pub fn handle_results(
             let [results]: [_; EXPECTED_LEVELS] = levels.try_into().unwrap();
 
             check_deploy(&results)?;
-            let metrics = check_transfer_metrics(&results, expected_transfers)?;
+            let metrics = check_transfer_metrics(&results, expected_transfers, exclude_warmup_transfers)?;
             check_balances(
                 &results,
                 &inbox.0[0][2 + expected_transfers..],
@@ -241,7 +247,7 @@ impl fmt::Display for TransferMetrics {
     }
 }
 
-fn check_transfer_metrics(level: &Level, expected_transfers: usize) -> Result<TransferMetrics> {
+fn check_transfer_metrics(level: &Level, expected_transfers: usize, exclude_warmup_transfers: usize) -> Result<TransferMetrics> {
     if expected_transfers + 1 != level.executions.len() {
         return Err(format!(
             "Expected {expected_transfers} transfers, got {}",
@@ -250,10 +256,12 @@ fn check_transfer_metrics(level: &Level, expected_transfers: usize) -> Result<Tr
         .into());
     }
 
-    let transfers = level.executions.len() - 1;
+    let total_transfers = level.executions.len() - 1;
+    let transfers = total_transfers - exclude_warmup_transfers;
+
     // The first execution is the minting call. We collect the time elapsed at the _end_ of the
     // minting, all the way up to the _end_ of the last execution (transfer).
-    let duration = level.executions[transfers].elapsed - level.executions[0].elapsed;
+    let duration = level.executions[total_transfers].elapsed - level.executions[exclude_warmup_transfers].elapsed;
     let tps = (transfers as f64) / duration.as_secs_f64();
 
     Ok(TransferMetrics {

--- a/scripts/jstz-bench.sh
+++ b/scripts/jstz-bench.sh
@@ -16,6 +16,10 @@ USAGE="Usage:
     -p: profile with samply
     -n: run natively
     -i <num_iterations>: number of runs
+    -w <num_warmup_tx>: number of warmup transactions
+       Run additional transactions before the benchmarking scenario.
+       This allows performance to be measured excluding warmup-time for
+       various caches to be populated or JIT compilation to take place.
     -j <disable|inline>: disable jit / use inline jit
     -m <all | jit-unsupported>: enable metrics"
 
@@ -32,12 +36,13 @@ METRICS=""
 METRICS_ARGS=()
 NATIVE=""
 JSTZ_SANDBOX_PARAMS=("--input" "kernels/jstz/target/riscv64gc-unknown-linux-musl/release/jstz")
+WARMUP_TX="0"
 
 CURR=$(pwd)
 RISCV_DIR=$(dirname "$0")/..
 cd "$RISCV_DIR"
 
-while getopts "i:t:m:spnj:" OPTION; do
+while getopts "i:t:m:w:spnj:" OPTION; do
   case "$OPTION" in
   i)
     ITERATIONS="$OPTARG"
@@ -69,6 +74,9 @@ while getopts "i:t:m:spnj:" OPTION; do
       ;;
     esac
     ;;
+  w)
+    WARMUP_TX="$OPTARG"
+    ;;
   m)
     SANDBOX_ENABLE_FEATURES+=("metrics")
     METRICS="y"
@@ -96,6 +104,8 @@ if [ -z "$TX" ]; then
   exit 1
 fi
 
+TOTAL_TX=$(("$TX" + "$WARMUP_TX"))
+
 if [ -n "$NATIVE" ] && [ -z "$STATIC_INBOX" ]; then
   echo "Native compilation without static inbox unsupported"
   echo "$USAGE"
@@ -109,10 +119,10 @@ make -C kernels/jstz inbox-bench &> /dev/null
 
 DATA_DIR=${DATA_DIR:=$(mktemp -d)}
 
-echo "[INFO]: generating $TX transfers"
+echo "[INFO]: generating $TX transfers with $WARMUP_TX warmup tx"
 INBOX_FILE="${DATA_DIR}/inbox.json"
 RUN_INBOX="$INBOX_FILE"
-kernels/jstz/inbox-bench generate --inbox-file "$INBOX_FILE" --transfers "$TX"
+kernels/jstz/inbox-bench generate --inbox-file "$INBOX_FILE" --transfers "$TOTAL_TX"
 
 log_file_args=()
 
@@ -190,7 +200,7 @@ run_jstz() {
 
 collect() {
   echo -e "\033[1m"
-  kernels/jstz/inbox-bench results --inbox-file "$INBOX_FILE" "${log_file_args[@]}" --expected-transfers "$TX"
+  kernels/jstz/inbox-bench results --inbox-file "$INBOX_FILE" "${log_file_args[@]}" --expected-transfers "$TOTAL_TX" --exclude-warmup-transfers "$WARMUP_TX"
   echo -e "\033[0m"
 }
 

--- a/scripts/jstz-bench.sh
+++ b/scripts/jstz-bench.sh
@@ -8,7 +8,17 @@
 
 set -e
 
-USAGE="Usage: -t <num_transfers> [ -s: static inbox ] [ -p: profile with samply ] [ -n: run natively ] [ -i <num_iterations>: number of runs ] [ -j <disable|inline>: disable jit / use inline jit ] [ -m <all | jit-unsupported>: enable metrics ]"
+USAGE="Usage:
+  REQUIRED:
+    -t <num_transfers>
+  OPTIONAL:
+    -s: static inbox
+    -p: profile with samply
+    -n: run natively
+    -i <num_iterations>: number of runs
+    -j <disable|inline>: disable jit / use inline jit
+    -m <all | jit-unsupported>: enable metrics"
+
 DEFAULT_ROLLUP_ADDRESS="sr163Lv22CdE8QagCwf48PWDTquk6isQwv57"
 
 ITERATIONS="1"


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

Closes RV-455

# What

Add the option to run 'warmup' transactions in the jstz benchmarking scenario. Additionally improves the formatting of the help/error message of the script.

# Why

As the JIT compilation gets more complex, it may take longer to ramp up to eventual performance. This is already the case, but does not have as much of an impact currently.  There is a change coming where we remove the block cache, however, and the presence (or not) of warmup transactions will have much more of an impact in the benchmark result.

*NB* this MR does not make use of them in our _actual_ benchmark for now - but at least allows the discussion to take place.

# How

We generate a `TOTAL_TX = TX + WARMUP_TX`. Results collection then can exclude the warmup tx from the scenario.

# Manually Testing

```
./scripts/jstz-bench -t 20 -w <0/5/10/20 etc>
```

# Tasks for the Author

- [ ] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [ ] Eliminate dead code and other spurious artefacts introduced in your changes.
- [ ] Document new public functions, methods and types.
- [ ] Make sure the documentation for updated functions, methods, and types is correct.
- [ ] Add tests for bugs that have been fixed.
- [ ] [Explain changes](#regressions) to regression test captures when applicable.
- [ ] Write commit messages to reflect the changes they're about.
- [ ] Self-review your changes to ensure they are high-quality.
- [ ] Complete all of the above before assigning this MR to reviewers.
