### PR TITLE
Memory governance request sent to jit

### DIFF
--- a/src/riscv/lib/src/interpreter/atomics.rs
+++ b/src/riscv/lib/src/interpreter/atomics.rs
@@ -693,6 +693,7 @@ pub(crate) mod test {
     use crate::interpreter::integer::run_addi;
     use crate::machine_state::MachineCoreState;
     use crate::machine_state::memory::M4K;
+    use crate::machine_state::memory::tests::DummyMemoryGovernanceHandler;
     use crate::machine_state::registers::a0;
     use crate::machine_state::registers::a1;
     use crate::machine_state::registers::a2;
@@ -717,7 +718,7 @@ pub(crate) mod test {
                 )| {
                     let mut state = state_cell.borrow_mut();
                     state.reset();
-                    state.main_memory.set_all_readable_writeable();
+                    state.main_memory.set_all_readable_writeable(&mut DummyMemoryGovernanceHandler);
 
                     state.hart.xregisters.write(a0, r1_addr);
                     state.write_to_bus(0, a0, r1_val)?;
@@ -763,7 +764,7 @@ pub(crate) mod test {
                 )| {
                     let mut state = state_cell.borrow_mut();
                     state.reset();
-                    state.main_memory.set_all_readable_writeable();
+                    state.main_memory.set_all_readable_writeable(&mut DummyMemoryGovernanceHandler);
 
                     state.hart.xregisters.write(a0, r1_addr);
                     state.write_to_bus(0, a0, r1_val)?;
@@ -964,7 +965,9 @@ pub(crate) mod test {
 
     backend_test!(test_alignment, F, {
         let mut state = MachineCoreState::<M4K, F>::new();
-        state.main_memory.set_all_readable_writeable();
+        state
+            .main_memory
+            .set_all_readable_writeable(&mut DummyMemoryGovernanceHandler);
         state.hart.xregisters.write(a0, 80); // LR.D starting address.
         state.hart.xregisters.write(a1, 84); // SC.W starting address.
         state.hart.xregisters.write(a2, 200); // Value to store.

--- a/src/riscv/lib/src/interpreter/load_store.rs
+++ b/src/riscv/lib/src/interpreter/load_store.rs
@@ -96,6 +96,7 @@ mod test {
     use crate::backend_test;
     use crate::machine_state::MachineCoreState;
     use crate::machine_state::memory::M4K;
+    use crate::machine_state::memory::tests::DummyMemoryGovernanceHandler;
     use crate::machine_state::registers::a1;
     use crate::machine_state::registers::a2;
     use crate::machine_state::registers::a3;
@@ -153,7 +154,7 @@ mod test {
         {
             let mut state = state_cell.borrow_mut();
             state.reset();
-            state.main_memory.set_all_readable_writeable();
+            state.main_memory.set_all_readable_writeable(&mut DummyMemoryGovernanceHandler);
 
             let mut perform_test = |offset: u64, signed: bool| -> Result<(), Exception> {
                 // Save test values v_i in registers ai

--- a/src/riscv/lib/src/interpreter/rv64d.rs
+++ b/src/riscv/lib/src/interpreter/rv64d.rs
@@ -374,6 +374,7 @@ mod tests {
     use crate::machine_state::MachineCoreState;
     use crate::machine_state::hart_state::HartState;
     use crate::machine_state::memory::M4K;
+    use crate::machine_state::memory::tests::DummyMemoryGovernanceHandler;
     use crate::machine_state::registers::fa2;
     use crate::machine_state::registers::fa3;
     use crate::machine_state::registers::parse_fregister;
@@ -415,7 +416,7 @@ mod tests {
         )| {
             let mut state = state_cell.borrow_mut();
             state.reset();
-            state.main_memory.set_all_readable_writeable();
+            state.main_memory.set_all_readable_writeable(&mut DummyMemoryGovernanceHandler);
 
             let mut perform_test = |offset: u64| -> Result<(), Exception> {
                 // Save test values v_i in registers ai

--- a/src/riscv/lib/src/interpreter/rv64dc.rs
+++ b/src/riscv/lib/src/interpreter/rv64dc.rs
@@ -78,6 +78,7 @@ mod test {
     use crate::machine_state::MachineCoreState;
     use crate::machine_state::memory::M4K;
     use crate::machine_state::memory::MemoryConfig;
+    use crate::machine_state::memory::tests::DummyMemoryGovernanceHandler;
     use crate::machine_state::registers::fa2;
     use crate::machine_state::registers::fa3;
     use crate::machine_state::registers::parse_xregister;
@@ -103,7 +104,7 @@ mod test {
         )| {
             let mut state = state_cell.borrow_mut();
             state.reset();
-            state.main_memory.set_all_readable_writeable();
+            state.main_memory.set_all_readable_writeable(&mut DummyMemoryGovernanceHandler);
 
             let mut perform_test = |offset: i64| -> Result<(), Exception> {
                 state.hart.fregisters.write(fa2, val.into());
@@ -138,7 +139,7 @@ mod test {
         )| {
             let mut state = state_cell.borrow_mut();
             state.reset();
-            state.main_memory.set_all_readable_writeable();
+            state.main_memory.set_all_readable_writeable(&mut DummyMemoryGovernanceHandler);
 
             let mut perform_test = |offset: i64| -> Result<(), Exception> {
                 state.hart.fregisters.write(fa2, val.into());

--- a/src/riscv/lib/src/interpreter/rv64f.rs
+++ b/src/riscv/lib/src/interpreter/rv64f.rs
@@ -406,6 +406,7 @@ mod tests {
     use crate::machine_state::MachineCoreState;
     use crate::machine_state::hart_state::HartState;
     use crate::machine_state::memory::M4K;
+    use crate::machine_state::memory::tests::DummyMemoryGovernanceHandler;
     use crate::machine_state::registers::fa1;
     use crate::machine_state::registers::fa4;
     use crate::machine_state::registers::parse_fregister;
@@ -457,7 +458,7 @@ mod tests {
         {
             let mut state = state_cell.borrow_mut();
             state.reset();
-            state.main_memory.set_all_readable_writeable();
+            state.main_memory.set_all_readable_writeable(&mut DummyMemoryGovernanceHandler);
 
             let mut perform_test = |offset: u64| -> Result<(), Exception> {
                 // Save test values v_i in registers ai

--- a/src/riscv/lib/src/jit.rs
+++ b/src/riscv/lib/src/jit.rs
@@ -308,6 +308,7 @@ mod tests {
     use crate::machine_state::memory::M4K;
     use crate::machine_state::memory::Memory;
     use crate::machine_state::memory::MemoryConfig;
+    use crate::machine_state::memory::tests::DummyMemoryGovernanceHandler;
     use crate::machine_state::registers::FValue;
     use crate::machine_state::registers::NonZeroXRegister;
     use crate::machine_state::registers::XRegister;
@@ -372,14 +373,11 @@ mod tests {
             // Create the states for the interpreted and jitted runs.
             let mut interpreted_state: TestMachineState<Interpreted<_, _>> =
                 MachineState::new(InterpretedBlockBuilder);
-            interpreted_state
-                .core
-                .main_memory
-                .set_all_readable_writeable();
+            interpreted_state.set_all_readable_writeable();
 
             let mut jitted_state: TestMachineState<Jitted<InlineCompiler<_>, _>> =
                 MachineState::new(InlineCompiler::default());
-            jitted_state.core.main_memory.set_all_readable_writeable();
+            jitted_state.set_all_readable_writeable();
 
             let mut interpreted_block = Interpreted::<_, _>::new();
             interpreted_block.start_block();
@@ -3116,7 +3114,8 @@ mod tests {
              -> Scenario {
                 ScenarioBuilder::default()
                     .set_setup_hook(setup_hook!(|core| {
-                        core.main_memory.set_all_readable_writeable();
+                        core.main_memory
+                            .set_all_readable_writeable(&mut DummyMemoryGovernanceHandler);
                         core.main_memory.write(addr, expected_rd).unwrap();
                         core.hart.xregisters.write(x1, addr);
                         core.hart.xregisters.write(x3, val);

--- a/src/riscv/lib/src/machine_state.rs
+++ b/src/riscv/lib/src/machine_state.rs
@@ -596,6 +596,19 @@ impl<MC: memory::MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: backen
         Ok(())
     }
 
+    /// Mark all memory as readable and writeable.
+    #[cfg(test)]
+    pub fn set_all_readable_writeable<MB, const PAGES: usize, const TOTAL_BYTES: usize>(&mut self)
+    where
+        M: backend::ManagerReadWrite,
+        MB: memory::buddy::Buddy<M>,
+        MC: MemoryConfig<State<M> = memory::state::MemoryImpl<PAGES, TOTAL_BYTES, MB, M>>,
+    {
+        self.core
+            .main_memory
+            .set_all_readable_writeable(&mut self.block_builder);
+    }
+
     /// Invalidate all instruction caches that are sensitive to
     /// instruction fences.
     fn invalidate_instruction_caches(&mut self)
@@ -1262,7 +1275,7 @@ mod tests {
         );
 
         state.reset();
-        state.core.main_memory.set_all_readable_writeable();
+        state.set_all_readable_writeable();
 
         let stack_top = M4K::TOTAL_BYTES as u64;
         state.core.hart.xregisters.write(sp, stack_top);
@@ -1283,7 +1296,7 @@ mod tests {
         );
 
         state.reset();
-        state.core.main_memory.set_all_readable_writeable();
+        state.set_all_readable_writeable();
 
         let stack_top = M4K::TOTAL_BYTES as u64;
         state.core.hart.xregisters.write(sp, stack_top);

--- a/src/riscv/lib/src/machine_state/block_cache/block.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/block.rs
@@ -25,6 +25,7 @@ use crate::machine_state::StepManyResult;
 use crate::machine_state::instruction::Instruction;
 use crate::machine_state::memory::Address;
 use crate::machine_state::memory::MemoryConfig;
+use crate::machine_state::memory::MemoryGovernanceListener;
 use crate::state::NewState;
 use crate::state_backend::AllocatedOf;
 use crate::state_backend::Atom;
@@ -50,7 +51,7 @@ pub trait Block<MC: MemoryConfig, M: ManagerBase>: NewState<M> {
     ///
     /// `Sized` bound is required to ensure any reference to `BlockBuilder` will be thin -
     /// see [`dispatch::DispatchFn`].
-    type BlockBuilder: Default + Sized;
+    type BlockBuilder: Default + Sized + MemoryGovernanceListener;
 
     /// Bind the block to the given allocated state.
     fn bind(allocated: AllocatedOf<BlockLayout, M>) -> Self

--- a/src/riscv/lib/src/machine_state/block_cache/block/dispatch.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/block/dispatch.rs
@@ -6,6 +6,7 @@
 //! This module exposes wrappers for the style of dispatch and compilation that is done.
 
 use std::marker::PhantomData;
+use std::ops::RangeInclusive;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::AtomicUsize;
@@ -21,6 +22,8 @@ use crate::machine_state::MachineCoreState;
 use crate::machine_state::instruction::Instruction;
 use crate::machine_state::memory::Address;
 use crate::machine_state::memory::MemoryConfig;
+use crate::machine_state::memory::MemoryGovernanceListener;
+use crate::machine_state::memory::PageState;
 use crate::state_backend::owned_backend::Owned;
 
 /// The function signature for dispatching a block run.
@@ -173,7 +176,7 @@ impl<C: CodeDispatcher<D, MC>, D: DispatchCompiler<MC>, MC: MemoryConfig> Defaul
 
 /// A compiler that can JIT-compile blocks of instructions, and hot-swap the execution of
 /// said block in the given dispatch target.
-pub trait DispatchCompiler<MC: MemoryConfig>: Default + Sized {
+pub trait DispatchCompiler<MC: MemoryConfig>: Default + Sized + MemoryGovernanceListener {
     /// Whether compilation should be attempted for the block.
     fn should_compile<C: CodeDispatcher<Self, MC>>(
         &self,
@@ -198,6 +201,16 @@ pub trait DispatchCompiler<MC: MemoryConfig>: Default + Sized {
 /// JIT compiler for blocks that performs compilation inline, in the same thread as execution.
 pub struct InlineCompiler<MC: MemoryConfig> {
     jit: JIT<MC>,
+}
+
+impl<MC: MemoryConfig> MemoryGovernanceListener for InlineCompiler<MC> {
+    fn handle_memory_permission_change(
+        &mut self,
+        _pages: RangeInclusive<usize>,
+        _state: PageState,
+    ) {
+        // TODO RV-761 - Implement handling of memory permissions in the JIT.
+    }
 }
 
 impl<MC: MemoryConfig> Default for InlineCompiler<MC> {
@@ -280,7 +293,18 @@ pub struct OutlineCompiler<MC: MemoryConfig> {
     // a reference to it - to ensure it is not dropped before we are done with execution,
     // even if the background compilation thread panics.
     _do_not_use_this_is_for_drop_only: Arc<Mutex<internal_corro::SendWrapper<JIT<MC>>>>,
-    sender: Sender<CompilationRequest>,
+    sender: Sender<JitRequest>,
+}
+
+impl<MC: MemoryConfig> MemoryGovernanceListener for OutlineCompiler<MC> {
+    fn handle_memory_permission_change(&mut self, pages: RangeInclusive<usize>, state: PageState) {
+        let _ = self
+            .sender
+            .send(JitRequest::MemoryPermissions(MemoryPermissionsRequest {
+                pages,
+                state,
+            }));
+    }
 }
 
 impl<MC: MemoryConfig + Send> OutlineCompiler<MC> {
@@ -301,25 +325,39 @@ impl<MC: MemoryConfig + Send> OutlineCompiler<MC> {
                 let jit = unsafe { jit_guard.as_mut() };
 
                 while let Ok(msg) = receiver.recv() {
-                    if let Some(jitfn) = jit.compile(&msg.instr, msg.program_counter) {
-                        debug_assert_eq!(
-                            msg.fun.load(Ordering::Acquire),
-                            Jitted::<Self, MC>::run_block_not_compiled as usize,
-                            "Unexpected function pointer in dispatch target"
-                        );
+                    match msg {
+                        JitRequest::Compile(CompilationRequest {
+                            instr,
+                            fun,
+                            program_counter,
+                        }) => {
+                            if let Some(jitfn) = jit.compile(&instr, program_counter) {
+                                debug_assert_eq!(
+                                    fun.load(Ordering::Acquire),
+                                    Jitted::<Self, MC>::run_block_not_compiled as usize,
+                                    "Unexpected function pointer in dispatch target"
+                                );
 
-                        // Safety: this function will be retrieved as a DispatchFn, rather than a
-                        // JitFn. The two function signatures are identical, apart from the first and
-                        // last parameters. These are both thin-pointers, and ignored by the JitFn.
-                        //
-                        // It's therefore safe to cast this function pointer to an identical ABI, where
-                        // this first and last parameter are thin-references to any value. This is the
-                        // case for both `Jitted` and `Jitted::BlockBuilder` which are both Sized.
-                        //
-                        // See <https://doc.rust-lang.org/std/primitive.fn.html#abi-compatibility> for more
-                        // information on ABI compatability.
-                        msg.fun.store(jitfn as usize, Ordering::Release);
-                    };
+                                // Safety: this function will be retrieved as a DispatchFn, rather than a
+                                // JitFn. The two function signatures are identical, apart from the first and
+                                // last parameters. These are both thin-pointers, and ignored by the JitFn.
+                                //
+                                // It's therefore safe to cast this function pointer to an identical ABI, where
+                                // this first and last parameter are thin-references to any value. This is the
+                                // case for both `Jitted` and `Jitted::BlockBuilder` which are both Sized.
+                                //
+                                // See <https://doc.rust-lang.org/std/primitive.fn.html#abi-compatibility> for more
+                                // information on ABI compatability.
+                                fun.store(jitfn as usize, Ordering::Release);
+                            };
+                        }
+                        JitRequest::MemoryPermissions(MemoryPermissionsRequest {
+                            pages: _,
+                            state: _,
+                        }) => {
+                            // TODO RV-761 - Implement handling of memory permissions in the JIT.
+                        }
+                    }
                 }
             }
             // because we used blocking recv with an asynchronous channel, this only fails when the
@@ -385,7 +423,7 @@ impl<MC: MemoryConfig + Send> DispatchCompiler<MC> for OutlineCompiler<MC> {
         // NB - any blocks already JIT compiled are safe to keep calling, as the
         // data behind the mutex (the JIT) is kept alive for as long as we maintain
         // our reference to it, despite the lock itself being poisoned.
-        let _ = self.sender.send(request);
+        let _ = self.sender.send(JitRequest::Compile(request));
 
         fun
     }
@@ -395,4 +433,16 @@ struct CompilationRequest {
     instr: Vec<Instruction>,
     fun: Arc<AtomicUsize>,
     program_counter: Address,
+}
+
+// TODO RV-761 - Implement handling of memory permissions in the JIT.
+#[expect(unused, reason = "Will Be Used Soon")]
+struct MemoryPermissionsRequest {
+    pages: RangeInclusive<usize>,
+    state: PageState,
+}
+
+enum JitRequest {
+    Compile(CompilationRequest),
+    MemoryPermissions(MemoryPermissionsRequest),
 }

--- a/src/riscv/lib/src/machine_state/block_cache/block/interpreted.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/block/interpreted.rs
@@ -5,6 +5,8 @@
 
 //! Interpreted blocks of instructions
 
+use std::ops::RangeInclusive;
+
 use perfect_derive::perfect_derive;
 
 use crate::default::ConstDefault;
@@ -18,6 +20,8 @@ use crate::machine_state::block_cache::block::run_block_inner;
 use crate::machine_state::instruction::Instruction;
 use crate::machine_state::memory::Address;
 use crate::machine_state::memory::MemoryConfig;
+use crate::machine_state::memory::MemoryGovernanceListener;
+use crate::machine_state::memory::PageState;
 use crate::state::NewState;
 use crate::state_backend::AllocatedOf;
 use crate::state_backend::Cell;
@@ -34,6 +38,16 @@ use crate::traps::Exception;
 /// Interpreted blocks are built automatically, and require no additional context.
 #[derive(Debug, Default)]
 pub struct InterpretedBlockBuilder;
+
+impl MemoryGovernanceListener for InterpretedBlockBuilder {
+    fn handle_memory_permission_change(
+        &mut self,
+        _pages: RangeInclusive<usize>,
+        _state: PageState,
+    ) {
+        // do nothing
+    }
+}
 
 /// Blocks that are executed via interpreting the individual instructions.
 ///

--- a/src/riscv/lib/src/machine_state/memory.rs
+++ b/src/riscv/lib/src/machine_state/memory.rs
@@ -2,12 +2,14 @@
 //
 // SPDX-License-Identifier: MIT
 
-mod buddy;
+pub(crate) mod buddy;
 mod config;
 mod protection;
-mod state;
+pub(crate) mod state;
 
 use std::num::NonZeroU64;
+use std::num::NonZeroUsize;
+use std::ops::RangeInclusive;
 
 use tezos_smart_rollup_constants::riscv::SbiError;
 
@@ -54,6 +56,15 @@ pub const PAGE_OFFSET_MASK: u64 = (1 << OFFSET_BITS.get()) - 1;
 
 /// Mask for obtaining a page-aligned-down address.
 pub const PAGE_MASK: u64 = !0 << OFFSET_BITS.get();
+
+/// Calculate the page range for a given address and length.
+pub fn get_page_range(address: Address, length: NonZeroUsize) -> std::ops::RangeInclusive<usize> {
+    let address = address as usize;
+    let start_page = address >> OFFSET_BITS.get();
+
+    let end_page = address.wrapping_add(length.get()).saturating_sub(1) >> OFFSET_BITS.get();
+    start_page..=end_page
+}
 
 /// Memory address
 pub type Address = XValue;
@@ -242,6 +253,7 @@ pub trait Memory<M: ManagerBase>: NewState<M> + Sized {
         address: Address,
         length: usize,
         perms: Permissions,
+        memory_governance_listener: &mut impl MemoryGovernanceListener,
     ) -> Result<(), MemoryGovernanceError>
     where
         M: ManagerWrite;
@@ -272,6 +284,7 @@ pub trait Memory<M: ManagerBase>: NewState<M> + Sized {
         length: usize,
         perms: Permissions,
         allow_replace: bool,
+        memory_governance_listener: &mut impl MemoryGovernanceListener,
     ) -> Result<Address, MemoryGovernanceError>
     where
         M: ManagerReadWrite;
@@ -281,12 +294,18 @@ pub trait Memory<M: ManagerBase>: NewState<M> + Sized {
         &mut self,
         address: Address,
         length: usize,
+        memory_governance_listener: &mut impl MemoryGovernanceListener,
     ) -> Result<(), MemoryGovernanceError>
     where
         M: ManagerReadWrite,
     {
         self.deallocate_pages(address, length)?;
-        self.protect_pages(address, length, Permissions::NONE)
+        self.protect_pages(
+            address,
+            length,
+            Permissions::NONE,
+            memory_governance_listener,
+        )
     }
 }
 
@@ -313,6 +332,31 @@ pub trait MemoryConfig: Send + 'static {
         F: FnManager<Ref<'a, M>>;
 }
 
+/// State of a range of memory pages
+pub enum PageState {
+    /// The range is immutable and marked as executable.
+    ImmutableExec,
+
+    /// No beneficial properties hold for the range.
+    Other,
+}
+
+impl From<Permissions> for PageState {
+    fn from(permissions: Permissions) -> Self {
+        if permissions.can_read() && permissions.can_exec() && !permissions.can_write() {
+            Self::ImmutableExec
+        } else {
+            Self::Other
+        }
+    }
+}
+
+/// Implementing types will be informed about changes to memory permissions
+pub trait MemoryGovernanceListener {
+    /// Called on changes to memory permissions.
+    fn handle_memory_permission_change(&mut self, pages: RangeInclusive<usize>, state: PageState);
+}
+
 // Re-export memory configurations
 pub use config::M1G;
 pub use config::M1M;
@@ -323,3 +367,41 @@ pub use config::M16G;
 pub use config::M32G;
 pub use config::M64G;
 pub use config::M64M;
+
+#[cfg(test)]
+pub mod tests {
+
+    use super::*;
+
+    /// Default memory governance handler that does nothing
+    #[derive(Default)]
+    pub struct DummyMemoryGovernanceHandler;
+
+    impl MemoryGovernanceListener for DummyMemoryGovernanceHandler {
+        fn handle_memory_permission_change(
+            &mut self,
+            _pages: RangeInclusive<usize>,
+            _state: PageState,
+        ) {
+            // do nothing
+        }
+    }
+
+    #[test]
+    fn test_get_page_range() {
+        // Single byte
+        let range = get_page_range(0, NonZeroUsize::new(1).unwrap());
+        assert_eq!(*range.start(), 0);
+        assert_eq!(*range.end(), 0);
+
+        // Exactly one page
+        let range = get_page_range(0, NonZeroUsize::new(4096).unwrap());
+        assert_eq!(*range.start(), 0);
+        assert_eq!(*range.end(), 0);
+
+        // Cross page boundary
+        let range = get_page_range(4090, NonZeroUsize::new(20).unwrap());
+        assert_eq!(*range.start(), 0);
+        assert_eq!(*range.end(), 1);
+    }
+}

--- a/src/riscv/lib/src/machine_state/memory/protection.rs
+++ b/src/riscv/lib/src/machine_state/memory/protection.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: MIT
 
+use std::ops::RangeInclusive;
+
 use bincode::Decode;
 use bincode::Encode;
 use bincode::de::Decoder;
@@ -115,23 +117,13 @@ impl<const PAGES: usize, M: ManagerBase> PagePermissions<PAGES, M> {
     }
 
     /// Change the access permissions for the given range.
-    pub fn modify_access(&mut self, address: Address, length: usize, accessible: bool)
+    pub fn modify_access(&mut self, page_range: RangeInclusive<usize>, accessible: bool)
     where
         M: ManagerWrite,
     {
-        if length < 1 {
-            return;
-        }
-
-        let address = address as usize;
-        let start_page = address >> super::OFFSET_BITS.get();
-        let end_page = address.wrapping_add(length).wrapping_sub(1) >> super::OFFSET_BITS.get();
-
-        (start_page..=end_page)
-            .filter(|&page| page < PAGES)
-            .for_each(|page| {
-                self.pages[page].write(accessible);
-            })
+        page_range.filter(|&page| page < PAGES).for_each(|page| {
+            self.pages[page].write(accessible);
+        })
     }
 }
 

--- a/src/riscv/lib/src/machine_state/memory/state.rs
+++ b/src/riscv/lib/src/machine_state/memory/state.rs
@@ -2,12 +2,16 @@
 //
 // SPDX-License-Identifier: MIT
 
+use std::num::NonZeroUsize;
+
 use super::Address;
 use super::BadMemoryAccess;
 use super::Memory;
+use super::MemoryGovernanceListener;
 use super::PAGE_SIZE;
 use super::Permissions;
 use super::buddy::Buddy;
+use super::get_page_range;
 use super::protection::PagePermissions;
 use crate::state_backend::DynCells;
 use crate::state_backend::Elem;
@@ -48,17 +52,6 @@ impl<const PAGES: usize, const TOTAL_BYTES: usize, B, M: ManagerBase>
         Ok(())
     }
 
-    /// Mark the whole memory as readable and writeable
-    #[cfg(test)]
-    pub(crate) fn set_all_readable_writeable(&mut self)
-    where
-        B: Buddy<M>,
-        M: ManagerReadWrite,
-    {
-        self.protect_pages(0, TOTAL_BYTES, Permissions::READ_WRITE)
-            .unwrap();
-    }
-
     /// Update an element in the region without checking memory protections. `address` is in bytes.
     #[cfg(test)]
     pub(crate) fn write_instruction_unchecked<E>(
@@ -74,9 +67,36 @@ impl<const PAGES: usize, const TOTAL_BYTES: usize, B, M: ManagerBase>
         Self::check_bounds(address, length, BadMemoryAccess)?;
 
         self.data.write(address as usize, value);
-        self.readable_pages.modify_access(address, length, true);
-        self.executable_pages.modify_access(address, length, true);
+
+        let Some(length) = NonZeroUsize::new(length) else {
+            return Ok(());
+        };
+
+        let page_range = get_page_range(address, length);
+
+        self.readable_pages.modify_access(page_range.clone(), true);
+        self.executable_pages
+            .modify_access(page_range.clone(), true);
+
         Ok(())
+    }
+
+    /// Mark the whole memory as readable and writeable
+    #[cfg(test)]
+    pub(crate) fn set_all_readable_writeable(
+        &mut self,
+        memory_governance_listener: &mut impl MemoryGovernanceListener,
+    ) where
+        B: Buddy<M>,
+        M: ManagerReadWrite,
+    {
+        self.protect_pages(
+            0,
+            TOTAL_BYTES,
+            Permissions::READ_WRITE,
+            memory_governance_listener,
+        )
+        .expect("Failed to set all memory as readable and writeable");
     }
 }
 
@@ -227,18 +247,27 @@ where
         address: Address,
         length: usize,
         perms: Permissions,
+        memory_governance_listener: &mut impl MemoryGovernanceListener,
     ) -> Result<(), super::MemoryGovernanceError>
     where
         M: ManagerWrite,
     {
+        let Some(non_zero_length) = NonZeroUsize::new(length) else {
+            return Ok(());
+        };
+
         Self::check_bounds(address, length, super::MemoryGovernanceError)?;
 
+        let page_range = get_page_range(address, non_zero_length);
+
         self.readable_pages
-            .modify_access(address, length, perms.can_read());
+            .modify_access(page_range.clone(), perms.can_read());
         self.writable_pages
-            .modify_access(address, length, perms.can_write());
+            .modify_access(page_range.clone(), perms.can_write());
         self.executable_pages
-            .modify_access(address, length, perms.can_exec());
+            .modify_access(page_range.clone(), perms.can_exec());
+
+        memory_governance_listener.handle_memory_permission_change(page_range, perms.into());
 
         Ok(())
     }
@@ -304,6 +333,7 @@ where
         length: usize,
         perms: Permissions,
         allow_replace: bool,
+        memory_governance_listener: &mut impl MemoryGovernanceListener,
     ) -> Result<Address, super::MemoryGovernanceError>
     where
         M: ManagerReadWrite,
@@ -312,7 +342,10 @@ where
         let address = self.allocate_pages(address_hint, length, allow_replace)?;
 
         // Configure the permissions on the page range
-        if self.protect_pages(address, length, perms).is_err() {
+        if self
+            .protect_pages(address, length, perms, memory_governance_listener)
+            .is_err()
+        {
             self.deallocate_pages(address, length)?;
         }
 
@@ -345,6 +378,7 @@ pub mod tests {
     use crate::backend_test;
     use crate::machine_state::memory::M4K;
     use crate::machine_state::memory::MemoryConfig;
+    use crate::machine_state::memory::tests::DummyMemoryGovernanceHandler;
     use crate::state::NewState;
     use crate::state_backend::owned_backend::Owned;
 
@@ -383,7 +417,13 @@ pub mod tests {
         // Request size that's not a multiple of page size
         let requested_size = (PAGE_SIZE.get() as usize) - 100;
         let address = memory
-            .allocate_and_protect_pages(None, requested_size, Permissions::READ_WRITE, false)
+            .allocate_and_protect_pages(
+                None,
+                requested_size,
+                Permissions::READ_WRITE,
+                false,
+                &mut DummyMemoryGovernanceHandler,
+            )
             .expect("Memory allocation should succeed");
 
         // Verify that memory is zeroed for the entire page, not just the requested length

--- a/src/riscv/lib/src/machine_state/page_cache/state.rs
+++ b/src/riscv/lib/src/machine_state/page_cache/state.rs
@@ -179,6 +179,7 @@ mod tests {
     use crate::machine_state::memory::MemoryConfig;
     use crate::machine_state::memory::PAGE_SIZE;
     use crate::machine_state::memory::Permissions;
+    use crate::machine_state::memory::tests::DummyMemoryGovernanceHandler;
     use crate::machine_state::page_cache::INSTRUCTION_ENTRIES;
     use crate::machine_state::page_cache::PageCache;
     use crate::machine_state::page_cache::state::PageEntry;
@@ -259,11 +260,16 @@ mod tests {
         // populating a read-only page should fail
         state
             .main_memory
-            .protect_pages(0, PAGE_SIZE.get() as usize, Permissions {
-                read: true,
-                exec: false,
-                write: false,
-            })
+            .protect_pages(
+                0,
+                PAGE_SIZE.get() as usize,
+                Permissions {
+                    read: true,
+                    exec: false,
+                    write: false,
+                },
+                &mut DummyMemoryGovernanceHandler,
+            )
             .unwrap();
         cache.populate_page(15, &state);
         assert_eq!(count_active_pages(&cache), 0);
@@ -271,7 +277,12 @@ mod tests {
         // populating a R+W should fail
         state
             .main_memory
-            .protect_pages(0, PAGE_SIZE.get() as usize, Permissions::READ_WRITE)
+            .protect_pages(
+                0,
+                PAGE_SIZE.get() as usize,
+                Permissions::READ_WRITE,
+                &mut DummyMemoryGovernanceHandler,
+            )
             .unwrap();
         cache.populate_page(15, &state);
         assert_eq!(count_active_pages(&cache), 0);
@@ -279,7 +290,12 @@ mod tests {
         // populating a R+W+X should fail
         state
             .main_memory
-            .protect_pages(0, PAGE_SIZE.get() as usize, Permissions::READ_WRITE_EXEC)
+            .protect_pages(
+                0,
+                PAGE_SIZE.get() as usize,
+                Permissions::READ_WRITE_EXEC,
+                &mut DummyMemoryGovernanceHandler,
+            )
             .unwrap();
         cache.populate_page(15, &state);
         assert_eq!(count_active_pages(&cache), 0);
@@ -287,11 +303,16 @@ mod tests {
         // populating a R+X page should succeed
         state
             .main_memory
-            .protect_pages(0, PAGE_SIZE.get() as usize, Permissions {
-                read: true,
-                exec: true,
-                write: false,
-            })
+            .protect_pages(
+                0,
+                PAGE_SIZE.get() as usize,
+                Permissions {
+                    read: true,
+                    exec: true,
+                    write: false,
+                },
+                &mut DummyMemoryGovernanceHandler,
+            )
             .unwrap();
         cache.populate_page(90, &state);
         assert_eq!(count_active_pages(&cache), 1);

--- a/src/riscv/lib/src/pvm/common.rs
+++ b/src/riscv/lib/src/pvm/common.rs
@@ -529,10 +529,7 @@ mod tests {
         // Setup PVM
         let mut pvm = Pvm::<MC, TestCacheConfig, B, Owned>::new(InterpretedBlockBuilder);
         pvm.reset();
-        pvm.machine_state
-            .core
-            .main_memory
-            .set_all_readable_writeable();
+        pvm.machine_state.set_all_readable_writeable();
 
         let level_addr = memory::FIRST_ADDRESS;
         let counter_addr = level_addr + 4;
@@ -638,10 +635,7 @@ mod tests {
             // Setup PVM
             let mut pvm = Pvm::<MC, TestCacheConfig, B, Owned>::new(InterpretedBlockBuilder);
             pvm.reset();
-            pvm.machine_state
-                .core
-                .main_memory
-                .set_all_readable_writeable();
+            pvm.machine_state.set_all_readable_writeable();
 
             // Write characters
             pvm.machine_state
@@ -685,10 +679,7 @@ mod tests {
         // Setup PVM
         let mut pvm = Pvm::<MC, TestCacheConfig, B<F>, F>::new(InterpretedBlockBuilder);
         pvm.reset();
-        pvm.machine_state
-            .core
-            .main_memory
-            .set_all_readable_writeable();
+        pvm.machine_state.set_all_readable_writeable();
 
         let input_address = memory::FIRST_ADDRESS;
         let buffer = [1u8, 2, 3, 4];
@@ -758,10 +749,7 @@ mod tests {
         // Setup PVM
         let mut pvm = Pvm::<MC, TestCacheConfig, B<F>, F>::new(InterpretedBlockBuilder);
         pvm.reset();
-        pvm.machine_state
-            .core
-            .main_memory
-            .set_all_readable_writeable();
+        pvm.machine_state.set_all_readable_writeable();
 
         const OUTPUT_BUFFER_SIZE: usize = 10;
         let input_address = memory::FIRST_ADDRESS;

--- a/src/riscv/lib/src/pvm/linux.rs
+++ b/src/riscv/lib/src/pvm/linux.rs
@@ -275,6 +275,7 @@ where
             program_start,
             program_length,
             Permissions::WRITE,
+            &mut self.machine_state.block_builder,
         )?;
 
         // Write program to main memory
@@ -287,6 +288,7 @@ where
             program_start,
             program_length,
             Permissions::NONE,
+            &mut self.machine_state.block_builder,
         )?;
 
         // Configure memory permissions using the ELF program headers, if present
@@ -296,6 +298,7 @@ where
                     mem_perms.start_address,
                     mem_perms.length as usize,
                     mem_perms.permissions,
+                    &mut self.machine_state.block_builder,
                 )?;
             }
         }
@@ -345,6 +348,7 @@ where
             stack_guard.to_machine_address(),
             PAGE_SIZE.get() as usize,
             Permissions::NONE,
+            &mut self.machine_state.block_builder,
         )?;
 
         // Make sure the stack region is readable and writable
@@ -352,6 +356,7 @@ where
             stack_bottom.to_machine_address(),
             stack_space,
             Permissions::READ_WRITE,
+            &mut self.machine_state.block_builder,
         )?;
 
         self.machine_state
@@ -767,9 +772,9 @@ impl<M: ManagerBase> SupervisorState<M> {
             RT_SIGPROCMASK => dispatch4!(rt_sigprocmask, &mut machine.core),
             RT_SIGRETURN => dispatch0!(rt_sigreturn, &mut machine.core),
             BRK => dispatch0!(brk),
-            MMAP => dispatch6!(mmap, &mut machine.core),
-            MPROTECT => dispatch3!(mprotect, &mut machine.core),
-            MUNMAP => dispatch2!(munmap, &mut machine.core),
+            MMAP => dispatch6!(mmap, machine),
+            MPROTECT => dispatch3!(mprotect, machine),
+            MUNMAP => dispatch2!(munmap, machine),
             MADVISE => dispatch0!(madvise),
             GETRANDOM => dispatch2!(getrandom, &mut machine.core),
             CLOCK_GETTIME => dispatch2!(clock_gettime, &mut machine.core),
@@ -1150,7 +1155,12 @@ mod tests {
         machine_state
             .core
             .main_memory
-            .protect_pages(0, MemLayout::TOTAL_BYTES, Permissions::READ_WRITE)
+            .protect_pages(
+                0,
+                MemLayout::TOTAL_BYTES,
+                Permissions::READ_WRITE,
+                &mut machine_state.block_builder,
+            )
             .unwrap();
 
         for fd in [0i32, 1, 2] {
@@ -1220,7 +1230,12 @@ mod tests {
         machine_state
             .core
             .main_memory
-            .protect_pages(0, MemLayout::TOTAL_BYTES, Permissions::READ_WRITE)
+            .protect_pages(
+                0,
+                MemLayout::TOTAL_BYTES,
+                Permissions::READ_WRITE,
+                &mut machine_state.block_builder,
+            )
             .unwrap();
 
         let mut supervisor_state = SupervisorState::<F>::new();
@@ -1350,7 +1365,12 @@ mod tests {
         machine_state
             .core
             .main_memory
-            .protect_pages(0, MemLayout::TOTAL_BYTES, Permissions::READ_WRITE)
+            .protect_pages(
+                0,
+                MemLayout::TOTAL_BYTES,
+                Permissions::READ_WRITE,
+                &mut machine_state.block_builder,
+            )
             .unwrap();
 
         let mut supervisor_state = SupervisorState::<F>::new();
@@ -1495,7 +1515,12 @@ mod tests {
         machine_state
             .core
             .main_memory
-            .protect_pages(0, MemLayout::TOTAL_BYTES, Permissions::READ_WRITE)
+            .protect_pages(
+                0,
+                MemLayout::TOTAL_BYTES,
+                Permissions::READ_WRITE,
+                &mut machine_state.block_builder,
+            )
             .unwrap();
 
         // Mask pointer (must be non-zero)
@@ -1806,7 +1831,12 @@ mod tests {
         machine_state
             .core
             .main_memory
-            .protect_pages(0, MemLayout::TOTAL_BYTES, Permissions::READ_WRITE)
+            .protect_pages(
+                0,
+                MemLayout::TOTAL_BYTES,
+                Permissions::READ_WRITE,
+                &mut machine_state.block_builder,
+            )
             .unwrap();
 
         let mut supervisor_state = SupervisorState::new();
@@ -1873,11 +1903,7 @@ mod tests {
         machine_state.reset();
 
         // Make sure everything is readable and writable. Otherwise, we'd get access faults.
-        machine_state
-            .core
-            .main_memory
-            .protect_pages(0, MemLayout::TOTAL_BYTES, Permissions::READ_WRITE)
-            .unwrap();
+        machine_state.set_all_readable_writeable();
 
         let mut supervisor_state = SupervisorState::new();
 
@@ -1968,6 +1994,7 @@ mod tests {
                 MemLayout::TOTAL_BYTES,
                 Permissions::READ_WRITE,
                 true,
+                &mut machine_state.block_builder,
             )
             .unwrap();
 
@@ -1994,7 +2021,7 @@ mod tests {
 
             // Call the function under test
             let result = supervisor_state.handle_mmap(
-                &mut machine_state.core,
+                &mut machine_state,
                 addr.into(),
                 length,
                 perms,
@@ -2022,7 +2049,7 @@ mod tests {
 
             // Call the function under test
             let result = supervisor_state.handle_mmap(
-                &mut machine_state.core,
+                &mut machine_state,
                 VirtAddr::new(addr),
                 length,
                 perms,
@@ -2048,7 +2075,12 @@ mod tests {
         machine_state
             .core
             .main_memory
-            .protect_pages(0, MemLayout::TOTAL_BYTES, Permissions::READ_WRITE)
+            .protect_pages(
+                0,
+                MemLayout::TOTAL_BYTES,
+                Permissions::READ_WRITE,
+                &mut machine_state.block_builder,
+            )
             .unwrap();
 
         // Write the initial stack pointer and program counter.

--- a/src/riscv/lib/src/pvm/linux/memory.rs
+++ b/src/riscv/lib/src/pvm/linux/memory.rs
@@ -27,7 +27,9 @@ use super::parameters::Flags;
 use super::parameters::NoFileDescriptor;
 use super::parameters::Visibility;
 use super::parameters::Zero;
-use crate::machine_state::MachineCoreState;
+use crate::machine_state::MachineState;
+use crate::machine_state::block_cache::BlockCacheConfig;
+use crate::machine_state::block_cache::block::Block;
 use crate::machine_state::memory::Memory;
 use crate::machine_state::memory::MemoryConfig;
 use crate::machine_state::memory::PAGE_SIZE;
@@ -71,19 +73,25 @@ impl<M: ManagerBase> SupervisorState<M> {
     /// Handle `mprotect` system call.
     ///
     /// See: <https://man7.org/linux/man-pages/man2/mprotect.2.html>
-    pub(super) fn handle_mprotect<MC>(
+    pub(super) fn handle_mprotect<MC, BCC, B>(
         &mut self,
-        core: &mut MachineCoreState<MC, M>,
+        machine_state: &mut MachineState<MC, BCC, B, M>,
         addr: PageAligned<VirtAddr>,
         length: u64,
         perms: Permissions,
     ) -> Result<u64, Error>
     where
         MC: MemoryConfig,
+        BCC: BlockCacheConfig,
+        B: Block<MC, M>,
         M: ManagerReadWrite,
     {
-        core.main_memory
-            .protect_pages(addr.to_machine_address(), length as usize, perms)?;
+        machine_state.core.main_memory.protect_pages(
+            addr.to_machine_address(),
+            length as usize,
+            perms,
+            &mut machine_state.block_builder,
+        )?;
 
         // Return 0 to indicate success.
         Ok(0)
@@ -96,9 +104,9 @@ impl<M: ManagerBase> SupervisorState<M> {
         clippy::too_many_arguments,
         reason = "The system call dispatch mechanism needs these arguments to exist, they can't be on a nested structure"
     )]
-    pub(super) fn handle_mmap<MC>(
+    pub(super) fn handle_mmap<MC, BCC, B>(
         &mut self,
-        core: &mut MachineCoreState<MC, M>,
+        machine_state: &mut MachineState<MC, BCC, B, M>,
         addr: VirtAddr,
         length: NonZeroU64,
         perms: Permissions,
@@ -108,6 +116,8 @@ impl<M: ManagerBase> SupervisorState<M> {
     ) -> Result<u64, Error>
     where
         MC: MemoryConfig,
+        BCC: BlockCacheConfig,
+        B: Block<MC, M>,
         M: ManagerReadWrite,
     {
         // We don't allow shared mappings
@@ -123,11 +133,12 @@ impl<M: ManagerBase> SupervisorState<M> {
         }
 
         let res_addr: VirtAddr = match flags.addr_hint {
-            AddressHint::Hint => core.main_memory.allocate_and_protect_pages(
+            AddressHint::Hint => machine_state.core.main_memory.allocate_and_protect_pages(
                 None,
                 length.get() as usize,
                 perms,
                 false,
+                &mut machine_state.block_builder,
             )?,
 
             AddressHint::Fixed { allow_replace } => {
@@ -135,11 +146,12 @@ impl<M: ManagerBase> SupervisorState<M> {
                     return Err(Error::InvalidArgument);
                 }
 
-                core.main_memory.allocate_and_protect_pages(
+                machine_state.core.main_memory.allocate_and_protect_pages(
                     Some(addr.to_machine_address()),
                     length.get() as usize,
                     perms,
                     allow_replace,
+                    &mut machine_state.block_builder,
                 )?
             }
         }
@@ -151,18 +163,22 @@ impl<M: ManagerBase> SupervisorState<M> {
     /// Handle `munmap` system call.
     ///
     /// See: <https://man7.org/linux/man-pages/man2/mmap.2.html>
-    pub(super) fn handle_munmap<MC>(
+    pub(super) fn handle_munmap<MC, BCC, B>(
         &mut self,
-        core: &mut MachineCoreState<MC, M>,
+        machine_state: &mut MachineState<MC, BCC, B, M>,
         addr: u64,
         length: u64,
     ) -> Result<u64, Error>
     where
         MC: MemoryConfig,
+        BCC: BlockCacheConfig,
+        B: Block<MC, M>,
         M: ManagerReadWrite,
     {
-        core.main_memory
-            .deallocate_and_protect_pages(addr, length as usize)
+        machine_state
+            .core
+            .main_memory
+            .deallocate_and_protect_pages(addr, length as usize, &mut machine_state.block_builder)
             .map_err(|_| Error::InvalidArgument)?;
 
         Ok(0)

--- a/src/riscv/lib/src/stepper/test.rs
+++ b/src/riscv/lib/src/stepper/test.rs
@@ -126,7 +126,12 @@ impl<MC: MemoryConfig, B: Block<MC, Owned>> TestStepper<MC, TestCacheConfig, B> 
             .machine_state
             .core
             .main_memory
-            .protect_pages(0, MC::TOTAL_BYTES, Permissions::READ_WRITE_EXEC)
+            .protect_pages(
+                0,
+                MC::TOTAL_BYTES,
+                Permissions::READ_WRITE_EXEC,
+                &mut stepper.machine_state.block_builder,
+            )
             .unwrap();
 
         stepper.machine_state.setup_boot(&elf_program)?;


### PR DESCRIPTION
Closes RV-760

# What

Main thread sends memory request to jit

# Why

This is part of the effort to refactor jit and give jit access to memory. The main thread needs to notify the jit which pages are valid for jit compilation(page with r+x permission)

# How

This MR does the following things

- Introduce a new memory permission request type
- Add memory governance trait for the block builder 
- Pass machine state to handler for mmap/munmap/mprotect and to memory functions
- Main thread send memory permission request to jit when `fn protect` is called

# Manually Testing

```
make all
```

# Regressions

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
