### PR TITLE
MachineState: separate instruction fetching from cache population

### DIFF
--- a/src/riscv/lib/src/machine_state.rs
+++ b/src/riscv/lib/src/machine_state.rs
@@ -108,6 +108,61 @@ impl<MC: memory::MemoryConfig, M: backend::ManagerBase> MachineCoreState<MC, M> 
         self.main_memory.reset();
         self.signal_actions.reset();
     }
+
+    /// Fetch the 16 bits of an instruction at the given physical address.
+    #[inline(always)]
+    fn fetch_instr_halfword(
+        &self,
+        phys_addr: Address,
+    ) -> Result<memory::InstructionData<u16>, Exception>
+    where
+        M: backend::ManagerRead,
+    {
+        self.main_memory
+            .read_exec(phys_addr)
+            .map_err(|_: BadMemoryAccess| Exception::InstructionAccessFault)
+    }
+
+    /// Fetch instruction from the address given by program counter
+    /// The spec stipulates translation is performed for each byte respectively.
+    /// However, we assume the `raw_pc` is 2-byte aligned.
+    #[inline]
+    fn fetch_instr(
+        &mut self,
+        addr: Address,
+    ) -> Result<memory::InstructionData<Instruction>, Exception>
+    where
+        M: backend::ManagerReadWrite,
+    {
+        let lower = self.fetch_instr_halfword(addr)?;
+
+        // The reasons to provide the second half in the lambda is
+        // because those bytes may be inaccessible or may trigger an exception when read.
+        // Hence we can't read all 4 bytes eagerly.
+        let instruction_data = if is_compressed(lower.data) {
+            let instr = parse_compressed_instruction(lower.data);
+            let instr = Instruction::from(&instr);
+
+            memory::InstructionData {
+                data: instr,
+                writable: lower.writable,
+            }
+        } else {
+            let next_addr = addr + 2;
+            let upper = self.fetch_instr_halfword(next_addr)?;
+
+            let combined = lower.combine_with_upper(upper);
+            let instr = parse_uncompressed_instruction(combined.data);
+            let instr = Instruction::from(&instr);
+
+            memory::InstructionData {
+                data: instr,
+                writable: combined.writable,
+            }
+        };
+
+        Ok(instruction_data)
+    }
 }
 
 /// The alignment of a stack pointer in RISC-V's ABI
@@ -275,80 +330,26 @@ impl<MC: memory::MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: backen
         self.block_cache.reset();
     }
 
-    /// Fetch the 16 bits of an instruction at the given physical address.
-    #[inline(always)]
-    fn fetch_instr_halfword(
-        &self,
-        phys_addr: Address,
-    ) -> Result<memory::InstructionData<u16>, Exception>
-    where
-        M: backend::ManagerRead,
-    {
-        self.core
-            .main_memory
-            .read_exec(phys_addr)
-            .map_err(|_: BadMemoryAccess| Exception::InstructionAccessFault)
-    }
-
-    /// Fetch instruction from the address given by program counter
-    /// The spec stipulates translation is performed for each byte respectively.
-    /// However, we assume the `raw_pc` is 2-byte aligned.
-    #[inline]
-    fn fetch_instr(&mut self, addr: Address) -> Result<Instruction, Exception>
-    where
-        M: backend::ManagerReadWrite,
-    {
-        let lower = self.fetch_instr_halfword(addr)?;
-
-        // The reasons to provide the second half in the lambda is
-        // because those bytes may be inaccessible or may trigger an exception when read.
-        // Hence we can't read all 4 bytes eagerly.
-        let instr = if is_compressed(lower.data) {
-            let instr = parse_compressed_instruction(lower.data);
-            let instr = Instruction::from(&instr);
-
-            // Writable memory means that the instruction is not cacheable
-            if !lower.writable {
-                self.block_cache.push_instr_compressed(addr, instr);
-            }
-
-            instr
-        } else {
-            let next_addr = addr + 2;
-            let upper = self.fetch_instr_halfword(next_addr)?;
-
-            let combined = lower.combine_with_upper(upper);
-            let instr = parse_uncompressed_instruction(combined.data);
-            let instr = Instruction::from(&instr);
-
-            // Writable memory means that the instruction is not cacheable
-            if !combined.writable {
-                self.block_cache.push_instr_uncompressed(addr, instr);
-            }
-
-            instr
-        };
-
-        Ok(instr)
-    }
-
-    /// Advance [`MachineState`] by executing an [`Instr`]
+    /// Fetch & run the instruction located at address `instr_pc`.
     ///
-    /// [`Instr`]: crate::parser::instruction::Instr
-    fn run_instr(&mut self, instr: &Instruction) -> Result<ProgramCounterUpdate<Address>, Exception>
-    where
-        M: backend::ManagerReadWrite,
-    {
-        instr.run(&mut self.core)
-    }
-
-    /// Fetch & run the instruction located at address `instr_pc`
+    /// Additionally, this will push the instruction to the block cache, iff the memory address is
+    /// *not* writable.
     fn run_instr_at(&mut self, addr: Address) -> Result<ProgramCounterUpdate<Address>, Exception>
     where
         M: backend::ManagerReadWrite,
     {
-        self.fetch_instr(addr)
-            .and_then(|instr| self.run_instr(&instr))
+        let memory::InstructionData {
+            data: instr,
+            writable,
+        } = self.core.fetch_instr(addr)?;
+
+        // If the memory backing the instruction is writable, we do not cache it as it may
+        // change at any time.
+        if !writable {
+            self.block_cache.push_instruction(addr, instr);
+        }
+
+        instr.run(&mut self.core)
     }
 
     /// Take an interrupt if available, and then

--- a/src/riscv/lib/src/machine_state/block_cache.rs
+++ b/src/riscv/lib/src/machine_state/block_cache.rs
@@ -232,13 +232,8 @@ pub trait BlockCache<MC: MemoryConfig, B: Block<MC, M>, M: ManagerBase> {
     where
         M: ManagerRead;
 
-    /// Insert a compressed instruction into the block cache at the given address.
-    fn push_instr_compressed(&mut self, addr: Address, instr: Instruction)
-    where
-        M: ManagerReadWrite;
-
-    /// Insert an uncompressed instruction into the block cache at the given  address.
-    fn push_instr_uncompressed(&mut self, addr: Address, instr: Instruction)
+    /// Insert an instruction into the block cache at the given address.
+    fn push_instruction(&mut self, addr: Address, instr: Instruction)
     where
         M: ManagerReadWrite;
 

--- a/src/riscv/lib/src/machine_state/block_cache/state.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/state.rs
@@ -18,7 +18,6 @@ use crate::machine_state::block_cache::config::BlockCacheConfig;
 use crate::machine_state::instruction::Instruction;
 use crate::machine_state::memory::Address;
 use crate::machine_state::memory::MemoryConfig;
-use crate::parser::instruction::InstrWidth;
 use crate::state::NewState;
 use crate::state_backend::AllocatedOf;
 use crate::state_backend::Atom;
@@ -332,7 +331,7 @@ impl<const SIZE: usize, B: Block<MC, M>, MC: MemoryConfig, M: ManagerBase>
     /// ensure it is valid (it is part of the same fence,
     /// on the same page and that the combined block will
     /// not exceed the maximum number of instructions).
-    fn cache_inner<const WIDTH: u64>(&mut self, addr: Address, instr: Instruction)
+    fn cache_inner(&mut self, addr: Address, instr: Instruction)
     where
         M: ManagerReadWrite,
     {
@@ -361,7 +360,7 @@ impl<const SIZE: usize, B: Block<MC, M>, MC: MemoryConfig, M: ManagerBase>
         entry.block.push_instr(instr);
         let new_len = len_instr + 1;
 
-        let next_addr = addr + WIDTH;
+        let next_addr = addr.wrapping_add(instr.width() as u64);
         self.next_instr_addr.write(next_addr);
 
         let possible_block = Self::entry(&self.entries, next_addr);
@@ -469,42 +468,17 @@ impl<const SIZE: usize, MC: MemoryConfig, B: Block<MC, M>, M: ManagerBase>
         }
     }
 
-    fn push_instr_compressed(&mut self, addr: Address, instr: Instruction)
+    fn push_instruction(&mut self, addr: Address, instr: Instruction)
     where
         M: ManagerReadWrite,
     {
-        debug_assert_eq!(
-            instr.width(),
-            InstrWidth::Compressed,
-            "expected compressed instruction, found: {instr:?}"
-        );
-
         let next_addr = self.next_instr_addr.read();
 
         if addr != next_addr {
             self.reset_to(addr);
         }
 
-        self.cache_inner::<{ InstrWidth::Compressed as u64 }>(addr, instr);
-    }
-
-    fn push_instr_uncompressed(&mut self, addr: Address, instr: Instruction)
-    where
-        M: ManagerReadWrite,
-    {
-        debug_assert_eq!(
-            instr.width(),
-            InstrWidth::Uncompressed,
-            "expected uncompressed instruction, found: {instr:?}"
-        );
-
-        let next_addr = self.next_instr_addr.read();
-
-        if addr != next_addr {
-            self.reset_to(addr);
-        }
-
-        self.cache_inner::<{ InstrWidth::Uncompressed as u64 }>(addr, instr);
+        self.cache_inner(addr, instr);
     }
 
     fn complete_current_block(
@@ -605,7 +579,7 @@ mod tests {
         let addr = 10;
 
         for offset in 0..(CACHE_INSTR as u64) {
-            state.push_instr_uncompressed(addr + offset * 4, uncompressed);
+            state.push_instruction(addr + offset * 4, uncompressed);
         }
 
         let block = state.get_block(addr);
@@ -631,7 +605,7 @@ mod tests {
         let addr = 10;
 
         for offset in 0..(CACHE_INSTR as u64) {
-            state.push_instr_compressed(addr + offset * 2, compressed);
+            state.push_instruction(addr + offset * 2, compressed);
         }
 
         let block = state.get_block(addr);
@@ -658,7 +632,7 @@ mod tests {
         let addr = 10;
 
         for offset in 0..((CACHE_INSTR / 2) as u64) {
-            state.push_instr_compressed(addr + offset * 2, compressed);
+            state.push_instruction(addr + offset * 2, compressed);
         }
 
         let block = state.get_block(addr);
@@ -684,7 +658,7 @@ mod tests {
         let addr = 10;
 
         for offset in 0..((CACHE_INSTR * 2) as u64) {
-            state.push_instr_compressed(addr + offset * 2, compressed);
+            state.push_instruction(addr + offset * 2, compressed);
         }
 
         let block = state.get_block(addr);
@@ -714,7 +688,7 @@ mod tests {
         let block_addr = memory::FIRST_ADDRESS;
 
         for offset in 0..10 {
-            block_state.push_instr_uncompressed(block_addr + offset * 4, addiw);
+            block_state.push_instruction(block_addr + offset * 4, addiw);
         }
 
         core_state.hart.pc.write(block_addr);
@@ -793,12 +767,11 @@ mod tests {
         let preceding_num_instr: u64 = 5;
 
         for offset in 0..(CACHE_INSTR as u64 - preceding_num_instr) {
-            state.push_instr_uncompressed(addr + offset * 4, uncompressed);
+            state.push_instruction(addr + offset * 4, uncompressed);
         }
 
         for offset in 0..preceding_num_instr {
-            state
-                .push_instr_uncompressed(addr - preceding_num_instr * 4 + offset * 4, uncompressed);
+            state.push_instruction(addr - preceding_num_instr * 4 + offset * 4, uncompressed);
         }
 
         let block = state.get_block(addr - 20);
@@ -828,12 +801,11 @@ mod tests {
         let preceding_num_instr: u64 = 5;
 
         for offset in 0..(CACHE_INSTR as u64 - preceding_num_instr + 1) {
-            state.push_instr_uncompressed(addr + offset * 4, uncompressed);
+            state.push_instruction(addr + offset * 4, uncompressed);
         }
 
         for offset in 0..preceding_num_instr {
-            state
-                .push_instr_uncompressed(addr - preceding_num_instr * 4 + offset * 4, uncompressed);
+            state.push_instruction(addr - preceding_num_instr * 4 + offset * 4, uncompressed);
         }
 
         let first_block = state.get_block(addr - preceding_num_instr * 4);
@@ -868,7 +840,7 @@ mod tests {
 
         let populate_block = |block: &mut TestState<Owned>| {
             for i in 0..TestCacheConfig::CACHE_SIZE {
-                block.push_instr_uncompressed(i as Address, Instruction {
+                block.push_instruction(i as Address, Instruction {
                     opcode: OpCode::X64Add,
                     args: Args {
                         rd: nz::a1.into(),
@@ -932,7 +904,7 @@ mod tests {
         // Fetching empty block fails
         assert!(block_cache.get_block(0).is_none());
 
-        block_cache.push_instr_compressed(0, Instruction::new_nop(InstrWidth::Compressed));
+        block_cache.push_instruction(0, Instruction::new_nop(InstrWidth::Compressed));
 
         // Fetching non-empty block succeeds
         assert!(block_cache.get_block(0).is_some());


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

- Relates to RV-758
- Relates to RV-764

# What

Move `fetch_instr` into the impl for `MachineCoreState`, rather than `MachineState`. Move the population of the block cache into `run_instr_at`.

# Why

This allows us to more easily fetch instructions when all we have access to is the `CoreState`. This will be necessary for handling the exception `ForceFetchRun` (which does not want to populate caches - since it will be run as a result of something in the cache). This also allows us to re-use `fetch_instr` when populating the upcoming `PageCache` in the first iteration.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
