### PR TITLE
ci: Use direnv to configure environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         id: nix-cache
         uses: nix-community/cache-nix-action@v6
         with:
-          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}-v1
+          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}-v2
           restore-prefixes-first-match: |
             nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}-
             nix-${{ runner.os }}-${{ runner.arch }}-
@@ -89,19 +89,29 @@ jobs:
         uses: Mozilla-Actions/sccache-action@v0.0.9
 
       - name: Pre-build Nix development shell
-        run: nix develop --profile ~/dev-shell --command true
+        run: |
+          # Direnv is not installed out of the box unfortunately.
+          nix profile install nixpkgs#direnv nixpkgs#nix-direnv
+
+          # Direnv is configured through `.envrc`. We create it, or override it in case one already
+          # exists.
+          echo "use flake" > .envrc
+
+          # Subsequent steps will have their environment configured using the $GITHUB_ENV variable.
+          direnv allow .
+          direnv export gha > "$GITHUB_ENV"
 
       # All downloads should be cached. If there is a cache miss, we should ensure that the cache
       # contains all downloads.
       - name: Prefetch Cargo downloads
         if: steps.rust-cache.outputs.cache-hit != 'true' && github.ref_name == 'main' 
-        run: nix develop --command find . -iname Cargo.lock -execdir cargo fetch \;
+        run: find . -iname Cargo.lock -execdir cargo fetch \;
 
       - name: Build dependencies
-        run: nix develop --command make build-deps-slim
+        run: make build-deps-slim
 
       - name: Run 'make ${{ matrix.make-target }}'
-        run: nix develop --command make ${{ matrix.make-target }}
+        run: make ${{ matrix.make-target }}
 
       - name: Save Rustup and Cargo cache
         if: github.ref_name == 'main'


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

# What

In the CI, we currently wrap all commands that need the Nix development environment in a `nix develop`. We can avoid this by using [direnv](https://direnv.net/) to configure the environment of the GHA job. This is what this change is mainly about.

The Nix cache suffix is bumped from `-v1` to `-v2` to make sure it will include the store paths for the Direnv installation.

# Why

Overall, using Direnv results in a more readable command run in each step.

It also paves the way for introducing a Direnv `.envrc` to the repository. 

Some people use Direnv locally. Using it in CI gives us extra confidence that development environments won't be broken.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
