### PR TITLE
fix(jit/tests): jit tests that branch would fail to run JIT-compiled code

### DIFF
--- a/src/riscv/lib/src/jit.rs
+++ b/src/riscv/lib/src/jit.rs
@@ -1140,137 +1140,226 @@ mod tests {
     }
 
     #[test]
-    fn test_jump_instructions() {
+    fn test_jr() {
         use crate::machine_state::registers::NonZeroXRegister::*;
 
-        let test_jr = |base_reg: NonZeroXRegister,
-                       base_val: i64,
-                       expected_pc: u64,
-                       instruction_width: InstrWidth|
-         -> Scenario {
+        let scenarios: &[Scenario] = &[
+            // JR not to start of block should exit
             ScenarioBuilder::default()
                 .set_instructions(&[
-                    I::new_li(base_reg, base_val, instruction_width),
-                    I::new_jr(base_reg, instruction_width),
-                    I::new_nop(instruction_width),
+                    I::new_li(x2, 10, Compressed),
+                    I::new_jr(x2, Compressed),
+                    I::new_nop(Compressed),
+                ])
+                .set_assert_hook(assert_hook!(|core| { assert_eq!(core.hart.pc.read(), 10) }))
+                .set_expected_steps(2)
+                .set_expected_exception(Exception::InstructionAccessFault)
+                .build(),
+            // JR to start of block should continue with evaluating the same block
+            ScenarioBuilder::default()
+                .set_instructions(&[
+                    I::new_li(x6, 0, Uncompressed),
+                    I::new_jr(x6, Compressed),
+                    I::new_nop(Compressed),
+                ])
+                // after 3 steps we will be evaluating the jump for the second time
+                .set_assert_hook(assert_hook!(|core| { assert_eq!(core.hart.pc.read(), 4) }))
+                .build(),
+        ];
+
+        for scenario in scenarios {
+            scenario.run()
+        }
+    }
+
+    #[test]
+    fn test_jr_imm() {
+        use crate::machine_state::registers::NonZeroXRegister::*;
+
+        let scenarios: &[Scenario] = &[
+            // JR_IMM not to start of block should exit
+            ScenarioBuilder::default()
+                .set_instructions(&[
+                    I::new_li(x2, 10, Compressed),
+                    I::new_jr_imm(x2, 10, Compressed),
+                    I::new_nop(Compressed),
+                ])
+                .set_assert_hook(assert_hook!(|core| { assert_eq!(core.hart.pc.read(), 20) }))
+                .set_expected_steps(2)
+                .set_expected_exception(Exception::InstructionAccessFault)
+                .build(),
+            // JR_IMM to start of block should continue with evaluating the same block
+            ScenarioBuilder::default()
+                .set_instructions(&[
+                    I::new_li(x6, 10, Uncompressed),
+                    I::new_jr_imm(x6, -10, Uncompressed),
+                    I::new_nop(Compressed),
+                ])
+                // after 3 steps we will be evaluating the jump for the second time
+                .set_assert_hook(assert_hook!(|core| { assert_eq!(core.hart.pc.read(), 4) }))
+                .build(),
+        ];
+
+        for scenario in scenarios {
+            scenario.run()
+        }
+    }
+
+    #[test]
+    fn test_jalr() {
+        use crate::machine_state::registers::NonZeroXRegister::*;
+
+        let scenarios: &[Scenario] = &[
+            // JALR not to start of block should exit
+            ScenarioBuilder::default()
+                .set_instructions(&[
+                    I::new_li(x2, 100_000, Compressed),
+                    I::new_jalr(x1, x2, Compressed),
+                    I::new_nop(Compressed),
                 ])
                 .set_assert_hook(assert_hook!(|core| {
-                    assert_eq!(core.hart.pc.read(), expected_pc);
+                    assert_eq!(core.hart.pc.read(), 100_000);
+                    assert_eq!(core.hart.xregisters.read_nz(x1), 4);
                 }))
                 .set_expected_steps(2)
-                // we jump, and all memory is set as non-executable.
-                // since we exit the block, we fall back to fetch/run - which will fail
                 .set_expected_exception(Exception::InstructionAccessFault)
-                .build()
-        };
-
-        let test_jr_imm = |base_reg: NonZeroXRegister,
-                           base_val: i64,
-                           offset: i64,
-                           expected_pc: u64,
-                           instruction_width: InstrWidth|
-         -> Scenario {
+                .build(),
+            // JALR to start of block should continue with evaluating the same block
             ScenarioBuilder::default()
                 .set_instructions(&[
-                    I::new_li(base_reg, base_val, instruction_width),
-                    I::new_jr_imm(base_reg, offset, instruction_width),
-                    I::new_nop(instruction_width),
+                    I::new_li(x6, 0, Uncompressed),
+                    I::new_jalr(x3, x6, Uncompressed),
+                    I::new_nop(Compressed),
+                ])
+                // after 3 steps we will be evaluating the jump for the second time
+                .set_assert_hook(assert_hook!(|core| {
+                    assert_eq!(core.hart.pc.read(), 4);
+                    assert_eq!(core.hart.xregisters.read_nz(x3), 8);
+                }))
+                .build(),
+        ];
+
+        for scenario in scenarios {
+            scenario.run()
+        }
+    }
+
+    #[test]
+    fn test_jalr_imm() {
+        use crate::machine_state::registers::NonZeroXRegister::*;
+
+        let scenarios: &[Scenario] = &[
+            // JALR_IMM not to start of block should exit
+            ScenarioBuilder::default()
+                .set_instructions(&[
+                    I::new_li(x2, 10, Compressed),
+                    I::new_jalr_imm(x1, x2, 10, Compressed),
+                    I::new_nop(Compressed),
                 ])
                 .set_assert_hook(assert_hook!(|core| {
-                    assert_eq!(core.hart.pc.read(), expected_pc);
+                    assert_eq!(core.hart.pc.read(), 20);
+                    assert_eq!(core.hart.xregisters.read_nz(x1), 4);
                 }))
                 .set_expected_steps(2)
-                // we jump, and all memory is set as non-executable.
-                // since we exit the block, we fall back to fetch/run - which will fail
                 .set_expected_exception(Exception::InstructionAccessFault)
-                .build()
-        };
-
-        let test_jalr = |base_reg: NonZeroXRegister,
-                         base_val: i64,
-                         rd: NonZeroXRegister,
-                         expected_pc: u64,
-                         expected_rd: u64,
-                         instruction_width: InstrWidth|
-         -> Scenario {
+                .build(),
+            // JALR_IMM to start of block should continue with evaluating the same block
             ScenarioBuilder::default()
                 .set_instructions(&[
-                    I::new_li(base_reg, base_val, instruction_width),
-                    I::new_jalr(rd, base_reg, instruction_width),
-                    I::new_nop(instruction_width),
+                    I::new_li(x1, 1000, Uncompressed),
+                    I::new_jalr_imm(x6, x1, -1000, Uncompressed),
+                    I::new_nop(Compressed),
+                ])
+                // after 3 steps we will be evaluating the jump for the second time
+                .set_assert_hook(assert_hook!(|core| {
+                    assert_eq!(core.hart.pc.read(), 4);
+                    assert_eq!(core.hart.xregisters.read_nz(x6), 8);
+                }))
+                .build(),
+        ];
+
+        for scenario in scenarios {
+            scenario.run()
+        }
+    }
+
+    #[test]
+    fn test_jalr_absolute() {
+        use crate::machine_state::registers::NonZeroXRegister::*;
+
+        let scenarios: &[Scenario] = &[
+            // JALR_ABSOLUTE not to start of block should exit
+            ScenarioBuilder::default()
+                .set_instructions(&[
+                    I::new_nop(Uncompressed),
+                    I::new_jalr_absolute(x1, 10, Compressed),
+                    I::new_nop(Compressed),
                 ])
                 .set_assert_hook(assert_hook!(|core| {
-                    assert_eq!(core.hart.pc.read(), expected_pc);
-                    assert_eq!(core.hart.xregisters.read_nz(rd), expected_rd);
+                    assert_eq!(core.hart.pc.read(), 10);
+                    assert_eq!(core.hart.xregisters.read_nz(x1), 6);
                 }))
                 .set_expected_steps(2)
-                // we jump, and all memory is set as non-executable.
-                // since we exit the block, we fall back to fetch/run - which will fail
                 .set_expected_exception(Exception::InstructionAccessFault)
-                .build()
-        };
-
-        let test_jalr_imm = |base_reg: NonZeroXRegister,
-                             base_val: i64,
-                             offset: i64,
-                             rd: NonZeroXRegister,
-                             expected_pc: u64,
-                             expected_rd: u64,
-                             instruction_width: InstrWidth|
-         -> Scenario {
+                .build(),
+            // JALR_ABSOLUTE to start of block should continue with evaluating the same block
             ScenarioBuilder::default()
                 .set_instructions(&[
-                    I::new_li(base_reg, base_val, instruction_width),
-                    I::new_jalr_imm(rd, base_reg, offset, instruction_width),
-                    I::new_nop(instruction_width),
+                    I::new_nop(Compressed),
+                    I::new_jalr_absolute(x3, 0, Uncompressed),
+                    I::new_nop(Compressed),
+                ])
+                // after 3 steps we will be evaluating the jump for the second time
+                .set_assert_hook(assert_hook!(|core| {
+                    assert_eq!(core.hart.pc.read(), 2);
+                    assert_eq!(core.hart.xregisters.read_nz(x3), 6);
+                }))
+                .build(),
+        ];
+
+        for scenario in scenarios {
+            scenario.run()
+        }
+    }
+
+    #[test]
+    fn test_j_absolute() {
+        let scenarios: &[Scenario] = &[
+            // J_ABSOLUTE not to start of block should exit
+            ScenarioBuilder::default()
+                .set_instructions(&[
+                    I::new_nop(Uncompressed),
+                    I::new_j_absolute(10, Compressed),
+                    I::new_nop(Compressed),
                 ])
                 .set_assert_hook(assert_hook!(|core| {
-                    assert_eq!(core.hart.pc.read(), expected_pc);
-                    assert_eq!(core.hart.xregisters.read_nz(rd), expected_rd);
+                    assert_eq!(core.hart.pc.read(), 10);
                 }))
                 .set_expected_steps(2)
-                // we jump, and all memory is set as non-executable.
-                // since we exit the block, we fall back to fetch/run - which will fail
                 .set_expected_exception(Exception::InstructionAccessFault)
-                .build()
-        };
-
-        let test_jalr_absolute = |target: i64,
-                                  rd: NonZeroXRegister,
-                                  instruction_width: InstrWidth,
-                                  expected_rd: u64|
-         -> Scenario {
+                .build(),
+            // J_ABSOLUTE to start of block should continue with evaluating the same block
             ScenarioBuilder::default()
                 .set_instructions(&[
-                    I::new_jalr_absolute(rd, target, instruction_width),
-                    I::new_nop(instruction_width),
+                    I::new_nop(Compressed),
+                    I::new_j_absolute(0, Uncompressed),
+                    I::new_nop(Compressed),
                 ])
+                // after 3 steps we will be evaluating the jump for the second time
                 .set_assert_hook(assert_hook!(|core| {
-                    assert_eq!(core.hart.pc.read(), target as u64);
-                    assert_eq!(core.hart.xregisters.read_nz(rd), expected_rd);
+                    assert_eq!(core.hart.pc.read(), 2);
                 }))
-                .set_expected_steps(1)
-                // we jump, and all memory is set as non-executable.
-                // since we exit the block, we fall back to fetch/run - which will fail
-                .set_expected_exception(Exception::InstructionAccessFault)
-                .build()
-        };
+                .build(),
+        ];
 
-        let test_j_absolute = |target: i64, instruction_width: InstrWidth| -> Scenario {
-            ScenarioBuilder::default()
-                .set_instructions(&[
-                    I::new_j_absolute(target, instruction_width),
-                    I::new_nop(instruction_width),
-                ])
-                .set_assert_hook(assert_hook!(|core| {
-                    assert_eq!(core.hart.pc.read(), target as u64);
-                }))
-                .set_expected_steps(1)
-                // we jump, and all memory is set as non-executable.
-                // since we exit the block, we fall back to fetch/run - which will fail
-                .set_expected_exception(Exception::InstructionAccessFault)
-                .build()
-        };
+        for scenario in scenarios {
+            scenario.run()
+        }
+    }
+
+    #[test]
+    fn test_jump_and_link_pc() {
+        use crate::machine_state::registers::NonZeroXRegister::*;
 
         let test_jump_and_link_pc = |offset: i64,
                                      initial_pc: u64,
@@ -1288,27 +1377,7 @@ mod tests {
                 .build()
         };
 
-        // FIXME: re-enable disable Jump scenarios
         let scenarios: &[Scenario] = &[
-            // Test jr
-            test_jr(x2, 10, 10, Compressed),
-            //test_jr(x6, 0, 0, Uncompressed),
-            // Test jr_imm
-            test_jr_imm(x2, 10, 10, 20, Compressed),
-            //test_jr_imm(x6, 10, -10, 0, Uncompressed),
-            // Test jalr
-            test_jalr(x2, 100_000, x1, 100_000, 8, Uncompressed),
-            //test_jalr(x6, 0, x3, 0, 4, Compressed),
-            // Test jalr_imm
-            test_jalr_imm(x1, 10, 10, x2, 20, 4, Compressed),
-            test_jalr_imm(x1, 1000, -10, x2, 990, 8, Uncompressed),
-            // Test jalr_absolute
-            test_jalr_absolute(10, x1, Compressed, 2),
-            //test_jalr_absolute(0, x3, Uncompressed, 4),
-            // Test j_absolute
-            test_j_absolute(10, Compressed),
-            //test_j_absolute(0, Uncompressed),
-            // Test jump_and_link_pc
             test_jump_and_link_pc(10, 0, 10, 2, Compressed),
             test_jump_and_link_pc(-10, 10, 0, 12, Compressed),
             test_jump_and_link_pc(1000, 1000, 2000, 1004, Uncompressed),

--- a/src/riscv/lib/src/jit.rs
+++ b/src/riscv/lib/src/jit.rs
@@ -420,6 +420,16 @@ mod tests {
                 .insert_block(initial_pc, jitted_block);
             let jitted_res = jitted_state.step_max_inner(max_steps);
 
+            // Assert the JIT-compiled block was called once.
+            let jit_called_counter = jitted_state
+                .block_cache
+                .get_block_called_times(initial_pc)
+                .expect("Block at initial_pc should be valid");
+            assert_eq!(
+                jit_called_counter, 1,
+                "Expected JIT-compiled block to be called exactly once"
+            );
+
             // Assert state equality.
             assert_eq!(
                 jitted_res, interpreted_res,

--- a/src/riscv/lib/src/jit.rs
+++ b/src/riscv/lib/src/jit.rs
@@ -320,6 +320,7 @@ mod tests {
     use crate::state::NewState;
     use crate::state_backend::FnManagerIdent;
     use crate::state_backend::ManagerRead;
+    use crate::traps::Exception;
 
     fn instructions<MC: MemoryConfig, M>(block: &Interpreted<MC, M>) -> Vec<Instruction>
     where
@@ -341,6 +342,7 @@ mod tests {
         instructions: Vec<Instruction>,
         setup_hook: Option<Box<SetupHook>>,
         assert_hook: Option<Box<AssertHook>>,
+        expected_exception: Option<Exception>,
     }
 
     impl Scenario {
@@ -351,6 +353,7 @@ mod tests {
                 instructions: instructions.to_vec(),
                 setup_hook: None,
                 assert_hook: None,
+                expected_exception: None,
             }
         }
 
@@ -399,7 +402,9 @@ mod tests {
             }
 
             // initialise starting parameters: pc and expected_steps
-            let expected_steps = self.expected_steps.unwrap_or(self.instructions.len());
+            let max_steps = self.instructions.len();
+            let expected_steps = self.expected_steps.unwrap_or(max_steps);
+
             let initial_pc = self.initial_pc.unwrap_or_default();
             interpreted_state.core.hart.pc.write(initial_pc);
             jitted_state.core.hart.pc.write(initial_pc);
@@ -408,15 +413,28 @@ mod tests {
             interpreted_state
                 .block_cache
                 .insert_block(initial_pc, interpreted_block);
-            let interpreted_res = interpreted_state.step_max_inner(expected_steps);
+            let interpreted_res = interpreted_state.step_max_inner(max_steps);
 
             jitted_state
                 .block_cache
                 .insert_block(initial_pc, jitted_block);
-            let jitted_res = jitted_state.step_max_inner(expected_steps);
+            let jitted_res = jitted_state.step_max_inner(max_steps);
 
             // Assert state equality.
-            assert_eq!(jitted_res, interpreted_res);
+            assert_eq!(
+                jitted_res, interpreted_res,
+                "JittedRes {jitted_res:?} should equal InterpretedRes {interpreted_res:?}"
+            );
+            assert_eq!(
+                jitted_res.steps, expected_steps,
+                "Expected {expected_steps} steps; scenarios ran for {}",
+                jitted_res.steps
+            );
+            assert_eq!(
+                jitted_res.error, self.expected_exception,
+                "Expected exception: {:?}, got {:?}",
+                self.expected_exception, jitted_res.error
+            );
 
             assert!(
                 interpreted_state.struct_ref::<FnManagerIdent>()
@@ -448,6 +466,7 @@ mod tests {
         instructions: Vec<Instruction>,
         setup_hook: Option<Box<SetupHook>>,
         assert_hook: Option<Box<AssertHook>>,
+        expected_exception: Option<Exception>,
     }
 
     impl ScenarioBuilder {
@@ -476,6 +495,11 @@ mod tests {
             self
         }
 
+        fn set_expected_exception(mut self, exception: Exception) -> Self {
+            self.expected_exception = Some(exception);
+            self
+        }
+
         fn build(self) -> Scenario {
             Scenario {
                 initial_pc: self.initial_pc,
@@ -483,6 +507,7 @@ mod tests {
                 instructions: self.instructions,
                 setup_hook: self.setup_hook,
                 assert_hook: self.assert_hook,
+                expected_exception: self.expected_exception,
             }
         }
     }
@@ -996,7 +1021,6 @@ mod tests {
                     I::new_x64_div_signed(nz::a2, a0, a1, Compressed),
                     I::new_nop(Uncompressed),
                 ])
-                .set_expected_steps(4)
                 .set_assert_hook(assert_hook!(|core| {
                     assert_eq!(core.hart.xregisters.read_nz(nz::a2), expected);
                 }))
@@ -1039,7 +1063,6 @@ mod tests {
                 .set_assert_hook(assert_hook!(|core| {
                     assert_eq!(core.hart.pc.read(), 6);
                 }))
-                .set_expected_steps(3)
                 .build(),
             ScenarioBuilder::default()
                 // Jump past 0 - in both worlds we should wrap around.
@@ -1047,7 +1070,6 @@ mod tests {
                 .set_assert_hook(assert_hook!(|core| {
                     assert_eq!(core.hart.pc.read(), u64::MAX - 3);
                 }))
-                .set_expected_steps(1)
                 .build(),
             ScenarioBuilder::default()
                 // Jump past u64::MAX - in both worlds we should wrap around but not
@@ -1064,6 +1086,9 @@ mod tests {
                     assert_eq!(core.hart.pc.read(), 1);
                 }))
                 .set_expected_steps(3)
+                // we jump, and all memory is set as non-executable.
+                // since we exit the block, we fall back to fetch/run - which will fail
+                .set_expected_exception(Exception::InstructionAccessFault)
                 .build(),
             ScenarioBuilder::default()
                 // jump by nothing
@@ -1076,9 +1101,16 @@ mod tests {
                     assert_eq!(core.hart.pc.read(), 2);
                 }))
                 .set_expected_steps(2)
+                // we jump, and all memory is set as non-executable.
+                // since we exit the block, we fall back to fetch/run - which will fail
+                .set_expected_exception(Exception::InstructionAccessFault)
                 .build(),
             ScenarioBuilder::default()
                 // jumping to start of the block should exit the block in both interpreted and jitted world
+                //
+                // since we jump to the start of the block, however, we will fallback to partial
+                // block evaluation on the 4th step. Therefore, we do not expect an
+                // InstructionAccessFault
                 .set_instructions(&[
                     I::new_nop(Compressed),
                     I::new_nop(Compressed),
@@ -1086,9 +1118,9 @@ mod tests {
                     I::new_nop(Uncompressed),
                 ])
                 .set_assert_hook(assert_hook!(|core| {
-                    assert_eq!(core.hart.pc.read(), 0);
+                    assert_eq!(core.hart.pc.read(), 2);
                 }))
-                .set_expected_steps(3)
+                .set_expected_steps(4)
                 .build(),
         ];
 
@@ -1116,6 +1148,9 @@ mod tests {
                     assert_eq!(core.hart.pc.read(), expected_pc);
                 }))
                 .set_expected_steps(2)
+                // we jump, and all memory is set as non-executable.
+                // since we exit the block, we fall back to fetch/run - which will fail
+                .set_expected_exception(Exception::InstructionAccessFault)
                 .build()
         };
 
@@ -1135,6 +1170,9 @@ mod tests {
                     assert_eq!(core.hart.pc.read(), expected_pc);
                 }))
                 .set_expected_steps(2)
+                // we jump, and all memory is set as non-executable.
+                // since we exit the block, we fall back to fetch/run - which will fail
+                .set_expected_exception(Exception::InstructionAccessFault)
                 .build()
         };
 
@@ -1156,6 +1194,9 @@ mod tests {
                     assert_eq!(core.hart.xregisters.read_nz(rd), expected_rd);
                 }))
                 .set_expected_steps(2)
+                // we jump, and all memory is set as non-executable.
+                // since we exit the block, we fall back to fetch/run - which will fail
+                .set_expected_exception(Exception::InstructionAccessFault)
                 .build()
         };
 
@@ -1178,6 +1219,9 @@ mod tests {
                     assert_eq!(core.hart.xregisters.read_nz(rd), expected_rd);
                 }))
                 .set_expected_steps(2)
+                // we jump, and all memory is set as non-executable.
+                // since we exit the block, we fall back to fetch/run - which will fail
+                .set_expected_exception(Exception::InstructionAccessFault)
                 .build()
         };
 
@@ -1196,6 +1240,9 @@ mod tests {
                     assert_eq!(core.hart.xregisters.read_nz(rd), expected_rd);
                 }))
                 .set_expected_steps(1)
+                // we jump, and all memory is set as non-executable.
+                // since we exit the block, we fall back to fetch/run - which will fail
+                .set_expected_exception(Exception::InstructionAccessFault)
                 .build()
         };
 
@@ -1209,6 +1256,9 @@ mod tests {
                     assert_eq!(core.hart.pc.read(), target as u64);
                 }))
                 .set_expected_steps(1)
+                // we jump, and all memory is set as non-executable.
+                // since we exit the block, we fall back to fetch/run - which will fail
+                .set_expected_exception(Exception::InstructionAccessFault)
                 .build()
         };
 
@@ -1225,29 +1275,29 @@ mod tests {
                     assert_eq!(core.hart.pc.read(), expected_pc);
                     assert_eq!(core.hart.xregisters.read_nz(x1), expected_x1);
                 }))
-                .set_expected_steps(1)
                 .build()
         };
 
+        // FIXME: re-enable disable Jump scenarios
         let scenarios: &[Scenario] = &[
             // Test jr
             test_jr(x2, 10, 10, Compressed),
-            test_jr(x6, 0, 0, Uncompressed),
+            //test_jr(x6, 0, 0, Uncompressed),
             // Test jr_imm
             test_jr_imm(x2, 10, 10, 20, Compressed),
-            test_jr_imm(x6, 10, -10, 0, Uncompressed),
+            //test_jr_imm(x6, 10, -10, 0, Uncompressed),
             // Test jalr
             test_jalr(x2, 100_000, x1, 100_000, 8, Uncompressed),
-            test_jalr(x6, 0, x3, 0, 4, Compressed),
+            //test_jalr(x6, 0, x3, 0, 4, Compressed),
             // Test jalr_imm
             test_jalr_imm(x1, 10, 10, x2, 20, 4, Compressed),
             test_jalr_imm(x1, 1000, -10, x2, 990, 8, Uncompressed),
             // Test jalr_absolute
             test_jalr_absolute(10, x1, Compressed, 2),
-            test_jalr_absolute(0, x3, Uncompressed, 4),
+            //test_jalr_absolute(0, x3, Uncompressed, 4),
             // Test j_absolute
             test_j_absolute(10, Compressed),
-            test_j_absolute(0, Uncompressed),
+            //test_j_absolute(0, Uncompressed),
             // Test jump_and_link_pc
             test_jump_and_link_pc(10, 0, 10, 2, Compressed),
             test_jump_and_link_pc(-10, 10, 0, 12, Compressed),
@@ -1481,6 +1531,9 @@ mod tests {
                         I::new_nop(InstrWidth::Compressed),
                     ])
                     .set_expected_steps(4)
+                    // we branch, and all memory is set as non-executable.
+                    // since we exit the block, we fall back to fetch/run - which will fail
+                    .set_expected_exception(Exception::InstructionAccessFault)
                     .set_assert_hook(assert_hook!(|core| {
                         assert_eq!(
                             expected_pc_branch,
@@ -1566,6 +1619,8 @@ mod tests {
                     I::new_nop(InstrWidth::Compressed),
                 ])
                 .set_expected_steps(3)
+                // we branch, and all memory is set as non-executable
+                .set_expected_exception(Exception::InstructionAccessFault)
                 .set_assert_hook(assert_hook!(|core| {
                     assert_eq!(
                         expected_pc_branch,
@@ -1627,6 +1682,7 @@ mod tests {
                 // The unknown instruction raises an exception. This does not count as a full step.
                 1,
             )
+            .set_expected_exception(Exception::IllegalInstruction)
             .set_instructions(&[
                 I::new_nop(Uncompressed),
                 I::new_unknown(Compressed),
@@ -1643,6 +1699,7 @@ mod tests {
     fn test_ecall() {
         let scenario: Scenario = ScenarioBuilder::default()
             .set_expected_steps(1)
+            .set_expected_exception(Exception::EnvCall)
             .set_instructions(&[
                 I::new_nop(Uncompressed),
                 I::new_ecall(),
@@ -2067,7 +2124,6 @@ mod tests {
                     constructor(x1, x2, imm as i64, InstrWidth::Uncompressed),
                     I::new_nop(InstrWidth::Compressed),
                 ])
-                .set_expected_steps(4)
                 .set_assert_hook(assert_hook!(|core| {
                     let value: u64 = core.main_memory.read(STORE_ADDRESS_BASE + imm).unwrap();
 
@@ -2098,6 +2154,7 @@ mod tests {
                     // A failed store does not count as a full step
                     2,
                 )
+                .set_expected_exception(Exception::StoreAMOAccessFault)
                 .set_assert_hook(assert_hook!(|core| {
                     let value: u64 = core.main_memory.read(MEMORY_SIZE - 8).unwrap();
 
@@ -2152,7 +2209,6 @@ mod tests {
                     new_load(x2, x1, imm as i64, InstrWidth::Uncompressed),
                     I::new_nop(InstrWidth::Compressed),
                 ])
-                .set_expected_steps(3)
                 .set_assert_hook(assert_hook!(|core| {
                     let value: u64 = core.hart.xregisters.read(x2);
                     assert_eq!(value, expected, "Found {value:x}, expected {expected:x}");
@@ -2176,6 +2232,7 @@ mod tests {
                     // A failed load does not count as a full step
                     1,
                 )
+                .set_expected_exception(Exception::LoadAccessFault)
                 .set_assert_hook(assert_hook!(|core| {
                     let value: u64 = core.hart.xregisters.read(x2);
                     assert_eq!(value, 0, "Found {value:x}, but expected load to fail");
@@ -2300,7 +2357,6 @@ mod tests {
                     constructor(x3, x1, x2, false, false, InstrWidth::Uncompressed),
                     I::new_nop(InstrWidth::Compressed),
                 ])
-                .set_expected_steps(4)
                 .set_assert_hook(assert_hook!(|core| {
                     let value: u64 = core.hart.xregisters.read(x3);
                     assert_eq!(value as i64, val1);
@@ -2330,7 +2386,6 @@ mod tests {
                     constructor(x3, x1, x2, false, false, InstrWidth::Uncompressed),
                     I::new_nop(InstrWidth::Compressed),
                 ])
-                .set_expected_steps(4)
                 .set_assert_hook(assert_hook!(|core| {
                     let value: u64 = core.hart.xregisters.read(x3);
                     assert_eq!(value, val1);
@@ -2367,6 +2422,7 @@ mod tests {
                     // A failed atomic operation does not count as a full step
                     2,
                 )
+                .set_expected_exception(Exception::StoreAMOAccessFault)
                 .set_assert_hook(assert_hook!(|core| {
                     let value: u64 = core.hart.xregisters.read(x3);
                     assert_eq!(value as i64, 0);
@@ -2403,6 +2459,7 @@ mod tests {
                     // A failed atomic operation does not count as a full step
                     2,
                 )
+                .set_expected_exception(Exception::StoreAMOAccessFault)
                 .set_assert_hook(assert_hook!(|core| {
                     let value: u64 = core.hart.xregisters.read(x3);
                     assert_eq!(value, 0);
@@ -2593,6 +2650,7 @@ mod tests {
                     // A failed atomic load does not count as a full step
                     1,
                 )
+                .set_expected_exception(Exception::StoreAMOAccessFault)
                 .set_assert_hook(assert_hook!(|core| {
                     let value: u64 = core.hart.xregisters.read(x3);
                     assert_eq!(value, 0);
@@ -2620,6 +2678,7 @@ mod tests {
                     // The failed atomic operation does not count as a full step
                     4,
                 )
+                .set_expected_exception(Exception::StoreAMOAccessFault)
                 .set_assert_hook(assert_hook!(|core| {
                     // Failure due to unaligned address should not modify the value in `rd`.
                     let value: u64 = core.hart.xregisters.read(x3);
@@ -2644,7 +2703,6 @@ mod tests {
                     I::new_x32_atomic_store(x3, x4, x2, false, false, InstrWidth::Uncompressed),
                     I::new_nop(InstrWidth::Compressed),
                 ])
-                .set_expected_steps(6)
                 .set_assert_hook(assert_hook!(|core| {
                     // Failure due to address outside the reservation set
                     // should set the value in `rd` to 1.
@@ -2675,7 +2733,6 @@ mod tests {
                     I::new_x32_atomic_store(x3, x4, x2, false, false, InstrWidth::Uncompressed),
                     I::new_nop(InstrWidth::Compressed),
                 ])
-                .set_expected_steps(7)
                 .set_assert_hook(assert_hook!(|core| {
                     // Failure due to address outside the current reservation set
                     // should set the value in `rd` to 1.
@@ -2743,6 +2800,7 @@ mod tests {
                     // A failed atomic load does not count as a full step
                     1,
                 )
+                .set_expected_exception(Exception::StoreAMOAccessFault)
                 .set_assert_hook(assert_hook!(|core| {
                     let value: u64 = core.hart.xregisters.read(x3);
                     assert_eq!(value, 0);
@@ -2770,6 +2828,7 @@ mod tests {
                     // The failed atomic operation does not count as a full step
                     4,
                 )
+                .set_expected_exception(Exception::StoreAMOAccessFault)
                 .set_assert_hook(assert_hook!(|core| {
                     // Failure due to unaligned address should not modify the value in `rd`.
                     let value: u64 = core.hart.xregisters.read(x3);
@@ -2794,7 +2853,6 @@ mod tests {
                     I::new_x64_atomic_store(x3, x4, x2, false, false, InstrWidth::Uncompressed),
                     I::new_nop(InstrWidth::Compressed),
                 ])
-                .set_expected_steps(6)
                 .set_assert_hook(assert_hook!(|core| {
                     // Failure due to address outside the reservation set
                     // should set the value in `rd` to 1.
@@ -2825,7 +2883,6 @@ mod tests {
                     I::new_x64_atomic_store(x3, x4, x2, false, false, InstrWidth::Uncompressed),
                     I::new_nop(InstrWidth::Compressed),
                 ])
-                .set_expected_steps(7)
                 .set_assert_hook(assert_hook!(|core| {
                     // Failure due to address outside the current reservation set
                     // should set the value in `rd` to 1.
@@ -2847,7 +2904,6 @@ mod tests {
                     I::new_x32_atomic_store(x3, x4, x2, false, false, InstrWidth::Compressed),
                     I::new_nop(InstrWidth::Compressed),
                 ])
-                .set_expected_steps(6)
                 .set_assert_hook(assert_hook!(|core| {
                     // Success due to address outside the current reservation set
                     // should set the value in `rd` to 0.
@@ -3079,7 +3135,6 @@ mod tests {
                     constructor(x3, x1, x2, false, false, InstrWidth::Uncompressed),
                     I::new_nop(InstrWidth::Compressed),
                 ])
-                .set_expected_steps(4)
                 .set_assert_hook(assert_hook!(|core| {
                     let value = core.hart.xregisters.read(x3);
                     assert_eq!(value, val1 as i32 as u64);
@@ -3115,6 +3170,7 @@ mod tests {
                     // A failed atomic operation does not count as a full step
                     2,
                 )
+                .set_expected_exception(Exception::StoreAMOAccessFault)
                 .set_assert_hook(assert_hook!(|core| {
                     let value = core.hart.xregisters.read(x3);
                     assert_eq!(value, 0);
@@ -3196,7 +3252,6 @@ mod tests {
                     ),
                     I::new_nop(InstrWidth::Uncompressed),
                 ])
-                .set_expected_steps(3)
                 .set_assert_hook(assert_hook!(|core| {
                     let res = core.hart.fregisters.read(f2);
                     let expected: FValue = (Double::from_u128_r(13872u128, Round::TowardZero))
@@ -3215,7 +3270,6 @@ mod tests {
                     I::new_f64_from_x64_unsigned(f2, x1, InstrRoundingMode::Dynamic, Compressed),
                     I::new_nop(InstrWidth::Uncompressed),
                 ])
-                .set_expected_steps(3)
                 .set_assert_hook(assert_hook!(|core| {
                     let res = core.hart.fregisters.read(f2);
                     let expected: FValue =

--- a/src/riscv/lib/src/machine_state/block_cache/block/dispatch.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/block/dispatch.rs
@@ -52,6 +52,14 @@ pub struct DispatchTarget<D: DispatchCompiler<MC>, MC: MemoryConfig> {
     /// considerations taken whilst converting pointer <--> usize.
     fun: Arc<AtomicUsize>,
     remaining_calls: usize,
+    /// A test only counter for the number of times this block has been called.
+    ///
+    /// This is used in the `jit.rs` tests to ensure that when running a scenario over InlineJit,
+    /// we *do* actually run the block. Previously this check did not exist, and a change resulted
+    /// in the tests using the partial block mechanism instead for certain classes of test, rather
+    /// than actually running the JIT-compiled function as intended.
+    #[cfg(test)]
+    call_counter: usize,
     _pd: PhantomData<(D, MC)>,
 }
 
@@ -68,6 +76,10 @@ impl<D: DispatchCompiler<MC>, MC: MemoryConfig> DispatchTarget<D, MC> {
         ));
 
         self.remaining_calls = 1000;
+        #[cfg(test)]
+        {
+            self.call_counter = 0;
+        }
     }
 
     /// Set the dispatch target to use the given `block_run` function.
@@ -91,6 +103,18 @@ impl<D: DispatchCompiler<MC>, MC: MemoryConfig> DispatchTarget<D, MC> {
         // Safety: the pointer is indeed a function pointer with an ABI matching `DispatchFn`.
         unsafe { std::mem::transmute::<*const (), DispatchFn<D, MC>>(fun) }
     }
+
+    /// Increase the call counter to keep track of how often it was dispatched for verification in tests.
+    #[cfg(test)]
+    pub(crate) fn record_called(&mut self) {
+        self.call_counter += 1;
+    }
+
+    /// Get the number of times this dispatch target has been called for verification in tests.
+    #[cfg(test)]
+    pub(crate) fn called_times(&self) -> usize {
+        self.call_counter
+    }
 }
 
 impl<D: DispatchCompiler<MC>, MC: MemoryConfig> Default for DispatchTarget<D, MC> {
@@ -100,6 +124,8 @@ impl<D: DispatchCompiler<MC>, MC: MemoryConfig> Default for DispatchTarget<D, MC
                 Jitted::<D, MC>::run_block_interpreted as usize,
             )),
             remaining_calls: 1000,
+            #[cfg(test)]
+            call_counter: 0,
             _pd: PhantomData,
         }
     }

--- a/src/riscv/lib/src/machine_state/block_cache/block/jitted.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/block/jitted.rs
@@ -111,6 +111,15 @@ impl<D: DispatchCompiler<MC>, MC: MemoryConfig> Jitted<D, MC> {
 
         block_result.steps
     }
+
+    /// Get the number of times this block has been called.
+    ///
+    /// For the case of Inline JIT, this is exactly equal to the number of times the JIT-compiled
+    /// function has been called (provided that compilation was successful).
+    #[cfg(test)]
+    pub(crate) fn called_count(&self) -> usize {
+        self.dispatch.called_times()
+    }
 }
 
 impl<D: DispatchCompiler<MC>, MC: MemoryConfig> NewState<Owned> for Jitted<D, MC> {
@@ -180,6 +189,9 @@ impl<D: DispatchCompiler<MC>, MC: MemoryConfig> Block<MC, Owned> for Jitted<D, M
         let mut result = ExceptionCode::NoException;
 
         let fun = self.dispatch.get();
+
+        #[cfg(test)]
+        self.dispatch.record_called();
 
         // SAFETY: The block builder is always the same instance, guaranteeing that any JIT-compiled
         // function is still alive.

--- a/src/riscv/lib/src/machine_state/block_cache/state.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/state.rs
@@ -314,6 +314,26 @@ impl<const SIZE: usize, B: Block<MC, M>, MC: MemoryConfig, M: ManagerBase>
         &mut entries[BlockCacheConfig::<SIZE>::cache_index(addr)]
     }
 
+    #[inline]
+    fn get_block_inner(&mut self, addr: Address) -> Option<BlockCall<'_, B, MC, M>>
+    where
+        M: ManagerRead,
+    {
+        let entry = Self::entry_mut(&mut self.entries, addr);
+
+        if entry.address.read() == addr
+            && self.fence_counter.read() == entry.fence_counter.read()
+            && entry.block.num_instr() > 0
+        {
+            Some(BlockCall {
+                entry,
+                partial: &mut self.partial_block,
+            })
+        } else {
+            None
+        }
+    }
+
     fn reset_to(&mut self, addr: Address)
     where
         M: ManagerWrite,
@@ -386,6 +406,19 @@ impl<const SIZE: usize, B: Block<MC, M>, MC: MemoryConfig, M: ManagerBase>
     }
 }
 
+#[cfg(test)]
+impl<const SIZE: usize, D: super::block::dispatch::DispatchCompiler<MC>, MC: MemoryConfig>
+    BlockCache<SIZE, super::block::Jitted<D, MC>, MC, crate::state_backend::owned_backend::Owned>
+{
+    /// Get the number of times a block was called.
+    ///
+    /// Returns `None` if the block does not correspond to a valid block.
+    pub(crate) fn get_block_called_times(&mut self, addr: Address) -> Option<usize> {
+        self.get_block_inner(addr)
+            .map(|block| block.entry.block.called_count())
+    }
+}
+
 impl<const SIZE: usize, MC: MemoryConfig, B: Block<MC, M>, M: ManagerBase>
     super::BlockCache<MC, B, M> for BlockCache<SIZE, B, MC, M>
 {
@@ -453,19 +486,7 @@ impl<const SIZE: usize, MC: MemoryConfig, B: Block<MC, M>, M: ManagerBase>
             "Get block was called with a partial block in progress"
         );
 
-        let entry = Self::entry_mut(&mut self.entries, addr);
-
-        if entry.address.read() == addr
-            && self.fence_counter.read() == entry.fence_counter.read()
-            && entry.block.num_instr() > 0
-        {
-            Some(BlockCall {
-                entry,
-                partial: &mut self.partial_block,
-            })
-        } else {
-            None
-        }
+        self.get_block_inner(addr)
     }
 
     fn push_instruction(&mut self, addr: Address, instr: Instruction)


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

Related to RV-758. (discovered whilst attempting to test the `ForceFetchRun` mechanism).

# What

Ensure that jit tests actually run the compiled code. This was a bug introduced unintentionally by #259 - in particular the use of `expected_steps` to supply the value for `max_steps`. 

# Why

The jit tests exist to ensure parity between interpreted/jit-compiled instruction sequences. Unfortunately, by using `expected_steps == max_steps` when passing this to `step_max_inner`, when we expected an exception/branch to occur, the result was instead the block would be too large to run in the steps remaining. The result was both interpreted & jit tests would exercise the partial block mechanism only.

# How

Instead, we now use the instruction-sequence length for `max_steps`, and assert that the jit-compiled code is always run.

We additionally now require that all scenarios define what exception they expect (or none).

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
