### PR TITLE
Disallow `.unwrap()` in non-test code

### DIFF
--- a/src/riscv/.clippy.toml
+++ b/src/riscv/.clippy.toml
@@ -1,0 +1,1 @@
+allow-unwrap-in-tests = true

--- a/src/riscv/Cargo.toml
+++ b/src/riscv/Cargo.toml
@@ -6,6 +6,7 @@ exclude = ["jstz", "dummy_kernel", "etherlink"]
 [workspace.lints.clippy]
 allow_attributes = "deny"
 allow_attributes_without_reason = "deny"
+unwrap_used = "deny"
 
 [workspace.lints.rustdoc]
 broken_intra_doc_links = "deny"

--- a/src/riscv/lib/src/machine_state/block_cache/config.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/config.rs
@@ -75,19 +75,22 @@ impl<const SIZE: usize> super::BlockCacheConfig for BlockCacheConfig<SIZE> {
         M: ManagerBase,
         M::ManagerRoot: ManagerReadWrite,
     {
+        let Ok(entries) = space
+            .4
+            .into_iter()
+            .map(Cached::bind)
+            .collect::<Vec<_>>()
+            .try_into()
+        else {
+            unreachable!("mismatching vector lengths for instruction cache");
+        };
+
         Self::State {
             current_block_addr: space.0,
             next_instr_addr: space.1,
             fence_counter: space.2,
             partial_block: PartialBlock::bind(space.3),
-            entries: space
-                .4
-                .into_iter()
-                .map(Cached::bind)
-                .collect::<Vec<_>>()
-                .try_into()
-                .map_err(|_| "mismatching vector lengths for instruction cache")
-                .unwrap(),
+            entries,
         }
     }
 

--- a/src/riscv/lib/src/machine_state/block_cache/state.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/state.rs
@@ -440,6 +440,10 @@ impl<const SIZE: usize, MC: MemoryConfig, B: Block<MC, M>, M: ManagerBase>
         B: Clone,
         M: ManagerClone,
     {
+        let Ok(entries) = self.entries.to_vec().try_into() else {
+            unreachable!("mismatching vector lengths in block cache")
+        };
+
         Self {
             current_block_addr: self.current_block_addr.clone(),
             fence_counter: self.fence_counter.clone(),
@@ -448,12 +452,7 @@ impl<const SIZE: usize, MC: MemoryConfig, B: Block<MC, M>, M: ManagerBase>
             // This may appear like a wild way to clone a boxed array. But! This way avoids that
             // the array gets temporarily allocated on the stack whhich causes a stack overflow on
             // most platforms.
-            entries: self
-                .entries
-                .to_vec()
-                .try_into()
-                .map_err(|_| "mismatching vector lengths in block cache")
-                .unwrap(),
+            entries,
         }
     }
 

--- a/src/riscv/lib/src/pvm/hooks.rs
+++ b/src/riscv/lib/src/pvm/hooks.rs
@@ -16,6 +16,8 @@ use std::io::stdout;
 
 use tezos_smart_rollup_utils::console::Console;
 
+use crate::log;
+
 /// PVM hooks
 pub trait PvmHooks {
     /// Write bytes to the debug output.
@@ -39,7 +41,10 @@ impl<H: PvmHooks> PvmHooks for &mut H {
 
 impl PvmHooks for Console<'_> {
     fn write_debug_bytes(&mut self, bytes: &[u8]) {
-        self.write_all(bytes).unwrap();
+        let result = self.write_all(bytes);
+        if let Err(error) = result {
+            log::error!("Error writing to console: {:?}", error);
+        }
     }
 }
 
@@ -54,7 +59,10 @@ pub struct StdoutDebugHooks;
 
 impl PvmHooks for StdoutDebugHooks {
     fn write_debug_bytes(&mut self, bytes: &[u8]) {
-        stdout().write_all(bytes).unwrap();
+        let result = stdout().write_all(bytes);
+        if let Err(error) = result {
+            log::error!("Error writing to stdout: {:?}", error);
+        }
     }
 }
 

--- a/src/riscv/lib/src/pvm/node_pvm.rs
+++ b/src/riscv/lib/src/pvm/node_pvm.rs
@@ -123,8 +123,9 @@ impl<M: state_backend::ManagerBase> NodePvm<M> {
         M: state_backend::ManagerReadWrite,
     {
         self.with_backend_mut(|pvm| {
-            let program = Program::from_elf(kernel).unwrap();
-            pvm.setup_linux_process(&program).unwrap()
+            let program = Program::from_elf(kernel).expect("Failed to parse boot sector ELF");
+            pvm.setup_linux_process(&program)
+                .expect("Failed to setup the machine with the boot sector");
         })
     }
 
@@ -172,7 +173,7 @@ impl NodePvm {
 
     /// Compute the root hash of the PVM state.
     pub fn hash(&self) -> Hash {
-        self.with_backend(|pvm| pvm.hash().unwrap())
+        self.with_backend(|pvm| pvm.hash().expect("Failed to compute PVM state hash"))
     }
 
     /// Produce the Merkle proof corresponding to the next step of the PVM.

--- a/src/riscv/lib/src/state_backend/proof_backend/tree.rs
+++ b/src/riscv/lib/src/state_backend/proof_backend/tree.rs
@@ -171,9 +171,10 @@ pub fn impl_modify_map_collect<
 
     // No Panic: We only add a single node as root at the beginning of the algorithm
     // which corresponds to this last node in the Done-queue
-    let new_root = done.pop().unwrap();
-
-    debug_assert!(done.is_empty());
+    let new_root = done
+        .pop()
+        .filter(|_| done.is_empty())
+        .expect("Unexpected number of results");
 
     Ok(new_root)
 }

--- a/src/riscv/lib/src/state_backend/proof_layout.rs
+++ b/src/riscv/lib/src/state_backend/proof_layout.rs
@@ -593,11 +593,12 @@ impl<const LEN: usize> ProofLayout for DynArray<LEN> {
             }
         }
 
-        if hashes.len() == 1 {
-            hashes.pop().unwrap()
-        } else {
-            Err(PartialHashError::Fatal)
-        }
+        // There must only be a single hash, the root hash. If there are more or less, that is an
+        // error.
+        hashes
+            .pop()
+            .filter(|_| hashes.is_empty())
+            .map_or(Err(PartialHashError::Fatal), |hash| hash)
     }
 }
 
@@ -1107,11 +1108,12 @@ where
         // Check that we iterated over all the elements of the state
         debug_assert_eq!(next_vec_index, LEN);
 
-        if hashes.len() == 1 {
-            hashes.pop().unwrap()
-        } else {
-            Err(PartialHashError::Fatal)
-        }
+        // There must only be a single hash, the root hash. If there are more or less, that is an
+        // error.
+        hashes
+            .pop()
+            .filter(|_| hashes.is_empty())
+            .map_or(Err(PartialHashError::Fatal), |hash| hash)
     }
 }
 

--- a/src/riscv/lib/src/stepper/pvm.rs
+++ b/src/riscv/lib/src/stepper/pvm.rs
@@ -8,8 +8,6 @@ mod reveals;
 use std::ops::Bound;
 use std::path::Path;
 
-use bincode::Decode;
-use bincode::Encode;
 use reveals::RevealRequestResponseMap;
 use tezos_smart_rollup_utils::inbox::Inbox;
 
@@ -53,7 +51,6 @@ use crate::state_backend::proof_backend::proof::serialise_merkle_tree;
 use crate::state_backend::verify_backend::ProofVerificationFailure;
 use crate::state_backend::verify_backend::Verifier;
 use crate::state_backend::verify_backend::handle_stepper_panics;
-use crate::storage::binary;
 
 /// Error during PVM stepping
 #[derive(Debug, derive_more::From, thiserror::Error, derive_more::Display)]
@@ -118,7 +115,7 @@ impl<H, MC: MemoryConfig, B: Block<MC, Owned>, BCC: BlockCacheConfig>
 
     /// Obtain the root hash for the PVM state.
     pub fn hash(&self) -> Hash {
-        self.pvm.hash().unwrap()
+        self.pvm.hash().expect("PVM state hash computation failed")
     }
 }
 
@@ -229,27 +226,6 @@ impl<H: PvmHooks, MC: MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: M
     /// the constituents of `N` that were produced from the constituents of `&M`.
     pub fn struct_ref(&self) -> AllocatedOf<PvmLayout<MC, BCC>, Ref<'_, M>> {
         self.pvm.struct_ref::<FnManagerIdent>()
-    }
-
-    /// Re-bind the PVM type by serialising and deserialising its state in order to eliminate
-    /// ephemeral state that doesn't make it into the serialised output.
-    ///
-    /// We additionally pass a new instance of the [`BlockBuilder`], to be used in the deserialised
-    /// pvm.
-    ///
-    /// [`BlockBuilder`]: Block::BlockBuilder
-    pub fn rebind_via_bincode(&mut self, block_builder: B::BlockBuilder)
-    where
-        for<'a> AllocatedOf<PvmLayout<MC, BCC>, Ref<'a, M>>: Encode,
-        AllocatedOf<PvmLayout<MC, BCC>, M>: Decode<()>,
-    {
-        let space = {
-            let refs = self.pvm.struct_ref::<FnManagerIdent>();
-            let data = binary::serialise(&refs).unwrap();
-            binary::deserialise(&data).unwrap()
-        };
-
-        self.pvm = Pvm::bind(space, block_builder);
     }
 
     /// Re-bind the PVM type by cloning the underlying regions.
@@ -386,14 +362,15 @@ impl<H: PvmHooks, MC: MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, Verifier
         let mutex = std::sync::Mutex::new(self);
         handle_stepper_panics(move || {
             {
-                let mut stepper = mutex.lock().unwrap();
+                let mut stepper = mutex.lock().expect("Mutex was poisoned on initialisation");
                 if !stepper.try_step() {
                     return Err(ProofVerificationFailure::StepperError);
                 };
             }
+
             // Since all panics were handled and returned as errors, at this point
             // the mutex cannot be poisoned.
-            Ok(mutex.into_inner().unwrap())
+            Ok(mutex.into_inner().expect("Unexpected poisoned mutex"))
         })?
     }
 

--- a/src/riscv/lib/tests/common/mod.rs
+++ b/src/riscv/lib/tests/common/mod.rs
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: MIT
 
+// This ensures that Clippy does't apply rules which are allowed in tests.
+#![cfg(test)]
+
 use std::fs;
 
 use octez_riscv::machine_state::block_cache::BlockCacheConfig;

--- a/src/riscv/lib/tests/test_proofs.rs
+++ b/src/riscv/lib/tests/test_proofs.rs
@@ -3,6 +3,9 @@
 //
 // SPDX-License-Identifier: MIT
 
+// This ensures that Clippy does't apply rules which are allowed in tests.
+#![cfg(test)]
+
 mod common;
 
 use std::io::Write;

--- a/src/riscv/lib/tests/test_regression.rs
+++ b/src/riscv/lib/tests/test_regression.rs
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: MIT
 
+// This ensures that Clippy does't apply rules which are allowed in tests.
+#![cfg(test)]
+
 use std::fs;
 use std::io::Write;
 use std::ops::Bound;

--- a/src/riscv/lib/tests/test_suite_parser.rs
+++ b/src/riscv/lib/tests/test_suite_parser.rs
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: MIT
 
+// This ensures that Clippy does't apply rules which are allowed in tests.
+#![cfg(test)]
+
 use core::panic;
 use std::fs::DirEntry;
 use std::process::Command;

--- a/src/riscv/sandbox/src/commands/bench/commands/parser.rs
+++ b/src/riscv/sandbox/src/commands/bench/commands/parser.rs
@@ -15,8 +15,7 @@ pub fn bench(opts: BenchParserRunOptions) -> Result<(), Box<dyn Error>> {
 
     let mut formatter = numfmt::Formatter::new()
         .precision(numfmt::Precision::Decimals(2))
-        .separator(',')
-        .unwrap();
+        .separator(',')?;
 
     for f in files.iter() {
         let kernel = std::fs::read(f)?;

--- a/src/riscv/sandbox/src/commands/run.rs
+++ b/src/riscv/sandbox/src/commands/run.rs
@@ -94,7 +94,7 @@ pub(crate) fn make_pvm_stepper<MC: memory::MemoryConfig, B: Block<MC, Owned>>(
         program,
         inbox.build(),
         console,
-        rollup_address.into_hash().as_ref().try_into().unwrap(),
+        rollup_address.into_hash().as_ref().try_into()?,
         common.inbox.origination_level,
         common.preimage.preimages_dir.clone(),
         block_builder,

--- a/src/riscv/sandbox/src/table/utils.rs
+++ b/src/riscv/sandbox/src/table/utils.rs
@@ -18,7 +18,7 @@ use crate::commands::bench::NamedStats;
 pub fn thousand_format<N: Numeric>(content: N, num_decimals: u8) -> String {
     let mut fmt = Formatter::new()
         .separator(',')
-        .unwrap()
+        .expect("Failed to set separator")
         .precision(numfmt::Precision::Decimals(num_decimals));
     fmt.fmt2(content).to_string()
 }


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

# What

Enables a Clippy lint rule that prevents `.unwrap()` in non-test code.

# Why

Using `.expect()` is preferred to understand why something has failed.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
