### PR TITLE
Use nextest as the test runner

### DIFF
--- a/nix/env.nix
+++ b/nix/env.nix
@@ -4,6 +4,7 @@
   rustup,
   taplo,
   cargo-audit,
+  cargo-nextest,
   ocaml-ng,
   cacert,
   curl,
@@ -28,6 +29,7 @@ mkShell {
       # Utilities
       taplo
       cargo-audit
+      cargo-nextest
 
       # Make sure there is an OCaml compiler available
       ocaml-ng.ocamlPackages_5_2.ocaml

--- a/src/riscv/Makefile
+++ b/src/riscv/Makefile
@@ -81,11 +81,11 @@ build-deps: build-deps-slim
 test: build
 	@make -C ../.. dummy/build
 	@make -C ../.. block-cache-tester/build
-	@cargo test --workspace $(EXTRA_FLAGS)
+	@cargo nextest run --workspace $(EXTRA_FLAGS)
 
 .PHONY: test-long
 test-long:
-	@cargo test --release $(EXTRA_FLAGS) --test test_determinism --test test_proofs -- test_jstz_determinism test_jstz_proofs_one_step --nocapture --ignored --test-threads=1
+	@cargo nextest run --release $(EXTRA_FLAGS) --test test_determinism --test test_proofs --run-ignored only test_jstz_determinism test_jstz_proofs_one_step
 
 .PHONY: coverage
 coverage:


### PR DESCRIPTION
# What

Use [cargo-nextest](https://nexte.st/) as the test runner to speed things up.

The Nix shell will bring the required executable. If you don't use the Nix shell, you can `cargo install cargo-nextest`.

# Why

On my M3 MBP, the time to run library tests goes from 120s to less than 40s.

The impact on CI is negligible, it seems to be less than one minute.

# Manually Testing

```
make riscv/test
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
