### PR TITLE
Merge "test-long" target into regular test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             make-target: check build audit
             title: Linux Checks
           - runs-on: ubuntu-latest
-            make-target: test test-long
+            make-target: test
             title: Linux Tests
           - runs-on: macos-latest
             make-target: check build

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,6 @@ build: riscv/build jstz/build dummy/build block-cache-tester/build etherlink/bui
 
 test: riscv/test jstz/test etherlink/test 
 
-test-long: riscv/test-long
-
 test-miri: riscv/test-miri
 
 clean: riscv/clean jstz/clean dummy/clean block-cache-tester/clean etherlink/clean
@@ -45,4 +43,4 @@ etherlink/%:
 	@make -C kernels/etherlink ${@:etherlink/%=%}
 
 # Mark all non-pattern targets as phony to make sure they're always executed
-.PHONY: all build-deps build-deps-slim check audit build test test-long test-miri clean 
+.PHONY: all build-deps build-deps-slim check audit build test test-miri clean 

--- a/src/riscv/Makefile
+++ b/src/riscv/Makefile
@@ -83,10 +83,6 @@ test: build
 	@make -C ../.. block-cache-tester/build
 	@cargo nextest run --workspace $(EXTRA_FLAGS)
 
-.PHONY: test-long
-test-long:
-	@cargo nextest run --release $(EXTRA_FLAGS) --test test_determinism --test test_proofs --run-ignored only test_jstz_determinism test_jstz_proofs_one_step
-
 .PHONY: coverage
 coverage:
 	@../../scripts/isa-suite-coverage.sh

--- a/src/riscv/lib/tests/test_determinism.rs
+++ b/src/riscv/lib/tests/test_determinism.rs
@@ -22,7 +22,6 @@ use octez_riscv::stepper::StepperStatus;
 use octez_riscv::stepper::pvm::PvmStepper;
 
 #[test]
-#[ignore]
 fn test_jstz_determinism() {
     let make_stepper = make_stepper_factory();
 

--- a/src/riscv/lib/tests/test_proofs.rs
+++ b/src/riscv/lib/tests/test_proofs.rs
@@ -34,13 +34,11 @@ use octez_riscv::stepper::pvm::PvmStepper;
 use rand::Rng;
 
 #[test]
-#[ignore]
 fn test_jstz_proofs_one_step() {
     test_jstz_proofs::<M64M, TestCacheConfig>(false, PvmStepper::verify_proof)
 }
 
 #[test]
-#[ignore]
 fn test_jstz_proofs_one_step_stream() {
     test_jstz_proofs::<M64M, TestCacheConfig>(false, PvmStepper::verify_proof_using_raw_bytes)
 }


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

# What

Runs this tests that were previously triggered through the `test-long` target into the regular test suite.

# Why

This simplifies the targets we need to manage for tests. Having one target is just more ergonomic and reduces the risk that you've missed it locally, given it is not run as part of the `all` target.

The "long" tests are now fast and resource-friendly enough that you won't notice them running in conjunction.

The speed-up in CI is less than 1 minute. Not massive, it's something.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
