### PR TITLE
Add support for using handler instead of signal disposition

### DIFF
--- a/src/riscv/lib/src/machine_state.rs
+++ b/src/riscv/lib/src/machine_state.rs
@@ -34,7 +34,6 @@ use crate::parser::is_compressed;
 use crate::parser::parse_compressed_instruction;
 use crate::parser::parse_uncompressed_instruction;
 use crate::program::Program;
-use crate::pvm::linux::signals::NO_HANDLER;
 use crate::pvm::linux::signals::Signal;
 use crate::pvm::linux::signals::SignalActions;
 use crate::pvm::linux::signals::SignalActionsLayout;
@@ -612,11 +611,7 @@ impl<MC: memory::MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: backen
     where
         M: ManagerReadWrite,
     {
-        // We only currently support the `action` field.
-        // TODO RV-732 Parse `sa_flags` subset.
-        let handler = self.core.signal_actions.read_action(signal);
-
-        if handler == NO_HANDLER || self.core.dispatch_signal(signal).is_err() {
+        if self.core.dispatch_signal(signal).is_err() {
             self.core.hart.pc.write(0);
         }
     }

--- a/src/riscv/lib/src/pvm/linux.rs
+++ b/src/riscv/lib/src/pvm/linux.rs
@@ -788,11 +788,7 @@ impl<M: ManagerBase> SupervisorState<M> {
                     .xregisters
                     .write_system_call_error(Error::NoSystemCall);
 
-                if machine.core.dispatch_signal(Signal::Sigsys).is_err() {
-                    // If handling the signal fails, set the program counter to zero as if there is
-                    // no handler.
-                    machine.core.hart.pc.write(0);
-                }
+                let _ = machine.core.dispatch_signal(Signal::Sigsys);
             }
 
             Err(error) => {
@@ -1085,6 +1081,7 @@ mod tests {
     use crate::machine_state::block_cache::block::InterpretedBlockBuilder;
     use crate::machine_state::memory::M4K;
     use crate::machine_state::registers::sp;
+    use crate::parser::instruction::InstrWidth;
     use crate::pvm::hooks::StdoutDebugHooks;
     use crate::pvm::linux::error::Error;
     use crate::pvm::linux::parameters::NoFileDescriptor;
@@ -1336,6 +1333,104 @@ mod tests {
         assert_eq!(
             do_sigaction(SIGSTOP, action, old),
             Err(Error::InvalidArgument.into_xvalue())
+        );
+    });
+
+    // Check that the `rt_sigaction` system call can set the disposition to ignore
+    backend_test!(rt_sigaction_ignore, F, {
+        type MemLayout = M4K;
+
+        let mut machine_state =
+            MachineState::<MemLayout, TestCacheConfig, Interpreted<MemLayout, F>, F>::new(
+                InterpretedBlockBuilder,
+            );
+        machine_state.reset();
+
+        // Make sure everything is readable and writable. Otherwise, we'd get access faults.
+        machine_state
+            .core
+            .main_memory
+            .protect_pages(0, MemLayout::TOTAL_BYTES, Permissions::READ_WRITE)
+            .unwrap();
+
+        let mut supervisor_state = SupervisorState::<F>::new();
+
+        // Write the initial stack pointer and program counter.
+        let stack_top = M4K::TOTAL_BYTES as u64;
+        machine_state.core.hart.xregisters.write(sp, stack_top);
+        let init_pc = 0;
+        machine_state.core.hart.pc.write(init_pc);
+
+        let ignore = signals::LinuxSigAction::new(signals::SIG_IGN);
+        let nullptr = VirtAddr::new(0x0);
+        let action = VirtAddr::new(0x100);
+
+        machine_state
+            .core
+            .main_memory
+            .write::<signals::LinuxSigAction>(action.to_machine_address(), ignore.clone())
+            .unwrap();
+
+        // System call number
+        machine_state
+            .core
+            .hart
+            .xregisters
+            .write(registers::a7, RT_SIGACTION);
+
+        // Signum
+        machine_state
+            .core
+            .hart
+            .xregisters
+            .write(registers::a0, Signal::Sigill as u64);
+
+        // New handler is located at this address
+        machine_state
+            .core
+            .hart
+            .xregisters
+            .write(registers::a1, action.to_machine_address());
+
+        // Old handler is nullptr
+        machine_state
+            .core
+            .hart
+            .xregisters
+            .write(registers::a2, nullptr.to_machine_address());
+
+        // Size of sigset_t
+        machine_state
+            .core
+            .hart
+            .xregisters
+            .write(registers::a3, signals::SIGSET_SIZE);
+
+        // Perform the system call
+        let result = supervisor_state.handle_system_call(
+            &mut machine_state,
+            StdoutDebugHooks,
+            default_on_tezos_handler,
+        );
+        assert!(result.is_continue());
+
+        // Cause the [`Exception::IllegalInstruction`].
+        // `unimp`, an illegal instruction.
+        const UNIMPLEMENTED: u32 = 0b_0000;
+
+        machine_state
+            .core
+            .main_memory
+            .write_instruction_unchecked(init_pc, UNIMPLEMENTED)
+            .unwrap();
+
+        machine_state
+            .step_max_handle::<Infallible>(Bound::Included(1), |_| ControlFlow::Continue(()));
+
+        // Check that the program counter increased
+        assert_eq!(
+            machine_state.core.hart.pc.read(),
+            init_pc + InstrWidth::Uncompressed as u64
         );
     });
 

--- a/src/riscv/lib/src/pvm/linux/signals.rs
+++ b/src/riscv/lib/src/pvm/linux/signals.rs
@@ -47,6 +47,8 @@ pub enum SignalError {
     Memory(#[from] BadMemoryAccess),
     #[error("Misaligned stack pointer")]
     MisalignedStackPointer,
+    #[error("Execution shall terminate")]
+    Terminate,
 }
 
 /// Linux sigaction struct, see <https://man7.org/linux/man-pages/man2/sigaction.2.html>
@@ -72,8 +74,17 @@ impl LinuxSigAction {
     }
 }
 
-/// The default signal handler - NULL
-pub const NO_HANDLER: VirtAddr = VirtAddr::new(0u64);
+/// Set the default signal disposition
+///
+/// Value:
+/// <https://github.com/torvalds/linux/blob/b320789d6883cc00ac78ce83bccbfe7ed58afcf0/include/uapi/asm-generic/signal-defs.h#L88>
+pub const SIG_DFL: VirtAddr = VirtAddr::new(0u64);
+
+/// Set the signal disposition to ignore
+///
+/// Value:
+/// <https://github.com/torvalds/linux/blob/b320789d6883cc00ac78ce83bccbfe7ed58afcf0/include/uapi/asm-generic/signal-defs.h#L89>
+pub const SIG_IGN: VirtAddr = VirtAddr::new(1u64);
 
 /// Flag that declares a signal handler has been set with `rt_sigaction(2)` so is called with
 /// parameters.
@@ -258,10 +269,17 @@ impl<MC: MemoryConfig, M: ManagerReadWrite> MachineCoreState<MC, M> {
     pub fn dispatch_signal(&mut self, signal: Signal) -> Result<(), SignalError> {
         let handler = self.signal_actions.read_action(signal);
 
-        // Having no handler configured isn't an error, it just means we don't do anything else
-        // before continuing the consequences of the signal.
-        if handler == NO_HANDLER {
-            return Ok(());
+        match handler {
+            SIG_IGN => return Ok(()),
+            SIG_DFL => {
+                match Disposition::default(signal) {
+                    Disposition::Term | Disposition::Core => {
+                        return Err(SignalError::Terminate);
+                    }
+                    Disposition::Stop => return Ok(()),
+                };
+            }
+            _ => (),
         }
 
         let restorer = self.push_signal_context(signal)?;
@@ -293,14 +311,7 @@ impl<MC: MemoryConfig, M: ManagerReadWrite> MachineCoreState<MC, M> {
     pub fn push_signal_context(&mut self, signal: Signal) -> Result<VirtAddr, SignalError> {
         let signal_index: SignalIndex = signal.into();
         let mask = self.signal_actions.read_mask(signal_index);
-
-        // TODO RV-756 Add support for changing signal disposition.
-        //
-        // For signals with a TERM or CORE disposition, we want to change the program counter to 0.
-        let pc = match Disposition::default(signal) {
-            Disposition::Term | Disposition::Core => 0,
-            Disposition::Stop => self.hart.pc.read(),
-        };
+        let pc = self.hart.pc.read();
 
         let restorer = self.signal_actions.read_restorer(signal_index);
 


### PR DESCRIPTION
Relates to RV-756


# What

Adds support for using signal handlers instead of the default disposition.
Adds support for ignoring signals.

I recommend viewing by-commit.

# Why
Signals each have a default disposition which declares how they operate by default when a signal is raised.
# How
Some mistakes were made in the implementation of signal handlers. They are alternatives to the dispositions, rather than temporary diversions from them. Signals can do one of three things when they are raised:
 - The default action (`SIG_DFL`) (0)
 - Be ignored (`SIG_IGN`)
 - Call a handler
   - The handler can have additional parameters if it is registered using `rt_sigaction(2)` instead of `signal(2)`
   
This fixes those mistakes and adds support for the default behaviour.

`SIG_DFL` is used instead of `NO_HANDLER`

# Manually Testing

```
make all
```
Changing the flag to `SIG_DFL` causes the test to fail.

# Regressions

<!--
    Explain changes to regression test captures. If there are no changes to these, delete this
    section.
-->

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
