### PR TITLE
chore: add profiling artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ target
 # Direnv
 .direnv
 .envrc
+
+# Profiling outputs
+riscv-sandbox-profile.json
+perf.data


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

# What

Ignore sandbox profiling output and perf data file.

# Why

We should not check these in, and are almost always not checked-in anyway, as the files are too large. But the warnings are annoying

# Manually Testing

```
./scripts/jstz-bench -t 200 -p
```

the output profiling data should be ignored


# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
