### PR TITLE
Give SIGKILL and SIGSTOP immutable dispositions

### DIFF
--- a/src/riscv/lib/src/pvm/linux.rs
+++ b/src/riscv/lib/src/pvm/linux.rs
@@ -1089,6 +1089,8 @@ mod tests {
     use crate::pvm::linux::error::Error;
     use crate::pvm::linux::parameters::NoFileDescriptor;
     use crate::pvm::linux::parameters::Zero;
+    use crate::pvm::linux::registers::XValue;
+    use crate::pvm::linux::registers::a0;
     use crate::pvm::linux::signals::Signal;
 
     /// Default handler for the `on_tezos` parameter of [`SupervisorState::handle_system_call`]
@@ -1239,77 +1241,102 @@ mod tests {
             .write::<signals::LinuxSigAction>(action.to_machine_address(), linux_sig_action.clone())
             .unwrap();
 
-        let mut do_sigaction =
-            |signal: u64, action: VirtAddr, old: VirtAddr| -> signals::LinuxSigAction {
-                // System call number
-                machine_state
-                    .core
-                    .hart
-                    .xregisters
-                    .write(registers::a7, RT_SIGACTION);
+        let mut do_sigaction = |signal: u64,
+                                action: VirtAddr,
+                                old: VirtAddr|
+         -> Result<signals::LinuxSigAction, XValue> {
+            // System call number
+            machine_state
+                .core
+                .hart
+                .xregisters
+                .write(registers::a7, RT_SIGACTION);
 
-                // Signum
-                machine_state
-                    .core
-                    .hart
-                    .xregisters
-                    .write(registers::a0, signal);
+            // Signum
+            machine_state
+                .core
+                .hart
+                .xregisters
+                .write(registers::a0, signal);
 
-                // New handler is located at this address
-                machine_state
-                    .core
-                    .hart
-                    .xregisters
-                    .write(registers::a1, action.to_machine_address());
+            // New handler is located at this address
+            machine_state
+                .core
+                .hart
+                .xregisters
+                .write(registers::a1, action.to_machine_address());
 
-                // Old handler will be located at this address
-                machine_state
-                    .core
-                    .hart
-                    .xregisters
-                    .write(registers::a2, old.to_machine_address());
+            // Old handler will be located at this address
+            machine_state
+                .core
+                .hart
+                .xregisters
+                .write(registers::a2, old.to_machine_address());
 
-                // Size of sigset_t
-                machine_state
-                    .core
-                    .hart
-                    .xregisters
-                    .write(registers::a3, signals::SIGSET_SIZE);
+            // Size of sigset_t
+            machine_state
+                .core
+                .hart
+                .xregisters
+                .write(registers::a3, signals::SIGSET_SIZE);
 
-                // Perform the system call
-                let result = supervisor_state.handle_system_call(
-                    &mut machine_state,
-                    StdoutDebugHooks,
-                    default_on_tezos_handler,
-                );
-                assert!(result.is_continue());
+            // Perform the system call
+            let result = supervisor_state.handle_system_call(
+                &mut machine_state,
+                StdoutDebugHooks,
+                default_on_tezos_handler,
+            );
+            assert!(result.is_continue());
 
-                // Return the value stored in the old handler
-                machine_state
-                    .core
-                    .main_memory
-                    .read::<signals::LinuxSigAction>(old.to_machine_address())
-                    .unwrap()
-            };
+            let error = machine_state.core.hart.xregisters.read(a0);
+            if error != 0 {
+                return Err(error);
+            }
 
-        const SIGPIPE: u64 = 13i32 as u64;
-        const SIGUSR1: u64 = 10i32 as u64;
+            // Return the value stored in the old handler
+            Ok(machine_state
+                .core
+                .main_memory
+                .read::<signals::LinuxSigAction>(old.to_machine_address())
+                .unwrap())
+        };
+
+        const SIGPIPE: u64 = Signal::Sigpipe as u64;
+        const SIGUSR1: u64 = Signal::Sigusr1 as u64;
+        const SIGKILL: u64 = Signal::Sigkill as u64;
+        const SIGSTOP: u64 = Signal::Sigstop as u64;
         let nullptr = signals::LinuxSigAction::new(VirtAddr::new(0x0));
 
         // The sigactions are initialised to zero
         // Check that the location of the old handler is zeroed out
-        assert_eq!(do_sigaction(SIGPIPE, action, old), nullptr);
-        assert_eq!(do_sigaction(SIGUSR1, action, old), nullptr);
+        assert_eq!(do_sigaction(SIGPIPE, action, old).unwrap(), nullptr);
+        assert_eq!(do_sigaction(SIGUSR1, action, old).unwrap(), nullptr);
 
         // Then check that the new handlers can be read independently
         // SIGUSR1[linux_sigaction], SIPIPE[linux_sigaction]
-        assert_eq!(do_sigaction(SIGUSR1, old, action), linux_sig_action);
+        assert_eq!(
+            do_sigaction(SIGUSR1, old, action).unwrap(),
+            linux_sig_action
+        );
         // SIGUSR1[nullptr], SIPIPE[linux_sigaction]
-        assert_eq!(do_sigaction(SIGUSR1, old, action), nullptr);
+        assert_eq!(do_sigaction(SIGUSR1, old, action).unwrap(), nullptr);
         // SIGUSR1[nullptr], SIPIPE[linux_sigaction]
-        assert_eq!(do_sigaction(SIGPIPE, old, action), linux_sig_action);
+        assert_eq!(
+            do_sigaction(SIGPIPE, old, action).unwrap(),
+            linux_sig_action
+        );
         // SIGUSR1[nullptr], SIPIPE[nullptr]
-        assert_eq!(do_sigaction(SIGPIPE, old, action), nullptr);
+        assert_eq!(do_sigaction(SIGPIPE, old, action).unwrap(), nullptr);
+
+        // These signals can't have their handling changed
+        assert_eq!(
+            do_sigaction(SIGKILL, action, old),
+            Err(Error::InvalidArgument.into_xvalue())
+        );
+        assert_eq!(
+            do_sigaction(SIGSTOP, action, old),
+            Err(Error::InvalidArgument.into_xvalue())
+        );
     });
 
     // Check that the `sigaltstack` system call can accept 0 for the `old` parameter.

--- a/src/riscv/lib/src/pvm/linux/signals.rs
+++ b/src/riscv/lib/src/pvm/linux/signals.rs
@@ -39,10 +39,10 @@ use crate::struct_layout;
 /// Errors relating to handling signals
 #[derive(Debug, Eq, thiserror::Error, PartialEq)]
 pub enum SignalError {
-    #[error(transparent)]
-    Memory(#[from] BadMemoryAccess),
     #[error("Bad signal context")]
     BadContext,
+    #[error(transparent)]
+    Memory(#[from] BadMemoryAccess),
     #[error("Misaligned stack pointer")]
     MisalignedStackPointer,
 }

--- a/src/riscv/lib/src/pvm/linux/signals.rs
+++ b/src/riscv/lib/src/pvm/linux/signals.rs
@@ -41,6 +41,8 @@ use crate::struct_layout;
 pub enum SignalError {
     #[error("Bad signal context")]
     BadContext,
+    #[error("Signals of this type cannot have their disposition changed")]
+    ImmutableDisposition,
     #[error(transparent)]
     Memory(#[from] BadMemoryAccess),
     #[error("Misaligned stack pointer")]
@@ -377,10 +379,20 @@ impl<MC: MemoryConfig, M: ManagerBase> MachineCoreState<MC, M> {
         }
     }
 
-    fn set_signal_action(&mut self, signal: Signal, action: LinuxSigAction)
+    fn set_signal_action(
+        &mut self,
+        signal: Signal,
+        action: LinuxSigAction,
+    ) -> Result<(), SignalError>
     where
         M: ManagerWrite,
     {
+        // These signals cannot have their dispositions changed, see
+        // <https://www.man7.org/linux/man-pages/man7/signal.7.html>
+        if signal == Signal::Sigkill || signal == Signal::Sigstop {
+            return Err(SignalError::ImmutableDisposition);
+        }
+
         let index: SignalIndex = signal.into();
         self.signal_actions.write_handler(index, action.sa_handler);
         self.signal_actions.write_action(index, action.sa_sigaction);
@@ -388,6 +400,7 @@ impl<MC: MemoryConfig, M: ManagerBase> MachineCoreState<MC, M> {
         self.signal_actions.write_flags(index, action.sa_flags);
         self.signal_actions
             .write_restorer(index, action.sa_restorer);
+        Ok(())
     }
 }
 
@@ -487,7 +500,7 @@ impl<M: ManagerClone> Clone for SignalActions<M> {
 pub const SIGSET_SIZE: u64 = 8;
 
 /// Linux signal signums in RISC-V, see <https://www.man7.org/linux/man-pages/man7/signal.7.html>
-#[derive(Debug, Clone, Copy, FromRepr)]
+#[derive(Debug, Clone, Copy, Eq, FromRepr, PartialEq)]
 #[repr(u64)]
 pub enum Signal {
     Sigill = 4,
@@ -674,7 +687,8 @@ impl<M: ManagerBase> SupervisorState<M> {
 
         if let Some(action) = action.address() {
             let new_action: LinuxSigAction = core.main_memory.read(action)?;
-            core.set_signal_action(signal, new_action);
+            core.set_signal_action(signal, new_action)
+                .map_err(|_| Error::InvalidArgument)?;
         }
 
         // Return 0 as an indicator of success


### PR DESCRIPTION
Part of RV-756

# What

These signals can't have their disposition/actions changed:

>[The signals SIGKILL and SIGSTOP cannot be caught, blocked, or ignored.](https://www.man7.org/linux/man-pages/man7/signal.7.html)

I also took the opportunity to reorder the error variants. Alphabetising frequently edited series of things makes them less likely to cause merge conflicts.

# Why
This brings signal handling closer to the way Linux handles them.

...and can be merged independently of my other related branches.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages to reflect the changes they're about.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
