### PR TITLE
fix(etherlink/bench): find repo-root independent of parent folder name

### DIFF
--- a/kernels/etherlink/xtask/src/main.rs
+++ b/kernels/etherlink/xtask/src/main.rs
@@ -124,7 +124,7 @@ fn find_repo_root() -> Result<PathBuf> {
 
     let mut dir = current_dir.as_path();
     loop {
-        if dir.ends_with("riscv-pvm") && dir.join(".github").exists() {
+        if dir.join(".github").exists() {
             return Ok(dir.to_path_buf());
         }
 


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

# What

Fix etherlink/test when repository has been cloned elsewhere that `riscv-pvm`.

# Why

On my machine, I use `riscv/pvm` as the path, as other riscv-related work is contained in the `riscv` folder.

# How 

Look for `.git` or `.jj` instead.

# Manually Testing

```
cd ..
mv riscv-pvm pvm-riscv
cd pvm-riscv
make etherlink/test
```


# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
