### PR TITLE
Self PC update by "tezos" system calls

### DIFF
--- a/src/riscv/lib/src/machine_state.rs
+++ b/src/riscv/lib/src/machine_state.rs
@@ -456,7 +456,7 @@ impl<MC: memory::MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: backen
     pub fn step_max_handle<E>(
         &mut self,
         mut step_bounds: Bound<usize>,
-        mut handle: impl FnMut(&mut Self, Bound<usize>) -> ControlFlow<E>,
+        mut handle: impl FnMut(&mut Self, Bound<usize>) -> ControlFlow<E, usize>,
     ) -> StepManyResult<E>
     where
         M: backend::ManagerReadWrite,
@@ -474,14 +474,19 @@ impl<MC: memory::MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: backen
                     // Raising the exception is not a completed step. Trying to handle it is.
                     // We don't have to check against `max_steps` because running the
                     // instruction that triggered the exception meant that `max_steps > 0`.
-                    steps = steps.saturating_add(1);
-                    step_bounds = bound_saturating_sub(step_bounds, 1);
 
                     // embed the step_bounds into the handler, as there is no other step_bounds
-                    // dependent logic in the call to `handle_exception`
+                    // dependent logic within `handle_exception`
                     match self.handle_exception(cause, |machine| handle(machine, step_bounds)) {
-                        ControlFlow::Continue(()) => {}
-                        ControlFlow::Break(error) => break Some(error),
+                        ControlFlow::Continue(steps_completed) => {
+                            steps = steps.saturating_add(steps_completed);
+                            step_bounds = bound_saturating_sub(step_bounds, steps_completed);
+                        }
+                        ControlFlow::Break(error) => {
+                            // Failing to handle the exception is also a step
+                            steps = steps.saturating_add(1);
+                            break Some(error);
+                        }
                     }
                 }
 
@@ -496,8 +501,8 @@ impl<MC: memory::MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: backen
     fn handle_exception<E>(
         &mut self,
         cause: Exception,
-        mut handle: impl FnMut(&mut Self) -> ControlFlow<E>,
-    ) -> ControlFlow<E>
+        mut handle: impl FnMut(&mut Self) -> ControlFlow<E, usize>,
+    ) -> ControlFlow<E, usize>
     where
         M: ManagerReadWrite,
     {
@@ -538,7 +543,7 @@ impl<MC: memory::MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: backen
             }
         }
 
-        ControlFlow::Continue(())
+        ControlFlow::Continue(1)
     }
 
     /// Handle [`Exception::ForceFetchRun`] by fetching instruction data from memory directly,
@@ -548,8 +553,8 @@ impl<MC: memory::MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: backen
     /// cannot be a `ForceFetchRun`.
     fn handle_force_fetch_run<E>(
         &mut self,
-        handle: impl FnMut(&mut Self) -> ControlFlow<E>,
-    ) -> ControlFlow<E>
+        handle: impl FnMut(&mut Self) -> ControlFlow<E, usize>,
+    ) -> ControlFlow<E, usize>
     where
         M: ManagerReadWrite,
     {
@@ -562,7 +567,7 @@ impl<MC: memory::MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: backen
         let exception = match result {
             Ok(update) => {
                 self.core.update_pc(instr_pc, update);
-                return ControlFlow::Continue(());
+                return ControlFlow::Continue(1);
             }
             // this should never happen (as we do not parse instruction data into an instruction
             // with OpCode::ForceFetchRun). If it does though, we shouldn't crash the PVM. Instead

--- a/src/riscv/lib/src/machine_state.rs
+++ b/src/riscv/lib/src/machine_state.rs
@@ -13,7 +13,6 @@ pub(crate) mod reservation_set;
 
 use std::num::NonZeroU64;
 use std::ops::Bound;
-use std::ops::ControlFlow;
 
 use block_cache::BlockCache;
 use block_cache::block::Block;
@@ -246,7 +245,7 @@ pub enum ProgramCounterUpdate<AddressRepr> {
 }
 
 /// Result type when running multiple steps at a time with [`MachineState::step_max`]
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StepManyResult<E> {
     pub steps: usize,
     pub error: Option<E>,
@@ -273,6 +272,39 @@ impl<E> StepManyResult<E> {
         self.steps += other.steps;
         self.error = other.error;
         self.error.is_some()
+    }
+
+    /// Like `merge_and_return`, but the arguments are swapped.
+    /// Unlike in `merge_and_return` the two results can have different type parameters here.
+    fn add_steps<F>(&mut self, first: StepManyResult<F>) {
+        self.steps += first.steps;
+    }
+
+    /// Helper for checking if control flow should continue as normal
+    pub fn is_continue(&self) -> bool {
+        self.error.is_none()
+    }
+
+    /// Helper for checking for a control flow break and handling the error
+    pub fn is_break(&self) -> bool {
+        self.error.is_some()
+    }
+
+    /// Indicating control flow for when there is no error. Usually one step of computation takes
+    /// place in this case, and we may use this constant if so.
+    pub fn continue_after_one_step() -> Self {
+        Self {
+            steps: 1,
+            error: None,
+        }
+    }
+
+    /// A step of computation usually happens just to identify that a control flow break should occur
+    pub fn break_after_one_step(err: E) -> Self {
+        Self {
+            steps: 1,
+            error: Some(err),
+        }
     }
 }
 
@@ -455,54 +487,54 @@ impl<MC: memory::MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: backen
     #[inline]
     pub fn step_max_handle<E>(
         &mut self,
-        mut step_bounds: Bound<usize>,
-        mut handle: impl FnMut(&mut Self, Bound<usize>) -> ControlFlow<E, usize>,
+        step_bounds: Bound<usize>,
+        mut handle: impl FnMut(&mut Self, Bound<usize>) -> StepManyResult<E>,
     ) -> StepManyResult<E>
     where
         M: backend::ManagerReadWrite,
     {
-        let mut steps = 0usize;
+        let calculate_bounds = |steps: usize| bound_saturating_sub(step_bounds, steps);
 
-        let error = loop {
-            let result = self.step_max(step_bounds);
+        // the latest result swaps between res1 and res2 since the error types returned by
+        // `step_max` and `handle` are different
+        let mut res1: StepManyResult<Exception>;
+        let mut res2: StepManyResult<E> = StepManyResult::default();
+        loop {
+            res1 = self.step_max(calculate_bounds(res2.steps));
+            res1.add_steps(res2);
 
-            steps = steps.saturating_add(result.steps);
-            step_bounds = bound_saturating_sub(step_bounds, result.steps);
-
-            match result.error {
+            match res1.error {
                 Some(cause) => {
-                    // Raising the exception is not a completed step. Trying to handle it is.
-                    // We don't have to check against `max_steps` because running the
-                    // instruction that triggered the exception meant that `max_steps > 0`.
-
                     // embed the step_bounds into the handler, as there is no other step_bounds
                     // dependent logic within `handle_exception`
-                    match self.handle_exception(cause, |machine| handle(machine, step_bounds)) {
-                        ControlFlow::Continue(steps_completed) => {
-                            steps = steps.saturating_add(steps_completed);
-                            step_bounds = bound_saturating_sub(step_bounds, steps_completed);
-                        }
-                        ControlFlow::Break(error) => {
-                            // Failing to handle the exception is also a step
-                            steps = steps.saturating_add(1);
-                            break Some(error);
-                        }
+                    res2 = self.handle_exception(cause, |machine| {
+                        handle(machine, calculate_bounds(res1.steps))
+                    });
+                    res2.add_steps(res1);
+                    if res2.is_break() {
+                        break res2;
                     }
                 }
 
-                None => break None,
+                None => {
+                    break StepManyResult {
+                        steps: res1.steps,
+                        error: None,
+                    };
+                }
             }
-        };
-
-        StepManyResult { steps, error }
+        }
     }
 
+    /// Raising the exception is not a completed step. Trying to handle it is.
+    /// We don't take `step_bounds` as a parameter and check against it, as running the
+    /// instruction that triggered the exception meant that `step_bounds > 0`.
     #[inline]
     fn handle_exception<E>(
         &mut self,
         cause: Exception,
-        mut handle: impl FnMut(&mut Self) -> ControlFlow<E, usize>,
-    ) -> ControlFlow<E, usize>
+        mut handle: impl FnMut(&mut Self) -> StepManyResult<E>,
+    ) -> StepManyResult<E>
     where
         M: ManagerReadWrite,
     {
@@ -543,7 +575,7 @@ impl<MC: memory::MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: backen
             }
         }
 
-        ControlFlow::Continue(1)
+        StepManyResult::continue_after_one_step()
     }
 
     /// Handle [`Exception::ForceFetchRun`] by fetching instruction data from memory directly,
@@ -553,8 +585,8 @@ impl<MC: memory::MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: backen
     /// cannot be a `ForceFetchRun`.
     fn handle_force_fetch_run<E>(
         &mut self,
-        handle: impl FnMut(&mut Self) -> ControlFlow<E, usize>,
-    ) -> ControlFlow<E, usize>
+        handle: impl FnMut(&mut Self) -> StepManyResult<E>,
+    ) -> StepManyResult<E>
     where
         M: ManagerReadWrite,
     {
@@ -567,7 +599,7 @@ impl<MC: memory::MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: backen
         let exception = match result {
             Ok(update) => {
                 self.core.update_pc(instr_pc, update);
-                return ControlFlow::Continue(1);
+                return StepManyResult::continue_after_one_step();
             }
             // this should never happen (as we do not parse instruction data into an instruction
             // with OpCode::ForceFetchRun). If it does though, we shouldn't crash the PVM. Instead
@@ -750,7 +782,6 @@ pub(crate) mod test_helpers {
 mod tests {
     use std::fs;
     use std::ops::Bound;
-    use std::ops::ControlFlow;
 
     use proptest::prop_assert_eq;
     use proptest::proptest;
@@ -912,7 +943,7 @@ mod tests {
                     // to indicate that it has reached the signal point. This is our cue that we
                     // have produced the right "start" state.
                     if syscall_number == -1 {
-                        return ControlFlow::Break(());
+                        return StepManyResult::break_after_one_step(());
                     }
 
                     handle_system_call(

--- a/src/riscv/lib/src/machine_state.rs
+++ b/src/riscv/lib/src/machine_state.rs
@@ -456,7 +456,7 @@ impl<MC: memory::MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: backen
     pub fn step_max_handle<E>(
         &mut self,
         mut step_bounds: Bound<usize>,
-        mut handle: impl FnMut(&mut Self) -> ControlFlow<E>,
+        mut handle: impl FnMut(&mut Self, Bound<usize>) -> ControlFlow<E>,
     ) -> StepManyResult<E>
     where
         M: backend::ManagerReadWrite,
@@ -477,7 +477,9 @@ impl<MC: memory::MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>, M: backen
                     steps = steps.saturating_add(1);
                     step_bounds = bound_saturating_sub(step_bounds, 1);
 
-                    match self.handle_exception(cause, &mut handle) {
+                    // embed the step_bounds into the handler, as there is no other step_bounds
+                    // dependent logic in the call to `handle_exception`
+                    match self.handle_exception(cause, |machine| handle(machine, step_bounds)) {
                         ControlFlow::Continue(()) => {}
                         ControlFlow::Break(error) => break Some(error),
                     }
@@ -896,9 +898,9 @@ mod tests {
 
             state.setup_linux_process(&program).unwrap();
 
-            let res = state
-                .machine_state
-                .step_max_handle::<()>(Bound::Unbounded, |machine| {
+            let res = state.machine_state.step_max_handle::<()>(
+                Bound::Unbounded,
+                |machine, step_bounds| {
                     let syscall_number = machine.core.hart.xregisters.read(a7) as i64;
 
                     // The `block-cache-tester` kernel will issue a system call with number -1
@@ -914,8 +916,10 @@ mod tests {
                         &mut state.status,
                         &mut state.reveal_request,
                         StdoutDebugHooks,
+                        step_bounds,
                     )
-                });
+                },
+            );
 
             assert_eq!(
                 res.error,
@@ -1219,7 +1223,7 @@ mod tests {
                 .push_instruction(initial_pc, Instruction::DEFAULT);
 
             let res: StepManyResult<()> =
-                state.step_max_handle(Bound::Included(1), |_| panic!("unexpected ECall"));
+                state.step_max_handle(Bound::Included(1), |_, _| panic!("unexpected ECall"));
 
             assert_eq!(state.core.hart.pc.read(), expected_pc);
             assert_eq!(res.steps, 1);

--- a/src/riscv/lib/src/pvm/common.rs
+++ b/src/riscv/lib/src/pvm/common.rs
@@ -262,13 +262,14 @@ impl<MC: MemoryConfig, BCC: BlockCacheConfig, B: block::Block<MC, M>, M: state_b
 
         let steps = self
             .machine_state
-            .step_max_handle(step_bounds, |machine_state| {
+            .step_max_handle(step_bounds, |machine_state, step_bounds| {
                 handle_system_call(
                     machine_state,
                     &mut self.system_state,
                     &mut self.status,
                     &mut self.reveal_request,
                     &mut hooks,
+                    step_bounds,
                 )
             })
             .steps;
@@ -451,6 +452,7 @@ pub(crate) fn handle_system_call<MC, BCC, B, M>(
     status: &mut Cell<PvmStatus, M>,
     reveal_request: &mut RevealRequest<M>,
     hooks: impl PvmHooks,
+    step_bounds: Bound<usize>,
 ) -> ControlFlow<()>
 where
     MC: MemoryConfig,
@@ -459,7 +461,7 @@ where
     M: state_backend::ManagerReadWrite,
 {
     system_state.handle_system_call(machine, hooks, |core| {
-        tezos::handle_tezos(core, status, reveal_request);
+        tezos::handle_tezos(core, status, reveal_request, step_bounds);
 
         if status.read() == PvmStatus::Evaluating {
             ControlFlow::Continue(())
@@ -516,6 +518,7 @@ mod tests {
                 &mut self.status,
                 &mut self.reveal_request,
                 hooks,
+                Bound::Included(1), // a single step to handle the exception
             )
             .is_continue()
         }

--- a/src/riscv/lib/src/pvm/common.rs
+++ b/src/riscv/lib/src/pvm/common.rs
@@ -453,7 +453,7 @@ pub(crate) fn handle_system_call<MC, BCC, B, M>(
     reveal_request: &mut RevealRequest<M>,
     hooks: impl PvmHooks,
     step_bounds: Bound<usize>,
-) -> ControlFlow<()>
+) -> ControlFlow<(), usize>
 where
     MC: MemoryConfig,
     BCC: BlockCacheConfig,
@@ -461,10 +461,10 @@ where
     M: state_backend::ManagerReadWrite,
 {
     system_state.handle_system_call(machine, hooks, |core| {
-        tezos::handle_tezos(core, status, reveal_request, step_bounds);
+        let steps_completed = tezos::handle_tezos(core, status, reveal_request, step_bounds);
 
         if status.read() == PvmStatus::Evaluating {
-            ControlFlow::Continue(())
+            ControlFlow::Continue(steps_completed)
         } else {
             ControlFlow::Break(())
         }

--- a/src/riscv/lib/src/pvm/common.rs
+++ b/src/riscv/lib/src/pvm/common.rs
@@ -5,7 +5,6 @@
 
 use std::fmt;
 use std::ops::Bound;
-use std::ops::ControlFlow;
 
 use bincode::Decode;
 use bincode::Encode;
@@ -17,6 +16,7 @@ use super::reveals::RevealRequest;
 use super::reveals::RevealRequestLayout;
 use crate::default::ConstDefault;
 use crate::machine_state;
+use crate::machine_state::StepManyResult;
 use crate::machine_state::block_cache::BlockCacheConfig;
 use crate::machine_state::block_cache::block;
 use crate::machine_state::block_cache::block::Block;
@@ -453,7 +453,7 @@ pub(crate) fn handle_system_call<MC, BCC, B, M>(
     reveal_request: &mut RevealRequest<M>,
     hooks: impl PvmHooks,
     step_bounds: Bound<usize>,
-) -> ControlFlow<(), usize>
+) -> StepManyResult<()>
 where
     MC: MemoryConfig,
     BCC: BlockCacheConfig,
@@ -461,12 +461,12 @@ where
     M: state_backend::ManagerReadWrite,
 {
     system_state.handle_system_call(machine, hooks, |core| {
-        let steps_completed = tezos::handle_tezos(core, status, reveal_request, step_bounds);
+        let steps = tezos::handle_tezos(core, status, reveal_request, step_bounds);
 
         if status.read() == PvmStatus::Evaluating {
-            ControlFlow::Continue(steps_completed)
+            StepManyResult { steps, error: None }
         } else {
-            ControlFlow::Break(())
+            StepManyResult::break_after_one_step(())
         }
     })
 }

--- a/src/riscv/lib/src/pvm/linux.rs
+++ b/src/riscv/lib/src/pvm/linux.rs
@@ -519,8 +519,8 @@ impl<M: ManagerBase> SupervisorState<M> {
         &mut self,
         machine: &mut MachineState<MC, BCC, B, M>,
         hooks: impl PvmHooks,
-        on_tezos: impl FnOnce(&mut MachineCoreState<MC, M>) -> ControlFlow<()>,
-    ) -> ControlFlow<()>
+        on_tezos: impl FnOnce(&mut MachineCoreState<MC, M>) -> ControlFlow<(), usize>,
+    ) -> ControlFlow<(), usize>
     where
         MC: MemoryConfig,
         BCC: BlockCacheConfig,
@@ -802,7 +802,7 @@ impl<M: ManagerBase> SupervisorState<M> {
             Ok(control_flow) => return control_flow,
         }
 
-        ControlFlow::Continue(())
+        ControlFlow::Continue(1)
     }
 
     /// Handle `set_tid_address` system call.
@@ -1094,7 +1094,7 @@ mod tests {
     use crate::pvm::linux::signals::Signal;
 
     /// Default handler for the `on_tezos` parameter of [`SupervisorState::handle_system_call`]
-    fn default_on_tezos_handler<MC, M>(core: &mut MachineCoreState<MC, M>) -> ControlFlow<()>
+    fn default_on_tezos_handler<MC, M>(core: &mut MachineCoreState<MC, M>) -> ControlFlow<(), usize>
     where
         MC: MemoryConfig,
         M: ManagerWrite,
@@ -1102,7 +1102,7 @@ mod tests {
         core.hart
             .xregisters
             .write_system_call_error(Error::NoSystemCall);
-        ControlFlow::Continue(())
+        ControlFlow::Continue(1)
     }
 
     // Check that the `set_tid_address` system call is working correctly.
@@ -1992,7 +1992,7 @@ mod tests {
             .write_instruction_unchecked(init_pc, UNIMPLEMENTED)
             .unwrap();
         let step_result = machine_state
-            .step_max_handle::<Infallible>(Bound::Included(1), |_, _| ControlFlow::Continue(()));
+            .step_max_handle::<Infallible>(Bound::Included(1), |_, _| ControlFlow::Continue(1));
         assert_eq!(step_result.error, None);
 
         // Check that the program counter is now at the handler.

--- a/src/riscv/lib/src/pvm/linux.rs
+++ b/src/riscv/lib/src/pvm/linux.rs
@@ -1992,7 +1992,7 @@ mod tests {
             .write_instruction_unchecked(init_pc, UNIMPLEMENTED)
             .unwrap();
         let step_result = machine_state
-            .step_max_handle::<Infallible>(Bound::Included(1), |_| ControlFlow::Continue(()));
+            .step_max_handle::<Infallible>(Bound::Included(1), |_, _| ControlFlow::Continue(()));
         assert_eq!(step_result.error, None);
 
         // Check that the program counter is now at the handler.

--- a/src/riscv/lib/src/pvm/linux.rs
+++ b/src/riscv/lib/src/pvm/linux.rs
@@ -13,7 +13,6 @@ pub(crate) mod signals;
 
 use std::convert::Infallible;
 use std::ffi::CStr;
-use std::ops::ControlFlow;
 use std::ops::Range;
 
 use perfect_derive::perfect_derive;
@@ -26,6 +25,7 @@ use super::Pvm;
 use crate::machine_state::MachineCoreState;
 use crate::machine_state::MachineError;
 use crate::machine_state::MachineState;
+use crate::machine_state::StepManyResult;
 use crate::machine_state::block_cache::BlockCacheConfig;
 use crate::machine_state::block_cache::block::Block;
 use crate::machine_state::memory::Address;
@@ -519,8 +519,8 @@ impl<M: ManagerBase> SupervisorState<M> {
         &mut self,
         machine: &mut MachineState<MC, BCC, B, M>,
         hooks: impl PvmHooks,
-        on_tezos: impl FnOnce(&mut MachineCoreState<MC, M>) -> ControlFlow<(), usize>,
-    ) -> ControlFlow<(), usize>
+        on_tezos: impl FnOnce(&mut MachineCoreState<MC, M>) -> StepManyResult<()>,
+    ) -> StepManyResult<()>
     where
         MC: MemoryConfig,
         BCC: BlockCacheConfig,
@@ -802,7 +802,7 @@ impl<M: ManagerBase> SupervisorState<M> {
             Ok(control_flow) => return control_flow,
         }
 
-        ControlFlow::Continue(1)
+        StepManyResult::continue_after_one_step()
     }
 
     /// Handle `set_tid_address` system call.
@@ -855,7 +855,7 @@ impl<M: ManagerBase> SupervisorState<M> {
 
         Ok(parameters::SystemCallResultExecution {
             result: status.exit_code(),
-            control_flow: ControlFlow::Break(()),
+            control_flow: StepManyResult::break_after_one_step(()),
         })
     }
 
@@ -876,7 +876,7 @@ impl<M: ManagerBase> SupervisorState<M> {
         // Return 0 as an indicator of success, even if this might not actually be used
         Ok(parameters::SystemCallResultExecution {
             result: 0,
-            control_flow: ControlFlow::Break(()),
+            control_flow: StepManyResult::break_after_one_step(()),
         })
     }
 
@@ -1070,7 +1070,6 @@ impl<M: ManagerAlloc> Default for SupervisorState<M> {
 mod tests {
     use std::num::NonZeroU64;
     use std::ops::Bound;
-    use std::ops::ControlFlow;
 
     use rand::Rng;
 
@@ -1094,7 +1093,7 @@ mod tests {
     use crate::pvm::linux::signals::Signal;
 
     /// Default handler for the `on_tezos` parameter of [`SupervisorState::handle_system_call`]
-    fn default_on_tezos_handler<MC, M>(core: &mut MachineCoreState<MC, M>) -> ControlFlow<(), usize>
+    fn default_on_tezos_handler<MC, M>(core: &mut MachineCoreState<MC, M>) -> StepManyResult<()>
     where
         MC: MemoryConfig,
         M: ManagerWrite,
@@ -1102,7 +1101,7 @@ mod tests {
         core.hart
             .xregisters
             .write_system_call_error(Error::NoSystemCall);
-        ControlFlow::Continue(1)
+        StepManyResult::continue_after_one_step()
     }
 
     // Check that the `set_tid_address` system call is working correctly.
@@ -1992,7 +1991,9 @@ mod tests {
             .write_instruction_unchecked(init_pc, UNIMPLEMENTED)
             .unwrap();
         let step_result = machine_state
-            .step_max_handle::<Infallible>(Bound::Included(1), |_, _| ControlFlow::Continue(1));
+            .step_max_handle::<Infallible>(Bound::Included(1), |_, _| {
+                StepManyResult::continue_after_one_step()
+            });
         assert_eq!(step_result.error, None);
 
         // Check that the program counter is now at the handler.

--- a/src/riscv/lib/src/pvm/linux.rs
+++ b/src/riscv/lib/src/pvm/linux.rs
@@ -527,10 +527,7 @@ impl<M: ManagerBase> SupervisorState<M> {
         B: Block<MC, M>,
         M: ManagerReadWrite,
     {
-        // We need to jump to the next instruction. The ECall instruction which triggered this
-        // function is 4 byte wide.
         let pc = machine.core.hart.pc.read().saturating_add(4);
-        machine.core.hart.pc.write(pc);
 
         /// Read an argument from a register and interpret it as a system call argument.
         /// If that fails, log the failure.
@@ -743,6 +740,12 @@ impl<M: ManagerBase> SupervisorState<M> {
 
         // Programs targeting a Linux kernel pass the system call number in register a7
         let system_call_no = machine.core.hart.xregisters.read(registers::a7);
+
+        if system_call_no != SBI_FIRMWARE_TEZOS {
+            // We need to jump to the next instruction. The ECall instruction which triggered this
+            // function is 4 byte wide.
+            machine.core.hart.pc.write(pc);
+        }
 
         let result = match system_call_no {
             GETCWD => dispatch2!(getcwd, &mut machine.core),

--- a/src/riscv/lib/src/pvm/linux/parameters.rs
+++ b/src/riscv/lib/src/pvm/linux/parameters.rs
@@ -19,16 +19,17 @@ pub struct SystemCallResultExecution {
     ///
     /// Breaking means leaving the step loop in the machine state. In other words, it will defer to
     /// the level above it to decide what to do.
-    pub control_flow: ControlFlow<()>,
+    pub control_flow: ControlFlow<(), usize>,
 }
 
 impl<T: Into<u64>> From<T> for SystemCallResultExecution {
     fn from(value: T) -> Self {
-        // The default action is to continue execution after the system call. In cases where the
-        // execution should halt, this should be specified.
+        // The default action is to continue execution after the system call, with the step counter
+        // advancing by 1.
+        // In cases where the execution should halt, this should be specified.
         SystemCallResultExecution {
             result: value.into(),
-            control_flow: ControlFlow::Continue(()),
+            control_flow: ControlFlow::Continue(1),
         }
     }
 }

--- a/src/riscv/lib/src/pvm/linux/parameters.rs
+++ b/src/riscv/lib/src/pvm/linux/parameters.rs
@@ -4,13 +4,13 @@
 
 use core::num::NonZeroU64;
 use std::fmt;
-use std::ops::ControlFlow;
 
 use super::MAIN_THREAD_ID;
 use super::error::Error;
+use crate::machine_state::StepManyResult;
 
 /// A type coupling the result of the system call with how the program should continue.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct SystemCallResultExecution {
     /// Result value that will be returned to the caller of the system call
     pub result: u64,
@@ -19,7 +19,7 @@ pub struct SystemCallResultExecution {
     ///
     /// Breaking means leaving the step loop in the machine state. In other words, it will defer to
     /// the level above it to decide what to do.
-    pub control_flow: ControlFlow<(), usize>,
+    pub control_flow: StepManyResult<()>,
 }
 
 impl<T: Into<u64>> From<T> for SystemCallResultExecution {
@@ -29,7 +29,7 @@ impl<T: Into<u64>> From<T> for SystemCallResultExecution {
         // In cases where the execution should halt, this should be specified.
         SystemCallResultExecution {
             result: value.into(),
-            control_flow: ControlFlow::Continue(1),
+            control_flow: StepManyResult::continue_after_one_step(),
         }
     }
 }

--- a/src/riscv/lib/src/pvm/tezos.rs
+++ b/src/riscv/lib/src/pvm/tezos.rs
@@ -357,7 +357,8 @@ pub(super) fn handle_tezos<MC, M>(
     status: &mut Cell<PvmStatus, M>,
     reveal_request: &mut RevealRequest<M>,
     _step_bounds: Bound<usize>,
-) where
+) -> usize
+where
     MC: MemoryConfig,
     M: ManagerReadWrite,
 {
@@ -372,4 +373,5 @@ pub(super) fn handle_tezos<MC, M>(
         SBI_TEZOS_REVEAL => handle_tezos_reveal(machine, reveal_request, status),
         _ => handle_not_supported(&mut machine.hart.xregisters),
     }
+    1
 }

--- a/src/riscv/lib/src/pvm/tezos.rs
+++ b/src/riscv/lib/src/pvm/tezos.rs
@@ -28,6 +28,10 @@ use tezos_smart_rollup_constants::riscv::SBI_TEZOS_REVEAL;
 use tezos_smart_rollup_constants::riscv::SBI_TEZOS_SECP256K1_VERIFY;
 use tezos_smart_rollup_constants::riscv::SbiError;
 
+// TODO: RV-691: Move constant to kernel_sdk
+/// Function ID for `sbi_tezos_secp256k1_bulk_verify`
+pub const SBI_TEZOS_SECP256K1_BULK_VERIFY: u64 = 0x0d;
+
 /// Maximum size of pvm memory access by a host function in bytes
 /// To limit size of proofs in refutation games
 pub const MAX_PVM_MEMORY_ACCESS: usize = 4096;
@@ -364,14 +368,26 @@ where
 {
     let sbi_function = machine.hart.xregisters.read(a6);
     match sbi_function {
-        SBI_TEZOS_INBOX_NEXT => handle_tezos_inbox_next(status),
-        SBI_TEZOS_ED25519_SIGN => sbi_wrap(machine, handle_tezos_ed25519_sign),
-        SBI_TEZOS_ED25519_VERIFY => sbi_wrap(machine, handle_tezos_ed25519_verify),
-        SBI_TEZOS_BLAKE2B_HASH256 => sbi_wrap(machine, handle_tezos_blake2b_hash256),
-        SBI_TEZOS_SECP256K1_VERIFY => sbi_wrap(machine, handle_tezos_secp256k1_verify),
-        SBI_TEZOS_KECCAK256_HASH => sbi_wrap(machine, handle_tezos_keccak256_hash),
-        SBI_TEZOS_REVEAL => handle_tezos_reveal(machine, reveal_request, status),
-        _ => handle_not_supported(&mut machine.hart.xregisters),
+        // TODO: RV-776: Introduce parallel system call handler here
+        // Below line is present to make linter happy temporarily
+        SBI_TEZOS_SECP256K1_BULK_VERIFY => 1,
+        sequential => {
+            // We need to jump to the next instruction. The ECall instruction which triggered this
+            // function is 4 byte wide.
+            let pc = machine.hart.pc.read().saturating_add(4);
+            machine.hart.pc.write(pc);
+
+            match sequential {
+                SBI_TEZOS_INBOX_NEXT => handle_tezos_inbox_next(status),
+                SBI_TEZOS_ED25519_SIGN => sbi_wrap(machine, handle_tezos_ed25519_sign),
+                SBI_TEZOS_ED25519_VERIFY => sbi_wrap(machine, handle_tezos_ed25519_verify),
+                SBI_TEZOS_BLAKE2B_HASH256 => sbi_wrap(machine, handle_tezos_blake2b_hash256),
+                SBI_TEZOS_SECP256K1_VERIFY => sbi_wrap(machine, handle_tezos_secp256k1_verify),
+                SBI_TEZOS_KECCAK256_HASH => sbi_wrap(machine, handle_tezos_keccak256_hash),
+                SBI_TEZOS_REVEAL => handle_tezos_reveal(machine, reveal_request, status),
+                _ => handle_not_supported(&mut machine.hart.xregisters),
+            }
+            1
+        }
     }
-    1
 }

--- a/src/riscv/lib/src/pvm/tezos.rs
+++ b/src/riscv/lib/src/pvm/tezos.rs
@@ -5,6 +5,7 @@
 //! Tezos-specific host functions for the PVM
 
 use std::cmp::min;
+use std::ops::Bound;
 
 use ed25519_dalek::Signature;
 use ed25519_dalek::Signer;
@@ -355,6 +356,7 @@ pub(super) fn handle_tezos<MC, M>(
     machine: &mut MachineCoreState<MC, M>,
     status: &mut Cell<PvmStatus, M>,
     reveal_request: &mut RevealRequest<M>,
+    _step_bounds: Bound<usize>,
 ) where
     MC: MemoryConfig,
     M: ManagerReadWrite,

--- a/src/riscv/lib/src/stepper/test.rs
+++ b/src/riscv/lib/src/stepper/test.rs
@@ -175,9 +175,11 @@ impl<MC: MemoryConfig, B: Block<MC, Owned>> Stepper for TestStepper<MC, TestCach
     type StepResult = TestStepperResult;
 
     fn step_max(&mut self, steps: Bound<usize>) -> Self::StepResult {
-        let result = self.machine_state.step_max_handle(steps, |machine_state| {
-            self.posix_state.handle_call(machine_state)
-        });
+        let result = self
+            .machine_state
+            .step_max_handle(steps, |machine_state, _| {
+                self.posix_state.handle_call(machine_state)
+            });
         self.handle_step_result(result)
     }
 }

--- a/src/riscv/lib/src/stepper/test/posix.rs
+++ b/src/riscv/lib/src/stepper/test/posix.rs
@@ -2,9 +2,8 @@
 //
 // SPDX-License-Identifier: MIT
 
-use std::ops::ControlFlow;
-
 use crate::machine_state::MachineState;
+use crate::machine_state::StepManyResult;
 use crate::machine_state::block_cache::BlockCacheConfig;
 use crate::machine_state::block_cache::block::Block;
 use crate::machine_state::memory::MemoryConfig;
@@ -31,15 +30,14 @@ pub struct PosixState<M: ManagerBase> {
 
 impl<M: ManagerBase> PosixState<M> {
     /// Handle a POSIX system call. Returns `Ok(true)` if it makes sense to continue execution.
-    pub fn handle_call<T, MC: MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>>(
+    pub fn handle_call<MC: MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>>(
         &mut self,
         machine: &mut MachineState<MC, BCC, B, M>,
-    ) -> ControlFlow<BreakReason, T>
+    ) -> StepManyResult<BreakReason>
     where
         M: ManagerReadWrite,
     {
-        let handle_exit = |code| ControlFlow::Break(BreakReason::Exit(code));
-
+        let handle_exit = |code| StepManyResult::break_after_one_step(BreakReason::Exit(code));
         // Successful physical memory tests set
         //   a7 = 93 & a0 = 0
         // Successful virtual memory tests set
@@ -58,7 +56,7 @@ impl<M: ManagerBase> PosixState<M> {
             (93, code) | (0, code) => handle_exit(code),
 
             // Unimplemented
-            _ => ControlFlow::Break(BreakReason::Error(format!(
+            _ => StepManyResult::break_after_one_step(BreakReason::Error(format!(
                 "Unknown system call number {a7_val}"
             ))),
         }

--- a/src/riscv/lib/src/stepper/test/posix.rs
+++ b/src/riscv/lib/src/stepper/test/posix.rs
@@ -31,10 +31,10 @@ pub struct PosixState<M: ManagerBase> {
 
 impl<M: ManagerBase> PosixState<M> {
     /// Handle a POSIX system call. Returns `Ok(true)` if it makes sense to continue execution.
-    pub fn handle_call<MC: MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>>(
+    pub fn handle_call<T, MC: MemoryConfig, BCC: BlockCacheConfig, B: Block<MC, M>>(
         &mut self,
         machine: &mut MachineState<MC, BCC, B, M>,
-    ) -> ControlFlow<BreakReason>
+    ) -> ControlFlow<BreakReason, T>
     where
         M: ManagerReadWrite,
     {


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->
Closes RV-777
# What
Remove the illusion that PC moves forward by an instruction on every system call. Currently the pc is incremented by `instr_width=4` of an ECALL at the start of the top-level handler, and then some of the system calls choose to further modify the PC (eg, `handle_srt_sigreturn` sets it to a fixed address).

This PR has every system call handler effectively returning a `ProgramCounterUpdate` which has been added as a field to `SystemCallResultExecution`. In practice most syscall handlers actually return a `Result<u64,..>` only which is converted using `Into` to the default `SystemCallResultExecution` which represent a `Next` update. It is helpful to know which syscalls don't return `Result<u6,..>`, but directly return `SystemCallResultExecution`, while reviewing. These are:
`exit`, `tkill` `rt_sigreturn`


<!--
    Summarise the changes in this MR.
-->

# Why
PC is possibly not incremented when running an ECall corresponding to a parallel syscall.
<!-- 
    Explain why this MR is needed.
-->

# How
Special care needs to be taken
Current
# Manually Testing

```
make all
```

# Regressions

<!--
    Explain changes to regression test captures. If there are no changes to these, delete this
    section.
-->

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
