### PR TITLE
Install `cargo-llvm-cov` only if not present

### DIFF
--- a/src/riscv/Makefile
+++ b/src/riscv/Makefile
@@ -73,7 +73,7 @@ endif
 	@find . -iname 'rust-toolchain*' -execdir sh -c "rustup show active-toolchain || rustup toolchain install" \; 2>/dev/null
 
 	# Enable 'llvm-cov' subcommand for Cargo
-	@cargo install --locked cargo-llvm-cov
+	@cargo llvm-cov --version || cargo install --locked cargo-llvm-cov
 
 .PHONY: build-deps
 build-deps: build-deps-slim


### PR DESCRIPTION
Fixes the installation of `cargo-llvm-cov` which would previously fail in CI because it is already installed.

It will now only install it if it isn't already present in the environment.