### PR TITLE
Coverage report

### DIFF
--- a/src/riscv/Makefile
+++ b/src/riscv/Makefile
@@ -93,6 +93,10 @@ test-deps:
 cobertura.xml: test-deps
 	@cargo llvm-cov --package octez-riscv --cobertura --output-path $@ nextest
 
+.PHONY: coverage-report
+coverage-report: test-deps
+	@cargo llvm-cov --package octez-riscv --html --open nextest
+
 .PHONY: coverage
 coverage:
 	@../../scripts/isa-suite-coverage.sh


### PR DESCRIPTION
This new make target lets you create a coverage report. It should be helpful in making the coverage bot less annoying.

```
make riscv/coverage-report
```