### PR TITLE
feat(page_cache): add CodePageEntry trait to abstract execution kind

### DIFF
--- a/src/riscv/lib/src/machine_state/page_cache.rs
+++ b/src/riscv/lib/src/machine_state/page_cache.rs
@@ -20,7 +20,10 @@
 // TODO: RV-767 - replace block cache with page cache
 #![cfg(test)]
 
+pub(crate) mod code_page_entry;
 pub(crate) mod state;
+
+use code_page_entry::CodePageEntry;
 
 use super::MachineCoreState;
 use super::ProgramCounterUpdate;
@@ -47,13 +50,13 @@ const INSTRUCTION_ENTRIES: usize = 1
         .expect("OFFSET_BITS is non-zero") as usize;
 
 /// Instance of the page cache.
-pub trait PageCache<MC: MemoryConfig, M: ManagerBase> {
+pub trait PageCache<CPE: CodePageEntry, MC: MemoryConfig, M: ManagerBase> {
     /// Instantiate a new page cache instance.
     fn new() -> Self;
 
     /// Retrieve code page that is dispatchable against the [`MachineCoreState`]. If found, such a
     /// page will contain the code for `addr`.
-    fn get_code_page(&mut self, addr: Address) -> Option<CodePage<'_>>
+    fn get_code_page(&mut self, addr: Address) -> Option<CodePage<'_, CPE>>
     where
         M: ManagerRead;
 
@@ -71,72 +74,93 @@ pub trait PageCache<MC: MemoryConfig, M: ManagerBase> {
 }
 
 /// A page containing code that may then be run against the [`MachineCoreState`].
-pub(crate) struct CodePage<'a> {
-    page: &'a [Instruction; INSTRUCTION_ENTRIES],
+pub(crate) struct CodePage<'a, CPE: CodePageEntry> {
+    page: &'a mut [CPE; INSTRUCTION_ENTRIES],
 }
 
-impl CodePage<'_> {
+impl<CPE: CodePageEntry> CodePage<'_, CPE> {
     /// Run a code page against the machine state.
-    pub(crate) fn run<MC, M, B>(
-        &self,
+    ///
+    /// # SAFETY
+    ///
+    /// The `compiler` must always be the same compiler when dispatching a given page (for the
+    /// lifetime of that page).
+    ///
+    /// This ensures dispatching can ensure the compiler's state is kept alive.
+    pub(crate) unsafe fn run<MC, M>(
+        &mut self,
         core: &mut MachineCoreState<MC, M>,
-        // TODO: RV-765: add support for inline JIT
-        //       for now, we allow anything to be passed as the 'dispatch compiler'.
-        _compiler: B,
-        mut instr_pc: Address,
+        compiler: &mut CPE::Compiler,
+        instr_pc: Address,
         max_steps: usize,
     ) -> StepManyResult<Exception>
     where
         MC: MemoryConfig,
         M: ManagerReadWrite,
     {
-        let mut result = StepManyResult::ZERO;
+        // SAFETY: the compiler remains the same for the lifetime of the page this code-page
+        // references
+        unsafe { CPE::run_entrypoint(self.page, core, compiler, instr_pc, max_steps) }
+    }
+}
 
-        // Since we know the instruction pc to always be halfword-aligned, there are half
-        // as many entries as the page size.
-        let mut instr_offset = (instr_pc & PAGE_OFFSET_MASK) >> 1;
+fn run_code_page_interpreted<I, MC, M>(
+    code_page: &[I; INSTRUCTION_ENTRIES],
+    core: &mut MachineCoreState<MC, M>,
+    mut instr_pc: Address,
+    max_steps: usize,
+) -> StepManyResult<Exception>
+where
+    I: AsRef<Instruction>,
+    MC: MemoryConfig,
+    M: ManagerReadWrite,
+{
+    let mut result = StepManyResult::ZERO;
 
-        while max_steps > result.steps && instr_offset < INSTRUCTION_ENTRIES as u64 {
-            let instr = &self.page[instr_offset as usize];
+    // Since we know the instruction pc to always be halfword-aligned, there are half
+    // as many entries as the page size.
+    let mut instr_offset = (instr_pc & PAGE_OFFSET_MASK) >> 1;
 
-            match instr.run(core) {
-                Ok(ProgramCounterUpdate::Next(width)) => {
-                    instr_pc += width as u64;
+    while max_steps > result.steps && instr_offset < INSTRUCTION_ENTRIES as u64 {
+        let instr = code_page[instr_offset as usize].as_ref();
 
-                    // we update the offset by half the width, as the offset is halfword aligned
-                    instr_offset += (width as u64) >> 1;
+        match instr.run(core) {
+            Ok(ProgramCounterUpdate::Next(width)) => {
+                instr_pc += width as u64;
 
-                    core.hart.pc.write(instr_pc);
-                    result.steps += 1;
-                }
+                // we update the offset by half the width, as the offset is halfword aligned
+                instr_offset += (width as u64) >> 1;
 
-                Ok(ProgramCounterUpdate::Set(new_instr_pc)) => {
-                    // A jump to a new instruction requires us to exit this loop. The targeted
-                    // instruction may not be part of the current page, but either way we should
-                    // allow the target of the jump to be considered as a potential hot-spot.
-                    core.hart.pc.write(new_instr_pc);
-                    result.steps += 1;
-                    break;
-                }
+                core.hart.pc.write(instr_pc);
+                result.steps += 1;
+            }
 
-                Ok(ProgramCounterUpdate::Relative(offset)) => {
-                    // While relative jumps are likely to be in the same page, we exit at this point to allow
-                    // the jump target to be considered as a potential hot-spot.
-                    core.hart.pc.write(instr_pc.wrapping_add_signed(offset));
-                    result.steps += 1;
-                    break;
-                }
+            Ok(ProgramCounterUpdate::Set(new_instr_pc)) => {
+                // A jump to a new instruction requires us to exit this loop. The targeted
+                // instruction may not be part of the current page, but either way we should
+                // allow the target of the jump to be considered as a potential hot-spot.
+                core.hart.pc.write(new_instr_pc);
+                result.steps += 1;
+                break;
+            }
 
-                Err(exception) => {
-                    // Exceptions are handled outside of block execution. So we exit the loop.
-                    result.error = Some(exception);
-                    break;
-                }
+            Ok(ProgramCounterUpdate::Relative(offset)) => {
+                // While relative jumps are likely to be in the same page, we exit at this point to allow
+                // the jump target to be considered as a potential hot-spot.
+                core.hart.pc.write(instr_pc.wrapping_add_signed(offset));
+                result.steps += 1;
+                break;
+            }
+
+            Err(exception) => {
+                // Exceptions are handled outside of block execution. So we exit the loop.
+                result.error = Some(exception);
+                break;
             }
         }
-
-        result
     }
+
+    result
 }
 
 #[cfg(test)]
@@ -158,7 +182,7 @@ mod tests {
 
     struct DispatchTest<'a, F: TestBackendFactory> {
         state: &'a std::cell::RefCell<MachineCoreState<M4K, F>>,
-        dispatch: &'a CodePage<'a>,
+        dispatch: &'a std::cell::RefCell<CodePage<'a, Instruction>>,
         pc_addr: u64,
         max_steps: usize,
         expected_steps: usize,
@@ -171,12 +195,15 @@ mod tests {
         let mut state = test.state.borrow_mut();
         state.reset();
 
-        let res = test.dispatch.run(
-            &mut state,
-            InterpretedBlockBuilder,
-            test.pc_addr,
-            test.max_steps,
-        );
+        // SAFETY: interpreted mode is always safe to call
+        let res = unsafe {
+            test.dispatch.borrow_mut().run(
+                &mut state,
+                &mut InterpretedBlockBuilder,
+                test.pc_addr,
+                test.max_steps,
+            )
+        };
 
         assert_eq!(res.steps, test.expected_steps);
         assert_eq!(res.error, test.expected_exception);
@@ -186,10 +213,12 @@ mod tests {
     }
 
     backend_test!(page_dispatch_respects_max_steps_compressed, F, {
-        let page_entry: Box<[Instruction; INSTRUCTION_ENTRIES]> =
+        let mut page_entry: Box<[Instruction; INSTRUCTION_ENTRIES]> =
             boxed_from_fn(|| Instruction::new_addi(nz::a0, nz::a0, 5, InstrWidth::Compressed));
 
-        let dispatch = &CodePage { page: &page_entry };
+        let dispatch = &std::cell::RefCell::new(CodePage {
+            page: &mut page_entry,
+        });
 
         let state = MachineCoreState::<M4K, F>::new();
         let state = &std::cell::RefCell::new(state);
@@ -234,7 +263,7 @@ mod tests {
     });
 
     backend_test!(page_dispatch_respects_max_steps_uncompressed, F, {
-        let page_entry: Box<[Instruction; INSTRUCTION_ENTRIES]> = boxed_from_fn({
+        let mut page_entry: Box<[Instruction; INSTRUCTION_ENTRIES]> = boxed_from_fn({
             let mut idx = 0;
             move || {
                 // we put uncompressed instructions on 4-byte aligned addresses
@@ -250,7 +279,9 @@ mod tests {
             }
         });
 
-        let dispatch = &CodePage { page: &page_entry };
+        let dispatch = &std::cell::RefCell::new(CodePage {
+            page: &mut page_entry,
+        });
 
         let state = MachineCoreState::<M4K, F>::new();
         let state = &std::cell::RefCell::new(state);
@@ -343,11 +374,12 @@ mod tests {
             page_entry.push(Instruction::new_nop(InstrWidth::Compressed));
         }
 
-        let dispatch = &CodePage {
-            page: &page_entry
-                .try_into()
-                .expect("page_entry has INSTRUCTION_ENTRIES entries"),
-        };
+        let mut page_entry = page_entry
+            .try_into()
+            .expect("page_entry has INSTRUCTION_ENTRIES entries");
+        let dispatch = &std::cell::RefCell::new(CodePage {
+            page: &mut page_entry,
+        });
 
         let state = MachineCoreState::<M4K, F>::new();
         let state = &std::cell::RefCell::new(state);

--- a/src/riscv/lib/src/machine_state/page_cache/code_page_entry.rs
+++ b/src/riscv/lib/src/machine_state/page_cache/code_page_entry.rs
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2024-2025 TriliTech <contact@trili.tech>
+// SPDX-FileCopyrightText: 2025 Nomadic Labs <contact@nomadic-labs.com>
+//
+// SPDX-License-Identifier: MIT
+
+//! Abstraction over the execution method when dispatching from a [`CodePage`].
+//!
+//! [`CodePage`]: super::CodePage
+
+// TODO: RV-765: add support for inline JIT
+
+use super::INSTRUCTION_ENTRIES;
+use crate::machine_state::MachineCoreState;
+use crate::machine_state::StepManyResult;
+use crate::machine_state::block_cache::block::InterpretedBlockBuilder;
+use crate::machine_state::instruction::Instruction;
+use crate::machine_state::memory::Address;
+use crate::machine_state::memory::MemoryConfig;
+use crate::state_backend::ManagerReadWrite;
+use crate::traps::Exception;
+
+/// Functionality required to dispatch entrypoints in a code page.
+///
+/// Entrypoints are semantically equivalent to instructions - but may
+/// take the opportunity to execute multiple instructions in a row before returning.
+pub trait CodePageEntry: AsRef<Instruction> + From<Instruction> + std::fmt::Debug + Sized {
+    /// Entrypoints may be just-in-time compiled to more efficient code,
+    /// if called frequently.
+    ///
+    /// We require the compiler capable of doing so to be passed in when
+    /// dispatching.
+    type Compiler;
+
+    /// Run a code-page entrypoint against the [`MachineCoreState`].
+    ///
+    /// This will run for up-to `max_steps`, but never over.
+    ///
+    /// # SAFETY
+    ///
+    /// The `compiler` must always be the same instance as passed to any
+    /// call to `run_entrypoint` within the same page, for the lifetime of that page. This ensures
+    /// that the compiler in question is guaranteed to be alive, for as long as this entrypoint may
+    /// be run.
+    unsafe fn run_entrypoint<MC, M>(
+        page: &mut [Self; INSTRUCTION_ENTRIES],
+        core: &mut MachineCoreState<MC, M>,
+        compiler: &mut Self::Compiler,
+        instr_pc: Address,
+        max_steps: usize,
+    ) -> StepManyResult<Exception>
+    where
+        MC: MemoryConfig,
+        M: ManagerReadWrite;
+}
+
+impl CodePageEntry for Instruction {
+    type Compiler = InterpretedBlockBuilder;
+
+    /// Run an entrypoint in a purely interpreted manner.
+    ///
+    /// # SAFETY
+    ///
+    /// This function is always safe to call.
+    unsafe fn run_entrypoint<MC, M>(
+        page: &mut [Self; INSTRUCTION_ENTRIES],
+        core: &mut MachineCoreState<MC, M>,
+        _compiler: &mut Self::Compiler,
+        instr_pc: Address,
+        max_steps: usize,
+    ) -> StepManyResult<Exception>
+    where
+        MC: MemoryConfig,
+        M: ManagerReadWrite,
+    {
+        super::run_code_page_interpreted(page, core, instr_pc, max_steps)
+    }
+}
+
+impl AsRef<Instruction> for Instruction {
+    fn as_ref(&self) -> &Instruction {
+        self
+    }
+}

--- a/src/riscv/lib/src/machine_state/page_cache/state.rs
+++ b/src/riscv/lib/src/machine_state/page_cache/state.rs
@@ -12,6 +12,7 @@
 //! [PageCache]: super::PageCache
 
 use super::INSTRUCTION_ENTRIES;
+use super::code_page_entry::CodePageEntry;
 use crate::array_utils::boxed_from_fn;
 use crate::default::ConstDefault;
 use crate::machine_state::MachineCoreState;
@@ -34,10 +35,13 @@ const LAST_HALFWORD_PAGE_OFFSET: u64 = PAGE_SIZE
     .checked_sub(std::mem::size_of::<u16>() as u64)
     .expect("page-size must contain at least one halfword");
 
-struct PageEntry {
+struct PageEntry<CPE: CodePageEntry> {
     // TODO: RV-773: consider re-using something like the EnrichedCell mechanism for faster
     // interpreted dispatch here.
-    entries: Box<[Instruction; INSTRUCTION_ENTRIES]>,
+    //
+    // TODO: RV-790: consider raising this pointer (Box) out of `PageEntrye` to exploit the
+    // `Option<Box<_>>` optimisation.
+    entries: Box<[CPE; INSTRUCTION_ENTRIES]>,
 }
 
 /// Default implementor of [`PageCache`].
@@ -50,12 +54,12 @@ struct PageEntry {
 /// connection with the concrete types that implement these traits.
 ///
 /// [`PageCache`]: super::PageCache
-pub struct PageCacheImpl<const PAGES: usize> {
-    pages: Box<[Option<PageEntry>; PAGES]>,
+pub struct PageCacheImpl<const PAGES: usize, CPE: CodePageEntry> {
+    pages: Box<[Option<PageEntry<CPE>>; PAGES]>,
 }
 
-impl<const PAGES: usize, MC: MemoryConfig, M: ManagerBase> super::PageCache<MC, M>
-    for PageCacheImpl<PAGES>
+impl<const PAGES: usize, CPE: CodePageEntry, MC: MemoryConfig, M: ManagerBase>
+    super::PageCache<CPE, MC, M> for PageCacheImpl<PAGES, CPE>
 {
     /// Construct a new page cache, which will be entirely unpopulated.
     fn new() -> Self {
@@ -65,7 +69,7 @@ impl<const PAGES: usize, MC: MemoryConfig, M: ManagerBase> super::PageCache<MC, 
     }
 
     /// Fetch a dispatch call, if the address corresponds to a populated page in the PageCache.
-    fn get_code_page(&mut self, address: Address) -> Option<super::CodePage<'_>>
+    fn get_code_page(&mut self, address: Address) -> Option<super::CodePage<'_, CPE>>
     where
         M: ManagerRead,
     {
@@ -87,7 +91,7 @@ impl<const PAGES: usize, MC: MemoryConfig, M: ManagerBase> super::PageCache<MC, 
     where
         M: ManagerReadWrite,
     {
-        let mut instructions = Vec::with_capacity(INSTRUCTION_ENTRIES);
+        let mut entries = Vec::with_capacity(INSTRUCTION_ENTRIES);
 
         let page_start = address & PAGE_MASK;
 
@@ -109,7 +113,7 @@ impl<const PAGES: usize, MC: MemoryConfig, M: ManagerBase> super::PageCache<MC, 
                 return;
             };
 
-            instructions.push(instr);
+            entries.push(CPE::from(instr));
         }
 
         // final halfword may need to use ForceFetchRun mechanism if it overlaps page boundary
@@ -132,14 +136,14 @@ impl<const PAGES: usize, MC: MemoryConfig, M: ManagerBase> super::PageCache<MC, 
             Instruction::DEFAULT
         };
 
-        instructions.push(final_entry);
+        entries.push(CPE::from(final_entry));
 
         if let Some(page_entry) = self
             .pages
             .get_mut((page_start >> OFFSET_BITS.get()) as usize)
         {
             *page_entry = Some(PageEntry {
-                entries: instructions
+                entries: entries
                     .try_into()
                     .expect("instructions has exactly the length expected for PageEntry::entries"),
             });
@@ -181,12 +185,15 @@ mod tests {
     use crate::machine_state::memory::Permissions;
     use crate::machine_state::page_cache::INSTRUCTION_ENTRIES;
     use crate::machine_state::page_cache::PageCache;
+    use crate::machine_state::page_cache::code_page_entry::CodePageEntry;
     use crate::machine_state::page_cache::state::PageEntry;
     use crate::parser::instruction::InstrWidth;
     use crate::state::NewState;
     use crate::state_backend::owned_backend::Owned;
 
-    fn count_active_pages<const PAGES: usize>(cache: &PageCacheImpl<PAGES>) -> usize {
+    fn count_active_pages<const PAGES: usize, CPE: CodePageEntry>(
+        cache: &PageCacheImpl<PAGES, CPE>,
+    ) -> usize {
         cache.pages.iter().fold(
             0,
             |acc, page_entry| if page_entry.is_some() { acc + 1 } else { acc },
@@ -197,7 +204,8 @@ mod tests {
     fn test_page_invalidation_resets_pages() {
         const PAGES: usize = M1M::TOTAL_BYTES / PAGE_SIZE.get() as usize;
 
-        let mut cache = <PageCacheImpl<PAGES> as PageCache<M1M, Owned>>::new();
+        let mut cache =
+            <PageCacheImpl<PAGES, Instruction> as PageCache<Instruction, M1M, Owned>>::new();
 
         let make_page = || PageEntry {
             entries: boxed_array![Instruction::DEFAULT; INSTRUCTION_ENTRIES],
@@ -212,45 +220,53 @@ mod tests {
         //
         // we expect the final page to not be invalidated - as upper bound of the half-open range
         // ends on the first byte of the page.
-        PageCache::<M1M, Owned>::invalidate_pages(
+        PageCache::<Instruction, M1M, Owned>::invalidate_pages(
             &mut cache,
             PAGE_SIZE.get()..(5 * PAGE_SIZE.get()),
         );
         assert_eq!(count_active_pages(&cache), 12);
-        assert!(PageCache::<M1M, Owned>::get_code_page(&mut cache, 0).is_some());
+        assert!(PageCache::<Instruction, M1M, Owned>::get_code_page(&mut cache, 0).is_some());
 
         for i in 1..5 {
             assert!(
-                PageCache::<M1M, Owned>::get_code_page(&mut cache, i * PAGE_SIZE.get()).is_none()
+                PageCache::<Instruction, M1M, Owned>::get_code_page(
+                    &mut cache,
+                    i * PAGE_SIZE.get()
+                )
+                .is_none()
             );
         }
 
-        assert!(PageCache::<M1M, Owned>::get_code_page(&mut cache, 5 * PAGE_SIZE.get()).is_some());
+        assert!(
+            PageCache::<Instruction, M1M, Owned>::get_code_page(&mut cache, 5 * PAGE_SIZE.get())
+                .is_some()
+        );
 
         // invalidate a range - non-page aligned
         //
         // in this instance, we expect both the starting and ending pages to be invalidated.
-        PageCache::<M1M, Owned>::invalidate_pages(
+        PageCache::<Instruction, M1M, Owned>::invalidate_pages(
             &mut cache,
             (10 * PAGE_SIZE.get() + 1)..(11 * PAGE_SIZE.get() + 1),
         );
         assert_eq!(count_active_pages(&cache), 10);
 
         // invalidate an already invalidated range does nothing
-        PageCache::<M1M, Owned>::invalidate_pages(
+        PageCache::<Instruction, M1M, Owned>::invalidate_pages(
             &mut cache,
             PAGE_SIZE.get()..(4 * PAGE_SIZE.get()),
         );
         assert_eq!(count_active_pages(&cache), 10);
 
         // invalidate all addresses clears all pages
-        PageCache::<M1M, Owned>::invalidate_pages(&mut cache, 0..u64::MAX);
+        PageCache::<Instruction, M1M, Owned>::invalidate_pages(&mut cache, 0..u64::MAX);
         assert_eq!(count_active_pages(&cache), 0);
     }
 
     backend_test!(test_populate_block_cache, F, {
         let mut state = MachineCoreState::<M4K, F>::new();
-        let mut cache = <PageCacheImpl<1> as PageCache<M4K, Owned>>::new();
+        let mut cache =
+            <PageCacheImpl<1, Instruction> as PageCache<Instruction, M4K, Owned>>::new();
 
         // populating a non R+X page should fail
         cache.populate_page(15, &state);
@@ -306,7 +322,7 @@ mod tests {
         proptest!(|(pc_addr in 0..M1M::TOTAL_BYTES as u64,
                     page: Box<[u8; PAGE_SIZE.get() as usize]>)| {
             // Arrange
-            let mut cache = <PageCacheImpl<PAGES> as PageCache<M1M, Owned>>::new();
+            let mut cache = <PageCacheImpl<PAGES, Instruction> as PageCache<Instruction, M1M, Owned>>::new();
             let mut state = state.borrow_mut();
             state.reset();
 
@@ -344,7 +360,7 @@ mod tests {
                 Instruction::DEFAULT
             };
 
-            let code_page = PageCache::<M1M, Owned>::get_code_page(&mut cache, pc_addr).expect("code page populated");
+            let mut code_page = PageCache::<Instruction, M1M, Owned>::get_code_page(&mut cache, pc_addr).expect("code page populated");
             let instr_from_code_page = code_page.page[pc_offset as usize / 2];
             assert_eq!(expected_instr, instr_from_code_page);
 
@@ -352,7 +368,8 @@ mod tests {
             let pc_last_halfword = page_start + (PAGE_SIZE.get() - InstrWidth::Compressed as u64);
             let last_halfword = state.fetch_instr_halfword(pc_last_halfword).unwrap();
             if !crate::parser::is_compressed(last_halfword.data) {
-                let step_res = code_page.run(&mut state, InterpretedBlockBuilder, pc_last_halfword, 1);
+                // SAFETY: interpreted is always safe to call
+                let step_res = unsafe { code_page.run(&mut state, &mut InterpretedBlockBuilder, pc_last_halfword, 1) };
                 assert_eq!(step_res.error, Some(crate::traps::Exception::ForceFetchRun));
                 assert_eq!(step_res.steps, 0, "raising an exception does not complete a step");
             }


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

Closes RV-764

# What

Make `PageCache` generic over the dispatch mechanism (for now just interpreted, but soon Jitted also)

# Why

We require the ability to run in all three modes (interpreted, inline/outline jit).  This allows to re-use various parts of the page cache which don't rely on the underlying dispatch mechanism.

# How

Essentially porting what the block cache did here - except we now deal with flat instructions rather than an `address -> sequence` map.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
