### PR TITLE
Self PC update by linux system call handlers

### DIFF
--- a/src/riscv/lib/src/machine_state.rs
+++ b/src/riscv/lib/src/machine_state.rs
@@ -68,8 +68,9 @@ pub struct MachineCoreState<MC: memory::MemoryConfig, M: backend::ManagerBase> {
 }
 
 impl<MC: memory::MemoryConfig, M: backend::ManagerBase> MachineCoreState<MC, M> {
+    /// Update the hart's pc given the update and explicitly given the current value of pc
     #[inline]
-    fn update_pc(&mut self, instr_pc: Address, update: ProgramCounterUpdate<Address>)
+    pub(crate) fn update_pc(&mut self, instr_pc: Address, update: ProgramCounterUpdate<Address>)
     where
         M: backend::ManagerWrite,
     {

--- a/src/riscv/lib/src/pvm/linux.rs
+++ b/src/riscv/lib/src/pvm/linux.rs
@@ -16,6 +16,7 @@ use std::ffi::CStr;
 use std::ops::ControlFlow;
 use std::ops::Range;
 
+use parameters::SystemCallResultExecution;
 use perfect_derive::perfect_derive;
 use tezos_smart_rollup_constants::riscv::SBI_FIRMWARE_TEZOS;
 
@@ -26,6 +27,7 @@ use super::Pvm;
 use crate::machine_state::MachineCoreState;
 use crate::machine_state::MachineError;
 use crate::machine_state::MachineState;
+use crate::machine_state::ProgramCounterUpdate;
 use crate::machine_state::block_cache::BlockCacheConfig;
 use crate::machine_state::block_cache::block::Block;
 use crate::machine_state::memory::Address;
@@ -36,6 +38,7 @@ use crate::machine_state::memory::Permissions;
 use crate::machine_state::registers;
 use crate::program::Program;
 use crate::pvm::hooks::PvmHooks;
+use crate::pvm::linux::parameters::ECALL_WIDTH;
 use crate::pvm::linux::signals::Signal;
 use crate::state::NewState;
 use crate::state_backend::AllocatedOf;
@@ -527,10 +530,7 @@ impl<M: ManagerBase> SupervisorState<M> {
         B: Block<MC, M>,
         M: ManagerReadWrite,
     {
-        // We need to jump to the next instruction. The ECall instruction which triggered this
-        // function is 4 byte wide.
-        let pc = machine.core.hart.pc.read().saturating_add(4);
-        machine.core.hart.pc.write(pc);
+        let pc = machine.core.hart.pc.read();
 
         /// Read an argument from a register and interpret it as a system call argument.
         /// If that fails, log the failure.
@@ -568,10 +568,7 @@ impl<M: ManagerBase> SupervisorState<M> {
         /// Check the result of a system call. If it failed, log the error.
         macro_rules! check_result {
             ($system_call:ident, $result:expr) => {{
-                let parameters::SystemCallResultExecution {
-                    result,
-                    control_flow,
-                } = $result
+                let res: SystemCallResultExecution = $result
                     .inspect(|res| {
                         crate::log::trace! {
                             result = format!("{res:?}"),
@@ -588,8 +585,7 @@ impl<M: ManagerBase> SupervisorState<M> {
                         }
                     })?
                     .into();
-                machine.core.hart.xregisters.write(registers::a0, result);
-                control_flow
+                res
             }};
         }
 
@@ -788,14 +784,28 @@ impl<M: ManagerBase> SupervisorState<M> {
                     .xregisters
                     .write_system_call_error(Error::NoSystemCall);
 
+                machine
+                    .core
+                    .update_pc(pc, ProgramCounterUpdate::Next(ECALL_WIDTH));
                 let _ = machine.core.dispatch_signal(Signal::Sigsys);
             }
 
             Err(error) => {
                 machine.core.hart.xregisters.write_system_call_error(error);
+                machine
+                    .core
+                    .update_pc(pc, ProgramCounterUpdate::Next(ECALL_WIDTH));
             }
 
-            Ok(control_flow) => return control_flow,
+            Ok(SystemCallResultExecution {
+                result,
+                control_flow,
+                pc_update,
+            }) => {
+                machine.core.hart.xregisters.write(registers::a0, result);
+                machine.core.update_pc(pc, pc_update);
+                return control_flow;
+            }
         }
 
         ControlFlow::Continue(())
@@ -852,6 +862,7 @@ impl<M: ManagerBase> SupervisorState<M> {
         Ok(parameters::SystemCallResultExecution {
             result: status.exit_code(),
             control_flow: ControlFlow::Break(()),
+            pc_update: ProgramCounterUpdate::Next(ECALL_WIDTH), // vacuous, never used
         })
     }
 
@@ -869,10 +880,10 @@ impl<M: ManagerBase> SupervisorState<M> {
         self.exited = true;
         self.exit_code = signal.exit_code();
 
-        // Return 0 as an indicator of success, even if this might not actually be used
         Ok(parameters::SystemCallResultExecution {
-            result: 0,
             control_flow: ControlFlow::Break(()),
+            result: 0, // indicator of success, even if this might not actually be used
+            ..SystemCallResultExecution::default()  // vacuous args, never used
         })
     }
 

--- a/src/riscv/lib/src/pvm/linux/parameters.rs
+++ b/src/riscv/lib/src/pvm/linux/parameters.rs
@@ -8,9 +8,12 @@ use std::ops::ControlFlow;
 
 use super::MAIN_THREAD_ID;
 use super::error::Error;
+use crate::machine_state::ProgramCounterUpdate;
+use crate::machine_state::memory::Address;
+use crate::parser::instruction::InstrWidth;
 
 /// A type coupling the result of the system call with how the program should continue.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug)]
 pub struct SystemCallResultExecution {
     /// Result value that will be returned to the caller of the system call
     pub result: u64,
@@ -20,15 +23,32 @@ pub struct SystemCallResultExecution {
     /// Breaking means leaving the step loop in the machine state. In other words, it will defer to
     /// the level above it to decide what to do.
     pub control_flow: ControlFlow<()>,
+
+    /// Not all system calls just move the PC to the next instruction
+    /// This account for that.
+    pub pc_update: ProgramCounterUpdate<Address>,
 }
+
+/// An ECALL is 4 bytes wide, ie, an uncompressed instr
+pub(crate) const ECALL_WIDTH: InstrWidth = InstrWidth::Uncompressed;
 
 impl<T: Into<u64>> From<T> for SystemCallResultExecution {
     fn from(value: T) -> Self {
         // The default action is to continue execution after the system call. In cases where the
         // execution should halt, this should be specified.
-        SystemCallResultExecution {
+        Self {
             result: value.into(),
+            ..Self::default()
+        }
+    }
+}
+
+impl Default for SystemCallResultExecution {
+    fn default() -> Self {
+        Self {
+            result: 0,
             control_flow: ControlFlow::Continue(()),
+            pc_update: ProgramCounterUpdate::Next(ECALL_WIDTH),
         }
     }
 }

--- a/src/riscv/lib/src/pvm/linux/signals.rs
+++ b/src/riscv/lib/src/pvm/linux/signals.rs
@@ -12,6 +12,7 @@ use strum::FromRepr;
 
 use super::error::Error;
 use crate::machine_state::MachineCoreState;
+use crate::machine_state::ProgramCounterUpdate;
 use crate::machine_state::RISCV_ABI_SP_ALIGNMENT;
 use crate::machine_state::memory::BadMemoryAccess;
 use crate::machine_state::memory::Memory;
@@ -21,6 +22,7 @@ use crate::machine_state::registers::sp;
 use crate::pvm::linux::Address;
 use crate::pvm::linux::SupervisorState;
 use crate::pvm::linux::VirtAddr;
+use crate::pvm::linux::parameters::SystemCallResultExecution;
 use crate::state::NewState;
 use crate::state_backend::AllocatedOf;
 use crate::state_backend::Atom;
@@ -779,13 +781,15 @@ impl<M: ManagerBase> SupervisorState<M> {
     pub(super) fn handle_rt_sigreturn(
         &self,
         core: &mut MachineCoreState<impl MemoryConfig, M>,
-    ) -> Result<u64, Error>
+    ) -> Result<SystemCallResultExecution, Error>
     where
         M: ManagerReadWrite,
     {
         let pc = core.pop_signal_context().map_err(|_| Error::Fault)?;
-        core.hart.pc.write(pc);
-        // Return 0 as an indicator of success
-        Ok(0)
+        Ok(SystemCallResultExecution {
+            result: 0, // indicator of success
+            pc_update: ProgramCounterUpdate::Set(pc),
+            ..SystemCallResultExecution::default()
+        })
     }
 }

--- a/src/riscv/lib/src/pvm/tezos.rs
+++ b/src/riscv/lib/src/pvm/tezos.rs
@@ -359,6 +359,10 @@ pub(super) fn handle_tezos<MC, M>(
     MC: MemoryConfig,
     M: ManagerReadWrite,
 {
+    // TODO: RV-777: remove below and instead have each system call return a `ProgramCounterUpdate`
+    let pc = machine.hart.pc.read().wrapping_add(4);
+    machine.hart.pc.write(pc);
+
     let sbi_function = machine.hart.xregisters.read(a6);
     match sbi_function {
         SBI_TEZOS_INBOX_NEXT => handle_tezos_inbox_next(status),


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->
Part of RV-777
Project Data Parallelism in System Calls: [Design Doc](https://linear.app/tezos/document/design-doc-0211bbf47d5d), [excalidraw](https://app.excalidraw.com/s/8ILYpjPL16O/8jXiLZz9ST2?next=%2Fs%2F8ILYpjPL16O%2F8jXiLZz9ST2)
# What
Remove the illusion that PC moves forward by an instruction on every system call. Currently the pc is incremented by `instr_width=4` on an ECALL at the start of the top-level handler, and then some of the system calls choose to further modify the PC (eg, `handle_srt_sigreturn` sets it to a fixed address). Use `ProgramCounterUpdate` to make the PC update logic more clear and explicit. 


<!--
    Summarise the changes in this MR.
-->

# Why
For code clarity, especially since more system calls with custom PC update logic are going to be implemented soon.
<!-- 
    Explain why this MR is needed.
-->

# How
This PR has every system call handler effectively returning a `ProgramCounterUpdate` which has been added as a field to `SystemCallResultExecution`. In practice most syscall handlers actually return a `Result<u64,..>` only which is converted using `Into` to the default `SystemCallResultExecution` which represent a `Next` update. It is helpful to know which syscalls don't return `Result<u6,..>`, but directly return `SystemCallResultExecution`, while reviewing. These are:
`exit`, `tkill` `rt_sigreturn`

The PC increments for host functions have been moved to `handle_tezos` and they happen without use of `ProgramCounterUpdate` at the moment. The next PR will involve a similar refactor to this PR for host functions.

There is a minor semantic change I've made [here](https://github.com/tezos/riscv-pvm/pull/335/files#diff-c0656d3081a3cd2dcda31be427ed813c730aa6af7b274a0389534c85d609e3e7R533). It only concerns logging. Previously the pc was reported after being incremented by 4. I made it the pc before incrementing, as pc+4 is not always actually the next instruction executed. This is because of `rt_sigreturn`, the only syscall which sets the pc to some value.
<!--
    Explain how the MR achieves its goal. If this is trivial or if the code speaks for itself, you
    can omit this.
-->

# Manually Testing

```
make all
```

# Regressions

<!--
    Explain changes to regression test captures. If there are no changes to these, delete this
    section.
-->

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
