### PR TITLE
ci(code-coverage): make report more robust wrt to newly introduced code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,8 +129,8 @@ jobs:
           diff-branch: main
           diff-storage: _xml_coverage_reports
           coverage-summary-title: "Code Coverage Summary"
-          uncovered-statements-increase-failure: true
-          new-uncovered-statements-failure: false
+          new-uncovered-statements-failure: true
+          uncovered-statements-increase-failure: false
           coverage-rate-reduction-failure: true
           togglable-report: true
 


### PR DESCRIPTION
This tweaks the settings for the code coverage CI step to be a little less annoying when introducing new code.

See [GHA marketplace](https://github.com/marketplace/actions/code-coverage-report-action) for details on the configuration options.