### PR TITLE
Remove unused variables from Makefiles

### DIFF
--- a/src/riscv/Makefile
+++ b/src/riscv/Makefile
@@ -6,13 +6,6 @@
 .PHONY: all
 all: build test check
 
-# In some situations we might want to override the compilation target.
-NATIVE_TARGET ?=
-
-ifneq ($(NATIVE_TARGET),)
-NATIVE_OPT := --target="$(NATIVE_TARGET)"
-endif
-
 # Mechanism to allow enabling additional features - for example JIT
 SANDBOX_ENABLE_FEATURES ?=
 
@@ -21,12 +14,12 @@ NIGHTLY_VERSION = nightly-2025-01-30
 
 .PHONY: build
 build: riscv-sandbox
-	@cargo build --release --workspace $(NATIVE_OPT)
+	@cargo build --release --workspace
 
 .PHONY: riscv-sandbox
 riscv-sandbox::
-	@cargo build --release --package riscv-sandbox $(NATIVE_OPT) $(SANDBOX_ENABLE_FEATURES:%=-F%)
-	@ln -f ../../target/$(NATIVE_TARGET)/release/riscv-sandbox $@
+	@cargo build --release --package riscv-sandbox $(SANDBOX_ENABLE_FEATURES:%=-F%)
+	@ln -f ../../target/release/riscv-sandbox $@
 
 .PHONY: riscv-sandbox.prof
 riscv-sandbox.prof::
@@ -54,10 +47,6 @@ build-deps-slim:
 	# The second command triggers installation for Rustup 1.28+.
 	@rustup show active-toolchain || rustup toolchain install
 	@rustup component add rustfmt clippy
-
-ifneq ($(NATIVE_TARGET),)
-	@rustup target add $(NATIVE_TARGET)
-endif
 
 	# Install Nightly for formatting with its Rustfmt
 	@rustup toolchain install $(NIGHTLY_VERSION) -c rustfmt -c rust-src


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

# What

Remove unused variables from our Makefiles. 

# Why

Remove unused cruft in an attempt to simplify them.

I noticed these when I started migrating the Sandbox crate to the root. Turns out these are not used, so I thought it might be useful to remove them up front.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
