### PR TITLE
chore(gitignore): ignore rust-analyzer configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 # Cargo
 target
 
+# Rust LSP
+.rust-analyzer.json
+
 # Direnv
 .direnv
 .envrc


### PR DESCRIPTION
Ignore `.rust-analyzer.json` which is used as a configuration file for Rust Analyzer in some instances (for example by NeoVim LSP setup).