### PR TITLE
fix(memory): reset did not reset permissions

### DIFF
--- a/src/riscv/lib/src/machine_state/memory/protection.rs
+++ b/src/riscv/lib/src/machine_state/memory/protection.rs
@@ -133,6 +133,14 @@ impl<const PAGES: usize, M: ManagerBase> PagePermissions<PAGES, M> {
                 self.pages[page].write(accessible);
             })
     }
+
+    /// Reset access permissions on all pages.
+    pub fn reset(&mut self)
+    where
+        M: ManagerWrite,
+    {
+        self.pages.iter_mut().for_each(|page| page.write(false));
+    }
 }
 
 impl<const PAGES: usize, M: ManagerBase> NewState<M> for PagePermissions<PAGES, M> {

--- a/src/riscv/lib/src/machine_state/memory/state.rs
+++ b/src/riscv/lib/src/machine_state/memory/state.rs
@@ -220,6 +220,10 @@ where
         for i in 0..outstanding {
             self.data.write(address.saturating_add(i), 0u8);
         }
+
+        self.readable_pages.reset();
+        self.writable_pages.reset();
+        self.executable_pages.reset();
     }
 
     fn protect_pages(
@@ -346,6 +350,7 @@ pub mod tests {
     use crate::machine_state::memory::M4K;
     use crate::machine_state::memory::MemoryConfig;
     use crate::state::NewState;
+    use crate::state_backend::FnManagerIdent;
     use crate::state_backend::owned_backend::Owned;
 
     #[test]
@@ -432,5 +437,34 @@ pub mod tests {
         check_address!(u8, 5, 0x33);
         check_address!(u8, 6, 0x22);
         check_address!(u8, 7, 0x11);
+    });
+
+    backend_test!(test_memory_reset, F, {
+        let clean_memory = <<M4K as MemoryConfig>::State<F>>::new();
+
+        let mut memory = <<M4K as MemoryConfig>::State<F>>::new();
+
+        // setting readable permissions should reset
+        memory.set_all_readable_writeable();
+        memory.write(5, 0xFFu8).unwrap();
+        memory.reset();
+
+        assert!(
+            M4K::struct_ref::<F, FnManagerIdent>(&clean_memory)
+                == M4K::struct_ref::<F, FnManagerIdent>(&memory),
+            "RW memory did not reset correctly"
+        );
+
+        // setting executable permissions should reset
+        memory
+            .write_instruction_unchecked(17, 0x1122334455667788u64)
+            .unwrap();
+        memory.reset();
+
+        assert!(
+            M4K::struct_ref::<F, FnManagerIdent>(&clean_memory)
+                == M4K::struct_ref::<F, FnManagerIdent>(&memory),
+            "X memory did not reset correctly"
+        );
     });
 }


### PR DESCRIPTION


<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

# What

Properly reset memory - including permissions which were previously missed.

# Why

Important to reset fully.

This additionally caused some flakiness within the `page_cache::state::populate_from_memory` test. Since memory reset did not touch permissions - sometimes we would infact fetch an uncompressed instruction from memory which crossed a page boundary successfully. The test did not expect this (as it expected only one page to have been allocated).

# Manually Testing

```
make all
```

The following test will fail on `main` eventually if run repeatedly, such as by doing:
```
while cargo test -p octez-riscv -- page_cache::state::tests::populate_from_memory; do :; done
```

This is no longer the case on this branch.

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
