### PR TITLE
feat(page_cache): enable jitted-based dispatch

### DIFF
--- a/src/riscv/lib/src/machine_state/block_cache/block/dispatch.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/block/dispatch.rs
@@ -173,6 +173,35 @@ impl<C: CodeDispatcher<D, MC>, D: DispatchCompiler<MC>, MC: MemoryConfig> Defaul
     }
 }
 
+impl<C: CodeDispatcher<D, MC>, D: DispatchCompiler<MC>, MC: MemoryConfig> std::fmt::Debug
+    for DispatchTarget<C, D, MC>
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let fun = self.get();
+
+        #[derive(Debug)]
+        enum Status {
+            Interpreted,
+            NotCompiled,
+            Compiled,
+        }
+
+        let status = if fun as usize == C::run_block_interpreted as usize {
+            Status::Interpreted
+        } else if fun as usize == C::run_block_not_compiled as usize {
+            Status::NotCompiled
+        } else {
+            Status::Compiled
+        };
+
+        f.debug_struct("DispatchTarget")
+            .field("status", &status)
+            .field("fun", &fun)
+            .field("remaining_calls", &self.remaining_calls)
+            .finish()
+    }
+}
+
 /// A compiler that can JIT-compile blocks of instructions, and hot-swap the execution of
 /// said block in the given dispatch target.
 pub trait DispatchCompiler<MC: MemoryConfig>: Default + Sized {
@@ -397,4 +426,55 @@ struct CompilationRequest {
     instr: Vec<Instruction>,
     fun: Arc<AtomicUsize>,
     program_counter: Address,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DispatchTarget;
+    use crate::jit::state_access::ExceptionCode;
+    use crate::machine_state::MachineCoreState;
+    use crate::machine_state::block_cache::block::InlineCompiler;
+    use crate::machine_state::block_cache::block::dispatch::CodeDispatcher;
+    use crate::machine_state::memory::Address;
+    use crate::machine_state::memory::M4K;
+    use crate::machine_state::page_cache::jitted::JittedPage;
+    use crate::state_backend::owned_backend::Owned;
+
+    #[test]
+    fn test_dispatch_debug_classification() {
+        let dispatch = DispatchTarget::<JittedPage<_, _>, InlineCompiler<_>, M4K>::default();
+        let format = format!("{dispatch:?}");
+
+        assert!(
+            format.contains("status: Interpreted"),
+            "unexpected formatting \"{format}\""
+        );
+
+        dispatch.set(<JittedPage<_, _> as CodeDispatcher<_, _>>::run_block_not_compiled);
+        let format = format!("{dispatch:?}");
+
+        assert!(
+            format.contains("status: NotCompiled"),
+            "unexpected formatting \"{format}\""
+        );
+
+        unsafe extern "C" fn compiled_dummy<C, D>(
+            _: &mut C,
+            _: &mut MachineCoreState<M4K, Owned>,
+            _: Address,
+            _: usize,
+            _: &mut ExceptionCode,
+            _: &mut D,
+        ) -> usize {
+            0
+        }
+
+        dispatch.set(compiled_dummy);
+        let format = format!("{dispatch:?}");
+
+        assert!(
+            format.contains("status: Compiled"),
+            "unexpected formatting \"{format}\""
+        );
+    }
 }

--- a/src/riscv/lib/src/machine_state/page_cache.rs
+++ b/src/riscv/lib/src/machine_state/page_cache.rs
@@ -21,6 +21,7 @@
 #![cfg(test)]
 
 pub(crate) mod code_page_entry;
+pub(crate) mod jitted;
 pub(crate) mod state;
 
 use code_page_entry::CodePageEntry;
@@ -50,7 +51,7 @@ const INSTRUCTION_ENTRIES: usize = 1
         .expect("OFFSET_BITS is non-zero") as usize;
 
 /// Instance of the page cache.
-pub trait PageCache<CPE: CodePageEntry, MC: MemoryConfig, M: ManagerBase> {
+pub trait PageCache<CPE: CodePageEntry<MC, M>, MC: MemoryConfig, M: ManagerBase> {
     /// Instantiate a new page cache instance.
     fn new() -> Self;
 
@@ -74,11 +75,11 @@ pub trait PageCache<CPE: CodePageEntry, MC: MemoryConfig, M: ManagerBase> {
 }
 
 /// A page containing code that may then be run against the [`MachineCoreState`].
-pub(crate) struct CodePage<'a, CPE: CodePageEntry> {
+pub(crate) struct CodePage<'a, CPE> {
     page: &'a mut [CPE; INSTRUCTION_ENTRIES],
 }
 
-impl<CPE: CodePageEntry> CodePage<'_, CPE> {
+impl<CPE> CodePage<'_, CPE> {
     /// Run a code page against the machine state.
     ///
     /// # SAFETY
@@ -95,6 +96,7 @@ impl<CPE: CodePageEntry> CodePage<'_, CPE> {
         max_steps: usize,
     ) -> StepManyResult<Exception>
     where
+        CPE: CodePageEntry<MC, M>,
         MC: MemoryConfig,
         M: ManagerReadWrite,
     {

--- a/src/riscv/lib/src/machine_state/page_cache/code_page_entry.rs
+++ b/src/riscv/lib/src/machine_state/page_cache/code_page_entry.rs
@@ -17,13 +17,16 @@ use crate::machine_state::block_cache::block::InterpretedBlockBuilder;
 use crate::machine_state::instruction::Instruction;
 use crate::machine_state::memory::Address;
 use crate::machine_state::memory::MemoryConfig;
+use crate::state_backend::ManagerBase;
 use crate::state_backend::ManagerReadWrite;
 
 /// Functionality required to dispatch entrypoints in a code page.
 ///
 /// Entrypoints are semantically equivalent to instructions - but may
 /// take the opportunity to execute multiple instructions in a row before returning.
-pub trait CodePageEntry: AsRef<Instruction> + From<Instruction> + std::fmt::Debug + Sized {
+pub trait CodePageEntry<MC: MemoryConfig, M: ManagerBase>:
+    AsRef<Instruction> + From<Instruction> + std::fmt::Debug + Sized
+{
     /// Entrypoints may be just-in-time compiled to more efficient code,
     /// if called frequently.
     ///
@@ -41,7 +44,7 @@ pub trait CodePageEntry: AsRef<Instruction> + From<Instruction> + std::fmt::Debu
     /// call to `run_entrypoint` within the same page, for the lifetime of that page. This ensures
     /// that the compiler in question is guaranteed to be alive, for as long as this entrypoint may
     /// be run.
-    unsafe fn run_entrypoint<MC, M>(
+    unsafe fn run_entrypoint(
         page: &mut [Self; INSTRUCTION_ENTRIES],
         core: &mut MachineCoreState<MC, M>,
         compiler: &mut Self::Compiler,
@@ -49,11 +52,10 @@ pub trait CodePageEntry: AsRef<Instruction> + From<Instruction> + std::fmt::Debu
         max_steps: usize,
     ) -> StepManyResult<Exception>
     where
-        MC: MemoryConfig,
         M: ManagerReadWrite;
 }
 
-impl CodePageEntry for Instruction {
+impl<MC: MemoryConfig, M: ManagerBase> CodePageEntry<MC, M> for Instruction {
     type Compiler = InterpretedBlockBuilder;
 
     /// Run an entrypoint in a purely interpreted manner.
@@ -61,7 +63,7 @@ impl CodePageEntry for Instruction {
     /// # SAFETY
     ///
     /// This function is always safe to call.
-    unsafe fn run_entrypoint<MC, M>(
+    unsafe fn run_entrypoint(
         page: &mut [Self; INSTRUCTION_ENTRIES],
         core: &mut MachineCoreState<MC, M>,
         _compiler: &mut Self::Compiler,
@@ -69,7 +71,6 @@ impl CodePageEntry for Instruction {
         max_steps: usize,
     ) -> StepManyResult<Exception>
     where
-        MC: MemoryConfig,
         M: ManagerReadWrite,
     {
         super::run_code_page_interpreted(page, core, instr_pc, max_steps)

--- a/src/riscv/lib/src/machine_state/page_cache/jitted.rs
+++ b/src/riscv/lib/src/machine_state/page_cache/jitted.rs
@@ -1,0 +1,271 @@
+// SPDX-FileCopyrightText: 2024-2025 TriliTech <contact@trili.tech>
+// SPDX-FileCopyrightText: 2025 Nomadic Labs <contact@nomadic-labs.com>
+//
+// SPDX-License-Identifier: MIT
+
+//! JIT-compilation support for entrypoints in pages.
+
+use super::INSTRUCTION_ENTRIES;
+use super::PAGE_OFFSET_MASK;
+use super::code_page_entry::CodePageEntry;
+use crate::exceptions::Exception;
+use crate::jit::state_access::ExceptionCode;
+use crate::machine_state::MachineCoreState;
+use crate::machine_state::StepManyResult;
+use crate::machine_state::block_cache::block::dispatch::CodeDispatcher;
+use crate::machine_state::block_cache::block::dispatch::DispatchCompiler;
+use crate::machine_state::block_cache::block::dispatch::DispatchTarget;
+use crate::machine_state::instruction::Instruction;
+use crate::machine_state::memory::Address;
+use crate::machine_state::memory::MemoryConfig;
+use crate::state_backend::owned_backend::Owned;
+
+/// Maximum number of instructions we pass to a compilation request
+///
+/// Doubles as a coarse upper-bound for the minimum number of steps required to safely dispatch
+/// the entrypoints.
+const MAX_INSTR_COMPILED: usize = 20;
+
+/// A full-page of Jit-supporting entrypoints.
+pub type JittedPage<D, MC> = [Jitted<D, MC>; INSTRUCTION_ENTRIES];
+
+/// Entrypoints that are compiled to native code for execution, when possible & desirable.
+///
+/// Not all instructions are currently supported, when a sequence contains
+/// unsupported instructions, a fallback to [`super::Interpreted`] mode may occur (if the
+/// unsupported instruction is attempted for compilation).
+#[derive(derive_more::Debug)]
+pub struct Jitted<D: DispatchCompiler<MC>, MC: MemoryConfig> {
+    instruction: Instruction,
+    dispatch: DispatchTarget<[Self; INSTRUCTION_ENTRIES], D, MC>,
+}
+
+impl<D: DispatchCompiler<MC>, MC: MemoryConfig> AsRef<Instruction> for Jitted<D, MC> {
+    fn as_ref(&self) -> &Instruction {
+        &self.instruction
+    }
+}
+
+impl<D: DispatchCompiler<MC>, MC: MemoryConfig> CodeDispatcher<D, MC> for JittedPage<D, MC> {
+    /// The default initial dispatcher for jit.
+    ///
+    /// This will run the entrypoint in interpreted mode by default, but may attempt to JIT-compile
+    /// the block.
+    ///
+    /// # SAFETY
+    ///
+    /// The `compiler` must be the same every time this function is called.
+    ///
+    /// This ensures that the builder in question is guaranteed to be alive, for at least as long
+    /// as this entrypoint may be run via [`CodePageEntry::run_entrypoint`].
+    unsafe extern "C" fn run_block_interpreted(
+        &mut self,
+        core: &mut MachineCoreState<MC, Owned>,
+        instr_pc: Address,
+        max_steps: usize,
+        result: &mut ExceptionCode,
+        compiler: &mut D,
+    ) -> usize {
+        let offset = (instr_pc & PAGE_OFFSET_MASK) >> 1;
+
+        if !compiler.should_compile(&mut self[offset as usize].dispatch) {
+            // Safety: the compiler passed to this function is always the same for the
+            // lifetime of the entrypoint
+            return unsafe {
+                self.run_block_not_compiled(core, instr_pc, max_steps, result, compiler)
+            };
+        }
+
+        // trigger JIT compilation
+        let instr = self
+            .iter()
+            .skip(offset as usize)
+            .take(MAX_INSTR_COMPILED)
+            .map(|entry| entry.instruction)
+            .collect::<Vec<_>>();
+
+        let fun = compiler.compile(&mut self[offset as usize].dispatch, instr, instr_pc);
+
+        // Safety: the compiler passed to this function is always the same for the
+        // lifetime of the entrypoint
+        unsafe { (fun)(self, core, instr_pc, max_steps, result, compiler) }
+    }
+
+    /// Run a block where JIT-compilation has been attempted, but failed for any reason.
+    ///
+    /// # SAFETY
+    ///
+    /// The `compiler` must be the same every time this function is called.
+    ///
+    /// This ensures that the builder in question is guaranteed to be alive, for at least as long
+    /// as this entrypoint may be run via [`CodePageEntry::run_entrypoint`].
+    unsafe extern "C" fn run_block_not_compiled(
+        &mut self,
+        core: &mut MachineCoreState<MC, Owned>,
+        instr_pc: Address,
+        max_steps: usize,
+        result: &mut ExceptionCode,
+        _compiler: &mut D,
+    ) -> usize {
+        let block_result = super::run_code_page_interpreted(self, core, instr_pc, max_steps);
+
+        *result = block_result
+            .error
+            .map(ExceptionCode::from_exception)
+            .unwrap_or(ExceptionCode::NoException);
+
+        block_result.steps
+    }
+}
+
+impl<D: DispatchCompiler<MC>, MC: MemoryConfig> From<Instruction> for Jitted<D, MC> {
+    fn from(instruction: Instruction) -> Self {
+        Self {
+            instruction,
+            dispatch: DispatchTarget::default(),
+        }
+    }
+}
+
+impl<D: DispatchCompiler<MC>, MC: MemoryConfig> CodePageEntry<MC, Owned> for Jitted<D, MC> {
+    type Compiler = D;
+
+    /// Run from an entrypoint, using the currently selected dispatch mechanism
+    ///
+    /// # SAFETY
+    ///
+    /// The `compiler` must be the same every time this function is called.
+    ///
+    /// This ensures that the builder in question is guaranteed to be alive, for at least as long
+    /// as this entrypoint may be run via [`CodePageEntry::run_entrypoint`].
+    unsafe fn run_entrypoint(
+        page: &mut [Self; INSTRUCTION_ENTRIES],
+        core: &mut MachineCoreState<MC, Owned>,
+        compiler: &mut Self::Compiler,
+        instr_pc: Address,
+        max_steps: usize,
+    ) -> StepManyResult<Exception> {
+        if max_steps < MAX_INSTR_COMPILED {
+            return super::run_code_page_interpreted(page, core, instr_pc, max_steps);
+        }
+
+        // Since we know the instruction pc to always be halfword-aligned, there are half
+        // as many entries as the page size.
+        let instr_offset = (instr_pc & PAGE_OFFSET_MASK) >> 1;
+
+        let entrypoint = &mut page[instr_offset as usize];
+
+        let fun = entrypoint.dispatch.get();
+
+        #[cfg(test)]
+        entrypoint.dispatch.record_called();
+
+        let mut result = ExceptionCode::NoException;
+
+        // SAFETY: The compiler builder is always the same instance, guaranteeing that any JIT-compiled
+        // function is still alive.
+        let steps = unsafe { (fun)(page, core, instr_pc, max_steps, &mut result, compiler) };
+
+        StepManyResult {
+            steps,
+            error: result.to_exception(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Jitted;
+    use super::MAX_INSTR_COMPILED;
+    use crate::array_utils::boxed_from_fn;
+    use crate::exceptions::Exception;
+    use crate::machine_state::MachineCoreState;
+    use crate::machine_state::block_cache::block::InlineCompiler;
+    use crate::machine_state::instruction::Instruction;
+    use crate::machine_state::memory::M4K;
+    use crate::machine_state::page_cache::CodePageEntry;
+    use crate::machine_state::page_cache::INSTRUCTION_ENTRIES;
+    use crate::parser::instruction::InstrWidth;
+    use crate::state::NewState;
+
+    #[test]
+    fn test_jitted_entrypoint_called() {
+        let mut page = boxed_from_fn::<_, INSTRUCTION_ENTRIES>(|| {
+            Jitted::<_, M4K>::from(Instruction::new_nop(InstrWidth::Compressed))
+        });
+
+        let mut jit = InlineCompiler::default();
+        let mut core = MachineCoreState::new();
+
+        // Safety: we only ever use the above JIT instance
+        let result = unsafe {
+            CodePageEntry::run_entrypoint(&mut page, &mut core, &mut jit, 100, MAX_INSTR_COMPILED)
+        };
+
+        assert!(result.error.is_none());
+        assert_eq!(result.steps, MAX_INSTR_COMPILED);
+
+        assert_eq!(
+            core.hart.pc.read(),
+            100 + (MAX_INSTR_COMPILED as u64) * InstrWidth::Compressed as u64
+        );
+
+        assert_eq!(page[100 >> 1].dispatch.called_times(), 1);
+    }
+
+    #[test]
+    fn test_interpreted_fallback_on_insufficient_steps() {
+        let mut page = boxed_from_fn::<_, INSTRUCTION_ENTRIES>(|| {
+            Jitted::<_, M4K>::from(Instruction::new_nop(InstrWidth::Compressed))
+        });
+
+        let mut jit = InlineCompiler::default();
+        let mut core = MachineCoreState::new();
+
+        let max_steps = MAX_INSTR_COMPILED - 1;
+
+        // Safety: we only ever use the above JIT instance
+        let result = unsafe {
+            CodePageEntry::run_entrypoint(&mut page, &mut core, &mut jit, 100, max_steps)
+        };
+
+        assert!(result.error.is_none());
+        assert_eq!(result.steps, max_steps);
+
+        assert_eq!(
+            core.hart.pc.read(),
+            100 + max_steps as u64 * InstrWidth::Compressed as u64
+        );
+
+        assert_eq!(page[100 >> 1].dispatch.called_times(), 0);
+    }
+
+    #[test]
+    fn test_not_compiled_fallback_on_compilation_failure() {
+        let mut page = boxed_from_fn::<_, INSTRUCTION_ENTRIES>(|| {
+            Jitted::<_, M4K>::from(Instruction::new_fence_i())
+        });
+
+        let mut jit = InlineCompiler::default();
+        let mut core = MachineCoreState::new();
+
+        let max_steps = MAX_INSTR_COMPILED;
+
+        // Safety: we only ever use the above JIT instance
+        let result = unsafe {
+            CodePageEntry::run_entrypoint(&mut page, &mut core, &mut jit, 100, max_steps)
+        };
+
+        assert_eq!(result.error, Some(Exception::FenceI));
+        assert_eq!(result.steps, 0);
+
+        // we have attempted compilation
+        assert_eq!(page[100 >> 1].dispatch.called_times(), 1);
+
+        let info = format!("{:?}", page[100 >> 1].dispatch);
+        assert!(
+            info.contains("status: NotCompiled"),
+            "unexpected status: \"{info}\""
+        );
+    }
+}

--- a/src/riscv/lib/src/machine_state/page_cache/state.rs
+++ b/src/riscv/lib/src/machine_state/page_cache/state.rs
@@ -11,6 +11,8 @@
 //!
 //! [PageCache]: super::PageCache
 
+use std::marker::PhantomData;
+
 use super::INSTRUCTION_ENTRIES;
 use super::code_page_entry::CodePageEntry;
 use crate::array_utils::boxed_from_fn;
@@ -35,7 +37,7 @@ const LAST_HALFWORD_PAGE_OFFSET: u64 = PAGE_SIZE
     .checked_sub(std::mem::size_of::<u16>() as u64)
     .expect("page-size must contain at least one halfword");
 
-struct PageEntry<CPE: CodePageEntry> {
+struct PageEntry<CPE> {
     // TODO: RV-773: consider re-using something like the EnrichedCell mechanism for faster
     // interpreted dispatch here.
     //
@@ -54,17 +56,19 @@ struct PageEntry<CPE: CodePageEntry> {
 /// connection with the concrete types that implement these traits.
 ///
 /// [`PageCache`]: super::PageCache
-pub struct PageCacheImpl<const PAGES: usize, CPE: CodePageEntry> {
+pub struct PageCacheImpl<const PAGES: usize, CPE, MC, M> {
     pages: Box<[Option<PageEntry<CPE>>; PAGES]>,
+    _pd: PhantomData<(MC, M)>,
 }
 
-impl<const PAGES: usize, CPE: CodePageEntry, MC: MemoryConfig, M: ManagerBase>
-    super::PageCache<CPE, MC, M> for PageCacheImpl<PAGES, CPE>
+impl<const PAGES: usize, CPE: CodePageEntry<MC, M>, MC: MemoryConfig, M: ManagerBase>
+    super::PageCache<CPE, MC, M> for PageCacheImpl<PAGES, CPE, MC, M>
 {
     /// Construct a new page cache, which will be entirely unpopulated.
     fn new() -> Self {
         Self {
             pages: boxed_from_fn(|| None),
+            _pd: PhantomData,
         }
     }
 
@@ -185,14 +189,13 @@ mod tests {
     use crate::machine_state::memory::Permissions;
     use crate::machine_state::page_cache::INSTRUCTION_ENTRIES;
     use crate::machine_state::page_cache::PageCache;
-    use crate::machine_state::page_cache::code_page_entry::CodePageEntry;
     use crate::machine_state::page_cache::state::PageEntry;
     use crate::parser::instruction::InstrWidth;
     use crate::state::NewState;
     use crate::state_backend::owned_backend::Owned;
 
-    fn count_active_pages<const PAGES: usize, CPE: CodePageEntry>(
-        cache: &PageCacheImpl<PAGES, CPE>,
+    fn count_active_pages<const PAGES: usize, CPE, MC, M>(
+        cache: &PageCacheImpl<PAGES, CPE, MC, M>,
     ) -> usize {
         cache.pages.iter().fold(
             0,
@@ -204,8 +207,7 @@ mod tests {
     fn test_page_invalidation_resets_pages() {
         const PAGES: usize = M1M::TOTAL_BYTES / PAGE_SIZE.get() as usize;
 
-        let mut cache =
-            <PageCacheImpl<PAGES, Instruction> as PageCache<Instruction, M1M, Owned>>::new();
+        let mut cache = PageCacheImpl::<PAGES, Instruction, M1M, Owned>::new();
 
         let make_page = || PageEntry {
             entries: boxed_array![Instruction::DEFAULT; INSTRUCTION_ENTRIES],
@@ -265,8 +267,7 @@ mod tests {
 
     backend_test!(test_populate_block_cache, F, {
         let mut state = MachineCoreState::<M4K, F>::new();
-        let mut cache =
-            <PageCacheImpl<1, Instruction> as PageCache<Instruction, M4K, Owned>>::new();
+        let mut cache = PageCacheImpl::<1, Instruction, M4K, F>::new();
 
         // populating a non R+X page should fail
         cache.populate_page(15, &state);
@@ -322,7 +323,7 @@ mod tests {
         proptest!(|(pc_addr in 0..M1M::TOTAL_BYTES as u64,
                     page: Box<[u8; PAGE_SIZE.get() as usize]>)| {
             // Arrange
-            let mut cache = <PageCacheImpl<PAGES, Instruction> as PageCache<Instruction, M1M, Owned>>::new();
+            let mut cache = PageCacheImpl::<PAGES, Instruction, M1M, F>::new();
             let mut state = state.borrow_mut();
             state.reset();
 
@@ -360,7 +361,7 @@ mod tests {
                 Instruction::DEFAULT
             };
 
-            let mut code_page = PageCache::<Instruction, M1M, Owned>::get_code_page(&mut cache, pc_addr).expect("code page populated");
+            let mut code_page = cache.get_code_page(pc_addr).expect("code page populated");
             let instr_from_code_page = code_page.page[pc_offset as usize / 2];
             assert_eq!(expected_instr, instr_from_code_page);
 


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

- closes RV-765
- closes RV-766

# What

Implement `CodePageEntry` for the new `page_cache::jitted::Jitted`

# Why

Allows the page cache to operate over Jitted execution (both inline and outline), like the block cache.

# How

Implement the require types/traits on the new `Jitted` struct.

This required to raise the `<MC, M>` bound from the `run_entrypoint` function up to the `CodePageEntry` trait declaration itself. This is now the same as the equivalent `Block` trait in the block cache.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
