### PR TITLE
refactor(dispatch): remove redundant constraints

### DIFF
--- a/src/riscv/lib/src/machine_state/block_cache/block/dispatch.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/block/dispatch.rs
@@ -86,7 +86,7 @@ pub trait CodeDispatcher<D: DispatchCompiler<MC>, MC: MemoryConfig>: Sized {
 /// Dispatch target that wraps a [`DispatchFn`].
 ///
 /// This is the target used for compilation - see [`DispatchCompiler::compile`].
-pub struct DispatchTarget<C: CodeDispatcher<D, MC>, D: DispatchCompiler<MC>, MC: MemoryConfig> {
+pub struct DispatchTarget<C, D, MC> {
     /// Function pointer stored as an atomic usize.
     ///
     /// This will allow the `fun` to be updated from a background thread.
@@ -121,7 +121,9 @@ impl<C: CodeDispatcher<D, MC>, D: DispatchCompiler<MC>, MC: MemoryConfig> Dispat
             self.call_counter = 0;
         }
     }
+}
 
+impl<C, D, MC: MemoryConfig> DispatchTarget<C, D, MC> {
     /// Set the dispatch target to use the given `block_run` function.
     pub fn set(&self, fun: DispatchFn<C, D, MC>) {
         // casting a function pointer as usize is ok to do.


### PR DESCRIPTION
# What

Removes some redundant trait bounds on `DispatchTarget` to be more conscious of when the constraints are actually needed.

# Why

The constraints are not used in the type definition. They are only used when the type is used in a way that requires the traits to be bound to variables. Otherwise, they serve no purpose and have the downside that you need to bind the traits with every mention of the type, regardless of whether the traits are used or no.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
