### PR TITLE
chore(make): check target also verifies asset checksums

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build-deps: riscv/build-deps jstz/build-deps etherlink/build-deps
 
 build-deps-slim: riscv/build-deps-slim
 
-check: riscv/check sandbox/check jstz/check dummy/check block-cache-tester/all etherlink/check
+check: riscv/check sandbox/check jstz/check dummy/check block-cache-tester/all etherlink/check assets/check
 
 build: sandbox/build jstz/build dummy/build block-cache-tester/build etherlink/build
 
@@ -44,6 +44,9 @@ block-cache-tester/%:
 
 etherlink/%: 
 	@make -C kernels/etherlink ${@:etherlink/%=%}
+
+assets/%:
+	@make -C assets ${@:assets/%=%}
 
 # Mark all non-pattern targets as phony to make sure they're always executed
 .PHONY: all build-deps build-deps-slim check audit build test test-miri clean 

--- a/assets/Makefile
+++ b/assets/Makefile
@@ -15,4 +15,8 @@ jstz jstz.checksum:
 	@cp ../kernels/jstz/target/riscv64gc-unknown-linux-musl/release/jstz $@
 	@sha256sum $@ > $@.checksum
 
-.PHONY: update-assets riscv-dummy.elf riscv-dummy.elf.checksum jstz jstz.checksum
+check:
+	@echo "Verifying asset checksums..."
+	@sha256sum -c jstz.checksum riscv-dummy.elf.checksum
+
+.PHONY: update-assets riscv-dummy.elf riscv-dummy.elf.checksum jstz jstz.checksum check


### PR DESCRIPTION
# What

Asset checksums are verified as part of the `check` target.

# Why

To make sure asset checksums stay valid.

# How

A `check` target is added to `assets/Makefile`, which is built as part of the main `check` target.

# Manually Testing

```
make assets/check
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
