### PR TITLE
refactor(memory): add helper to split address into page_idx & offset

### DIFF
--- a/src/riscv/lib/src/machine_state/memory.rs
+++ b/src/riscv/lib/src/machine_state/memory.rs
@@ -61,6 +61,20 @@ pub type Address = XValue;
 /// Lowest address
 pub const FIRST_ADDRESS: Address = 0;
 
+/// Convert an address into the page index.
+///
+/// The address will be contained within the page pointed to by this index.
+#[inline]
+pub fn address_to_page_index(address: Address) -> usize {
+    (address >> OFFSET_BITS.get()) as usize
+}
+
+/// Isolate the 'page offset' component of an address.
+#[inline]
+pub fn address_to_page_offset(address: Address) -> usize {
+    (address & PAGE_OFFSET_MASK) as usize
+}
+
 /// Memory access permissions
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Permissions {
@@ -323,3 +337,25 @@ pub use config::M16G;
 pub use config::M32G;
 pub use config::M64G;
 pub use config::M64M;
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use crate::machine_state::memory::Address;
+    use crate::machine_state::memory::OFFSET_BITS;
+    use crate::machine_state::memory::PAGE_SIZE;
+
+    #[test]
+    fn split_address_to_page_and_offset() {
+        proptest!(|(address: Address)| {
+            let page_idx = super::address_to_page_index(address);
+            let offset = super::address_to_page_offset(address);
+
+            let original_address = (page_idx as u64) << OFFSET_BITS.get() | (offset as u64);
+
+            prop_assert_eq!(address, original_address);
+            prop_assert!((offset as u64) < PAGE_SIZE.get());
+        });
+    }
+}

--- a/src/riscv/lib/src/machine_state/memory/protection.rs
+++ b/src/riscv/lib/src/machine_state/memory/protection.rs
@@ -11,6 +11,7 @@ use bincode::error::EncodeError;
 use perfect_derive::perfect_derive;
 
 use super::Address;
+use super::address_to_page_index;
 use crate::array_utils::boxed_from_fn;
 use crate::state::NewState;
 use crate::state_backend::AllocatedOf;
@@ -73,11 +74,11 @@ impl<const PAGES: usize, M: ManagerBase> PagePermissions<PAGES, M> {
             return true;
         }
 
-        let address = address as usize;
-
         // Extract the page index range from using the start and end addresses
-        let start_page = address >> super::OFFSET_BITS.get();
-        let end_page = address.wrapping_add(length).wrapping_sub(1) >> super::OFFSET_BITS.get();
+        let start_page = address_to_page_index(address);
+
+        let end_address = address.wrapping_add(length as Address).wrapping_sub(1);
+        let end_page = address_to_page_index(end_address);
 
         for page in start_page..=end_page {
             if unsafe { !self.pages.get_unchecked(page).read() } {
@@ -102,15 +103,16 @@ impl<const PAGES: usize, M: ManagerBase> PagePermissions<PAGES, M> {
         E: NarrowlySized,
         M: ManagerRead,
     {
-        let address = address as usize;
-
-        let start_page = address >> super::OFFSET_BITS.get();
+        let start_page = address_to_page_index(address);
         if unsafe { !self.pages.get_unchecked(start_page).read() } {
             return false;
         }
 
-        let end_page =
-            address.wrapping_add(E::NARROW_SIZE.get()).wrapping_sub(1) >> super::OFFSET_BITS.get();
+        let end_address = address
+            .wrapping_add(E::NARROW_SIZE.get() as Address)
+            .wrapping_sub(1);
+
+        let end_page = address_to_page_index(end_address);
         unsafe { self.pages.get_unchecked(end_page).read() }
     }
 
@@ -123,9 +125,10 @@ impl<const PAGES: usize, M: ManagerBase> PagePermissions<PAGES, M> {
             return;
         }
 
-        let address = address as usize;
-        let start_page = address >> super::OFFSET_BITS.get();
-        let end_page = address.wrapping_add(length).wrapping_sub(1) >> super::OFFSET_BITS.get();
+        let start_page = address_to_page_index(address);
+
+        let end_address = address.wrapping_add(length as Address).wrapping_sub(1);
+        let end_page = address_to_page_index(end_address);
 
         (start_page..=end_page)
             .filter(|&page| page < PAGES)

--- a/src/riscv/lib/src/machine_state/page_cache.rs
+++ b/src/riscv/lib/src/machine_state/page_cache.rs
@@ -33,7 +33,7 @@ use super::instruction::Instruction;
 use super::memory;
 use super::memory::Address;
 use super::memory::MemoryConfig;
-use super::memory::PAGE_OFFSET_MASK;
+use super::memory::address_to_page_offset;
 use crate::exceptions::Exception;
 use crate::state_backend::ManagerBase;
 use crate::state_backend::ManagerRead;
@@ -119,19 +119,21 @@ where
 {
     let mut result = StepManyResult::ZERO;
 
+    let page_offset = address_to_page_offset(instr_pc);
+
     // Since we know the instruction pc to always be halfword-aligned, there are half
     // as many entries as the page size.
-    let mut instr_offset = (instr_pc & PAGE_OFFSET_MASK) >> 1;
+    let mut instr_offset = page_offset >> 1;
 
-    while max_steps > result.steps && instr_offset < INSTRUCTION_ENTRIES as u64 {
-        let instr = code_page[instr_offset as usize].as_ref();
+    while max_steps > result.steps && instr_offset < INSTRUCTION_ENTRIES {
+        let instr = code_page[instr_offset].as_ref();
 
         match instr.run(core) {
             Ok(ProgramCounterUpdate::Next(width)) => {
                 instr_pc += width as u64;
 
                 // we update the offset by half the width, as the offset is halfword aligned
-                instr_offset += (width as u64) >> 1;
+                instr_offset += (width as usize) >> 1;
 
                 core.hart.pc.write(instr_pc);
                 result.steps += 1;

--- a/src/riscv/lib/src/machine_state/page_cache/jitted.rs
+++ b/src/riscv/lib/src/machine_state/page_cache/jitted.rs
@@ -6,7 +6,6 @@
 //! JIT-compilation support for entrypoints in pages.
 
 use super::INSTRUCTION_ENTRIES;
-use super::PAGE_OFFSET_MASK;
 use super::code_page_entry::CodePageEntry;
 use crate::exceptions::Exception;
 use crate::jit::state_access::ExceptionCode;
@@ -18,6 +17,7 @@ use crate::machine_state::block_cache::block::dispatch::DispatchTarget;
 use crate::machine_state::instruction::Instruction;
 use crate::machine_state::memory::Address;
 use crate::machine_state::memory::MemoryConfig;
+use crate::machine_state::memory::address_to_page_offset;
 use crate::state_backend::owned_backend::Owned;
 
 /// Maximum number of instructions we pass to a compilation request
@@ -66,9 +66,12 @@ impl<D: DispatchCompiler<MC>, MC: MemoryConfig> CodeDispatcher<D, MC> for Jitted
         result: &mut ExceptionCode,
         compiler: &mut D,
     ) -> usize {
-        let offset = (instr_pc & PAGE_OFFSET_MASK) >> 1;
+        let page_offset = address_to_page_offset(instr_pc);
 
-        if !compiler.should_compile(&mut self[offset as usize].dispatch) {
+        // instr_pc is always halfword aligned
+        let offset = page_offset >> 1;
+
+        if !compiler.should_compile(&mut self[offset].dispatch) {
             // Safety: the compiler passed to this function is always the same for the
             // lifetime of the entrypoint
             return unsafe {
@@ -79,12 +82,12 @@ impl<D: DispatchCompiler<MC>, MC: MemoryConfig> CodeDispatcher<D, MC> for Jitted
         // trigger JIT compilation
         let instr = self
             .iter()
-            .skip(offset as usize)
+            .skip(offset)
             .take(MAX_INSTR_COMPILED)
             .map(|entry| entry.instruction)
             .collect::<Vec<_>>();
 
-        let fun = compiler.compile(&mut self[offset as usize].dispatch, instr, instr_pc);
+        let fun = compiler.compile(&mut self[offset].dispatch, instr, instr_pc);
 
         // Safety: the compiler passed to this function is always the same for the
         // lifetime of the entrypoint
@@ -149,11 +152,13 @@ impl<D: DispatchCompiler<MC>, MC: MemoryConfig> CodePageEntry<MC, Owned> for Jit
             return super::run_code_page_interpreted(page, core, instr_pc, max_steps);
         }
 
+        let page_offset = address_to_page_offset(instr_pc);
+
         // Since we know the instruction pc to always be halfword-aligned, there are half
         // as many entries as the page size.
-        let instr_offset = (instr_pc & PAGE_OFFSET_MASK) >> 1;
+        let instr_offset = page_offset >> 1;
 
-        let entrypoint = &mut page[instr_offset as usize];
+        let entrypoint = &mut page[instr_offset];
 
         let fun = entrypoint.dispatch.get();
 

--- a/src/riscv/lib/src/machine_state/page_cache/state.rs
+++ b/src/riscv/lib/src/machine_state/page_cache/state.rs
@@ -25,6 +25,7 @@ use crate::machine_state::memory::MemoryConfig;
 use crate::machine_state::memory::OFFSET_BITS;
 use crate::machine_state::memory::PAGE_MASK;
 use crate::machine_state::memory::PAGE_SIZE;
+use crate::machine_state::memory::address_to_page_index;
 use crate::parser::is_compressed;
 use crate::parser::parse_compressed_instruction;
 use crate::state_backend::ManagerBase;
@@ -77,11 +78,10 @@ impl<const PAGES: usize, CPE: CodePageEntry<MC, M>, MC: MemoryConfig, M: Manager
     where
         M: ManagerRead,
     {
-        // TODO: RV-779: add & use utility to retreiving page_idx & offset from address.
-        let page_index = address >> OFFSET_BITS.get();
+        let page_index = address_to_page_index(address);
 
         self.pages
-            .get_mut(page_index as usize)
+            .get_mut(page_index)
             .and_then(|entry| entry.as_mut())
             .map(|page| super::CodePage {
                 page: &mut page.entries,
@@ -156,14 +156,14 @@ impl<const PAGES: usize, CPE: CodePageEntry<MC, M>, MC: MemoryConfig, M: Manager
 
     /// Invalidate a range of pages corresponding to the provided range of memory.
     fn invalidate_pages(&mut self, addresses: std::ops::Range<u64>) {
-        let start_page = addresses.start >> OFFSET_BITS.get();
-        let end_page = addresses.end.wrapping_sub(1) >> OFFSET_BITS.get();
+        let start_page = address_to_page_index(addresses.start);
+        let end_page = address_to_page_index(addresses.end.wrapping_sub(1));
 
         // shortcut in-case of ranges out of bounds of memory
-        let end_page = end_page.min(self.pages.len().saturating_sub(1) as u64);
+        let end_page = end_page.min(self.pages.len().saturating_sub(1));
 
         for page_idx in start_page..=end_page {
-            if let Some(entry) = self.pages.get_mut(page_idx as usize) {
+            if let Some(entry) = self.pages.get_mut(page_idx) {
                 *entry = None;
             }
         }


### PR DESCRIPTION
- closes RV-779

# What

Add helper to have only one place where we turn an address into a page_idx and/or offset into that page

# Why

We do this in multiple places. Only doing it in one ensures we don't accidentally introduce incompatibilities between e.g. main memory and the page cache (or in future, the JIT router)

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
