### PR TITLE
test(proofs): ensure proof size is under 20 KiB

### DIFF
--- a/src/riscv/lib/tests/test_proofs.rs
+++ b/src/riscv/lib/tests/test_proofs.rs
@@ -129,11 +129,14 @@ fn run_steps_ladder<MC, BCC, F>(
             let start = Instant::now();
             let proof = stepper.produce_proof().unwrap();
             let time = start.elapsed();
+
             let serialisation: Vec<u8> = serialise_proof(&proof).collect();
-            eprintln!(
-                "> Proof of size {} KiB produced in {:?}",
-                serialisation.len() / 1024,
-                time
+            let proof_size_kib = serialisation.len() / 1024;
+
+            eprintln!("> Proof of size {proof_size_kib} KiB produced in {time:?}");
+            assert!(
+                proof_size_kib < 20,
+                "Proof size is too large ({proof_size_kib} KiB) when running {ladder:?}"
             );
 
             eprintln!("> Checking initial proof hash ...");


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

# What

Assert the proof size is less or equal to 20 KiB in tests.

# Why

Detect too-large proofs in a reproducible way.


# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
