### PR TITLE
refactor(memory): operate over lengths of `NonZeroU64`

### DIFF
--- a/src/riscv/lib/src/interpreter/rv64dc.rs
+++ b/src/riscv/lib/src/interpreter/rv64dc.rs
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2024 Nomadic Labs <contact@nomadic-labs.com>
-// SPDX-FileCopyrightText: 2024 Trilitech <contact@trili.tech>
+// SPDX-FileCopyrightText: 2024-2025 Trilitech <contact@trili.tech>
 //
 // SPDX-License-Identifier: MIT
 
@@ -89,7 +89,7 @@ mod test {
 
     type MC = M4K;
 
-    const OUT_OF_BOUNDS_OFFSET: i64 = MC::TOTAL_BYTES as i64;
+    const OUT_OF_BOUNDS_OFFSET: i64 = MC::TOTAL_BYTES.get() as i64;
 
     backend_test!(test_cfsd_cfld, F, {
         let state = MachineCoreState::<MC, F>::new();

--- a/src/riscv/lib/src/jit.rs
+++ b/src/riscv/lib/src/jit.rs
@@ -2188,7 +2188,7 @@ mod tests {
         type ConstructStoreFn =
             fn(rs1: XRegister, rs2: XRegister, imm: i64, width: InstrWidth) -> I;
 
-        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES as u64;
+        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES.get();
         const XREG_VALUE: u64 = 0xFFEEDDCCBBAA9988;
 
         let valid_store = |constructor: ConstructStoreFn, imm: u64, expected: u64| {
@@ -2270,7 +2270,7 @@ mod tests {
 
         type ConstructLoadFn = fn(rd: XRegister, rs1: XRegister, imm: i64, width: InstrWidth) -> I;
 
-        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES as u64;
+        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES.get();
 
         let valid_load = |new_load: ConstructLoadFn, imm: u64, expected: u64| {
             const LOAD_ADDRESS_BASE: u64 = MEMORY_SIZE / 2;
@@ -2415,7 +2415,7 @@ mod tests {
             width: InstrWidth,
         ) -> I;
 
-        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES as u64;
+        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES.get();
 
         const ADDRESS_BASE_ATOMICS: u64 = MEMORY_SIZE / 2;
 
@@ -2684,7 +2684,7 @@ mod tests {
 
         use crate::machine_state::registers::NonZeroXRegister as NZ;
         use crate::machine_state::registers::*;
-        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES as u64;
+        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES.get();
         const ADDRESS_BASE_ATOMICS: u64 = MEMORY_SIZE / 2;
 
         let scenarios: &[Scenario] = &[
@@ -2834,7 +2834,7 @@ mod tests {
 
         use crate::machine_state::registers::NonZeroXRegister as NZ;
         use crate::machine_state::registers::*;
-        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES as u64;
+        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES.get();
         const ADDRESS_BASE_ATOMICS: u64 = MEMORY_SIZE / 2;
 
         let scenarios: &[Scenario] = &[
@@ -3104,7 +3104,7 @@ mod tests {
         use crate::machine_state::registers::XRegister::x2;
         use crate::machine_state::registers::XRegister::x3;
 
-        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES as u64;
+        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES.get();
         const ADDRESS_BASE_ATOMICS: u64 = MEMORY_SIZE / 2;
 
         let test_atomic_swap =
@@ -3182,7 +3182,7 @@ mod tests {
         use crate::machine_state::registers::NonZeroXRegister as NZ;
         use crate::machine_state::registers::XRegister::*;
 
-        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES as u64;
+        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES.get();
 
         const ADDRESS_BASE_ATOMICS: u64 = MEMORY_SIZE / 2;
 

--- a/src/riscv/lib/src/lib.rs
+++ b/src/riscv/lib/src/lib.rs
@@ -14,6 +14,7 @@ pub mod jit;
 mod kernel_loader;
 pub mod log;
 pub mod machine_state;
+mod num;
 pub mod parser;
 mod program;
 pub mod pvm;

--- a/src/riscv/lib/src/machine_state.rs
+++ b/src/riscv/lib/src/machine_state.rs
@@ -1262,7 +1262,7 @@ mod tests {
         state.reset();
         state.core.main_memory.set_all_readable_writeable();
 
-        let stack_top = M4K::TOTAL_BYTES as u64;
+        let stack_top = M4K::TOTAL_BYTES.get();
         state.core.hart.xregisters.write(sp, stack_top);
 
         let init_pc = 0xFE;
@@ -1283,7 +1283,7 @@ mod tests {
         state.reset();
         state.core.main_memory.set_all_readable_writeable();
 
-        let stack_top = M4K::TOTAL_BYTES as u64;
+        let stack_top = M4K::TOTAL_BYTES.get();
         state.core.hart.xregisters.write(sp, stack_top);
 
         let init_pc = 0x100;

--- a/src/riscv/lib/src/machine_state/memory.rs
+++ b/src/riscv/lib/src/machine_state/memory.rs
@@ -254,7 +254,7 @@ pub trait Memory<M: ManagerBase>: NewState<M> + Sized {
     fn protect_pages(
         &mut self,
         address: Address,
-        length: usize,
+        length: u64,
         perms: Permissions,
     ) -> Result<(), MemoryGovernanceError>
     where
@@ -264,7 +264,7 @@ pub trait Memory<M: ManagerBase>: NewState<M> + Sized {
     fn allocate_pages(
         &mut self,
         address_hint: Option<Address>,
-        length: usize,
+        length: u64,
         allow_replace: bool,
     ) -> Result<Address, MemoryGovernanceError>
     where
@@ -274,7 +274,7 @@ pub trait Memory<M: ManagerBase>: NewState<M> + Sized {
     fn deallocate_pages(
         &mut self,
         address: Address,
-        length: usize,
+        length: u64,
     ) -> Result<(), MemoryGovernanceError>
     where
         M: ManagerReadWrite;
@@ -283,7 +283,7 @@ pub trait Memory<M: ManagerBase>: NewState<M> + Sized {
     fn allocate_and_protect_pages(
         &mut self,
         address_hint: Option<Address>,
-        length: usize,
+        length: u64,
         perms: Permissions,
         allow_replace: bool,
     ) -> Result<Address, MemoryGovernanceError>
@@ -294,7 +294,7 @@ pub trait Memory<M: ManagerBase>: NewState<M> + Sized {
     fn deallocate_and_protect_pages(
         &mut self,
         address: Address,
-        length: usize,
+        length: u64,
     ) -> Result<(), MemoryGovernanceError>
     where
         M: ManagerReadWrite,

--- a/src/riscv/lib/src/machine_state/memory.rs
+++ b/src/riscv/lib/src/machine_state/memory.rs
@@ -254,7 +254,7 @@ pub trait Memory<M: ManagerBase>: NewState<M> + Sized {
     fn protect_pages(
         &mut self,
         address: Address,
-        length: u64,
+        length: NonZeroU64,
         perms: Permissions,
     ) -> Result<(), MemoryGovernanceError>
     where
@@ -264,7 +264,7 @@ pub trait Memory<M: ManagerBase>: NewState<M> + Sized {
     fn allocate_pages(
         &mut self,
         address_hint: Option<Address>,
-        length: u64,
+        length: NonZeroU64,
         allow_replace: bool,
     ) -> Result<Address, MemoryGovernanceError>
     where
@@ -274,7 +274,7 @@ pub trait Memory<M: ManagerBase>: NewState<M> + Sized {
     fn deallocate_pages(
         &mut self,
         address: Address,
-        length: u64,
+        length: NonZeroU64,
     ) -> Result<(), MemoryGovernanceError>
     where
         M: ManagerReadWrite;
@@ -283,7 +283,7 @@ pub trait Memory<M: ManagerBase>: NewState<M> + Sized {
     fn allocate_and_protect_pages(
         &mut self,
         address_hint: Option<Address>,
-        length: u64,
+        length: NonZeroU64,
         perms: Permissions,
         allow_replace: bool,
     ) -> Result<Address, MemoryGovernanceError>
@@ -294,7 +294,7 @@ pub trait Memory<M: ManagerBase>: NewState<M> + Sized {
     fn deallocate_and_protect_pages(
         &mut self,
         address: Address,
-        length: u64,
+        length: NonZeroU64,
     ) -> Result<(), MemoryGovernanceError>
     where
         M: ManagerReadWrite,
@@ -307,7 +307,7 @@ pub trait Memory<M: ManagerBase>: NewState<M> + Sized {
 /// Memory configuration
 pub trait MemoryConfig: Send + 'static {
     /// Number of bytes in the memory
-    const TOTAL_BYTES: usize;
+    const TOTAL_BYTES: NonZeroU64;
 
     /// Layout for memory instance's state
     type Layout: CommitmentLayout + ProofLayout;

--- a/src/riscv/lib/src/machine_state/memory/config.rs
+++ b/src/riscv/lib/src/machine_state/memory/config.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: MIT
 
+use std::num::NonZeroU64;
+
 use super::buddy::BuddyLayout;
 use super::buddy::BuddyLayoutProxy;
 use super::protection::PagePermissions;
@@ -44,7 +46,8 @@ impl<const PAGES: usize, const TOTAL_BYTES: usize> super::MemoryConfig
 where
     BuddyLayoutProxy<PAGES>: BuddyLayout + 'static,
 {
-    const TOTAL_BYTES: usize = TOTAL_BYTES;
+    const TOTAL_BYTES: NonZeroU64 =
+        NonZeroU64::new(TOTAL_BYTES as u64).expect("constant `TOTAL_BYTES` must be non-zero");
 
     type Layout = (
         DynArray<TOTAL_BYTES>,

--- a/src/riscv/lib/src/machine_state/memory/protection.rs
+++ b/src/riscv/lib/src/machine_state/memory/protection.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: MIT
 
+use std::num::NonZeroU64;
+
 use bincode::Decode;
 use bincode::Encode;
 use bincode::de::Decoder;
@@ -65,19 +67,14 @@ impl<const PAGES: usize, M: ManagerBase> PagePermissions<PAGES, M> {
     /// The address and length must be valid for an address space consisting of a number of `PAGES`.
     /// This function is not defined for address and length combinations which are out of bounds.
     #[inline]
-    pub unsafe fn can_access(&self, address: Address, length: u64) -> bool
+    pub unsafe fn can_access(&self, address: Address, length: NonZeroU64) -> bool
     where
         M: ManagerRead,
     {
-        // Zero-sized accesses are always valid
-        if length < 1 {
-            return true;
-        }
-
         // Extract the page index range from using the start and end addresses
         let start_page = address_to_page_index(address);
 
-        let end_address = address.wrapping_add(length as Address).wrapping_sub(1);
+        let end_address = address.wrapping_add(length.get()).wrapping_sub(1);
         let end_page = address_to_page_index(end_address);
 
         for page in start_page..=end_page {
@@ -117,17 +114,13 @@ impl<const PAGES: usize, M: ManagerBase> PagePermissions<PAGES, M> {
     }
 
     /// Change the access permissions for the given range.
-    pub fn modify_access(&mut self, address: Address, length: u64, accessible: bool)
+    pub fn modify_access(&mut self, address: Address, length: NonZeroU64, accessible: bool)
     where
         M: ManagerWrite,
     {
-        if length < 1 {
-            return;
-        }
-
         let start_page = address_to_page_index(address);
 
-        let end_address = address.wrapping_add(length as Address).wrapping_sub(1);
+        let end_address = address.wrapping_add(length.get()).wrapping_sub(1);
         let end_page = address_to_page_index(end_address);
 
         (start_page..=end_page)

--- a/src/riscv/lib/src/machine_state/memory/protection.rs
+++ b/src/riscv/lib/src/machine_state/memory/protection.rs
@@ -65,7 +65,7 @@ impl<const PAGES: usize, M: ManagerBase> PagePermissions<PAGES, M> {
     /// The address and length must be valid for an address space consisting of a number of `PAGES`.
     /// This function is not defined for address and length combinations which are out of bounds.
     #[inline]
-    pub unsafe fn can_access(&self, address: Address, length: usize) -> bool
+    pub unsafe fn can_access(&self, address: Address, length: u64) -> bool
     where
         M: ManagerRead,
     {
@@ -117,7 +117,7 @@ impl<const PAGES: usize, M: ManagerBase> PagePermissions<PAGES, M> {
     }
 
     /// Change the access permissions for the given range.
-    pub fn modify_access(&mut self, address: Address, length: usize, accessible: bool)
+    pub fn modify_access(&mut self, address: Address, length: u64, accessible: bool)
     where
         M: ManagerWrite,
     {

--- a/src/riscv/lib/src/machine_state/memory/state.rs
+++ b/src/riscv/lib/src/machine_state/memory/state.rs
@@ -75,9 +75,7 @@ impl<const PAGES: usize, const TOTAL_BYTES: usize, B, M: ManagerBase>
         E: Elem,
         M: ManagerWrite,
     {
-        let length = E::STORED_SIZE
-            .try_into()
-            .expect("Elem size `E::STORED_SIZE` must fit into u64");
+        let length = E::STORED_SIZE;
 
         Self::check_bounds(address, length, BadMemoryAccess)?;
 
@@ -100,9 +98,7 @@ where
         E: Elem,
         M: ManagerRead,
     {
-        let length = E::STORED_SIZE
-            .try_into()
-            .expect("Elem size `E::STORED_SIZE` must fit into u64");
+        let length = E::STORED_SIZE;
 
         Self::check_bounds(address, length, BadMemoryAccess)?;
 
@@ -122,9 +118,7 @@ where
         E: Elem,
         M: ManagerRead,
     {
-        let length = E::STORED_SIZE
-            .try_into()
-            .expect("Elem size `E::STORED_SIZE` must fit into u64");
+        let length = E::STORED_SIZE;
 
         Self::check_bounds(address, length, BadMemoryAccess)?;
 
@@ -150,7 +144,7 @@ where
         M: ManagerRead,
     {
         let Some(length) =
-            NonZeroU64::new(E::STORED_SIZE.get().saturating_mul(values.len()) as u64)
+            NonZeroU64::new(E::STORED_SIZE.get().saturating_mul(values.len() as u64))
         else {
             // nothing to read
             return Ok(());
@@ -175,9 +169,7 @@ where
         E: Elem,
         M: ManagerReadWrite,
     {
-        let length = E::STORED_SIZE
-            .try_into()
-            .expect("Elem size `E::STORED_SIZE` must fit into u64");
+        let length = E::STORED_SIZE;
 
         Self::check_bounds(address, length, BadMemoryAccess)?;
 
@@ -198,7 +190,7 @@ where
         M: ManagerReadWrite,
     {
         let Some(length) =
-            NonZeroU64::new(E::STORED_SIZE.get().saturating_mul(values.len()) as u64)
+            NonZeroU64::new(E::STORED_SIZE.get().saturating_mul(values.len() as u64))
         else {
             // nothing to write
             return Ok(());
@@ -234,7 +226,7 @@ where
     where
         M: ManagerWrite,
     {
-        const SIZE_OF_U64: usize = u64::STORED_SIZE.get();
+        const SIZE_OF_U64: usize = u64::STORED_SIZE.get() as usize;
 
         let mut address = 0;
         let mut outstanding = TOTAL_BYTES;

--- a/src/riscv/lib/src/machine_state/memory/state.rs
+++ b/src/riscv/lib/src/machine_state/memory/state.rs
@@ -11,6 +11,7 @@ use super::PAGE_SIZE;
 use super::Permissions;
 use super::buddy::Buddy;
 use super::protection::PagePermissions;
+use crate::num::NonZeroLength;
 use crate::state_backend::DynCells;
 use crate::state_backend::Elem;
 use crate::state_backend::ManagerBase;
@@ -45,7 +46,7 @@ impl<const PAGES: usize, const TOTAL_BYTES: usize, B, M: ManagerBase>
 
     /// Ensure the access is within bounds.
     #[inline]
-    fn check_bounds<E>(address: Address, length: NonZeroU64, error: E) -> Result<(), E> {
+    fn check_bounds<E>(address: Address, length: NonZeroLength, error: E) -> Result<(), E> {
         if length.get() > Self::TOTAL_BYTES.get().saturating_sub(address) {
             return Err(error);
         }
@@ -150,7 +151,7 @@ where
             return Ok(());
         };
 
-        Self::check_bounds(address, length, BadMemoryAccess)?;
+        Self::check_bounds(address, NonZeroLength::wrap(length), BadMemoryAccess)?;
 
         // SAFETY: The bounds check above ensures the access check below is safe
         unsafe {
@@ -196,7 +197,7 @@ where
             return Ok(());
         };
 
-        Self::check_bounds(address, length, BadMemoryAccess)?;
+        Self::check_bounds(address, NonZeroLength::wrap(length), BadMemoryAccess)?;
 
         // SAFETY: The bounds check above ensures the access check below is safe
         unsafe {
@@ -257,7 +258,11 @@ where
     where
         M: ManagerWrite,
     {
-        Self::check_bounds(address, length, super::MemoryGovernanceError)?;
+        Self::check_bounds(
+            address,
+            NonZeroLength::wrap(length),
+            super::MemoryGovernanceError,
+        )?;
 
         self.readable_pages
             .modify_access(address, length, perms.can_read());
@@ -277,7 +282,11 @@ where
     where
         M: ManagerReadWrite,
     {
-        Self::check_bounds(address, length, super::MemoryGovernanceError)?;
+        Self::check_bounds(
+            address,
+            NonZeroLength::wrap(length),
+            super::MemoryGovernanceError,
+        )?;
 
         // TODO: RV-799: use `NonZeroU64::div_ceil` once stabilised.
         let pages = length.get().div_ceil(super::PAGE_SIZE.get());
@@ -304,7 +313,11 @@ where
         match address_hint {
             // Caller wants to allocate at a specific address
             Some(address) => {
-                Self::check_bounds(address, length, super::MemoryGovernanceError)?;
+                Self::check_bounds(
+                    address,
+                    NonZeroLength::wrap(length),
+                    super::MemoryGovernanceError,
+                )?;
 
                 // Buddy memory manager works on page indices, not addresses
                 let idx = address >> super::OFFSET_BITS.get();

--- a/src/riscv/lib/src/machine_state/memory/state.rs
+++ b/src/riscv/lib/src/machine_state/memory/state.rs
@@ -40,8 +40,8 @@ impl<const PAGES: usize, const TOTAL_BYTES: usize, B, M: ManagerBase>
 {
     /// Ensure the access is within bounds.
     #[inline]
-    fn check_bounds<E>(address: Address, length: usize, error: E) -> Result<(), E> {
-        if length > TOTAL_BYTES.saturating_sub(address as usize) {
+    fn check_bounds<E>(address: Address, length: u64, error: E) -> Result<(), E> {
+        if length > (TOTAL_BYTES as u64).saturating_sub(address) {
             return Err(error);
         }
 
@@ -55,7 +55,7 @@ impl<const PAGES: usize, const TOTAL_BYTES: usize, B, M: ManagerBase>
         B: Buddy<M>,
         M: ManagerReadWrite,
     {
-        self.protect_pages(0, TOTAL_BYTES, Permissions::READ_WRITE)
+        self.protect_pages(0, TOTAL_BYTES as u64, Permissions::READ_WRITE)
             .unwrap();
     }
 
@@ -70,7 +70,7 @@ impl<const PAGES: usize, const TOTAL_BYTES: usize, B, M: ManagerBase>
         E: Elem,
         M: ManagerWrite,
     {
-        let length = E::STORED_SIZE.get();
+        let length = E::STORED_SIZE.get() as u64;
         Self::check_bounds(address, length, BadMemoryAccess)?;
 
         self.data.write(address as usize, value);
@@ -92,7 +92,8 @@ where
         E: Elem,
         M: ManagerRead,
     {
-        Self::check_bounds(address, E::STORED_SIZE.get(), BadMemoryAccess)?;
+        let length = E::STORED_SIZE.get() as u64;
+        Self::check_bounds(address, length, BadMemoryAccess)?;
 
         // SAFETY: The bounds check above ensures the access check below is safe
         unsafe {
@@ -110,8 +111,7 @@ where
         E: Elem,
         M: ManagerRead,
     {
-        let length = E::STORED_SIZE.get();
-
+        let length = E::STORED_SIZE.get() as u64;
         Self::check_bounds(address, length, BadMemoryAccess)?;
 
         // SAFETY: The bounds check above ensures the access check below is safe
@@ -135,7 +135,7 @@ where
         E: Elem,
         M: ManagerRead,
     {
-        let length = E::STORED_SIZE.get() * values.len();
+        let length = (E::STORED_SIZE.get() * values.len()) as u64;
         Self::check_bounds(address, length, BadMemoryAccess)?;
 
         // SAFETY: The bounds check above ensures the access check below is safe
@@ -155,7 +155,8 @@ where
         E: Elem,
         M: ManagerReadWrite,
     {
-        Self::check_bounds(address, E::STORED_SIZE.get(), BadMemoryAccess)?;
+        let length = E::STORED_SIZE.get() as u64;
+        Self::check_bounds(address, length, BadMemoryAccess)?;
 
         // SAFETY: The bounds check above ensures the access check below is safe
         unsafe {
@@ -173,7 +174,7 @@ where
         E: Elem + Copy,
         M: ManagerReadWrite,
     {
-        let length = E::STORED_SIZE.get() * values.len();
+        let length = (E::STORED_SIZE.get() * values.len()) as u64;
         Self::check_bounds(address, length, BadMemoryAccess)?;
 
         // SAFETY: The bounds check above ensures the access check below is safe
@@ -229,7 +230,7 @@ where
     fn protect_pages(
         &mut self,
         address: Address,
-        length: usize,
+        length: u64,
         perms: Permissions,
     ) -> Result<(), super::MemoryGovernanceError>
     where
@@ -250,15 +251,14 @@ where
     fn deallocate_pages(
         &mut self,
         address: Address,
-        length: usize,
+        length: u64,
     ) -> Result<(), super::MemoryGovernanceError>
     where
         M: ManagerReadWrite,
     {
         Self::check_bounds(address, length, super::MemoryGovernanceError)?;
 
-        // See RV-561: Use `u64` for indices and lengths that come from the PVM
-        let pages = (length as u64).div_ceil(super::PAGE_SIZE.get());
+        let pages = length.div_ceil(super::PAGE_SIZE.get());
 
         // Buddy memory manager works on page indices, not addresses
         let idx = address >> super::OFFSET_BITS.get();
@@ -270,16 +270,13 @@ where
     fn allocate_pages(
         &mut self,
         address_hint: Option<Address>,
-        length: usize,
+        length: u64,
         allow_replace: bool,
     ) -> Result<Address, super::MemoryGovernanceError>
     where
         M: ManagerReadWrite,
     {
-        // The interface works on usize at the moment, however, going forward we'll convert all
-        // length types to u64 to avoid machine-specific behavior for lengths.
-        // See RV-561: Use `u64` for indices and lengths that come from the PVM
-        let pages = (length as u64).div_ceil(super::PAGE_SIZE.get());
+        let pages = length.div_ceil(super::PAGE_SIZE.get());
 
         match address_hint {
             // Caller wants to allocate at a specific address
@@ -305,7 +302,7 @@ where
     fn allocate_and_protect_pages(
         &mut self,
         address_hint: Option<Address>,
-        length: usize,
+        length: u64,
         perms: Permissions,
         allow_replace: bool,
     ) -> Result<Address, super::MemoryGovernanceError>
@@ -324,19 +321,19 @@ where
         // altogether. This speeds things up.
         // As we allocate in multiples of pages, we must also clear in multiples of pages.
         let mut remaining = length
-            .div_ceil(PAGE_SIZE.get() as usize)
-            .saturating_mul(PAGE_SIZE.get() as usize);
+            .div_ceil(PAGE_SIZE.get())
+            .saturating_mul(PAGE_SIZE.get());
 
         while remaining >= 8 {
             remaining -= 8;
-            let address = (address as usize).saturating_add(remaining);
-            self.data.write(address, 0u64);
+            let address = address.saturating_add(remaining);
+            self.data.write(address as usize, 0u64);
         }
 
         // Zero initialise the tail byte by byte
         for i in 0..remaining {
-            let address = (address as usize).saturating_add(i);
-            self.data.write(address, 0u8);
+            let address = address.saturating_add(i);
+            self.data.write(address as usize, 0u8);
         }
 
         Ok(address)
@@ -386,7 +383,7 @@ pub mod tests {
         }
 
         // Request size that's not a multiple of page size
-        let requested_size = (PAGE_SIZE.get() as usize) - 100;
+        let requested_size = PAGE_SIZE.get() - 100;
         let address = memory
             .allocate_and_protect_pages(None, requested_size, Permissions::READ_WRITE, false)
             .expect("Memory allocation should succeed");

--- a/src/riscv/lib/src/machine_state/memory/state.rs
+++ b/src/riscv/lib/src/machine_state/memory/state.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: MIT
 
+use std::num::NonZeroU64;
+
 use super::Address;
 use super::BadMemoryAccess;
 use super::Memory;
@@ -38,10 +40,13 @@ pub struct MemoryImpl<const PAGES: usize, const TOTAL_BYTES: usize, B, M: Manage
 impl<const PAGES: usize, const TOTAL_BYTES: usize, B, M: ManagerBase>
     MemoryImpl<PAGES, TOTAL_BYTES, B, M>
 {
+    const TOTAL_BYTES: NonZeroU64 = NonZeroU64::new(TOTAL_BYTES as u64)
+        .expect("memory size `TOTAL_BYTES` must be greater than zero");
+
     /// Ensure the access is within bounds.
     #[inline]
-    fn check_bounds<E>(address: Address, length: u64, error: E) -> Result<(), E> {
-        if length > (TOTAL_BYTES as u64).saturating_sub(address) {
+    fn check_bounds<E>(address: Address, length: NonZeroU64, error: E) -> Result<(), E> {
+        if length.get() > Self::TOTAL_BYTES.get().saturating_sub(address) {
             return Err(error);
         }
 
@@ -55,7 +60,7 @@ impl<const PAGES: usize, const TOTAL_BYTES: usize, B, M: ManagerBase>
         B: Buddy<M>,
         M: ManagerReadWrite,
     {
-        self.protect_pages(0, TOTAL_BYTES as u64, Permissions::READ_WRITE)
+        self.protect_pages(0, Self::TOTAL_BYTES, Permissions::READ_WRITE)
             .unwrap();
     }
 
@@ -70,7 +75,10 @@ impl<const PAGES: usize, const TOTAL_BYTES: usize, B, M: ManagerBase>
         E: Elem,
         M: ManagerWrite,
     {
-        let length = E::STORED_SIZE.get() as u64;
+        let length = E::STORED_SIZE
+            .try_into()
+            .expect("Elem size `E::STORED_SIZE` must fit into u64");
+
         Self::check_bounds(address, length, BadMemoryAccess)?;
 
         self.data.write(address as usize, value);
@@ -92,7 +100,10 @@ where
         E: Elem,
         M: ManagerRead,
     {
-        let length = E::STORED_SIZE.get() as u64;
+        let length = E::STORED_SIZE
+            .try_into()
+            .expect("Elem size `E::STORED_SIZE` must fit into u64");
+
         Self::check_bounds(address, length, BadMemoryAccess)?;
 
         // SAFETY: The bounds check above ensures the access check below is safe
@@ -111,7 +122,10 @@ where
         E: Elem,
         M: ManagerRead,
     {
-        let length = E::STORED_SIZE.get() as u64;
+        let length = E::STORED_SIZE
+            .try_into()
+            .expect("Elem size `E::STORED_SIZE` must fit into u64");
+
         Self::check_bounds(address, length, BadMemoryAccess)?;
 
         // SAFETY: The bounds check above ensures the access check below is safe
@@ -135,7 +149,13 @@ where
         E: Elem,
         M: ManagerRead,
     {
-        let length = (E::STORED_SIZE.get() * values.len()) as u64;
+        let Some(length) =
+            NonZeroU64::new(E::STORED_SIZE.get().saturating_mul(values.len()) as u64)
+        else {
+            // nothing to read
+            return Ok(());
+        };
+
         Self::check_bounds(address, length, BadMemoryAccess)?;
 
         // SAFETY: The bounds check above ensures the access check below is safe
@@ -155,7 +175,10 @@ where
         E: Elem,
         M: ManagerReadWrite,
     {
-        let length = E::STORED_SIZE.get() as u64;
+        let length = E::STORED_SIZE
+            .try_into()
+            .expect("Elem size `E::STORED_SIZE` must fit into u64");
+
         Self::check_bounds(address, length, BadMemoryAccess)?;
 
         // SAFETY: The bounds check above ensures the access check below is safe
@@ -174,7 +197,13 @@ where
         E: Elem + Copy,
         M: ManagerReadWrite,
     {
-        let length = (E::STORED_SIZE.get() * values.len()) as u64;
+        let Some(length) =
+            NonZeroU64::new(E::STORED_SIZE.get().saturating_mul(values.len()) as u64)
+        else {
+            // nothing to write
+            return Ok(());
+        };
+
         Self::check_bounds(address, length, BadMemoryAccess)?;
 
         // SAFETY: The bounds check above ensures the access check below is safe
@@ -230,7 +259,7 @@ where
     fn protect_pages(
         &mut self,
         address: Address,
-        length: u64,
+        length: NonZeroU64,
         perms: Permissions,
     ) -> Result<(), super::MemoryGovernanceError>
     where
@@ -251,14 +280,15 @@ where
     fn deallocate_pages(
         &mut self,
         address: Address,
-        length: u64,
+        length: NonZeroU64,
     ) -> Result<(), super::MemoryGovernanceError>
     where
         M: ManagerReadWrite,
     {
         Self::check_bounds(address, length, super::MemoryGovernanceError)?;
 
-        let pages = length.div_ceil(super::PAGE_SIZE.get());
+        // TODO: RV-799: use `NonZeroU64::div_ceil` once stabilised.
+        let pages = length.get().div_ceil(super::PAGE_SIZE.get());
 
         // Buddy memory manager works on page indices, not addresses
         let idx = address >> super::OFFSET_BITS.get();
@@ -270,13 +300,14 @@ where
     fn allocate_pages(
         &mut self,
         address_hint: Option<Address>,
-        length: u64,
+        length: NonZeroU64,
         allow_replace: bool,
     ) -> Result<Address, super::MemoryGovernanceError>
     where
         M: ManagerReadWrite,
     {
-        let pages = length.div_ceil(super::PAGE_SIZE.get());
+        // TODO: RV-799: use `NonZeroU64::div_ceil` once stabilised.
+        let pages = length.get().div_ceil(super::PAGE_SIZE.get());
 
         match address_hint {
             // Caller wants to allocate at a specific address
@@ -302,7 +333,7 @@ where
     fn allocate_and_protect_pages(
         &mut self,
         address_hint: Option<Address>,
-        length: u64,
+        length: NonZeroU64,
         perms: Permissions,
         allow_replace: bool,
     ) -> Result<Address, super::MemoryGovernanceError>
@@ -320,7 +351,10 @@ where
         // Zero initialise in 8-byte chunks. Using larger writes first, means we do fewer writes
         // altogether. This speeds things up.
         // As we allocate in multiples of pages, we must also clear in multiples of pages.
+        //
+        // TODO: RV-799: use `NonZeroU64::div_ceil` once stabilised.
         let mut remaining = length
+            .get()
             .div_ceil(PAGE_SIZE.get())
             .saturating_mul(PAGE_SIZE.get());
 
@@ -352,22 +386,34 @@ pub mod tests {
 
     #[test]
     fn bounds_check() {
-        type OwnedM0 = MemoryImpl<0, 0, (), Owned>;
         type OwnedM4K = <M4K as MemoryConfig>::State<Owned>;
 
-        // Zero-sized reads or writes are always valid
-        assert!(OwnedM0::check_bounds(0, 0, ()).is_ok());
-        assert!(OwnedM0::check_bounds(1, 0, ()).is_ok());
-        assert!(OwnedM4K::check_bounds(0, 0, ()).is_ok());
-        assert!(OwnedM4K::check_bounds(4096, 0, ()).is_ok());
-        assert!(OwnedM4K::check_bounds(2 * 4096, 0, ()).is_ok());
-
         // Bounds checks
-        assert!(OwnedM0::check_bounds(0, 1, ()).is_err());
-        assert!(OwnedM0::check_bounds(1, 1, ()).is_err());
-        assert!(OwnedM4K::check_bounds(4096, 1, ()).is_err());
-        assert!(OwnedM4K::check_bounds(2 * 4096, 1, ()).is_err());
+        assert!(OwnedM4K::check_bounds(4095, NonZeroU64::new(1).unwrap(), ()).is_ok());
+        assert!(OwnedM4K::check_bounds(4096, NonZeroU64::new(1).unwrap(), ()).is_err());
+        assert!(OwnedM4K::check_bounds(2 * 4096, NonZeroU64::new(1).unwrap(), ()).is_err());
     }
+
+    // ensure read/write of empty arrays is ok, even if permissions
+    // are not set
+    backend_test!(test_read_write_all_empty_ok, F, {
+        let mut memory = <<M4K as MemoryConfig>::State<F>>::new();
+
+        let res = memory.write_all::<u8>(0, &[]);
+        assert_eq!(Ok(()), res);
+
+        let res = memory.read_all::<u8>(0, &mut []);
+        assert_eq!(Ok(()), res);
+
+        // double check permissions are in fact, not set
+        let res = memory.write_all::<u8>(0, &[1]);
+        assert!(res.is_err());
+
+        let buff = &mut [1];
+        let res = memory.read_all::<u8>(0, buff);
+        assert!(res.is_err());
+        assert_eq!(&[1], buff);
+    });
 
     // This test verifies that memory is fully zeroed up to the page boundary, not just the
     // requested length, when allocating memory.
@@ -383,7 +429,7 @@ pub mod tests {
         }
 
         // Request size that's not a multiple of page size
-        let requested_size = PAGE_SIZE.get() - 100;
+        let requested_size = NonZeroU64::new(PAGE_SIZE.get() - 100).unwrap();
         let address = memory
             .allocate_and_protect_pages(None, requested_size, Permissions::READ_WRITE, false)
             .expect("Memory allocation should succeed");

--- a/src/riscv/lib/src/machine_state/page_cache/state.rs
+++ b/src/riscv/lib/src/machine_state/page_cache/state.rs
@@ -205,9 +205,9 @@ mod tests {
 
     #[test]
     fn test_page_invalidation_resets_pages() {
-        const PAGES: usize = M1M::TOTAL_BYTES / PAGE_SIZE.get() as usize;
+        const PAGES: u64 = M1M::TOTAL_BYTES.get() / PAGE_SIZE.get();
 
-        let mut cache = PageCacheImpl::<PAGES, Instruction, M1M, Owned>::new();
+        let mut cache = PageCacheImpl::<{ PAGES as usize }, Instruction, M1M, Owned>::new();
 
         let make_page = || PageEntry {
             entries: boxed_array![Instruction::DEFAULT; INSTRUCTION_ENTRIES],
@@ -276,7 +276,7 @@ mod tests {
         // populating a read-only page should fail
         state
             .main_memory
-            .protect_pages(0, PAGE_SIZE.get(), Permissions {
+            .protect_pages(0, PAGE_SIZE, Permissions {
                 read: true,
                 exec: false,
                 write: false,
@@ -288,7 +288,7 @@ mod tests {
         // populating a R+W should fail
         state
             .main_memory
-            .protect_pages(0, PAGE_SIZE.get(), Permissions::READ_WRITE)
+            .protect_pages(0, PAGE_SIZE, Permissions::READ_WRITE)
             .unwrap();
         cache.populate_page(15, &state);
         assert_eq!(count_active_pages(&cache), 0);
@@ -296,7 +296,7 @@ mod tests {
         // populating a R+W+X should fail
         state
             .main_memory
-            .protect_pages(0, PAGE_SIZE.get(), Permissions::READ_WRITE_EXEC)
+            .protect_pages(0, PAGE_SIZE, Permissions::READ_WRITE_EXEC)
             .unwrap();
         cache.populate_page(15, &state);
         assert_eq!(count_active_pages(&cache), 0);
@@ -304,7 +304,7 @@ mod tests {
         // populating a R+X page should succeed
         state
             .main_memory
-            .protect_pages(0, PAGE_SIZE.get(), Permissions {
+            .protect_pages(0, PAGE_SIZE, Permissions {
                 read: true,
                 exec: true,
                 write: false,
@@ -315,15 +315,15 @@ mod tests {
     });
 
     backend_test!(populate_from_memory, F, {
-        const PAGES: usize = M1M::TOTAL_BYTES / PAGE_SIZE.get() as usize;
+        const PAGES: u64 = M1M::TOTAL_BYTES.get() / PAGE_SIZE.get();
 
         let state = MachineCoreState::<M1M, F>::new();
         let state = &std::cell::RefCell::new(state);
 
-        proptest!(|(pc_addr in 0..M1M::TOTAL_BYTES as u64,
+        proptest!(|(pc_addr in 0..M1M::TOTAL_BYTES.get(),
                     page: Box<[u8; PAGE_SIZE.get() as usize]>)| {
             // Arrange
-            let mut cache = PageCacheImpl::<PAGES, Instruction, M1M, F>::new();
+            let mut cache = PageCacheImpl::<{ PAGES as usize}, Instruction, M1M, F>::new();
             let mut state = state.borrow_mut();
             state.reset();
 

--- a/src/riscv/lib/src/machine_state/page_cache/state.rs
+++ b/src/riscv/lib/src/machine_state/page_cache/state.rs
@@ -276,7 +276,7 @@ mod tests {
         // populating a read-only page should fail
         state
             .main_memory
-            .protect_pages(0, PAGE_SIZE.get() as usize, Permissions {
+            .protect_pages(0, PAGE_SIZE.get(), Permissions {
                 read: true,
                 exec: false,
                 write: false,
@@ -288,7 +288,7 @@ mod tests {
         // populating a R+W should fail
         state
             .main_memory
-            .protect_pages(0, PAGE_SIZE.get() as usize, Permissions::READ_WRITE)
+            .protect_pages(0, PAGE_SIZE.get(), Permissions::READ_WRITE)
             .unwrap();
         cache.populate_page(15, &state);
         assert_eq!(count_active_pages(&cache), 0);
@@ -296,7 +296,7 @@ mod tests {
         // populating a R+W+X should fail
         state
             .main_memory
-            .protect_pages(0, PAGE_SIZE.get() as usize, Permissions::READ_WRITE_EXEC)
+            .protect_pages(0, PAGE_SIZE.get(), Permissions::READ_WRITE_EXEC)
             .unwrap();
         cache.populate_page(15, &state);
         assert_eq!(count_active_pages(&cache), 0);
@@ -304,7 +304,7 @@ mod tests {
         // populating a R+X page should succeed
         state
             .main_memory
-            .protect_pages(0, PAGE_SIZE.get() as usize, Permissions {
+            .protect_pages(0, PAGE_SIZE.get(), Permissions {
                 read: true,
                 exec: true,
                 write: false,

--- a/src/riscv/lib/src/machine_state/registers.rs
+++ b/src/riscv/lib/src/machine_state/registers.rs
@@ -27,6 +27,7 @@ use crate::default::ConstDefault;
 use crate::instruction_context::ICB;
 use crate::jit::builder::typed;
 use crate::machine_state::backend;
+use crate::num::NonZeroLength;
 use crate::state::NewState;
 use crate::state_backend::CellsProj;
 use crate::state_backend::owned_backend::Owned;
@@ -569,8 +570,7 @@ impl FValue {
 }
 
 impl backend::Elem for FValue {
-    const STORED_SIZE: NonZeroU64 = NonZeroU64::new(8).unwrap();
-    const STORED_SIZE_USIZE: NonZeroUsize = NonZeroUsize::new(8).unwrap();
+    const STORED_SIZE: NonZeroLength = NonZeroLength::new(8).unwrap();
 
     #[inline(always)]
     unsafe fn read_unaligned(source: *const u8) -> Self {

--- a/src/riscv/lib/src/machine_state/registers.rs
+++ b/src/riscv/lib/src/machine_state/registers.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023-2024 TriliTech <contact@trili.tech>
+// SPDX-FileCopyrightText: 2023-2025 TriliTech <contact@trili.tech>
 //
 // SPDX-License-Identifier: MIT
 
@@ -15,6 +15,7 @@
 
 use std::fmt;
 use std::mem::Discriminant;
+use std::num::NonZeroU64;
 use std::num::NonZeroUsize;
 
 use arbitrary_int::u5;
@@ -568,7 +569,8 @@ impl FValue {
 }
 
 impl backend::Elem for FValue {
-    const STORED_SIZE: NonZeroUsize = NonZeroUsize::new(8).unwrap();
+    const STORED_SIZE: NonZeroU64 = NonZeroU64::new(8).unwrap();
+    const STORED_SIZE_USIZE: NonZeroUsize = NonZeroUsize::new(8).unwrap();
 
     #[inline(always)]
     unsafe fn read_unaligned(source: *const u8) -> Self {

--- a/src/riscv/lib/src/num.rs
+++ b/src/riscv/lib/src/num.rs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2025 TriliTech <contact@trili.tech>
+//
+// SPDX-License-Identifier: MIT
+
+use std::num::NonZeroU64;
+
+/// Non-zero length equivalent in size to a `u64`.
+#[derive(Debug, Clone, Copy)]
+#[repr(transparent)]
+pub struct NonZeroLength {
+    inner: NonZeroU64,
+}
+
+impl NonZeroLength {
+    pub const fn new(value: u64) -> Option<Self> {
+        match NonZeroU64::new(value) {
+            None => None,
+            Some(inner) => Some(Self { inner }),
+        }
+    }
+
+    pub const fn get(self) -> u64 {
+        self.inner.get()
+    }
+
+    pub const fn wrap(v: NonZeroU64) -> Self {
+        Self { inner: v }
+    }
+
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        match self.inner.checked_mul(rhs.inner) {
+            None => None,
+            Some(inner) => Some(Self { inner }),
+        }
+    }
+
+    pub const fn as_usize(self) -> usize {
+        self.inner.get() as usize
+    }
+}

--- a/src/riscv/lib/src/pvm/linux.rs
+++ b/src/riscv/lib/src/pvm/linux.rs
@@ -13,6 +13,7 @@ pub(crate) mod signals;
 
 use std::convert::Infallible;
 use std::ffi::CStr;
+use std::num::NonZeroU64;
 use std::ops::ControlFlow;
 use std::ops::Range;
 
@@ -271,33 +272,38 @@ where
             .map(|(addr, data)| addr.saturating_add(data.len() as u64))
             .max()
             .unwrap_or(0);
-        let program_length = program_end.saturating_sub(program_start);
 
-        // Allow the program to be written to main memory
-        self.machine_state.core.main_memory.protect_pages(
-            program_start,
-            program_length,
-            Permissions::WRITE,
-        )?;
+        if let Some(program_length) = NonZeroU64::new(program_end.saturating_sub(program_start)) {
+            // Allow the program to be written to main memory
+            self.machine_state.core.main_memory.protect_pages(
+                program_start,
+                program_length,
+                Permissions::WRITE,
+            )?;
 
-        // Write program to main memory
-        for (&addr, data) in program.segments.iter() {
-            self.machine_state.core.main_memory.write_all(addr, data)?;
-        }
+            // Write program to main memory
+            for (&addr, data) in program.segments.iter() {
+                self.machine_state.core.main_memory.write_all(addr, data)?;
+            }
 
-        // Remove access to the program that has just been placed into memory
-        self.machine_state.core.main_memory.protect_pages(
-            program_start,
-            program_length,
-            Permissions::NONE,
-        )?;
+            // Remove access to the program that has just been placed into memory
+            self.machine_state.core.main_memory.protect_pages(
+                program_start,
+                program_length,
+                Permissions::NONE,
+            )?;
+        };
 
         // Configure memory permissions using the ELF program headers, if present
         if let Some(program_headers) = &program.program_headers {
             for mem_perms in program_headers.permissions.iter() {
+                let Some(length) = NonZeroU64::new(mem_perms.length) else {
+                    continue;
+                };
+
                 self.machine_state.core.main_memory.protect_pages(
                     mem_perms.start_address,
-                    mem_perms.length,
+                    length,
                     mem_perms.permissions,
                 )?;
             }
@@ -319,7 +325,7 @@ where
     where
         M: ManagerReadWrite,
     {
-        let stack_top = VirtAddr::new(MC::TOTAL_BYTES as u64);
+        let stack_top = VirtAddr::new(MC::TOTAL_BYTES.get());
 
         // We must fit at least one guard page between the program break and the stack
         let guarded_stack_space = stack_top - self.system_state.program.end;
@@ -338,24 +344,25 @@ where
             return Err(MachineError::MemoryTooSmall);
         }
 
-        // At this point we know that `stack_top` >= `stack_bottom`
-        let stack_space = (stack_top - stack_bottom) as u64;
-
         // Guard the stack with a guard page. This prevents stack overflows spilling into the heap
         // or even worse, the program's .bss or .data area.
         let stack_guard = stack_bottom - PAGE_SIZE.get();
-        self.machine_state.core.main_memory.protect_pages(
-            stack_guard.to_machine_address(),
-            PAGE_SIZE.get(),
-            Permissions::NONE,
-        )?;
 
-        // Make sure the stack region is readable and writable
-        self.machine_state.core.main_memory.protect_pages(
-            stack_bottom.to_machine_address(),
-            stack_space,
-            Permissions::READ_WRITE,
-        )?;
+        // At this point we know that `stack_top` >= `stack_bottom`
+        if let Some(stack_space) = NonZeroU64::new((stack_top - stack_bottom) as u64) {
+            self.machine_state.core.main_memory.protect_pages(
+                stack_guard.to_machine_address(),
+                PAGE_SIZE,
+                Permissions::NONE,
+            )?;
+
+            // Make sure the stack region is readable and writable
+            self.machine_state.core.main_memory.protect_pages(
+                stack_bottom.to_machine_address(),
+                stack_space,
+                Permissions::READ_WRITE,
+            )?;
+        }
 
         self.machine_state
             .core
@@ -420,17 +427,20 @@ where
 
         // Mark all memory as allocated. This also has the benefit of initialising the buddy memory
         // manager properly.
-        self.machine_state.core.main_memory.allocate_pages(
-            Some(0),
-            MC::TOTAL_BYTES as u64,
-            true,
-        )?;
+        self.machine_state
+            .core
+            .main_memory
+            .allocate_pages(Some(0), MC::TOTAL_BYTES, true)?;
 
         // Make sure only the heap can be used for allocation by the user kernel.
-        self.machine_state.core.main_memory.deallocate_pages(
-            self.system_state.heap.start.to_machine_address(),
-            (self.system_state.heap.end - self.system_state.heap.start) as u64,
-        )?;
+        if let Some(heap_size) =
+            NonZeroU64::new((self.system_state.heap.end - self.system_state.heap.start) as u64)
+        {
+            self.machine_state
+                .core
+                .main_memory
+                .deallocate_pages(self.system_state.heap.start.to_machine_address(), heap_size)?;
+        }
 
         Ok(())
     }
@@ -1015,9 +1025,7 @@ impl<M: ManagerBase> SupervisorState<M> {
 
         struct MemorySize<MC>(MC);
         impl<MC: MemoryConfig> MemorySize<MC> {
-            const SIZE: u64 = MC::TOTAL_BYTES as u64;
-
-            const UPPER_BOUND: () = assert!(MC::TOTAL_BYTES <= u64::MAX as usize);
+            const SIZE: u64 = MC::TOTAL_BYTES.get();
 
             // Hard limit on the size of the data segment
             const RLIMIT_DATA: u64 = Self::SIZE;
@@ -1031,8 +1039,6 @@ impl<M: ManagerBase> SupervisorState<M> {
             // Hard limit on the size of a process's virtual memory (B)
             const RLIMIT_AS: u64 = Self::SIZE;
         }
-
-        let () = MemorySize::<MC>::UPPER_BOUND;
 
         // If new_limit is not NULL, the system call is being used to write new limits, so ignore
         // it and return a permissions error
@@ -1124,7 +1130,7 @@ mod tests {
     // Check that the `set_tid_address` system call is working correctly.
     backend_test!(set_tid_address, F, {
         type MemLayout = M4K;
-        const MEM_BYTES: usize = MemLayout::TOTAL_BYTES;
+        const MEM_BYTES: usize = MemLayout::TOTAL_BYTES.get() as usize;
 
         let mut machine_state =
             MachineState::<MemLayout, TestCacheConfig, Interpreted<MemLayout, F>, F>::new(
@@ -1169,7 +1175,7 @@ mod tests {
         machine_state
             .core
             .main_memory
-            .protect_pages(0, MemLayout::TOTAL_BYTES as u64, Permissions::READ_WRITE)
+            .protect_pages(0, MemLayout::TOTAL_BYTES, Permissions::READ_WRITE)
             .unwrap();
 
         for fd in [0i32, 1, 2] {
@@ -1239,7 +1245,7 @@ mod tests {
         machine_state
             .core
             .main_memory
-            .protect_pages(0, MemLayout::TOTAL_BYTES as u64, Permissions::READ_WRITE)
+            .protect_pages(0, MemLayout::TOTAL_BYTES, Permissions::READ_WRITE)
             .unwrap();
 
         let mut supervisor_state = SupervisorState::<F>::new();
@@ -1369,14 +1375,14 @@ mod tests {
         machine_state
             .core
             .main_memory
-            .protect_pages(0, MemLayout::TOTAL_BYTES as u64, Permissions::READ_WRITE)
+            .protect_pages(0, MemLayout::TOTAL_BYTES, Permissions::READ_WRITE)
             .unwrap();
 
         let mut supervisor_state = SupervisorState::<F>::new();
 
         let mut do_ignore = |signal: Signal| {
             // Write the initial stack pointer and program counter.
-            let stack_top = M4K::TOTAL_BYTES as u64;
+            let stack_top = M4K::TOTAL_BYTES.get();
             machine_state.core.hart.xregisters.write(sp, stack_top);
             let init_pc = 0;
             machine_state.core.hart.pc.write(init_pc);
@@ -1514,7 +1520,7 @@ mod tests {
         machine_state
             .core
             .main_memory
-            .protect_pages(0, MemLayout::TOTAL_BYTES as u64, Permissions::READ_WRITE)
+            .protect_pages(0, MemLayout::TOTAL_BYTES, Permissions::READ_WRITE)
             .unwrap();
 
         // Mask pointer (must be non-zero)
@@ -1825,7 +1831,7 @@ mod tests {
         machine_state
             .core
             .main_memory
-            .protect_pages(0, MemLayout::TOTAL_BYTES as u64, Permissions::READ_WRITE)
+            .protect_pages(0, MemLayout::TOTAL_BYTES, Permissions::READ_WRITE)
             .unwrap();
 
         let mut supervisor_state = SupervisorState::new();
@@ -1895,7 +1901,7 @@ mod tests {
         machine_state
             .core
             .main_memory
-            .protect_pages(0, MemLayout::TOTAL_BYTES as u64, Permissions::READ_WRITE)
+            .protect_pages(0, MemLayout::TOTAL_BYTES, Permissions::READ_WRITE)
             .unwrap();
 
         let mut supervisor_state = SupervisorState::new();
@@ -1984,7 +1990,7 @@ mod tests {
             .main_memory
             .allocate_and_protect_pages(
                 Some(0),
-                MemLayout::TOTAL_BYTES as u64,
+                MemLayout::TOTAL_BYTES,
                 Permissions::READ_WRITE,
                 true,
             )

--- a/src/riscv/lib/src/pvm/linux.rs
+++ b/src/riscv/lib/src/pvm/linux.rs
@@ -271,7 +271,7 @@ where
             .map(|(addr, data)| addr.saturating_add(data.len() as u64))
             .max()
             .unwrap_or(0);
-        let program_length = program_end.saturating_sub(program_start) as usize;
+        let program_length = program_end.saturating_sub(program_start);
 
         // Allow the program to be written to main memory
         self.machine_state.core.main_memory.protect_pages(
@@ -297,7 +297,7 @@ where
             for mem_perms in program_headers.permissions.iter() {
                 self.machine_state.core.main_memory.protect_pages(
                     mem_perms.start_address,
-                    mem_perms.length as usize,
+                    mem_perms.length,
                     mem_perms.permissions,
                 )?;
             }
@@ -339,14 +339,14 @@ where
         }
 
         // At this point we know that `stack_top` >= `stack_bottom`
-        let stack_space = (stack_top - stack_bottom) as usize;
+        let stack_space = (stack_top - stack_bottom) as u64;
 
         // Guard the stack with a guard page. This prevents stack overflows spilling into the heap
         // or even worse, the program's .bss or .data area.
         let stack_guard = stack_bottom - PAGE_SIZE.get();
         self.machine_state.core.main_memory.protect_pages(
             stack_guard.to_machine_address(),
-            PAGE_SIZE.get() as usize,
+            PAGE_SIZE.get(),
             Permissions::NONE,
         )?;
 
@@ -420,15 +420,16 @@ where
 
         // Mark all memory as allocated. This also has the benefit of initialising the buddy memory
         // manager properly.
-        self.machine_state
-            .core
-            .main_memory
-            .allocate_pages(Some(0), MC::TOTAL_BYTES, true)?;
+        self.machine_state.core.main_memory.allocate_pages(
+            Some(0),
+            MC::TOTAL_BYTES as u64,
+            true,
+        )?;
 
         // Make sure only the heap can be used for allocation by the user kernel.
         self.machine_state.core.main_memory.deallocate_pages(
             self.system_state.heap.start.to_machine_address(),
-            (self.system_state.heap.end - self.system_state.heap.start) as usize,
+            (self.system_state.heap.end - self.system_state.heap.start) as u64,
         )?;
 
         Ok(())
@@ -1168,7 +1169,7 @@ mod tests {
         machine_state
             .core
             .main_memory
-            .protect_pages(0, MemLayout::TOTAL_BYTES, Permissions::READ_WRITE)
+            .protect_pages(0, MemLayout::TOTAL_BYTES as u64, Permissions::READ_WRITE)
             .unwrap();
 
         for fd in [0i32, 1, 2] {
@@ -1238,7 +1239,7 @@ mod tests {
         machine_state
             .core
             .main_memory
-            .protect_pages(0, MemLayout::TOTAL_BYTES, Permissions::READ_WRITE)
+            .protect_pages(0, MemLayout::TOTAL_BYTES as u64, Permissions::READ_WRITE)
             .unwrap();
 
         let mut supervisor_state = SupervisorState::<F>::new();
@@ -1368,7 +1369,7 @@ mod tests {
         machine_state
             .core
             .main_memory
-            .protect_pages(0, MemLayout::TOTAL_BYTES, Permissions::READ_WRITE)
+            .protect_pages(0, MemLayout::TOTAL_BYTES as u64, Permissions::READ_WRITE)
             .unwrap();
 
         let mut supervisor_state = SupervisorState::<F>::new();
@@ -1513,7 +1514,7 @@ mod tests {
         machine_state
             .core
             .main_memory
-            .protect_pages(0, MemLayout::TOTAL_BYTES, Permissions::READ_WRITE)
+            .protect_pages(0, MemLayout::TOTAL_BYTES as u64, Permissions::READ_WRITE)
             .unwrap();
 
         // Mask pointer (must be non-zero)
@@ -1824,7 +1825,7 @@ mod tests {
         machine_state
             .core
             .main_memory
-            .protect_pages(0, MemLayout::TOTAL_BYTES, Permissions::READ_WRITE)
+            .protect_pages(0, MemLayout::TOTAL_BYTES as u64, Permissions::READ_WRITE)
             .unwrap();
 
         let mut supervisor_state = SupervisorState::new();
@@ -1894,7 +1895,7 @@ mod tests {
         machine_state
             .core
             .main_memory
-            .protect_pages(0, MemLayout::TOTAL_BYTES, Permissions::READ_WRITE)
+            .protect_pages(0, MemLayout::TOTAL_BYTES as u64, Permissions::READ_WRITE)
             .unwrap();
 
         let mut supervisor_state = SupervisorState::new();
@@ -1983,7 +1984,7 @@ mod tests {
             .main_memory
             .allocate_and_protect_pages(
                 Some(0),
-                MemLayout::TOTAL_BYTES,
+                MemLayout::TOTAL_BYTES as u64,
                 Permissions::READ_WRITE,
                 true,
             )

--- a/src/riscv/lib/src/pvm/linux/memory.rs
+++ b/src/riscv/lib/src/pvm/linux/memory.rs
@@ -82,6 +82,11 @@ impl<M: ManagerBase> SupervisorState<M> {
         MC: MemoryConfig,
         M: ManagerReadWrite,
     {
+        let Some(length) = NonZeroU64::new(length) else {
+            // // Length 0 means no protections need to be changed.
+            return Ok(0);
+        };
+
         core.main_memory
             .protect_pages(addr.to_machine_address(), length, perms)?;
 
@@ -123,10 +128,9 @@ impl<M: ManagerBase> SupervisorState<M> {
         }
 
         let res_addr: VirtAddr = match flags.addr_hint {
-            AddressHint::Hint => {
-                core.main_memory
-                    .allocate_and_protect_pages(None, length.get(), perms, false)?
-            }
+            AddressHint::Hint => core
+                .main_memory
+                .allocate_and_protect_pages(None, length, perms, false)?,
 
             AddressHint::Fixed { allow_replace } => {
                 if !addr.is_aligned(PAGE_SIZE) {
@@ -135,7 +139,7 @@ impl<M: ManagerBase> SupervisorState<M> {
 
                 core.main_memory.allocate_and_protect_pages(
                     Some(addr.to_machine_address()),
-                    length.get(),
+                    length,
                     perms,
                     allow_replace,
                 )?
@@ -153,7 +157,11 @@ impl<M: ManagerBase> SupervisorState<M> {
         &mut self,
         core: &mut MachineCoreState<MC, M>,
         addr: u64,
-        length: u64,
+        // while not explicitly required to be non-zero, this does partially match the
+        // linux implementation which requires both page-aligned addresses and length > 0
+        //
+        // see <https://github.com/torvalds/linux/blob/50c19e20ed2ef359cf155a39c8462b0a6351b9fa/mm/vma.c#L1573>
+        length: NonZeroU64,
     ) -> Result<u64, Error>
     where
         MC: MemoryConfig,

--- a/src/riscv/lib/src/pvm/linux/memory.rs
+++ b/src/riscv/lib/src/pvm/linux/memory.rs
@@ -83,7 +83,7 @@ impl<M: ManagerBase> SupervisorState<M> {
         M: ManagerReadWrite,
     {
         core.main_memory
-            .protect_pages(addr.to_machine_address(), length as usize, perms)?;
+            .protect_pages(addr.to_machine_address(), length, perms)?;
 
         // Return 0 to indicate success.
         Ok(0)
@@ -123,12 +123,10 @@ impl<M: ManagerBase> SupervisorState<M> {
         }
 
         let res_addr: VirtAddr = match flags.addr_hint {
-            AddressHint::Hint => core.main_memory.allocate_and_protect_pages(
-                None,
-                length.get() as usize,
-                perms,
-                false,
-            )?,
+            AddressHint::Hint => {
+                core.main_memory
+                    .allocate_and_protect_pages(None, length.get(), perms, false)?
+            }
 
             AddressHint::Fixed { allow_replace } => {
                 if !addr.is_aligned(PAGE_SIZE) {
@@ -137,7 +135,7 @@ impl<M: ManagerBase> SupervisorState<M> {
 
                 core.main_memory.allocate_and_protect_pages(
                     Some(addr.to_machine_address()),
-                    length.get() as usize,
+                    length.get(),
                     perms,
                     allow_replace,
                 )?
@@ -162,7 +160,7 @@ impl<M: ManagerBase> SupervisorState<M> {
         M: ManagerReadWrite,
     {
         core.main_memory
-            .deallocate_and_protect_pages(addr, length as usize)
+            .deallocate_and_protect_pages(addr, length)
             .map_err(|_| Error::InvalidArgument)?;
 
         Ok(0)

--- a/src/riscv/lib/src/pvm/linux/signals.rs
+++ b/src/riscv/lib/src/pvm/linux/signals.rs
@@ -37,6 +37,7 @@ use crate::machine_state::memory::Memory;
 use crate::machine_state::memory::MemoryConfig;
 use crate::machine_state::registers::nz;
 use crate::machine_state::registers::sp;
+use crate::num::NonZeroLength;
 use crate::pvm::Pvm;
 use crate::pvm::linux::Address;
 use crate::pvm::linux::SupervisorState;
@@ -117,8 +118,7 @@ pub const SA_SIGINFO: u32 = 0x4000000;
 const SIZE_SIGACTION: u64 = 32;
 
 impl Elem for LinuxSigAction {
-    const STORED_SIZE: NonZeroU64 = { NonZeroU64::new(SIZE_SIGACTION).unwrap() };
-    const STORED_SIZE_USIZE: NonZeroUsize = { NonZeroUsize::new(SIZE_SIGACTION as usize).unwrap() };
+    const STORED_SIZE: NonZeroLength = NonZeroLength::new(SIZE_SIGACTION).unwrap();
 
     unsafe fn read_unaligned(source: *const u8) -> Self {
         // SAFETY: The bitwise representation is the same as `write_unaligned` and matches each

--- a/src/riscv/lib/src/pvm/linux/signals.rs
+++ b/src/riscv/lib/src/pvm/linux/signals.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+use std::num::NonZeroU64;
 use std::num::NonZeroUsize;
 use std::ops::Add;
 use std::ops::Sub;
@@ -766,7 +767,8 @@ where
         const ECALL: u32 = 0b1110011;
 
         const RESTORER_FUNCTION: [u32; 2] = [LOAD_SIGRETURN, ECALL];
-        const RESTORER_LENGTH: u64 = size_of_val(&RESTORER_FUNCTION) as u64;
+        const RESTORER_LENGTH: NonZeroU64 = NonZeroU64::new(size_of_val(&RESTORER_FUNCTION) as u64)
+            .expect("constant `RESTORER_FUNCTION` is non-zero sized");
 
         // Ensure the restorer is in its own page
         let address = address
@@ -789,7 +791,7 @@ where
         // Make the restorer page R+X
         self.machine_state.core.main_memory.protect_pages(
             address.to_machine_address(),
-            PAGE_SIZE.get(),
+            PAGE_SIZE,
             Permissions {
                 read: true,
                 exec: true,
@@ -797,7 +799,7 @@ where
             },
         )?;
 
-        let restorer_end = address + RESTORER_LENGTH;
+        let restorer_end = address + RESTORER_LENGTH.get();
 
         // Store where the restorer is kept so that the signal handlers can find it
         self.machine_state
@@ -843,11 +845,11 @@ mod tests {
         pvm.machine_state
             .core
             .main_memory
-            .protect_pages(0, MC::TOTAL_BYTES as u64, Permissions::READ_WRITE)
+            .protect_pages(0, MC::TOTAL_BYTES, Permissions::READ_WRITE)
             .unwrap();
 
         // Write the initial stack pointer and program counter.
-        let stack_top = M1M::TOTAL_BYTES as u64;
+        let stack_top = M1M::TOTAL_BYTES.get();
         pvm.machine_state.core.hart.xregisters.write(sp, stack_top);
         let init_pc = 10;
         pvm.machine_state.core.hart.pc.write(init_pc);
@@ -923,11 +925,11 @@ mod tests {
         pvm.machine_state
             .core
             .main_memory
-            .protect_pages(0, MC::TOTAL_BYTES as u64, Permissions::READ_WRITE)
+            .protect_pages(0, MC::TOTAL_BYTES, Permissions::READ_WRITE)
             .unwrap();
 
         // Write the initial stack pointer and program counter.
-        let stack_top = M1M::TOTAL_BYTES as u64;
+        let stack_top = M1M::TOTAL_BYTES.get();
         pvm.machine_state.core.hart.xregisters.write(sp, stack_top);
         let init_pc = 10;
         pvm.machine_state.core.hart.pc.write(init_pc);

--- a/src/riscv/lib/src/pvm/linux/signals.rs
+++ b/src/riscv/lib/src/pvm/linux/signals.rs
@@ -766,7 +766,7 @@ where
         const ECALL: u32 = 0b1110011;
 
         const RESTORER_FUNCTION: [u32; 2] = [LOAD_SIGRETURN, ECALL];
-        const RESTORER_LENGTH: usize = size_of_val(&RESTORER_FUNCTION);
+        const RESTORER_LENGTH: u64 = size_of_val(&RESTORER_FUNCTION) as u64;
 
         // Ensure the restorer is in its own page
         let address = address
@@ -789,7 +789,7 @@ where
         // Make the restorer page R+X
         self.machine_state.core.main_memory.protect_pages(
             address.to_machine_address(),
-            PAGE_SIZE.get() as usize,
+            PAGE_SIZE.get(),
             Permissions {
                 read: true,
                 exec: true,
@@ -797,7 +797,7 @@ where
             },
         )?;
 
-        let restorer_end = address + RESTORER_LENGTH as u64;
+        let restorer_end = address + RESTORER_LENGTH;
 
         // Store where the restorer is kept so that the signal handlers can find it
         self.machine_state
@@ -843,7 +843,7 @@ mod tests {
         pvm.machine_state
             .core
             .main_memory
-            .protect_pages(0, MC::TOTAL_BYTES, Permissions::READ_WRITE)
+            .protect_pages(0, MC::TOTAL_BYTES as u64, Permissions::READ_WRITE)
             .unwrap();
 
         // Write the initial stack pointer and program counter.
@@ -923,7 +923,7 @@ mod tests {
         pvm.machine_state
             .core
             .main_memory
-            .protect_pages(0, MC::TOTAL_BYTES, Permissions::READ_WRITE)
+            .protect_pages(0, MC::TOTAL_BYTES as u64, Permissions::READ_WRITE)
             .unwrap();
 
         // Write the initial stack pointer and program counter.

--- a/src/riscv/lib/src/pvm/linux/signals.rs
+++ b/src/riscv/lib/src/pvm/linux/signals.rs
@@ -114,17 +114,21 @@ pub const SIG_IGN: VirtAddr = VirtAddr::new(1u64);
 pub const SA_SIGINFO: u32 = 0x4000000;
 
 /// `size_of(struct sigaction)` on the Kernel side
-const SIZE_SIGACTION: usize = 32;
+const SIZE_SIGACTION: u64 = 32;
 
 impl Elem for LinuxSigAction {
-    const STORED_SIZE: NonZeroUsize = { NonZeroUsize::new(SIZE_SIGACTION).unwrap() };
+    const STORED_SIZE: NonZeroU64 = { NonZeroU64::new(SIZE_SIGACTION).unwrap() };
+    const STORED_SIZE_USIZE: NonZeroUsize = { NonZeroUsize::new(SIZE_SIGACTION as usize).unwrap() };
 
     unsafe fn read_unaligned(source: *const u8) -> Self {
         // SAFETY: The bitwise representation is the same as `write_unaligned` and matches each
         // field.
         unsafe {
-            LinuxSigAction::read_from_bytes(from_raw_parts(source, Self::STORED_SIZE.get()))
-                .expect("Bad sigaction")
+            LinuxSigAction::read_from_bytes(from_raw_parts(
+                source,
+                Self::STORED_SIZE.get() as usize,
+            ))
+            .expect("Bad sigaction")
         }
     }
 
@@ -132,7 +136,7 @@ impl Elem for LinuxSigAction {
         // SAFETY: The bitwise representation is the same as `read_unaligned` and matches each
         // field.
         unsafe {
-            let _ = self.write_to(from_raw_parts_mut(dest, Self::STORED_SIZE.get()));
+            let _ = self.write_to(from_raw_parts_mut(dest, Self::STORED_SIZE.get() as usize));
         }
     }
 }

--- a/src/riscv/lib/src/state_backend/elems.rs
+++ b/src/riscv/lib/src/state_backend/elems.rs
@@ -6,11 +6,12 @@ use std::num::NonZeroU64;
 use std::num::NonZeroUsize;
 
 use crate::machine_state::memory::PAGE_SIZE;
+use crate::num::NonZeroLength;
 
 /// Types that are less than one page wide
 pub trait NarrowlySized: Elem {
     /// Size of the type
-    const NARROW_SIZE: NonZeroU64 = {
+    const NARROW_SIZE: NonZeroLength = {
         if Self::STORED_SIZE.get() >= PAGE_SIZE.get() {
             panic!("Type is too wide");
         }
@@ -29,12 +30,7 @@ impl<T: Copy + 'static> StaticCopy for T {}
 /// Values that can be stored in dynamic regions
 pub trait Elem {
     /// Size of the stored representation in bytes
-    const STORED_SIZE: NonZeroU64;
-
-    /// Size of the stored representation in bytes.
-    ///
-    /// `STORED_SIZE_USIZE.get()` must be equivalent to `STORED_SIZE.get() as usize`.
-    const STORED_SIZE_USIZE: NonZeroUsize;
+    const STORED_SIZE: NonZeroLength;
 
     /// Read a value from its stored representation.
     ///
@@ -66,11 +62,8 @@ pub fn elem_bytes<E: Elem>(value: E) -> Box<[u8]> {
 macro_rules! impl_dyn_value_prim {
     ( $x:ty ) => {
         impl Elem for $x {
-            const STORED_SIZE: NonZeroU64 =
-                NonZeroU64::new(std::mem::size_of::<$x>() as u64).expect("Type has zero size");
-
-            const STORED_SIZE_USIZE: NonZeroUsize =
-                NonZeroUsize::new(std::mem::size_of::<$x>()).expect("Type has zero size");
+            const STORED_SIZE: NonZeroLength =
+                NonZeroLength::new(std::mem::size_of::<$x>() as u64).expect("Type has zero size");
 
             #[inline]
             unsafe fn read_unaligned(source: *const u8) -> Self {
@@ -97,30 +90,23 @@ impl_dyn_value_prim!(u128);
 impl_dyn_value_prim!(i128);
 
 impl<E: Elem, const LEN: usize> Elem for [E; LEN] {
-    const STORED_SIZE: NonZeroU64 = {
-        let len = NonZeroU64::new(LEN as u64).expect("Array length must be non-zero");
+    const STORED_SIZE: NonZeroLength = {
+        let len = NonZeroLength::new(LEN as u64).expect("Array length must be non-zero");
         E::STORED_SIZE
-            .checked_mul(len)
-            .expect("Array size must not overflow")
-    };
-
-    const STORED_SIZE_USIZE: NonZeroUsize = {
-        let len = NonZeroUsize::new(LEN).expect("Array length must be non-zero");
-        E::STORED_SIZE_USIZE
             .checked_mul(len)
             .expect("Array size must not overflow")
     };
 
     unsafe fn read_unaligned(source: *const u8) -> Self {
         std::array::from_fn(|i| {
-            let offset = E::STORED_SIZE_USIZE.get().wrapping_mul(i);
+            let offset = E::STORED_SIZE.as_usize().wrapping_mul(i);
             unsafe { E::read_unaligned(source.add(offset)) }
         })
     }
 
     unsafe fn write_unaligned(self, dest: *mut u8) {
         for (i, elem) in self.into_iter().enumerate() {
-            let offset = E::STORED_SIZE_USIZE.get().wrapping_mul(i);
+            let offset = E::STORED_SIZE.as_usize().wrapping_mul(i);
             unsafe { elem.write_unaligned(dest.add(offset)) };
         }
     }

--- a/src/riscv/lib/src/state_backend/elems.rs
+++ b/src/riscv/lib/src/state_backend/elems.rs
@@ -1,7 +1,8 @@
-// SPDX-FileCopyrightText: 2023-2024 TriliTech <contact@trili.tech>
+// SPDX-FileCopyrightText: 2023-2025 TriliTech <contact@trili.tech>
 //
 // SPDX-License-Identifier: MIT
 
+use std::num::NonZeroU64;
 use std::num::NonZeroUsize;
 
 use crate::machine_state::memory::PAGE_SIZE;
@@ -9,8 +10,8 @@ use crate::machine_state::memory::PAGE_SIZE;
 /// Types that are less than one page wide
 pub trait NarrowlySized: Elem {
     /// Size of the type
-    const NARROW_SIZE: NonZeroUsize = {
-        if Self::STORED_SIZE.get() >= PAGE_SIZE.get() as usize {
+    const NARROW_SIZE: NonZeroU64 = {
+        if Self::STORED_SIZE.get() >= PAGE_SIZE.get() {
             panic!("Type is too wide");
         }
 
@@ -28,7 +29,12 @@ impl<T: Copy + 'static> StaticCopy for T {}
 /// Values that can be stored in dynamic regions
 pub trait Elem {
     /// Size of the stored representation in bytes
-    const STORED_SIZE: NonZeroUsize;
+    const STORED_SIZE: NonZeroU64;
+
+    /// Size of the stored representation in bytes.
+    ///
+    /// `STORED_SIZE_USIZE.get()` must be equivalent to `STORED_SIZE.get() as usize`.
+    const STORED_SIZE_USIZE: NonZeroUsize;
 
     /// Read a value from its stored representation.
     ///
@@ -47,7 +53,7 @@ pub trait Elem {
 
 /// Capture the stored representation of an element from a dynamic region.
 pub fn elem_bytes<E: Elem>(value: E) -> Box<[u8]> {
-    let mut value_bytes = vec![0u8; E::STORED_SIZE.get()];
+    let mut value_bytes = vec![0u8; E::STORED_SIZE.get() as usize];
 
     // SAFETY: The vector has been allocated with sufficient space.
     unsafe {
@@ -60,7 +66,10 @@ pub fn elem_bytes<E: Elem>(value: E) -> Box<[u8]> {
 macro_rules! impl_dyn_value_prim {
     ( $x:ty ) => {
         impl Elem for $x {
-            const STORED_SIZE: NonZeroUsize =
+            const STORED_SIZE: NonZeroU64 =
+                NonZeroU64::new(std::mem::size_of::<$x>() as u64).expect("Type has zero size");
+
+            const STORED_SIZE_USIZE: NonZeroUsize =
                 NonZeroUsize::new(std::mem::size_of::<$x>()).expect("Type has zero size");
 
             #[inline]
@@ -88,23 +97,30 @@ impl_dyn_value_prim!(u128);
 impl_dyn_value_prim!(i128);
 
 impl<E: Elem, const LEN: usize> Elem for [E; LEN] {
-    const STORED_SIZE: NonZeroUsize = {
-        let len = NonZeroUsize::new(LEN).expect("Array length must be non-zero");
+    const STORED_SIZE: NonZeroU64 = {
+        let len = NonZeroU64::new(LEN as u64).expect("Array length must be non-zero");
         E::STORED_SIZE
+            .checked_mul(len)
+            .expect("Array size must not overflow")
+    };
+
+    const STORED_SIZE_USIZE: NonZeroUsize = {
+        let len = NonZeroUsize::new(LEN).expect("Array length must be non-zero");
+        E::STORED_SIZE_USIZE
             .checked_mul(len)
             .expect("Array size must not overflow")
     };
 
     unsafe fn read_unaligned(source: *const u8) -> Self {
         std::array::from_fn(|i| {
-            let offset = E::STORED_SIZE.get().wrapping_mul(i);
+            let offset = E::STORED_SIZE_USIZE.get().wrapping_mul(i);
             unsafe { E::read_unaligned(source.add(offset)) }
         })
     }
 
     unsafe fn write_unaligned(self, dest: *mut u8) {
         for (i, elem) in self.into_iter().enumerate() {
-            let offset = E::STORED_SIZE.get().wrapping_mul(i);
+            let offset = E::STORED_SIZE_USIZE.get().wrapping_mul(i);
             unsafe { elem.write_unaligned(dest.add(offset)) };
         }
     }

--- a/src/riscv/lib/src/state_backend/owned_backend.rs
+++ b/src/riscv/lib/src/state_backend/owned_backend.rs
@@ -102,7 +102,7 @@ impl ManagerRead for Owned {
         region: &Self::DynRegion<LEN>,
         address: usize,
     ) -> E {
-        assert!(address + E::STORED_SIZE_USIZE.get() <= LEN);
+        assert!(address + E::STORED_SIZE.as_usize() <= LEN);
 
         // SAFETY: The assertion above ensures that the address can be read for at least
         // `E::STORED_SIZE` bytes.
@@ -117,8 +117,8 @@ impl ManagerRead for Owned {
         for (i, value) in values.iter_mut().enumerate() {
             *value = Self::dyn_region_read::<E, LEN>(
                 region,
-                E::STORED_SIZE_USIZE
-                    .get()
+                E::STORED_SIZE
+                    .as_usize()
                     .wrapping_mul(i)
                     .wrapping_add(address),
             );
@@ -170,7 +170,7 @@ impl ManagerWrite for Owned {
         address: usize,
         value: E,
     ) {
-        assert!(address + E::STORED_SIZE_USIZE.get() <= LEN);
+        assert!(address + E::STORED_SIZE.as_usize() <= LEN);
 
         // SAFETY: The assertion above ensures that the address can be written for at least
         // `E::STORED_SIZE` bytes.
@@ -185,8 +185,8 @@ impl ManagerWrite for Owned {
         for (i, value) in values.iter().enumerate() {
             Self::dyn_region_write::<E, LEN>(
                 region,
-                E::STORED_SIZE_USIZE
-                    .get()
+                E::STORED_SIZE
+                    .as_usize()
                     .wrapping_mul(i)
                     .wrapping_add(address),
                 *value,

--- a/src/riscv/lib/src/state_backend/owned_backend.rs
+++ b/src/riscv/lib/src/state_backend/owned_backend.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 TriliTech <contact@trili.tech>
+// SPDX-FileCopyrightText: 2024-2025 TriliTech <contact@trili.tech>
 // SPDX-FileCopyrightText: 2025 Nomadic Labs <contact@nomadic-labs.com>
 //
 // SPDX-License-Identifier: MIT
@@ -102,7 +102,7 @@ impl ManagerRead for Owned {
         region: &Self::DynRegion<LEN>,
         address: usize,
     ) -> E {
-        assert!(address + E::STORED_SIZE.get() <= LEN);
+        assert!(address + E::STORED_SIZE_USIZE.get() <= LEN);
 
         // SAFETY: The assertion above ensures that the address can be read for at least
         // `E::STORED_SIZE` bytes.
@@ -117,7 +117,10 @@ impl ManagerRead for Owned {
         for (i, value) in values.iter_mut().enumerate() {
             *value = Self::dyn_region_read::<E, LEN>(
                 region,
-                E::STORED_SIZE.get().wrapping_mul(i).wrapping_add(address),
+                E::STORED_SIZE_USIZE
+                    .get()
+                    .wrapping_mul(i)
+                    .wrapping_add(address),
             );
         }
     }
@@ -167,7 +170,7 @@ impl ManagerWrite for Owned {
         address: usize,
         value: E,
     ) {
-        assert!(address + E::STORED_SIZE.get() <= LEN);
+        assert!(address + E::STORED_SIZE_USIZE.get() <= LEN);
 
         // SAFETY: The assertion above ensures that the address can be written for at least
         // `E::STORED_SIZE` bytes.
@@ -182,7 +185,10 @@ impl ManagerWrite for Owned {
         for (i, value) in values.iter().enumerate() {
             Self::dyn_region_write::<E, LEN>(
                 region,
-                E::STORED_SIZE.get().wrapping_mul(i).wrapping_add(address),
+                E::STORED_SIZE_USIZE
+                    .get()
+                    .wrapping_mul(i)
+                    .wrapping_add(address),
                 *value,
             );
         }

--- a/src/riscv/lib/src/state_backend/proof_backend.rs
+++ b/src/riscv/lib/src/state_backend/proof_backend.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2024-2025 Nomadic Labs <contact@nomadic-labs.com>
+// SPDX-FileCopyrightText: 2025 Trilitech <contact@trili.tech>
 //
 // SPDX-License-Identifier: MIT
 
@@ -109,8 +110,7 @@ impl<M: ManagerRead> ManagerRead for ProofGen<M> {
         for (offset, value) in values.iter_mut().enumerate() {
             *value = Self::dyn_region_read(
                 region,
-                E::STORED_SIZE
-                    .get()
+                (E::STORED_SIZE.get() as usize)
                     .wrapping_mul(offset)
                     .wrapping_add(address),
             );
@@ -167,7 +167,7 @@ impl<M: ManagerBase> ManagerWrite for ProofGen<M> {
         address: usize,
         value: E,
     ) {
-        assert!(address + E::STORED_SIZE.get() <= LEN);
+        assert!(address + E::STORED_SIZE.get() as usize <= LEN);
 
         for (offset, byte) in elem_bytes(value).into_iter().enumerate() {
             region.writes.insert(address + offset, byte);
@@ -182,8 +182,7 @@ impl<M: ManagerBase> ManagerWrite for ProofGen<M> {
         for (offset, &value) in values.iter().enumerate() {
             Self::dyn_region_write(
                 region,
-                E::STORED_SIZE
-                    .get()
+                (E::STORED_SIZE.get() as usize)
                     .wrapping_mul(offset)
                     .wrapping_add(address),
                 value,
@@ -414,14 +413,17 @@ impl<M: ManagerRead, const LEN: usize> ProofDynRegion<LEN, M> {
     /// Version of [`ManagerRead::dyn_region_read`] which does not record
     /// the access as a read.
     fn unrecorded_read<E: Elem>(&self, address: usize) -> E {
-        assert!(address + E::STORED_SIZE.get() <= LEN);
+        assert!(address + E::STORED_SIZE.get() as usize <= LEN);
 
         // Read the underlying bytes of the value.
-        let mut value_bytes = vec![0u8; E::STORED_SIZE.get()];
+        let mut value_bytes = vec![0u8; E::STORED_SIZE.get() as usize];
         M::dyn_region_read_all(&self.source, address, &mut value_bytes);
 
         // Overwrite any byte that has been written during the proof step.
-        for (&i, &byte) in self.writes.range(address..address + E::STORED_SIZE.get()) {
+        for (&i, &byte) in self
+            .writes
+            .range(address..address + E::STORED_SIZE.get() as usize)
+        {
             value_bytes[i - address] = byte;
         }
 
@@ -472,7 +474,8 @@ pub struct DynAccess(BTreeSet<usize>);
 impl DynAccess {
     /// Insert all addresses touched while accessing an element of a given size.
     pub fn insert<E: Elem>(&mut self, address: usize) {
-        self.0.extend(address..address + E::STORED_SIZE.get())
+        self.0
+            .extend(address..address + E::STORED_SIZE.get() as usize)
     }
 
     /// Check whether any address within a given range of addresses
@@ -612,7 +615,7 @@ mod tests {
 
     const LEAVES: usize = 8;
     const DYN_REGION_SIZE: usize = MERKLE_LEAF_SIZE.get() * LEAVES;
-    const ELEM_SIZE: usize = u64::STORED_SIZE.get();
+    const ELEM_SIZE: usize = u64::STORED_SIZE.get() as usize;
 
     #[test]
     fn test_proof_gen_dyn_region() {

--- a/src/riscv/lib/src/state_backend/region.rs
+++ b/src/riscv/lib/src/state_backend/region.rs
@@ -659,6 +659,7 @@ impl<const LEN: usize, M: ManagerClone> Clone for DynCells<LEN, M> {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use std::num::NonZeroU64;
     use std::num::NonZeroUsize;
 
     use bincode::Encode;
@@ -694,7 +695,8 @@ pub(crate) mod tests {
     }
 
     impl Elem for Flipper {
-        const STORED_SIZE: NonZeroUsize = NonZeroUsize::new(2).unwrap();
+        const STORED_SIZE: NonZeroU64 = NonZeroU64::new(2).unwrap();
+        const STORED_SIZE_USIZE: NonZeroUsize = NonZeroUsize::new(2).unwrap();
 
         unsafe fn read_unaligned(source: *const u8) -> Self {
             unsafe {
@@ -793,7 +795,10 @@ pub(crate) mod tests {
 
             // This should panic because we are trying to write an element at the address which
             // corresponds to the end of the buffer.
-            state.write(LEN * Flipper::STORED_SIZE.get(), Flipper { a: 1, b: 2 });
+            state.write(LEN * Flipper::STORED_SIZE_USIZE.get(), Flipper {
+                a: 1,
+                b: 2,
+            });
         }
     );
 

--- a/src/riscv/lib/src/state_backend/verify_backend.rs
+++ b/src/riscv/lib/src/state_backend/verify_backend.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 TriliTech <contact@trili.tech>
+// SPDX-FileCopyrightText: 2024-2025 TriliTech <contact@trili.tech>
 // SPDX-FileCopyrightText: 2025 Nomadic Labs <contact@nomadic-labs.com>
 //
 // SPDX-License-Identifier: MIT
@@ -150,7 +150,7 @@ impl ManagerRead for Verifier {
         region: &Self::DynRegion<LEN>,
         address: usize,
     ) -> E {
-        let mut raw_data = vec![0u8; E::STORED_SIZE.get()];
+        let mut raw_data = vec![0u8; E::STORED_SIZE.get() as usize];
         region.read_bytes(address, &mut raw_data);
 
         // SAFETY: The byte vector has been allocated with sufficient space.
@@ -165,7 +165,9 @@ impl ManagerRead for Verifier {
         for (i, value) in values.iter_mut().enumerate() {
             *value = Self::dyn_region_read(
                 region,
-                E::STORED_SIZE.get().wrapping_mul(i).wrapping_add(address),
+                (E::STORED_SIZE.get() as usize)
+                    .wrapping_mul(i)
+                    .wrapping_add(address),
             );
         }
     }
@@ -243,7 +245,9 @@ impl ManagerWrite for Verifier {
         for (i, value) in values.iter().enumerate() {
             Self::dyn_region_write(
                 region,
-                E::STORED_SIZE.get().wrapping_mul(i).wrapping_add(address),
+                (E::STORED_SIZE.get() as usize)
+                    .wrapping_mul(i)
+                    .wrapping_add(address),
                 *value,
             );
         }

--- a/src/riscv/lib/src/stepper/test.rs
+++ b/src/riscv/lib/src/stepper/test.rs
@@ -126,7 +126,7 @@ impl<MC: MemoryConfig, B: Block<MC, Owned>> TestStepper<MC, TestCacheConfig, B> 
             .machine_state
             .core
             .main_memory
-            .protect_pages(0, MC::TOTAL_BYTES, Permissions::READ_WRITE_EXEC)
+            .protect_pages(0, MC::TOTAL_BYTES as u64, Permissions::READ_WRITE_EXEC)
             .unwrap();
 
         stepper.machine_state.setup_boot(&elf_program)?;

--- a/src/riscv/lib/src/stepper/test.rs
+++ b/src/riscv/lib/src/stepper/test.rs
@@ -126,7 +126,7 @@ impl<MC: MemoryConfig, B: Block<MC, Owned>> TestStepper<MC, TestCacheConfig, B> 
             .machine_state
             .core
             .main_memory
-            .protect_pages(0, MC::TOTAL_BYTES as u64, Permissions::READ_WRITE_EXEC)
+            .protect_pages(0, MC::TOTAL_BYTES, Permissions::READ_WRITE_EXEC)
             .unwrap();
 
         stepper.machine_state.setup_boot(&elf_program)?;


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

- closes RV-561
- related to RV-760

# What

adjust `lengths` in memory to be `NonZeroU64`.

# Why

reads/writes/permission changes of `length == 0` have no effect. This is now made explicit.

Additionally, this makes clearer, for future, that only permission changes that could actually have an effect need be listened to by the JIT Router/Page Cache. Essentially, we'll adjust `protections.rs` to work over page index ranges (with the exception of `can_access_narrow`). This is far easier/more clear if we can avoid any empty ranges.

We adjust length from usize -> u64 to be consistent w.r.t. lengths in the Pvm. e.g. we wish to avoid potential issues when running on 32-bit hardware, should someone choose to.

# Manually Testing

```
make all
```

# Regressions

None

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
