### PR TITLE
chore: add Thomas and Daniel as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Request review from RISC-V PVM team
-* @victor-dumitrescu @felixp72 @kurtisc @NSant215 @HantangSun @jobjo @emturner @vapourismo 
+* @victor-dumitrescu @felixp72 @kurtisc @NSant215 @jobjo @emturner @vapourismo @thomasathorne @danielpapp-trilitech


### PR DESCRIPTION
Make @thomasathorne and @danielpapp-trilitech code owners for code review.