### PR TITLE
refactor(proofs): merge error types

### DIFF
--- a/src/riscv/lib/src/state_backend/proof_backend/proof.rs
+++ b/src/riscv/lib/src/state_backend/proof_backend/proof.rs
@@ -23,7 +23,7 @@ use crate::bits::ones;
 use crate::pvm::node_pvm::NodePvm;
 use crate::pvm::node_pvm::NodePvmLayout;
 use crate::state_backend::OwnedProofPart;
-use crate::state_backend::ProofLayoutError;
+use crate::state_backend::ProofError;
 use crate::state_backend::hash::Hash;
 use crate::state_backend::verify_backend::Verifier;
 use crate::storage::DIGEST_SIZE;
@@ -317,14 +317,14 @@ fn deserialise_final_hash(
 pub fn deserialise_proof<I: Iterator<Item = u8>>(
     mut bytes: I,
 ) -> deserialiser::Result<(Proof, NodePvm<Verifier>)> {
-    let final_state_hash = deserialise_final_hash(&mut bytes)
-        .map_err(|e| ProofLayoutError::TagDeserialise(e.into()))?;
+    let final_state_hash =
+        deserialise_final_hash(&mut bytes).map_err(|e| ProofError::TagDeserialise(e.into()))?;
 
     let (space, proof_tree) =
         deserialise_stream::deserialise::<NodePvmLayout>(bytes.collect::<Vec<u8>>().as_slice())?;
 
     let merkle_tree = match proof_tree {
-        OwnedProofPart::Absent => return Err(ProofLayoutError::AbsentProof.into()),
+        OwnedProofPart::Absent => return Err(ProofError::AbsentProof),
         OwnedProofPart::Present(tree) => tree,
     };
 

--- a/src/riscv/lib/src/state_backend/proof_backend/proof/deserialise_owned.rs
+++ b/src/riscv/lib/src/state_backend/proof_backend/proof/deserialise_owned.rs
@@ -10,17 +10,16 @@ use bincode::Decode;
 use super::deserialiser::Deserialiser;
 use super::deserialiser::DeserialiserNode;
 use super::deserialiser::Partial;
-use super::deserialiser::ProofLayoutResult;
+use super::deserialiser::Result;
 use super::deserialiser::Suspended;
 use crate::state_backend::AllocatedOf;
 use crate::state_backend::OwnedProofPart;
+use crate::state_backend::ProofError;
 use crate::state_backend::ProofLayout;
-use crate::state_backend::ProofLayoutError;
 use crate::state_backend::ProofPart;
 use crate::state_backend::ProofTree;
 use crate::state_backend::proof_backend::proof::MerkleProofLeaf;
 use crate::state_backend::proof_backend::proof::deserialiser;
-use crate::state_backend::proof_backend::proof::deserialiser::ProofParseResult;
 use crate::state_backend::proof_backend::tree::Tree;
 use crate::state_backend::verify_backend::Verifier;
 use crate::storage::binary;
@@ -33,15 +32,13 @@ impl<'t> Deserialiser for ProofTreeDeserialiser<'t> {
 
     type DeserialiserNode<R> = OwnedBranchComb<R, Self>;
 
-    fn into_leaf_raw<const LEN: usize>(
-        self,
-    ) -> ProofLayoutResult<Self::Suspended<Partial<Box<[u8; LEN]>>>> {
+    fn into_leaf_raw<const LEN: usize>(self) -> Result<Self::Suspended<Partial<Box<[u8; LEN]>>>> {
         self.deserialise_as_leaf()?
             .map_present_fallible(|data| {
                 let data_len = data.len();
                 let bytes: Box<[u8; LEN]> =
                     data.try_into()
-                        .map_err(|_| ProofLayoutError::UnexpectedLeafSize {
+                        .map_err(|_| ProofError::UnexpectedLeafSize {
                             expected: LEN,
                             got: data_len,
                         })?;
@@ -50,7 +47,7 @@ impl<'t> Deserialiser for ProofTreeDeserialiser<'t> {
             .map(|data| OwnedParserComb::new(Ok(data)))
     }
 
-    fn into_leaf<T: Decode<()>>(self) -> ProofLayoutResult<Self::Suspended<Partial<(T, Vec<u8>)>>> {
+    fn into_leaf<T: Decode<()>>(self) -> Result<Self::Suspended<Partial<(T, Vec<u8>)>>> {
         let leaf_data = self
             .deserialise_as_leaf()?
             .map_present_fallible(|data| Ok((binary::deserialise::<T>(data.as_ref())?, data)));
@@ -58,7 +55,7 @@ impl<'t> Deserialiser for ProofTreeDeserialiser<'t> {
         Ok(OwnedParserComb::new(leaf_data))
     }
 
-    fn into_node(self) -> ProofLayoutResult<Self::DeserialiserNode<Partial<()>>> {
+    fn into_node(self) -> Result<Self::DeserialiserNode<Partial<()>>> {
         let branches = self.deserialise_as_node()?;
         Ok(OwnedBranchComb::new(branches))
     }
@@ -72,10 +69,10 @@ impl<'t> From<ProofTree<'t>> for ProofTreeDeserialiser<'t> {
 
 impl ProofTreeDeserialiser<'_> {
     /// Deserialise the proof as a leaf.
-    pub fn deserialise_as_leaf(self) -> ProofLayoutResult<Partial<Vec<u8>>> {
+    pub fn deserialise_as_leaf(self) -> Result<Partial<Vec<u8>>> {
         match self.0 {
             ProofPart::Absent => Ok(Partial::Absent),
-            ProofPart::Present(Tree::Node(_)) => Err(ProofLayoutError::UnexpectedNode),
+            ProofPart::Present(Tree::Node(_)) => Err(ProofError::UnexpectedNode),
             ProofPart::Present(Tree::Leaf(MerkleProofLeaf::Blind(hash))) => {
                 Ok(Partial::Blinded(*hash))
             }
@@ -86,14 +83,14 @@ impl ProofTreeDeserialiser<'_> {
     }
 
     /// Deserialise the proof as a node.
-    pub fn deserialise_as_node(self) -> ProofLayoutResult<Partial<Vec<Self>>> {
+    pub fn deserialise_as_node(self) -> Result<Partial<Vec<Self>>> {
         match self.0 {
             ProofPart::Absent => Ok(Partial::Absent),
             ProofPart::Present(Tree::Leaf(MerkleProofLeaf::Blind(hash))) => {
                 Ok(Partial::Blinded(*hash))
             }
             ProofPart::Present(Tree::Leaf(MerkleProofLeaf::Read(_))) => {
-                Err(ProofLayoutError::UnexpectedLeaf)
+                Err(ProofError::UnexpectedLeaf)
             }
             ProofPart::Present(Tree::Node(trees)) => Ok(Partial::Present(
                 trees
@@ -108,12 +105,12 @@ impl ProofTreeDeserialiser<'_> {
 
 /// Suspended computation combinator for [`ProofTreeDeserialiser`] deserialiser.
 pub struct OwnedParserComb<'t, R> {
-    result: ProofParseResult<R>,
+    result: Result<R>,
     _pd: PhantomData<fn(ProofTreeDeserialiser<'t>)>,
 }
 
 impl<R> OwnedParserComb<'_, R> {
-    fn new(result: ProofParseResult<R>) -> Self {
+    fn new(result: Result<R>) -> Self {
         Self {
             result,
             _pd: PhantomData,
@@ -123,7 +120,7 @@ impl<R> OwnedParserComb<'_, R> {
 
 /// Branch deserialiser combinator for [`ProofTreeDeserialiser`] deserialiser.
 pub struct OwnedBranchComb<R, B> {
-    f: ProofParseResult<R>,
+    f: Result<R>,
     node_data: Partial<VecDeque<B>>,
 }
 
@@ -154,10 +151,9 @@ impl<'t, R> DeserialiserNode<R> for OwnedBranchComb<R, ProofTreeDeserialiser<'t>
         mut self,
         branch_deserialiser: impl FnOnce(
             Self::Parent,
-        ) -> ProofLayoutResult<
-            <Self::Parent as Deserialiser>::Suspended<T>,
-        >,
-    ) -> ProofLayoutResult<<Self::Parent as Deserialiser>::DeserialiserNode<(R, T)>>
+        )
+            -> Result<<Self::Parent as Deserialiser>::Suspended<T>>,
+    ) -> Result<<Self::Parent as Deserialiser>::DeserialiserNode<(R, T)>>
     where
         T: 'static,
         R: 'static,
@@ -168,7 +164,7 @@ impl<'t, R> DeserialiserNode<R> for OwnedBranchComb<R, ProofTreeDeserialiser<'t>
             Partial::Present(ref mut branches) => {
                 branches
                     .pop_front()
-                    .ok_or(ProofLayoutError::BadNumberOfBranches {
+                    .ok_or(ProofError::BadNumberOfBranches {
                         expected: 1,
                         got: 0,
                     })?
@@ -196,11 +192,11 @@ impl<'t, R> DeserialiserNode<R> for OwnedBranchComb<R, ProofTreeDeserialiser<'t>
         }
     }
 
-    fn done(self) -> ProofLayoutResult<<Self::Parent as Deserialiser>::Suspended<R>> {
+    fn done(self) -> Result<<Self::Parent as Deserialiser>::Suspended<R>> {
         if let Partial::Present(branches) = self.node_data {
             if !branches.is_empty() {
                 let length = branches.len();
-                return Err(ProofLayoutError::BadNumberOfBranches {
+                return Err(ProofError::BadNumberOfBranches {
                     expected: 0,
                     got: length,
                 });
@@ -231,7 +227,7 @@ impl<'t, R> Suspended for OwnedParserComb<'t, R> {
 }
 
 impl<R> OwnedParserComb<'_, R> {
-    pub fn into_result(self) -> ProofParseResult<R> {
+    pub fn into_result(self) -> Result<R> {
         self.result
     }
 }
@@ -240,6 +236,5 @@ impl<R> OwnedParserComb<'_, R> {
 pub fn deserialise<L: ProofLayout>(
     proof: ProofTree,
 ) -> deserialiser::Result<(AllocatedOf<L, Verifier>, OwnedProofPart)> {
-    let comp_fn = L::into_verifier_alloc::<ProofTreeDeserialiser>(proof.into())?;
-    Ok(comp_fn.into_result()?)
+    L::into_verifier_alloc::<ProofTreeDeserialiser>(proof.into())?.into_result()
 }

--- a/src/riscv/lib/src/state_backend/proof_backend/proof/deserialise_stream.rs
+++ b/src/riscv/lib/src/state_backend/proof_backend/proof/deserialise_stream.rs
@@ -15,18 +15,16 @@ use super::Tag;
 use super::deserialiser::Deserialiser;
 use super::deserialiser::DeserialiserNode;
 use super::deserialiser::Partial;
-use super::deserialiser::ProofLayoutResult;
+use super::deserialiser::Result;
 use super::deserialiser::Suspended;
 use crate::state_backend::AllocatedOf;
 use crate::state_backend::OwnedProofPart;
+use crate::state_backend::ProofError;
 use crate::state_backend::ProofLayout;
-use crate::state_backend::ProofLayoutError;
-use crate::state_backend::ProofParseError;
 use crate::state_backend::TagError;
 use crate::state_backend::proof_backend::proof::InvalidTagError;
 use crate::state_backend::proof_backend::proof::NotEnoughBytesError;
 use crate::state_backend::proof_backend::proof::deserialiser;
-use crate::state_backend::proof_backend::proof::deserialiser::ProofParseResult;
 use crate::state_backend::verify_backend::Verifier;
 use crate::storage::Hash;
 
@@ -76,7 +74,7 @@ pub struct StreamInput<'cd> {
 
 impl StreamInput<'_> {
     /// Interpret the next bytes as `T` using [`Decode`].
-    fn deserialise<T: Decode<()>>(&mut self) -> ProofParseResult<T> {
+    fn deserialise<T: Decode<()>>(&mut self) -> Result<T> {
         Ok(crate::storage::binary::deserialise_from(&mut self.cursor)?)
     }
 }
@@ -93,9 +91,7 @@ impl<'t> Deserialiser for StreamDeserialiser<'t> {
 
     type DeserialiserNode<R> = StreamBranchComb<'t, R>;
 
-    fn into_leaf_raw<const LEN: usize>(
-        self,
-    ) -> ProofLayoutResult<Self::Suspended<Partial<Box<[u8; LEN]>>>> {
+    fn into_leaf_raw<const LEN: usize>(self) -> Result<Self::Suspended<Partial<Box<[u8; LEN]>>>> {
         let tag = match self.next_tag() {
             None => {
                 return Ok(StreamParserComb::new(|_| Ok(Partial::Absent)));
@@ -104,7 +100,7 @@ impl<'t> Deserialiser for StreamDeserialiser<'t> {
             Some(Ok(tag)) => tag,
         };
         Ok(StreamParserComb::new(match tag {
-            Tag::Node => return Err(ProofLayoutError::UnexpectedNode),
+            Tag::Node => return Err(ProofError::UnexpectedNode),
             Tag::Leaf(leaf_type) => move |input: &mut StreamInput| match leaf_type {
                 LeafTag::Blind => Ok(Partial::Blinded(input.deserialise::<Hash>()?)),
                 LeafTag::Read => {
@@ -118,7 +114,7 @@ impl<'t> Deserialiser for StreamDeserialiser<'t> {
         }))
     }
 
-    fn into_leaf<T: Decode<()>>(self) -> ProofLayoutResult<Self::Suspended<Partial<(T, Vec<u8>)>>> {
+    fn into_leaf<T: Decode<()>>(self) -> Result<Self::Suspended<Partial<(T, Vec<u8>)>>> {
         let tag = match self.next_tag() {
             None => {
                 return Ok(StreamParserComb::new(|_| Ok(Partial::Absent)));
@@ -127,7 +123,7 @@ impl<'t> Deserialiser for StreamDeserialiser<'t> {
             Some(Ok(tag)) => tag,
         };
         Ok(StreamParserComb::new(match tag {
-            Tag::Node => return Err(ProofLayoutError::UnexpectedNode),
+            Tag::Node => return Err(ProofError::UnexpectedNode),
             Tag::Leaf(leaf_type) => move |input: &mut StreamInput| match leaf_type {
                 LeafTag::Blind => Ok(Partial::Blinded(input.deserialise::<Hash>()?)),
                 LeafTag::Read => Ok({
@@ -141,7 +137,7 @@ impl<'t> Deserialiser for StreamDeserialiser<'t> {
         }))
     }
 
-    fn into_node(self) -> ProofLayoutResult<Self::DeserialiserNode<Partial<()>>> {
+    fn into_node(self) -> Result<Self::DeserialiserNode<Partial<()>>> {
         let tags = match self {
             StreamDeserialiser::Absent => {
                 return Ok(StreamBranchComb {
@@ -159,7 +155,7 @@ impl<'t> Deserialiser for StreamDeserialiser<'t> {
             .map_err(TagError::InvalidTag)?;
 
         match tag {
-            Tag::Leaf(LeafTag::Read) => Err(ProofLayoutError::UnexpectedLeaf),
+            Tag::Leaf(LeafTag::Read) => Err(ProofError::UnexpectedLeaf),
             Tag::Leaf(LeafTag::Blind) => Ok(StreamBranchComb {
                 f: Box::new(move |input: &mut StreamInput| {
                     Ok(Partial::Blinded(input.deserialise()?))
@@ -207,7 +203,7 @@ pub struct StreamParserComb<'t, R> {
         clippy::type_complexity,
         reason = "FnOnce is a trait and trait aliases are not stable yet"
     )]
-    f: Box<dyn FnOnce(&mut StreamInput) -> ProofParseResult<R> + 'static>,
+    f: Box<dyn FnOnce(&mut StreamInput) -> Result<R> + 'static>,
     _pd: PhantomData<fn(StreamInput<'t>)>,
 }
 
@@ -232,7 +228,7 @@ impl<'t, R> Suspended for StreamParserComb<'t, R> {
 
 impl<R> StreamParserComb<'_, R> {
     /// Create a new [`StreamParserComb`] with the given function.
-    pub fn new(f: impl FnOnce(&mut StreamInput) -> ProofParseResult<R> + 'static) -> Self {
+    pub fn new(f: impl FnOnce(&mut StreamInput) -> Result<R> + 'static) -> Self {
         StreamParserComb {
             f: Box::new(f),
             _pd: PhantomData,
@@ -246,7 +242,7 @@ pub struct StreamBranchComb<'t, R> {
         clippy::type_complexity,
         reason = "FnOnce is a trait and trait aliases are not stable yet"
     )]
-    f: Box<dyn FnOnce(&mut StreamInput) -> ProofParseResult<R> + 'static>,
+    f: Box<dyn FnOnce(&mut StreamInput) -> Result<R> + 'static>,
     /// The none case represents that the father node was blind or absent.
     node_state: Option<Rc<RefCell<TagIter<'t>>>>,
 }
@@ -258,10 +254,9 @@ impl<'t, R> DeserialiserNode<R> for StreamBranchComb<'t, R> {
         self,
         branch_deserialiser: impl FnOnce(
             Self::Parent,
-        ) -> ProofLayoutResult<
-            <Self::Parent as Deserialiser>::Suspended<T>,
-        >,
-    ) -> ProofLayoutResult<<Self::Parent as Deserialiser>::DeserialiserNode<(R, T)>>
+        )
+            -> Result<<Self::Parent as Deserialiser>::Suspended<T>>,
+    ) -> Result<<Self::Parent as Deserialiser>::DeserialiserNode<(R, T)>>
     where
         T: 'static,
         R: 'static,
@@ -301,7 +296,7 @@ impl<'t, R> DeserialiserNode<R> for StreamBranchComb<'t, R> {
         }
     }
 
-    fn done(self) -> ProofLayoutResult<<Self::Parent as Deserialiser>::Suspended<R>> {
+    fn done(self) -> Result<<Self::Parent as Deserialiser>::Suspended<R>> {
         Ok(StreamParserComb {
             f: self.f,
             _pd: PhantomData,
@@ -310,8 +305,8 @@ impl<'t, R> DeserialiserNode<R> for StreamBranchComb<'t, R> {
 }
 
 impl<R> StreamParserComb<'_, R> {
-    /// Deserialise the input and return the result if all bytes have been consumed.  
-    pub fn into_result(self, input: &mut StreamInput) -> ProofParseResult<R> {
+    /// Deserialise the input and return the result if all bytes have been consumed.
+    pub fn into_result(self, input: &mut StreamInput) -> Result<R> {
         let result = (self.f)(input);
 
         // A correct deserialisation makes sure all bytes are consumed.
@@ -322,7 +317,7 @@ impl<R> StreamParserComb<'_, R> {
         // tracking issue: <https://github.com/rust-lang/rust/issues/86423>
         let mut next_byte = [0_u8];
         match input.cursor.read_exact(&mut next_byte) {
-            Ok(()) => Err(ProofParseError::RemainingBytes),
+            Ok(()) => Err(ProofError::RemainingBytes),
             Err(_eof) => Ok(result?),
         }
     }
@@ -339,5 +334,5 @@ pub fn deserialise<L: ProofLayout>(
 
     // SAFETY: The `Deserialiser` trait provided to the `FromProof` implementation of T
     // can not execute the suspended computation, it can only compose them due to encapsulation
-    Ok(comp_fn.into_result(&mut tags_rc.borrow_mut().remaining_to_stream_input())?)
+    comp_fn.into_result(&mut tags_rc.borrow_mut().remaining_to_stream_input())
 }

--- a/src/riscv/lib/src/state_backend/proof_backend/proof/deserialiser.rs
+++ b/src/riscv/lib/src/state_backend/proof_backend/proof/deserialiser.rs
@@ -16,35 +16,13 @@
 use bincode::Decode;
 
 use crate::state_backend::OwnedProofPart;
-use crate::state_backend::ProofLayoutError;
-use crate::state_backend::ProofParseError;
+use crate::state_backend::ProofError;
 use crate::state_backend::hash::Hash;
 use crate::state_backend::proof_backend::merkle::MERKLE_LEAF_SIZE;
 
-/// Result type used when deserialising with [`Deserialiser`] traits.
-pub(in crate::state_backend) type ProofLayoutResult<R, E = ProofLayoutError> =
-    std::result::Result<R, E>;
-
-/// Result type used when running the [`Suspended`] computation.
-pub(in crate::state_backend) type ProofParseResult<R, E = ProofParseError> =
-    std::result::Result<R, E>;
-
-/// Error type used when deserialising a proof - including both the layout and contents of the
-/// proof.
-#[derive(Debug, PartialEq, thiserror::Error)]
-pub enum Error {
-    /// Error during usage of [`Deserialiser`] traits.
-    #[error("{0}")]
-    Deserialise(#[from] ProofLayoutError),
-
-    /// Error during parsing a proof's content - running a deserialisation's [`Suspended`] computation.
-    #[error("{0}")]
-    ParseProof(#[from] ProofParseError),
-}
-
 /// Result type used when deserialising a proof - including both the layout and contents of the
 /// proof.
-pub type Result<T, E = Error> = std::result::Result<T, E>;
+pub type Result<T, E = ProofError> = std::result::Result<T, E>;
 
 /// Possible outcomes when parsing a node or a leaf from a Merkle proof
 /// where the leaf is assumed to have type `T`.
@@ -122,21 +100,17 @@ pub trait Deserialiser {
     type DeserialiserNode<R>: DeserialiserNode<R, Parent = Self>;
 
     /// It is expected for the proof to be a leaf. Obtain the raw bytes from that leaf.
-    fn into_leaf_raw<const LEN: usize>(
-        self,
-    ) -> ProofLayoutResult<Self::Suspended<Partial<Box<[u8; LEN]>>>>;
+    fn into_leaf_raw<const LEN: usize>(self) -> Result<Self::Suspended<Partial<Box<[u8; LEN]>>>>;
 
     /// It is expected for the proof to be a leaf. Parse the raw bytes of that leaf into a type `T`.
     #[expect(
         clippy::type_complexity,
         reason = "Adding an alias for Partial<(T, Vec<u8>)> would only decrease readability"
     )]
-    fn into_leaf<T: Decode<()> + 'static>(
-        self,
-    ) -> ProofLayoutResult<Self::Suspended<Partial<(T, Vec<u8>)>>>;
+    fn into_leaf<T: Decode<()> + 'static>(self) -> Result<Self::Suspended<Partial<(T, Vec<u8>)>>>;
 
     /// It is expected for the proof to be a node. Obtain the deserialiser for the branch case.
-    fn into_node(self) -> ProofLayoutResult<Self::DeserialiserNode<Partial<()>>>;
+    fn into_node(self) -> Result<Self::DeserialiserNode<Partial<()>>>;
 }
 
 /// The trait used for deserialising a proof's node.
@@ -150,10 +124,9 @@ pub trait DeserialiserNode<R> {
         self,
         branch_deserialiser: impl FnOnce(
             Self::Parent,
-        ) -> ProofLayoutResult<
-            <Self::Parent as Deserialiser>::Suspended<T>,
-        >,
-    ) -> ProofLayoutResult<<Self::Parent as Deserialiser>::DeserialiserNode<(R, T)>>
+        )
+            -> Result<<Self::Parent as Deserialiser>::Suspended<T>>,
+    ) -> Result<<Self::Parent as Deserialiser>::DeserialiserNode<(R, T)>>
     where
         T: 'static,
         R: 'static;
@@ -169,7 +142,7 @@ pub trait DeserialiserNode<R> {
 
     /// Signal the end of deserialisation of the node's branches.
     /// Call this method after all calls to [`DeserialiserNode::next_branch`] have been made.
-    fn done(self) -> ProofLayoutResult<<Self::Parent as Deserialiser>::Suspended<R>>;
+    fn done(self) -> Result<<Self::Parent as Deserialiser>::Suspended<R>>;
 }
 
 /// The trait represents a computation function obtained after deserialising a proof.
@@ -199,10 +172,9 @@ mod tests {
     use super::Deserialiser;
     use super::DeserialiserNode;
     use super::Partial;
-    use super::ProofLayoutResult;
+    use super::Result;
     use super::Suspended;
-    use crate::state_backend::ProofLayoutError;
-    use crate::state_backend::ProofParseError;
+    use crate::state_backend::ProofError;
     use crate::state_backend::ProofTree;
     use crate::state_backend::TagError;
     use crate::state_backend::proof_backend::proof::InvalidTagError;
@@ -217,7 +189,6 @@ mod tests {
     use crate::state_backend::proof_backend::proof::deserialise_stream::StreamDeserialiser;
     use crate::state_backend::proof_backend::proof::deserialise_stream::StreamParserComb;
     use crate::state_backend::proof_backend::proof::deserialise_stream::TagIter;
-    use crate::state_backend::proof_backend::proof::deserialiser::ProofParseResult;
     use crate::state_backend::proof_backend::proof::serialise_raw_tags;
     use crate::state_backend::proof_backend::proof::tag_offset;
     use crate::storage::DIGEST_SIZE;
@@ -225,7 +196,7 @@ mod tests {
 
     fn generic_computation<T: Into<i32> + Decode<()> + 'static, D: Deserialiser>(
         proof: D,
-    ) -> ProofLayoutResult<<D as Deserialiser>::Suspended<i32>> {
+    ) -> Result<<D as Deserialiser>::Suspended<i32>> {
         // The tree structure:
         // Node (root)
         // ├── Leaf (type: Hash)
@@ -254,21 +225,17 @@ mod tests {
         }))
     }
 
-    fn computation_i16<D: Deserialiser>(
-        proof: D,
-    ) -> ProofLayoutResult<<D as Deserialiser>::Suspended<i32>> {
+    fn computation_i16<D: Deserialiser>(proof: D) -> Result<<D as Deserialiser>::Suspended<i32>> {
         generic_computation::<i16, D>(proof)
     }
 
-    fn computation_bool<D: Deserialiser>(
-        proof: D,
-    ) -> ProofLayoutResult<<D as Deserialiser>::Suspended<i32>> {
+    fn computation_bool<D: Deserialiser>(proof: D) -> Result<<D as Deserialiser>::Suspended<i32>> {
         generic_computation::<bool, D>(proof)
     }
 
     fn computation_leaves<D: Deserialiser>(
         proof: D,
-    ) -> ProofLayoutResult<<D as Deserialiser>::Suspended<i32>> {
+    ) -> Result<<D as Deserialiser>::Suspended<i32>> {
         // The tree structure
         // Node (root)
         // ├── Leaf 1 (type: i32)
@@ -303,9 +270,9 @@ mod tests {
     }
 
     fn run_owned_deserialiser<'t>(
-        deser: impl FnOnce(ProofTreeDeserialiser<'t>) -> ProofLayoutResult<OwnedParserComb<'t, i32>>,
+        deser: impl FnOnce(ProofTreeDeserialiser<'t>) -> Result<OwnedParserComb<'t, i32>>,
         merkle_proof: &'t MerkleProof,
-    ) -> ProofLayoutResult<ProofParseResult<i32>> {
+    ) -> Result<Result<i32>> {
         let proof: ProofTreeDeserialiser = ProofTree::Present(merkle_proof).into();
         let suspended = deser(proof);
         suspended.map(|res| res.into_result())
@@ -313,9 +280,9 @@ mod tests {
 
     /// Nested results are used to distinguish between deserialisation and parsing leaves stages
     fn run_stream_deserialiser<'t>(
-        deser: impl FnOnce(StreamDeserialiser<'t>) -> ProofLayoutResult<StreamParserComb<'t, i32>>,
+        deser: impl FnOnce(StreamDeserialiser<'t>) -> Result<StreamParserComb<'t, i32>>,
         bytes: &'t [u8],
-    ) -> ProofLayoutResult<ProofParseResult<i32>> {
+    ) -> Result<Result<i32>> {
         let tags = Rc::new(RefCell::new(TagIter::new(bytes)));
         let comp_fn = deser(StreamDeserialiser::new_present(tags.clone()))?;
         Ok(comp_fn.into_result(&mut tags.borrow_mut().remaining_to_stream_input()))
@@ -335,7 +302,7 @@ mod tests {
         ]);
         let proof: ProofTreeDeserialiser = ProofTree::Present(&merkle_proof).into();
         let comp_fn = computation_i16(proof).unwrap();
-        assert_eq!(comp_fn.into_result(), Ok(0));
+        assert_eq!(comp_fn.into_result().unwrap(), 0);
     }
 
     #[test]
@@ -378,7 +345,7 @@ mod tests {
 
         // Corresponds to a bincode::Error & std::io::Error because the hash deserialisation is done by
         // serde/bincode.
-        if let Ok(Err(ProofParseError::Deserialise(bincode::error::DecodeError::Io {
+        if let Ok(Err(ProofError::Deserialise(bincode::error::DecodeError::Io {
             inner: io_err,
             additional: 32,
         }))) = res
@@ -395,11 +362,14 @@ mod tests {
 
         // In this case, the error happens earlier, at the tag deserialisation, so it is an error
         // thrown by our own `Deserialiser` traits.
-        assert_eq!(
-            res,
-            Err(ProofLayoutError::TagDeserialise(TagError::NotEnoughBytes(
-                NotEnoughBytesError
-            )))
+        assert!(
+            matches!(
+                res,
+                Err(ProofError::TagDeserialise(TagError::NotEnoughBytes(
+                    NotEnoughBytesError
+                )))
+            ),
+            "{res:?}"
         );
 
         // the same test for the OwnedDeserialiser
@@ -412,11 +382,14 @@ mod tests {
 
         // Corresponds to a bincode::Error only because the deserialisation will throw an EOF error.
         eprintln!("Result: {res:?}");
-        assert_eq!(
-            res,
-            Ok(Err(ProofParseError::Deserialise(
-                bincode::error::DecodeError::UnexpectedEnd { additional: 27 }
-            )))
+        assert!(
+            matches!(
+                res,
+                Ok(Err(ProofError::Deserialise(
+                    bincode::error::DecodeError::UnexpectedEnd { additional: 27 }
+                )))
+            ),
+            "{res:?}"
         )
     }
 
@@ -435,7 +408,7 @@ mod tests {
 
         let res = run_stream_deserialiser(computation_bool, &raw_bytes_content);
 
-        assert!(matches!(res, Ok(Err(ProofParseError::Deserialise(_)))));
+        assert!(matches!(res, Ok(Err(ProofError::Deserialise(_)))));
 
         let merkle_proof = MerkleProof::Node(vec![
             MerkleProof::leaf_read(hash_read.to_vec()),
@@ -443,7 +416,7 @@ mod tests {
         ]);
         let res = run_owned_deserialiser(computation_bool, &merkle_proof);
         eprintln!("Result: {res:?}");
-        assert!(matches!(res, Ok(Err(ProofParseError::Deserialise(_)))));
+        assert!(matches!(res, Ok(Err(ProofError::Deserialise(_)))));
     }
 
     #[test]
@@ -464,7 +437,7 @@ mod tests {
         // This test only makes sense for the stream deserialiser.
         let res = run_stream_deserialiser(computation_bool, &raw_bytes_content);
 
-        matches!(res, Ok(Err(ProofParseError::RemainingBytes)));
+        matches!(res, Ok(Err(ProofError::RemainingBytes)));
     }
 
     #[test]
@@ -479,16 +452,14 @@ mod tests {
         let comp_fn =
             computation_i16::<ProofTreeDeserialiser>(ProofTree::Present(&absent_shape).into());
 
-        let res = comp_fn.unwrap().into_result();
-
-        assert_eq!(res, Ok(-1));
+        assert_eq!(comp_fn.unwrap().into_result().unwrap(), -1);
 
         // For computation_2, the provided merkle proof will resolve as blinded
         // since root is blinded
         let merkle_proof = MerkleProof::leaf_blind(Hash::blake3_hash_bytes(&[6, 7, 8]));
         let proof: ProofTreeDeserialiser = ProofTree::Present(&merkle_proof).into();
         let comp_fn = computation_leaves(proof).unwrap();
-        assert_eq!(comp_fn.into_result(), Ok(-1));
+        assert_eq!(comp_fn.into_result().unwrap(), -1);
     }
 
     fn raw_tags_to_bytes<const LEN: usize>(tags: [u8; LEN]) -> Vec<u8> {
@@ -520,7 +491,7 @@ mod tests {
         let merkle_proof = MerkleProof::leaf_blind(Hash::blake3_hash_bytes(&[6, 7, 8]));
         let proof: ProofTreeDeserialiser = ProofTree::Present(&merkle_proof).into();
         let comp_fn = computation_leaves(proof).unwrap();
-        assert_eq!(comp_fn.into_result(), Ok(-1));
+        assert_eq!(comp_fn.into_result().unwrap(), -1);
     }
 
     #[test]
@@ -545,7 +516,7 @@ mod tests {
         // Tree is missing branches
         let comp_fn =
             computation_i16::<ProofTreeDeserialiser>(ProofTree::Present(&bad_shape_1).into());
-        assert!(comp_fn.is_err_and(|e| matches!(e, ProofLayoutError::BadNumberOfBranches { .. })));
+        assert!(comp_fn.is_err_and(|e| matches!(e, ProofError::BadNumberOfBranches { .. })));
 
         // First 2 children of root are ok in shape (blinded) but the total number of children does not correspond
         // Ideally, we would like to have expected: 2, got: 5, but the implemenetation for `ProofTreeDeserialiser`
@@ -554,7 +525,7 @@ mod tests {
             computation_i16::<ProofTreeDeserialiser>(ProofTree::Present(&bad_shape_2).into());
         assert!(comp_fn.is_err_and(|e| {
             println!("{e:?}");
-            matches!(e, ProofLayoutError::BadNumberOfBranches {
+            matches!(e, ProofError::BadNumberOfBranches {
                 expected: 0,
                 got: 3
             })
@@ -563,12 +534,12 @@ mod tests {
         // The first child is a node, but is expected to be a leaf
         let comp_fn =
             computation_i16::<ProofTreeDeserialiser>(ProofTree::Present(&bad_shape_3).into());
-        assert!(comp_fn.is_err_and(|e| matches!(e, ProofLayoutError::UnexpectedNode)));
+        assert!(comp_fn.is_err_and(|e| matches!(e, ProofError::UnexpectedNode)));
 
         // The second child is a leaf, but is expected to be a node
         let comp_fn =
             computation_i16::<ProofTreeDeserialiser>(ProofTree::Present(&bad_shape_4).into());
-        assert!(comp_fn.is_err_and(|e| { matches!(e, ProofLayoutError::UnexpectedLeaf) }));
+        assert!(comp_fn.is_err_and(|e| { matches!(e, ProofError::UnexpectedLeaf) }));
     }
 
     #[test]
@@ -593,7 +564,7 @@ mod tests {
         );
         assert!(matches!(
             res,
-            Err(ProofLayoutError::TagDeserialise(TagError::InvalidTag(
+            Err(ProofError::TagDeserialise(TagError::InvalidTag(
                 InvalidTagError
             )))
         ));
@@ -602,21 +573,21 @@ mod tests {
         // will be counted towards the blinded hashes a RemainingBytes error will occur.
         let bytes = &[tag_shape_2.as_slice(), data_shape_2.as_ref()].concat();
         let res = run_stream_deserialiser(computation_i16, bytes);
-        assert!(matches!(res, Ok(Err(ProofParseError::RemainingBytes))));
+        assert!(matches!(res, Ok(Err(ProofError::RemainingBytes))));
 
         // The first child is a node, but is expected to be a leaf
         let res = run_stream_deserialiser(
             computation_i16,
             &[tag_shape_3.as_ref(), data_shape_3.as_ref()].concat(),
         );
-        assert!(matches!(res, Err(ProofLayoutError::UnexpectedNode)));
+        assert!(matches!(res, Err(ProofError::UnexpectedNode)));
 
         // The second child is a read leaf, but is expected to be a node
         let res = run_stream_deserialiser(
             computation_i16,
             &[tag_shape_4.as_slice(), data_shape_4.as_ref()].concat(),
         );
-        assert!(matches!(res, Err(ProofLayoutError::UnexpectedLeaf)));
+        assert!(matches!(res, Err(ProofError::UnexpectedLeaf)));
     }
 
     #[test]
@@ -630,7 +601,7 @@ mod tests {
 
         let proof: ProofTreeDeserialiser = ProofTree::Present(&merkleproof).into();
         let comp_fn = computation_leaves(proof).unwrap();
-        assert_eq!(comp_fn.into_result(), Ok(0x140A_0000 + 0xC0005));
+        assert_eq!(comp_fn.into_result().unwrap(), 0x140A_0000 + 0xC0005);
     }
 
     #[test]

--- a/src/riscv/lib/src/state_backend/proof_layout.rs
+++ b/src/riscv/lib/src/state_backend/proof_layout.rs
@@ -33,45 +33,18 @@ use super::proof_backend::proof::MerkleProof;
 use super::proof_backend::proof::MerkleProofLeaf;
 use super::proof_backend::proof::deserialiser::Deserialiser;
 use super::proof_backend::proof::deserialiser::DeserialiserNode;
+use super::proof_backend::proof::deserialiser::Result;
 use super::proof_backend::proof::deserialiser::Suspended;
 use super::proof_backend::tree::Tree;
+use super::verify_backend;
 use super::verify_backend::PartialState;
 use super::verify_backend::Verifier;
-use super::verify_backend::{self};
 use crate::array_utils::boxed_array;
 use crate::state_backend::proof_backend::proof::InvalidTagError;
 use crate::state_backend::proof_backend::proof::NotEnoughBytesError;
 use crate::state_backend::proof_backend::proof::deserialiser::Partial;
-use crate::state_backend::proof_backend::proof::deserialiser::ProofLayoutResult;
 use crate::state_backend::verify_backend::PageId;
 use crate::storage::binary;
-
-/// Errors occurring when parsing the layout of a Merkle proof
-#[derive(Debug, thiserror::Error)]
-pub enum ProofParseError {
-    #[error("Error during deserialisation: {0}")]
-    Deserialise(#[from] DecodeError),
-
-    #[error("Not enough bytes")]
-    NotEnoughBytes(#[from] NotEnoughBytesError),
-
-    #[error("Deserialising as a stream and not all bytes were consumed")]
-    RemainingBytes,
-}
-
-// bincode::Error does not implement `PartialEq`, so we implement it manually.
-impl PartialEq for ProofParseError {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (ProofParseError::Deserialise(e1), ProofParseError::Deserialise(e2)) => {
-                e1.to_string() == e2.to_string()
-            }
-            (ProofParseError::NotEnoughBytes(e1), ProofParseError::NotEnoughBytes(e2)) => e1 == e2,
-            (ProofParseError::RemainingBytes, ProofParseError::RemainingBytes) => true,
-            _ => false,
-        }
-    }
-}
 
 /// Errors occurring when parsing the tag structure of a Merkle proof.
 #[derive(Debug, PartialEq, thiserror::Error)]
@@ -83,9 +56,18 @@ pub enum TagError {
     NotEnoughBytes(#[from] NotEnoughBytesError),
 }
 
-/// Errors occurring when parsing the layout of a Merkle proof
-#[derive(Debug, PartialEq, thiserror::Error)]
-pub enum ProofLayoutError {
+/// Errors occurring when parsing a Merkle proof
+#[derive(Debug, thiserror::Error)]
+pub enum ProofError {
+    #[error("Error during deserialisation: {0}")]
+    Deserialise(#[from] DecodeError),
+
+    #[error("Not enough bytes")]
+    NotEnoughBytes(#[from] NotEnoughBytesError),
+
+    #[error("Deserialising as a stream and not all bytes were consumed")]
+    RemainingBytes,
+
     #[error("Error during tag deserialisation: {0}")]
     TagDeserialise(#[from] TagError),
 
@@ -107,7 +89,7 @@ pub enum ProofLayoutError {
 
 /// Common result type for parsing a Merkle proof.
 pub(crate) type VerifierAllocResult<D, L> =
-    ProofLayoutResult<<D as Deserialiser>::Suspended<(VerifierAlloc<L>, OwnedProofPart)>>;
+    Result<<D as Deserialiser>::Suspended<(VerifierAlloc<L>, OwnedProofPart)>>;
 
 /// Regions for the verifier backend for a specific layout.
 pub type VerifierAlloc<L> = <L as Layout>::Allocated<verify_backend::Verifier>;
@@ -121,7 +103,7 @@ pub enum PartialHashError {
     Encode(#[from] EncodeError),
 
     #[error("Error from proof: {0}")]
-    FromProof(#[from] ProofLayoutError),
+    FromProof(#[from] ProofError),
 
     /// Indicates that a hash could not be computed due to absent data,
     /// but from which it is possible to recover if the level at which
@@ -152,7 +134,7 @@ pub type ProofTree<'a> = ProofPart<'a, MerkleProof>;
 
 impl<'a> ProofTree<'a> {
     /// Interpret this part of the Merkle proof as a node with `LEN` branches.
-    pub fn into_branches<const LEN: usize>(self) -> ProofLayoutResult<Box<[Self; LEN]>> {
+    pub fn into_branches<const LEN: usize>(self) -> Result<Box<[Self; LEN]>> {
         let ProofTree::Present(proof) = self else {
             // The requested branches are not represented in the Merkle proof at all, not even
             // through a blinded node.
@@ -163,7 +145,7 @@ impl<'a> ProofTree<'a> {
             Tree::Node(branches) => {
                 let branches: &[MerkleProof; LEN] =
                     branches.as_slice().try_into().map_err(|_| {
-                        ProofLayoutError::BadNumberOfBranches {
+                        ProofError::BadNumberOfBranches {
                             got: branches.len(),
                             expected: LEN,
                         }
@@ -183,16 +165,16 @@ impl<'a> ProofTree<'a> {
 
             Tree::Leaf(leaf) => match leaf {
                 MerkleProofLeaf::Blind(_hash) => Ok(boxed_array![ProofTree::Absent; LEN]),
-                _ => Err(ProofLayoutError::UnexpectedLeaf)?,
+                _ => Err(ProofError::UnexpectedLeaf)?,
             },
         }
     }
 
     /// Interpret this part of the Merkle proof as a leaf.
-    pub fn into_leaf(self) -> ProofLayoutResult<ProofPart<'a, [u8]>> {
+    pub fn into_leaf(self) -> Result<ProofPart<'a, [u8]>> {
         if let ProofTree::Present(proof) = self {
             match proof {
-                Tree::Node(_) => Err(ProofLayoutError::UnexpectedNode),
+                Tree::Node(_) => Err(ProofError::UnexpectedNode),
                 Tree::Leaf(leaf) => match leaf {
                     MerkleProofLeaf::Blind(_) => Ok(ProofPart::Absent),
                     MerkleProofLeaf::Read(data) => Ok(ProofPart::Present(data.as_slice())),
@@ -206,13 +188,13 @@ impl<'a> ProofTree<'a> {
     /// For the purpose of computing the final hash of a `Verifier` state,
     /// interpret this part of a Merkle proof as a leaf and return its hash if
     /// it is a blinded leaf or hash the data if it is present.
-    pub(crate) fn partial_hash_leaf(self) -> ProofLayoutResult<Hash, PartialHashError> {
+    pub(crate) fn partial_hash_leaf(self) -> Result<Hash, PartialHashError> {
         let ProofTree::Present(proof) = self else {
             return Err(PartialHashError::PotentiallyRecoverable);
         };
 
         let Tree::Leaf(leaf) = proof else {
-            return Err(ProofLayoutError::UnexpectedNode.into());
+            return Err(ProofError::UnexpectedNode.into());
         };
 
         let hash = match leaf {
@@ -233,14 +215,14 @@ impl<'a> ProofTree<'a> {
     /// If the proof tree is absent, return absent branches and no proof hash.
     pub fn into_branches_with_hash<const LEN: usize>(
         self,
-    ) -> ProofLayoutResult<(Box<[ProofTree<'a>; LEN]>, Option<Hash>), PartialHashError> {
+    ) -> Result<(Box<[ProofTree<'a>; LEN]>, Option<Hash>), PartialHashError> {
         let ProofTree::Present(proof) = self else {
             return Ok((boxed_array![ProofTree::Absent; LEN], None));
         };
 
         match proof {
             Tree::Node(branches) if branches.len() != LEN => Err(PartialHashError::FromProof(
-                ProofLayoutError::BadNumberOfBranches {
+                ProofError::BadNumberOfBranches {
                     got: branches.len(),
                     expected: LEN,
                 },
@@ -259,7 +241,7 @@ impl<'a> ProofTree<'a> {
                 MerkleProofLeaf::Blind(hash) => {
                     Ok((boxed_array![ProofTree::Absent; LEN], Some(*hash)))
                 }
-                _ => Err(ProofLayoutError::UnexpectedLeaf)?,
+                _ => Err(ProofError::UnexpectedLeaf)?,
             },
         }
     }
@@ -313,9 +295,7 @@ impl OwnedProofPart {
 pub trait ProofLayout: Layout {
     /// Obtain the complete Merkle tree which captures an execution trace
     /// using the proof-generating backend.
-    fn to_merkle_tree(
-        state: RefProofGenOwnedAlloc<Self>,
-    ) -> ProofLayoutResult<MerkleTree, HashError>;
+    fn to_merkle_tree(state: RefProofGenOwnedAlloc<Self>) -> Result<MerkleTree, HashError>;
 
     /// Parse a Merkle proof into the allocated form of this layout.
     fn into_verifier_alloc<D: Deserialiser>(proof: D) -> VerifierAllocResult<D, Self>;
@@ -325,16 +305,14 @@ pub trait ProofLayout: Layout {
     fn partial_state_hash(
         state: RefVerifierAlloc<Self>,
         proof: ProofTree,
-    ) -> ProofLayoutResult<Hash, PartialHashError>;
+    ) -> Result<Hash, PartialHashError>;
 }
 
 impl<T: ProofLayout> ProofLayout for Box<T>
 where
     AllocatedOf<T, Verifier>: 'static,
 {
-    fn to_merkle_tree(
-        state: RefProofGenOwnedAlloc<Self>,
-    ) -> ProofLayoutResult<MerkleTree, HashError> {
+    fn to_merkle_tree(state: RefProofGenOwnedAlloc<Self>) -> Result<MerkleTree, HashError> {
         T::to_merkle_tree(*state)
     }
 
@@ -345,7 +323,7 @@ where
     fn partial_state_hash(
         state: RefVerifierAlloc<Self>,
         proof: ProofTree,
-    ) -> ProofLayoutResult<Hash, PartialHashError> {
+    ) -> Result<Hash, PartialHashError> {
         T::partial_state_hash(*state, proof)
     }
 }
@@ -354,9 +332,7 @@ impl<T> ProofLayout for Atom<T>
 where
     T: Encode + Decode<()> + 'static,
 {
-    fn to_merkle_tree(
-        state: RefProofGenOwnedAlloc<Self>,
-    ) -> ProofLayoutResult<MerkleTree, HashError> {
+    fn to_merkle_tree(state: RefProofGenOwnedAlloc<Self>) -> Result<MerkleTree, HashError> {
         // The Merkle leaf must hold the serialisation of the initial state.
         // Directly serialising the `ProofGen` state would produce the serialisation
         // of the final state. Therefore, we rebind and serialise the wrapped `Owned` state.
@@ -375,7 +351,7 @@ where
     fn partial_state_hash(
         state: RefVerifierAlloc<Self>,
         proof: ProofTree,
-    ) -> ProofLayoutResult<Hash, PartialHashError> {
+    ) -> Result<Hash, PartialHashError> {
         let region = state.into_region();
         match region.get_partial_region() {
             PartialState::Complete(region) => Ok(Hash::blake3_hash(region)?),
@@ -389,9 +365,7 @@ impl<T, const LEN: usize> ProofLayout for Array<T, LEN>
 where
     T: Encode + Decode<()> + 'static,
 {
-    fn to_merkle_tree(
-        state: RefProofGenOwnedAlloc<Self>,
-    ) -> ProofLayoutResult<MerkleTree, HashError> {
+    fn to_merkle_tree(state: RefProofGenOwnedAlloc<Self>) -> Result<MerkleTree, HashError> {
         // RV-282: Break down into multiple leaves if the size of the `Cells`
         // is too large for a proof.
         //
@@ -426,7 +400,7 @@ where
     fn partial_state_hash(
         state: RefVerifierAlloc<Self>,
         proof: ProofTree,
-    ) -> ProofLayoutResult<Hash, PartialHashError> {
+    ) -> Result<Hash, PartialHashError> {
         let region = state.into_region();
         match region.get_partial_region() {
             PartialState::Complete(region) => Ok(Hash::blake3_hash(region)?),
@@ -437,9 +411,7 @@ where
 }
 
 impl<const LEN: usize> ProofLayout for DynArray<LEN> {
-    fn to_merkle_tree(
-        state: RefProofGenOwnedAlloc<Self>,
-    ) -> ProofLayoutResult<MerkleTree, HashError> {
+    fn to_merkle_tree(state: RefProofGenOwnedAlloc<Self>) -> Result<MerkleTree, HashError> {
         let region = state.region_ref();
         let mut writer = MerkleWriter::new(
             MERKLE_LEAF_SIZE,
@@ -466,7 +438,7 @@ impl<const LEN: usize> ProofLayout for DynArray<LEN> {
             start: usize,
             left_length: usize,
             proof: D,
-        ) -> ProofLayoutResult<D::Suspended<(Vec<PageData>, OwnedProofPart)>> {
+        ) -> Result<D::Suspended<(Vec<PageData>, OwnedProofPart)>> {
             let page = verify_backend::PageId::from_address(start);
 
             if left_length <= MERKLE_LEAF_SIZE.get() {
@@ -487,7 +459,7 @@ impl<const LEN: usize> ProofLayout for DynArray<LEN> {
                 let ctx = proof
                     .into_node()?
                     .map(|node_partial| (vec![], node_partial.map_present(|()| vec![])));
-                let ctx = Ok::<_, ProofLayoutError>(ctx);
+                let ctx = Ok::<_, ProofError>(ctx);
                 let r = work_merkle_params::<MERKLE_ARITY>(start, left_length).fold(
                     ctx,
                     |ctx, (start, length)| {
@@ -524,7 +496,7 @@ impl<const LEN: usize> ProofLayout for DynArray<LEN> {
     fn partial_state_hash(
         state: RefVerifierAlloc<Self>,
         proof: ProofTree,
-    ) -> ProofLayoutResult<Hash, PartialHashError> {
+    ) -> Result<Hash, PartialHashError> {
         enum Event<'a> {
             Span(usize, usize, ProofTree<'a>),
             Node(Option<Hash>),
@@ -533,7 +505,7 @@ impl<const LEN: usize> ProofLayout for DynArray<LEN> {
         let mut queue = VecDeque::new();
         queue.push_back(Event::Span(0usize, LEN, proof));
 
-        let mut hashes: Vec<ProofLayoutResult<Hash, PartialHashError>> = Vec::new();
+        let mut hashes: Vec<Result<Hash, PartialHashError>> = Vec::new();
 
         while let Some(event) = queue.pop_front() {
             match event {
@@ -677,9 +649,7 @@ where
     AllocatedOf<A, Verifier>: 'static,
     AllocatedOf<B, Verifier>: 'static,
 {
-    fn to_merkle_tree(
-        state: RefProofGenOwnedAlloc<Self>,
-    ) -> ProofLayoutResult<MerkleTree, HashError> {
+    fn to_merkle_tree(state: RefProofGenOwnedAlloc<Self>) -> Result<MerkleTree, HashError> {
         let children = vec![A::to_merkle_tree(state.0)?, B::to_merkle_tree(state.1)?];
         Ok(MerkleTree::make_merkle_node(children))
     }
@@ -691,7 +661,7 @@ where
     fn partial_state_hash(
         state: RefVerifierAlloc<Self>,
         proof: ProofTree,
-    ) -> ProofLayoutResult<Hash, PartialHashError> {
+    ) -> Result<Hash, PartialHashError> {
         let (branches, proof_hash) = proof.into_branches_with_hash::<2>()?;
 
         let hashes = [
@@ -712,9 +682,7 @@ where
     AllocatedOf<B, Verifier>: 'static,
     AllocatedOf<C, Verifier>: 'static,
 {
-    fn to_merkle_tree(
-        state: RefProofGenOwnedAlloc<Self>,
-    ) -> ProofLayoutResult<MerkleTree, HashError> {
+    fn to_merkle_tree(state: RefProofGenOwnedAlloc<Self>) -> Result<MerkleTree, HashError> {
         let children = vec![
             A::to_merkle_tree(state.0)?,
             B::to_merkle_tree(state.1)?,
@@ -730,7 +698,7 @@ where
     fn partial_state_hash(
         state: RefVerifierAlloc<Self>,
         proof: ProofTree,
-    ) -> ProofLayoutResult<Hash, PartialHashError> {
+    ) -> Result<Hash, PartialHashError> {
         let (branches, proof_hash) = proof.into_branches_with_hash::<3>()?;
 
         let hashes = [
@@ -754,9 +722,7 @@ where
     AllocatedOf<C, Verifier>: 'static,
     AllocatedOf<D, Verifier>: 'static,
 {
-    fn to_merkle_tree(
-        state: RefProofGenOwnedAlloc<Self>,
-    ) -> ProofLayoutResult<MerkleTree, HashError> {
+    fn to_merkle_tree(state: RefProofGenOwnedAlloc<Self>) -> Result<MerkleTree, HashError> {
         let children = vec![
             A::to_merkle_tree(state.0)?,
             B::to_merkle_tree(state.1)?,
@@ -773,7 +739,7 @@ where
     fn partial_state_hash(
         state: RefVerifierAlloc<Self>,
         proof: ProofTree,
-    ) -> ProofLayoutResult<Hash, PartialHashError> {
+    ) -> Result<Hash, PartialHashError> {
         let (branches, proof_hash) = proof.into_branches_with_hash::<4>()?;
 
         let hashes = [
@@ -800,9 +766,7 @@ where
     AllocatedOf<D, Verifier>: 'static,
     AllocatedOf<E, Verifier>: 'static,
 {
-    fn to_merkle_tree(
-        state: RefProofGenOwnedAlloc<Self>,
-    ) -> ProofLayoutResult<MerkleTree, HashError> {
+    fn to_merkle_tree(state: RefProofGenOwnedAlloc<Self>) -> Result<MerkleTree, HashError> {
         let children = vec![
             A::to_merkle_tree(state.0)?,
             B::to_merkle_tree(state.1)?,
@@ -819,7 +783,7 @@ where
     fn partial_state_hash(
         state: RefVerifierAlloc<Self>,
         proof: ProofTree,
-    ) -> ProofLayoutResult<Hash, PartialHashError> {
+    ) -> Result<Hash, PartialHashError> {
         let (branches, proof_hash) = proof.into_branches_with_hash::<5>()?;
 
         let hashes = [
@@ -849,9 +813,7 @@ where
     AllocatedOf<E, Verifier>: 'static,
     AllocatedOf<F, Verifier>: 'static,
 {
-    fn to_merkle_tree(
-        state: RefProofGenOwnedAlloc<Self>,
-    ) -> ProofLayoutResult<MerkleTree, HashError> {
+    fn to_merkle_tree(state: RefProofGenOwnedAlloc<Self>) -> Result<MerkleTree, HashError> {
         let children = vec![
             A::to_merkle_tree(state.0)?,
             B::to_merkle_tree(state.1)?,
@@ -870,7 +832,7 @@ where
     fn partial_state_hash(
         state: RefVerifierAlloc<Self>,
         proof: ProofTree,
-    ) -> ProofLayoutResult<Hash, PartialHashError> {
+    ) -> Result<Hash, PartialHashError> {
         let (branches, proof_hash) = proof.into_branches_with_hash::<6>()?;
 
         let hashes = [
@@ -891,13 +853,11 @@ where
     T: ProofLayout + 'static,
     AllocatedOf<T, Verifier>: 'static,
 {
-    fn to_merkle_tree(
-        state: RefProofGenOwnedAlloc<Self>,
-    ) -> ProofLayoutResult<MerkleTree, HashError> {
+    fn to_merkle_tree(state: RefProofGenOwnedAlloc<Self>) -> Result<MerkleTree, HashError> {
         let children = state
             .into_iter()
             .map(T::to_merkle_tree)
-            .collect::<ProofLayoutResult<Vec<_>, _>>()?;
+            .collect::<Result<Vec<_>, _>>()?;
 
         Ok(MerkleTree::make_merkle_node(children))
     }
@@ -941,13 +901,13 @@ where
     fn partial_state_hash(
         state: RefVerifierAlloc<Self>,
         proof: ProofTree,
-    ) -> ProofLayoutResult<Hash, PartialHashError> {
+    ) -> Result<Hash, PartialHashError> {
         let (branches, proof_hash) = proof.into_branches_with_hash::<LEN>()?;
         let hashes = state
             .into_iter()
             .zip(branches.iter())
             .map(|(state, proof)| T::partial_state_hash(state, *proof))
-            .collect::<Vec<ProofLayoutResult<Hash, PartialHashError>>>();
+            .collect::<Vec<Result<Hash, PartialHashError>>>();
         combine_partial_hashes(hashes, proof_hash)
     }
 }
@@ -957,13 +917,11 @@ where
     T: ProofLayout,
     AllocatedOf<T, Verifier>: 'static,
 {
-    fn to_merkle_tree(
-        state: RefProofGenOwnedAlloc<Self>,
-    ) -> ProofLayoutResult<MerkleTree, HashError> {
+    fn to_merkle_tree(state: RefProofGenOwnedAlloc<Self>) -> Result<MerkleTree, HashError> {
         let leaves = state
             .into_iter()
             .map(T::to_merkle_tree)
-            .collect::<ProofLayoutResult<Vec<_>, _>>()?;
+            .collect::<Result<Vec<_>, _>>()?;
 
         build_custom_merkle_tree(MERKLE_ARITY, leaves)
     }
@@ -980,7 +938,7 @@ where
         fn parametrised_deserialiser<T: ProofLayout, D: Deserialiser>(
             length: usize,
             proof: D,
-        ) -> ProofLayoutResult<D::Suspended<NestedSuspendedResult<T>>>
+        ) -> Result<D::Suspended<NestedSuspendedResult<T>>>
         where
             AllocatedOf<T, Verifier>: 'static,
         {
@@ -1035,7 +993,7 @@ where
     fn partial_state_hash(
         state: RefVerifierAlloc<Self>,
         proof: ProofTree,
-    ) -> ProofLayoutResult<Hash, PartialHashError> {
+    ) -> Result<Hash, PartialHashError> {
         enum Event<'a> {
             Span(usize, usize, ProofTree<'a>),
             Node(Option<Hash>),
@@ -1053,7 +1011,7 @@ where
         let mut queue = VecDeque::new();
         queue.push_back(Event::Span(0usize, LEN, proof));
 
-        let mut hashes: Vec<ProofLayoutResult<Hash, PartialHashError>> = Vec::new();
+        let mut hashes: Vec<Result<Hash, PartialHashError>> = Vec::new();
 
         while let Some(event) = queue.pop_front() {
             match event {
@@ -1123,9 +1081,9 @@ where
 /// case its hash can be recovered from the proof, or it is part of a blinded
 /// subtree whose hash cannot be computed as this point.
 pub fn combine_partial_hashes(
-    hash_results: impl AsRef<[ProofLayoutResult<Hash, PartialHashError>]>,
+    hash_results: impl AsRef<[Result<Hash, PartialHashError>]>,
     proof_hash: Option<Hash>,
-) -> ProofLayoutResult<Hash, PartialHashError> {
+) -> Result<Hash, PartialHashError> {
     let hash_results = hash_results.as_ref();
     if hash_results.is_empty() {
         return Ok(Hash::combine::<Hash, _>([]));

--- a/src/riscv/lib/src/state_backend/verify_backend.rs
+++ b/src/riscv/lib/src/state_backend/verify_backend.rs
@@ -24,11 +24,11 @@ use super::ManagerWrite;
 use super::PartialHashError;
 use super::Ref;
 use crate::state_backend::Elem;
+use crate::state_backend::ProofError;
 use crate::state_backend::elem_bytes;
 use crate::state_backend::hash::Hash;
 use crate::state_backend::owned_backend::Owned;
 use crate::state_backend::proof_backend::merkle::MERKLE_LEAF_SIZE;
-use crate::state_backend::proof_backend::proof::deserialiser;
 
 /// Panic payload that is raised when a value isn't present in a part of the Verifier backend.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, derive_more::Display, thiserror::Error)]
@@ -59,7 +59,7 @@ pub(crate) fn handle_stepper_panics<R, F: FnOnce() -> R + std::panic::UnwindSafe
 #[derive(Debug, thiserror::Error)]
 pub enum ProofVerificationFailure {
     #[error("Deserialisation error: {0}")]
-    BadDeserialisation(#[from] deserialiser::Error),
+    BadDeserialisation(#[from] ProofError),
 
     #[error("Stepper error")]
     StepperError,

--- a/src/riscv/lib/tests/test_proofs.rs
+++ b/src/riscv/lib/tests/test_proofs.rs
@@ -23,7 +23,6 @@ use octez_riscv::state_backend::AllocatedOf;
 use octez_riscv::state_backend::hash;
 use octez_riscv::state_backend::owned_backend::Owned;
 use octez_riscv::state_backend::proof_backend::proof::Proof;
-use octez_riscv::state_backend::proof_backend::proof::deserialiser;
 use octez_riscv::state_backend::proof_backend::proof::serialise_proof;
 use octez_riscv::state_backend::verify_backend::NotFound;
 use octez_riscv::state_backend::verify_backend::ProofVerificationFailure;
@@ -203,9 +202,7 @@ fn basic_invalid_proofs_are_rejected<MC: MemoryConfig, BCC: BlockCacheConfig>(
     let empty_proof = proof_helpers::empty(state_hash);
     assert!(matches!(
         verify_fn(stepper, empty_proof),
-        Err(ProofVerificationFailure::BadDeserialisation(
-            deserialiser::Error::Deserialise(_)
-        ))
+        Err(ProofVerificationFailure::BadDeserialisation(_))
     ));
 
     let invalid_final_hash_proof = proof_helpers::with_final_hash(proof, state_hash);


### PR DESCRIPTION
Part of RV-798

# What

Merge `ProofLayoutError` and `ProofParseError` error types. This also impacts their dedicated `Result` types.

# Why

As part of RV-798, we're making the proof deserialisation mechanism capable of monadic parsing. 

Functionally, this means that you can inspect the data associated with a leaf or node to make decisions about the shape of the Merkle tree that you are going to parse. A practical example is storing the number of leafs associated with a Merkle-isation of a byte vector. We want to be able to encode variably sized byte vectors, for example.

When we switch to a monadic model, one thing changes: there is no more separation between layout and data parsing errors. They get mixed because there is no more separation into the layout phase and then data parsing phase. E.g. you expect a leaf, you parse it, you used the parsed data at one level higher to decide about the layout, where you will descend into parsing eventually again.

To make the refactor to monadic proof parsing easier to review, I want to merge the error types ahead of it.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
