### PR TITLE
chore: speed up edit-test cycle by disabling LTO

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,6 +12,7 @@ debug = true
 
 [profile.test]
 opt-level = 1
+lto = false
 
 # Required in order to build OCaml bindings with ocaml-rs on MacOS
 [target.'cfg(target_os = "macos")']


### PR DESCRIPTION
Turn off [LTO](https://doc.rust-lang.org/rustc/codegen-options/index.html#lto) for test builds.

This speeds up linking. You will see an improvement in your edit-test cycles.

There appears to be a little speed-up in CI as well. 

- This PR: [12m37s](https://github.com/tezos/riscv-pvm/actions/runs/18197770508/job/51808474410?pr=394)
- Main: [14m45s](https://github.com/tezos/riscv-pvm/actions/runs/18194016423/job/51795496911)