### PR TITLE
refactor(memory): enforce lengths are non-zero

### DIFF
--- a/src/riscv/lib/src/interpreter/rv64dc.rs
+++ b/src/riscv/lib/src/interpreter/rv64dc.rs
@@ -89,7 +89,7 @@ mod test {
 
     type MC = M4K;
 
-    const OUT_OF_BOUNDS_OFFSET: i64 = MC::TOTAL_BYTES as i64;
+    const OUT_OF_BOUNDS_OFFSET: i64 = MC::TOTAL_BYTES.get() as i64;
 
     backend_test!(test_cfsd_cfld, F, {
         let state = MachineCoreState::<MC, F>::new();

--- a/src/riscv/lib/src/jit.rs
+++ b/src/riscv/lib/src/jit.rs
@@ -2188,7 +2188,7 @@ mod tests {
         type ConstructStoreFn =
             fn(rs1: XRegister, rs2: XRegister, imm: i64, width: InstrWidth) -> I;
 
-        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES as u64;
+        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES.get() as u64;
         const XREG_VALUE: u64 = 0xFFEEDDCCBBAA9988;
 
         let valid_store = |constructor: ConstructStoreFn, imm: u64, expected: u64| {
@@ -2270,7 +2270,7 @@ mod tests {
 
         type ConstructLoadFn = fn(rd: XRegister, rs1: XRegister, imm: i64, width: InstrWidth) -> I;
 
-        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES as u64;
+        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES.get() as u64;
 
         let valid_load = |new_load: ConstructLoadFn, imm: u64, expected: u64| {
             const LOAD_ADDRESS_BASE: u64 = MEMORY_SIZE / 2;
@@ -2415,7 +2415,7 @@ mod tests {
             width: InstrWidth,
         ) -> I;
 
-        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES as u64;
+        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES.get() as u64;
 
         const ADDRESS_BASE_ATOMICS: u64 = MEMORY_SIZE / 2;
 
@@ -2684,7 +2684,7 @@ mod tests {
 
         use crate::machine_state::registers::NonZeroXRegister as NZ;
         use crate::machine_state::registers::*;
-        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES as u64;
+        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES.get() as u64;
         const ADDRESS_BASE_ATOMICS: u64 = MEMORY_SIZE / 2;
 
         let scenarios: &[Scenario] = &[
@@ -2834,7 +2834,7 @@ mod tests {
 
         use crate::machine_state::registers::NonZeroXRegister as NZ;
         use crate::machine_state::registers::*;
-        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES as u64;
+        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES.get() as u64;
         const ADDRESS_BASE_ATOMICS: u64 = MEMORY_SIZE / 2;
 
         let scenarios: &[Scenario] = &[
@@ -3104,7 +3104,7 @@ mod tests {
         use crate::machine_state::registers::XRegister::x2;
         use crate::machine_state::registers::XRegister::x3;
 
-        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES as u64;
+        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES.get() as u64;
         const ADDRESS_BASE_ATOMICS: u64 = MEMORY_SIZE / 2;
 
         let test_atomic_swap =
@@ -3182,7 +3182,7 @@ mod tests {
         use crate::machine_state::registers::NonZeroXRegister as NZ;
         use crate::machine_state::registers::XRegister::*;
 
-        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES as u64;
+        const MEMORY_SIZE: u64 = M4K::TOTAL_BYTES.get() as u64;
 
         const ADDRESS_BASE_ATOMICS: u64 = MEMORY_SIZE / 2;
 

--- a/src/riscv/lib/src/machine_state.rs
+++ b/src/riscv/lib/src/machine_state.rs
@@ -1262,7 +1262,7 @@ mod tests {
         state.reset();
         state.core.main_memory.set_all_readable_writeable();
 
-        let stack_top = M4K::TOTAL_BYTES as u64;
+        let stack_top = M4K::TOTAL_BYTES.get() as u64;
         state.core.hart.xregisters.write(sp, stack_top);
 
         let init_pc = 0xFE;
@@ -1283,7 +1283,7 @@ mod tests {
         state.reset();
         state.core.main_memory.set_all_readable_writeable();
 
-        let stack_top = M4K::TOTAL_BYTES as u64;
+        let stack_top = M4K::TOTAL_BYTES.get() as u64;
         state.core.hart.xregisters.write(sp, stack_top);
 
         let init_pc = 0x100;

--- a/src/riscv/lib/src/machine_state/memory.rs
+++ b/src/riscv/lib/src/machine_state/memory.rs
@@ -8,6 +8,7 @@ mod protection;
 mod state;
 
 use std::num::NonZeroU64;
+use std::num::NonZeroUsize;
 
 use tezos_smart_rollup_constants::riscv::SbiError;
 
@@ -254,7 +255,7 @@ pub trait Memory<M: ManagerBase>: NewState<M> + Sized {
     fn protect_pages(
         &mut self,
         address: Address,
-        length: usize,
+        length: NonZeroUsize,
         perms: Permissions,
     ) -> Result<(), MemoryGovernanceError>
     where
@@ -264,7 +265,7 @@ pub trait Memory<M: ManagerBase>: NewState<M> + Sized {
     fn allocate_pages(
         &mut self,
         address_hint: Option<Address>,
-        length: usize,
+        length: NonZeroUsize,
         allow_replace: bool,
     ) -> Result<Address, MemoryGovernanceError>
     where
@@ -274,7 +275,7 @@ pub trait Memory<M: ManagerBase>: NewState<M> + Sized {
     fn deallocate_pages(
         &mut self,
         address: Address,
-        length: usize,
+        length: NonZeroUsize,
     ) -> Result<(), MemoryGovernanceError>
     where
         M: ManagerReadWrite;
@@ -283,7 +284,7 @@ pub trait Memory<M: ManagerBase>: NewState<M> + Sized {
     fn allocate_and_protect_pages(
         &mut self,
         address_hint: Option<Address>,
-        length: usize,
+        length: NonZeroUsize,
         perms: Permissions,
         allow_replace: bool,
     ) -> Result<Address, MemoryGovernanceError>
@@ -294,7 +295,7 @@ pub trait Memory<M: ManagerBase>: NewState<M> + Sized {
     fn deallocate_and_protect_pages(
         &mut self,
         address: Address,
-        length: usize,
+        length: NonZeroUsize,
     ) -> Result<(), MemoryGovernanceError>
     where
         M: ManagerReadWrite,
@@ -307,7 +308,7 @@ pub trait Memory<M: ManagerBase>: NewState<M> + Sized {
 /// Memory configuration
 pub trait MemoryConfig: Send + 'static {
     /// Number of bytes in the memory
-    const TOTAL_BYTES: usize;
+    const TOTAL_BYTES: NonZeroUsize;
 
     /// Layout for memory instance's state
     type Layout: CommitmentLayout + ProofLayout;

--- a/src/riscv/lib/src/machine_state/memory/config.rs
+++ b/src/riscv/lib/src/machine_state/memory/config.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: MIT
 
+use std::num::NonZeroUsize;
+
 use super::buddy::BuddyLayout;
 use super::buddy::BuddyLayoutProxy;
 use super::protection::PagePermissions;
@@ -44,7 +46,8 @@ impl<const PAGES: usize, const TOTAL_BYTES: usize> super::MemoryConfig
 where
     BuddyLayoutProxy<PAGES>: BuddyLayout + 'static,
 {
-    const TOTAL_BYTES: usize = TOTAL_BYTES;
+    const TOTAL_BYTES: NonZeroUsize = NonZeroUsize::new(TOTAL_BYTES)
+        .expect("size of memory `TOTAL_BYTES` must be greater than zero");
 
     type Layout = (
         DynArray<TOTAL_BYTES>,

--- a/src/riscv/lib/src/machine_state/memory/protection.rs
+++ b/src/riscv/lib/src/machine_state/memory/protection.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: MIT
 
+use std::num::NonZeroUsize;
+
 use bincode::Decode;
 use bincode::Encode;
 use bincode::de::Decoder;
@@ -65,19 +67,16 @@ impl<const PAGES: usize, M: ManagerBase> PagePermissions<PAGES, M> {
     /// The address and length must be valid for an address space consisting of a number of `PAGES`.
     /// This function is not defined for address and length combinations which are out of bounds.
     #[inline]
-    pub unsafe fn can_access(&self, address: Address, length: usize) -> bool
+    pub unsafe fn can_access(&self, address: Address, length: NonZeroUsize) -> bool
     where
         M: ManagerRead,
     {
-        // Zero-sized accesses are always valid
-        if length < 1 {
-            return true;
-        }
-
         // Extract the page index range from using the start and end addresses
         let start_page = address_to_page_index(address);
 
-        let end_address = address.wrapping_add(length as Address).wrapping_sub(1);
+        let end_address = address
+            .wrapping_add(length.get() as Address)
+            .wrapping_sub(1);
         let end_page = address_to_page_index(end_address);
 
         for page in start_page..=end_page {
@@ -117,17 +116,15 @@ impl<const PAGES: usize, M: ManagerBase> PagePermissions<PAGES, M> {
     }
 
     /// Change the access permissions for the given range.
-    pub fn modify_access(&mut self, address: Address, length: usize, accessible: bool)
+    pub fn modify_access(&mut self, address: Address, length: NonZeroUsize, accessible: bool)
     where
         M: ManagerWrite,
     {
-        if length < 1 {
-            return;
-        }
-
         let start_page = address_to_page_index(address);
 
-        let end_address = address.wrapping_add(length as Address).wrapping_sub(1);
+        let end_address = address
+            .wrapping_add(length.get() as Address)
+            .wrapping_sub(1);
         let end_page = address_to_page_index(end_address);
 
         (start_page..=end_page)

--- a/src/riscv/lib/src/machine_state/memory/state.rs
+++ b/src/riscv/lib/src/machine_state/memory/state.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: MIT
 
+use std::num::NonZeroUsize;
+
 use super::Address;
 use super::BadMemoryAccess;
 use super::Memory;
@@ -40,8 +42,8 @@ impl<const PAGES: usize, const TOTAL_BYTES: usize, B, M: ManagerBase>
 {
     /// Ensure the access is within bounds.
     #[inline]
-    fn check_bounds<E>(address: Address, length: usize, error: E) -> Result<(), E> {
-        if length > TOTAL_BYTES.saturating_sub(address as usize) {
+    fn check_bounds<E>(address: Address, length: NonZeroUsize, error: E) -> Result<(), E> {
+        if length.get() > TOTAL_BYTES.saturating_sub(address as usize) {
             return Err(error);
         }
 
@@ -55,7 +57,10 @@ impl<const PAGES: usize, const TOTAL_BYTES: usize, B, M: ManagerBase>
         B: Buddy<M>,
         M: ManagerReadWrite,
     {
-        self.protect_pages(0, TOTAL_BYTES, Permissions::READ_WRITE)
+        let length =
+            NonZeroUsize::new(TOTAL_BYTES).expect("`TOTAL_BYTES` must be greater than zero");
+
+        self.protect_pages(0, length, Permissions::READ_WRITE)
             .unwrap();
     }
 
@@ -70,7 +75,8 @@ impl<const PAGES: usize, const TOTAL_BYTES: usize, B, M: ManagerBase>
         E: Elem,
         M: ManagerWrite,
     {
-        let length = E::STORED_SIZE.get();
+        let length = E::STORED_SIZE;
+
         Self::check_bounds(address, length, BadMemoryAccess)?;
 
         self.data.write(address as usize, value);
@@ -92,7 +98,7 @@ where
         E: Elem,
         M: ManagerRead,
     {
-        Self::check_bounds(address, E::STORED_SIZE.get(), BadMemoryAccess)?;
+        Self::check_bounds(address, E::STORED_SIZE, BadMemoryAccess)?;
 
         // SAFETY: The bounds check above ensures the access check below is safe
         unsafe {
@@ -110,9 +116,7 @@ where
         E: Elem,
         M: ManagerRead,
     {
-        let length = E::STORED_SIZE.get();
-
-        Self::check_bounds(address, length, BadMemoryAccess)?;
+        Self::check_bounds(address, E::STORED_SIZE, BadMemoryAccess)?;
 
         // SAFETY: The bounds check above ensures the access check below is safe
         unsafe {
@@ -135,7 +139,13 @@ where
         E: Elem,
         M: ManagerRead,
     {
-        let length = E::STORED_SIZE.get() * values.len();
+        let Some(values_len) = NonZeroUsize::new(values.len()) else {
+            // zero-sized reads always valid
+            return Ok(());
+        };
+
+        let length = E::STORED_SIZE.saturating_mul(values_len);
+
         Self::check_bounds(address, length, BadMemoryAccess)?;
 
         // SAFETY: The bounds check above ensures the access check below is safe
@@ -155,7 +165,7 @@ where
         E: Elem,
         M: ManagerReadWrite,
     {
-        Self::check_bounds(address, E::STORED_SIZE.get(), BadMemoryAccess)?;
+        Self::check_bounds(address, E::STORED_SIZE, BadMemoryAccess)?;
 
         // SAFETY: The bounds check above ensures the access check below is safe
         unsafe {
@@ -173,7 +183,12 @@ where
         E: Elem + Copy,
         M: ManagerReadWrite,
     {
-        let length = E::STORED_SIZE.get() * values.len();
+        let Some(values_len) = NonZeroUsize::new(values.len()) else {
+            // zero-sized writes always valid
+            return Ok(());
+        };
+
+        let length = E::STORED_SIZE.saturating_mul(values_len);
         Self::check_bounds(address, length, BadMemoryAccess)?;
 
         // SAFETY: The bounds check above ensures the access check below is safe
@@ -229,7 +244,7 @@ where
     fn protect_pages(
         &mut self,
         address: Address,
-        length: usize,
+        length: NonZeroUsize,
         perms: Permissions,
     ) -> Result<(), super::MemoryGovernanceError>
     where
@@ -250,7 +265,7 @@ where
     fn deallocate_pages(
         &mut self,
         address: Address,
-        length: usize,
+        length: NonZeroUsize,
     ) -> Result<(), super::MemoryGovernanceError>
     where
         M: ManagerReadWrite,
@@ -258,7 +273,7 @@ where
         Self::check_bounds(address, length, super::MemoryGovernanceError)?;
 
         // See RV-561: Use `u64` for indices and lengths that come from the PVM
-        let pages = (length as u64).div_ceil(super::PAGE_SIZE.get());
+        let pages = (length.get() as u64).div_ceil(super::PAGE_SIZE.get());
 
         // Buddy memory manager works on page indices, not addresses
         let idx = address >> super::OFFSET_BITS.get();
@@ -270,7 +285,7 @@ where
     fn allocate_pages(
         &mut self,
         address_hint: Option<Address>,
-        length: usize,
+        length: NonZeroUsize,
         allow_replace: bool,
     ) -> Result<Address, super::MemoryGovernanceError>
     where
@@ -279,7 +294,7 @@ where
         // The interface works on usize at the moment, however, going forward we'll convert all
         // length types to u64 to avoid machine-specific behavior for lengths.
         // See RV-561: Use `u64` for indices and lengths that come from the PVM
-        let pages = (length as u64).div_ceil(super::PAGE_SIZE.get());
+        let pages = (length.get() as u64).div_ceil(super::PAGE_SIZE.get());
 
         match address_hint {
             // Caller wants to allocate at a specific address
@@ -305,7 +320,7 @@ where
     fn allocate_and_protect_pages(
         &mut self,
         address_hint: Option<Address>,
-        length: usize,
+        length: NonZeroUsize,
         perms: Permissions,
         allow_replace: bool,
     ) -> Result<Address, super::MemoryGovernanceError>
@@ -324,6 +339,7 @@ where
         // altogether. This speeds things up.
         // As we allocate in multiples of pages, we must also clear in multiples of pages.
         let mut remaining = length
+            .get()
             .div_ceil(PAGE_SIZE.get() as usize)
             .saturating_mul(PAGE_SIZE.get() as usize);
 
@@ -355,21 +371,12 @@ pub mod tests {
 
     #[test]
     fn bounds_check() {
-        type OwnedM0 = MemoryImpl<0, 0, (), Owned>;
         type OwnedM4K = <M4K as MemoryConfig>::State<Owned>;
 
-        // Zero-sized reads or writes are always valid
-        assert!(OwnedM0::check_bounds(0, 0, ()).is_ok());
-        assert!(OwnedM0::check_bounds(1, 0, ()).is_ok());
-        assert!(OwnedM4K::check_bounds(0, 0, ()).is_ok());
-        assert!(OwnedM4K::check_bounds(4096, 0, ()).is_ok());
-        assert!(OwnedM4K::check_bounds(2 * 4096, 0, ()).is_ok());
-
         // Bounds checks
-        assert!(OwnedM0::check_bounds(0, 1, ()).is_err());
-        assert!(OwnedM0::check_bounds(1, 1, ()).is_err());
-        assert!(OwnedM4K::check_bounds(4096, 1, ()).is_err());
-        assert!(OwnedM4K::check_bounds(2 * 4096, 1, ()).is_err());
+        assert!(OwnedM4K::check_bounds(4095, NonZeroUsize::new(1).unwrap(), ()).is_ok());
+        assert!(OwnedM4K::check_bounds(4096, NonZeroUsize::new(1).unwrap(), ()).is_err());
+        assert!(OwnedM4K::check_bounds(2 * 4096, NonZeroUsize::new(1).unwrap(), ()).is_err());
     }
 
     // This test verifies that memory is fully zeroed up to the page boundary, not just the
@@ -387,6 +394,7 @@ pub mod tests {
 
         // Request size that's not a multiple of page size
         let requested_size = (PAGE_SIZE.get() as usize) - 100;
+        let requested_size = NonZeroUsize::new(requested_size).unwrap();
         let address = memory
             .allocate_and_protect_pages(None, requested_size, Permissions::READ_WRITE, false)
             .expect("Memory allocation should succeed");

--- a/src/riscv/lib/src/machine_state/page_cache/state.rs
+++ b/src/riscv/lib/src/machine_state/page_cache/state.rs
@@ -172,6 +172,8 @@ impl<const PAGES: usize, CPE: CodePageEntry<MC, M>, MC: MemoryConfig, M: Manager
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroUsize;
+
     use proptest::prelude::*;
 
     use super::PageCacheImpl;
@@ -205,7 +207,7 @@ mod tests {
 
     #[test]
     fn test_page_invalidation_resets_pages() {
-        const PAGES: usize = M1M::TOTAL_BYTES / PAGE_SIZE.get() as usize;
+        const PAGES: usize = M1M::TOTAL_BYTES.get() / PAGE_SIZE.get() as usize;
 
         let mut cache = PageCacheImpl::<PAGES, Instruction, M1M, Owned>::new();
 
@@ -274,9 +276,10 @@ mod tests {
         assert_eq!(count_active_pages(&cache), 0);
 
         // populating a read-only page should fail
+        let page_size: NonZeroUsize = PAGE_SIZE.try_into().unwrap();
         state
             .main_memory
-            .protect_pages(0, PAGE_SIZE.get() as usize, Permissions {
+            .protect_pages(0, page_size, Permissions {
                 read: true,
                 exec: false,
                 write: false,
@@ -288,7 +291,7 @@ mod tests {
         // populating a R+W should fail
         state
             .main_memory
-            .protect_pages(0, PAGE_SIZE.get() as usize, Permissions::READ_WRITE)
+            .protect_pages(0, page_size, Permissions::READ_WRITE)
             .unwrap();
         cache.populate_page(15, &state);
         assert_eq!(count_active_pages(&cache), 0);
@@ -296,7 +299,7 @@ mod tests {
         // populating a R+W+X should fail
         state
             .main_memory
-            .protect_pages(0, PAGE_SIZE.get() as usize, Permissions::READ_WRITE_EXEC)
+            .protect_pages(0, page_size, Permissions::READ_WRITE_EXEC)
             .unwrap();
         cache.populate_page(15, &state);
         assert_eq!(count_active_pages(&cache), 0);
@@ -304,7 +307,7 @@ mod tests {
         // populating a R+X page should succeed
         state
             .main_memory
-            .protect_pages(0, PAGE_SIZE.get() as usize, Permissions {
+            .protect_pages(0, page_size, Permissions {
                 read: true,
                 exec: true,
                 write: false,
@@ -315,12 +318,12 @@ mod tests {
     });
 
     backend_test!(populate_from_memory, F, {
-        const PAGES: usize = M1M::TOTAL_BYTES / PAGE_SIZE.get() as usize;
+        const PAGES: usize = M1M::TOTAL_BYTES.get() / PAGE_SIZE.get() as usize;
 
         let state = MachineCoreState::<M1M, F>::new();
         let state = &std::cell::RefCell::new(state);
 
-        proptest!(|(pc_addr in 0..M1M::TOTAL_BYTES as u64,
+        proptest!(|(pc_addr in 0..M1M::TOTAL_BYTES.get() as u64,
                     page: Box<[u8; PAGE_SIZE.get() as usize]>)| {
             // Arrange
             let mut cache = PageCacheImpl::<PAGES, Instruction, M1M, F>::new();

--- a/src/riscv/lib/src/pvm/linux.rs
+++ b/src/riscv/lib/src/pvm/linux.rs
@@ -13,6 +13,7 @@ pub(crate) mod signals;
 
 use std::convert::Infallible;
 use std::ffi::CStr;
+use std::num::NonZeroUsize;
 use std::ops::ControlFlow;
 use std::ops::Range;
 
@@ -271,33 +272,39 @@ where
             .map(|(addr, data)| addr.saturating_add(data.len() as u64))
             .max()
             .unwrap_or(0);
+
         let program_length = program_end.saturating_sub(program_start) as usize;
+        if let Some(program_length) = NonZeroUsize::new(program_length) {
+            // Allow the program to be written to main memory
+            self.machine_state.core.main_memory.protect_pages(
+                program_start,
+                program_length,
+                Permissions::WRITE,
+            )?;
 
-        // Allow the program to be written to main memory
-        self.machine_state.core.main_memory.protect_pages(
-            program_start,
-            program_length,
-            Permissions::WRITE,
-        )?;
+            // Write program to main memory
+            for (&addr, data) in program.segments.iter() {
+                self.machine_state.core.main_memory.write_all(addr, data)?;
+            }
 
-        // Write program to main memory
-        for (&addr, data) in program.segments.iter() {
-            self.machine_state.core.main_memory.write_all(addr, data)?;
-        }
-
-        // Remove access to the program that has just been placed into memory
-        self.machine_state.core.main_memory.protect_pages(
-            program_start,
-            program_length,
-            Permissions::NONE,
-        )?;
+            // Remove access to the program that has just been placed into memory
+            self.machine_state.core.main_memory.protect_pages(
+                program_start,
+                program_length,
+                Permissions::NONE,
+            )?;
+        };
 
         // Configure memory permissions using the ELF program headers, if present
         if let Some(program_headers) = &program.program_headers {
             for mem_perms in program_headers.permissions.iter() {
+                let Some(length) = NonZeroUsize::new(mem_perms.length as usize) else {
+                    continue;
+                };
+
                 self.machine_state.core.main_memory.protect_pages(
                     mem_perms.start_address,
-                    mem_perms.length as usize,
+                    length,
                     mem_perms.permissions,
                 )?;
             }
@@ -319,7 +326,7 @@ where
     where
         M: ManagerReadWrite,
     {
-        let stack_top = VirtAddr::new(MC::TOTAL_BYTES as u64);
+        let stack_top = VirtAddr::new(MC::TOTAL_BYTES.get() as u64);
 
         // We must fit at least one guard page between the program break and the stack
         let guarded_stack_space = stack_top - self.system_state.program.end;
@@ -338,24 +345,27 @@ where
             return Err(MachineError::MemoryTooSmall);
         }
 
-        // At this point we know that `stack_top` >= `stack_bottom`
-        let stack_space = (stack_top - stack_bottom) as usize;
-
         // Guard the stack with a guard page. This prevents stack overflows spilling into the heap
         // or even worse, the program's .bss or .data area.
         let stack_guard = stack_bottom - PAGE_SIZE.get();
-        self.machine_state.core.main_memory.protect_pages(
-            stack_guard.to_machine_address(),
-            PAGE_SIZE.get() as usize,
-            Permissions::NONE,
-        )?;
 
-        // Make sure the stack region is readable and writable
-        self.machine_state.core.main_memory.protect_pages(
-            stack_bottom.to_machine_address(),
-            stack_space,
-            Permissions::READ_WRITE,
-        )?;
+        // At this point we know that `stack_top` >= `stack_bottom`
+        let stack_space = (stack_top - stack_bottom) as usize;
+        if let Some(stack_space) = NonZeroUsize::new(stack_space) {
+            self.machine_state.core.main_memory.protect_pages(
+                stack_guard.to_machine_address(),
+                // TODO: RV-561: use u64 everywhere in the PVM
+                PAGE_SIZE.try_into().expect("`PAGE_SIZE` fits into usize"),
+                Permissions::NONE,
+            )?;
+
+            // Make sure the stack region is readable and writable
+            self.machine_state.core.main_memory.protect_pages(
+                stack_bottom.to_machine_address(),
+                stack_space,
+                Permissions::READ_WRITE,
+            )?;
+        }
 
         self.machine_state
             .core
@@ -426,10 +436,13 @@ where
             .allocate_pages(Some(0), MC::TOTAL_BYTES, true)?;
 
         // Make sure only the heap can be used for allocation by the user kernel.
-        self.machine_state.core.main_memory.deallocate_pages(
-            self.system_state.heap.start.to_machine_address(),
-            (self.system_state.heap.end - self.system_state.heap.start) as usize,
-        )?;
+        let heap_size = (self.system_state.heap.end - self.system_state.heap.start) as usize;
+        if let Some(heap_size) = NonZeroUsize::new(heap_size) {
+            self.machine_state
+                .core
+                .main_memory
+                .deallocate_pages(self.system_state.heap.start.to_machine_address(), heap_size)?;
+        }
 
         Ok(())
     }
@@ -1014,9 +1027,7 @@ impl<M: ManagerBase> SupervisorState<M> {
 
         struct MemorySize<MC>(MC);
         impl<MC: MemoryConfig> MemorySize<MC> {
-            const SIZE: u64 = MC::TOTAL_BYTES as u64;
-
-            const UPPER_BOUND: () = assert!(MC::TOTAL_BYTES <= u64::MAX as usize);
+            const SIZE: u64 = MC::TOTAL_BYTES.get() as u64;
 
             // Hard limit on the size of the data segment
             const RLIMIT_DATA: u64 = Self::SIZE;
@@ -1030,8 +1041,6 @@ impl<M: ManagerBase> SupervisorState<M> {
             // Hard limit on the size of a process's virtual memory (B)
             const RLIMIT_AS: u64 = Self::SIZE;
         }
-
-        let () = MemorySize::<MC>::UPPER_BOUND;
 
         // If new_limit is not NULL, the system call is being used to write new limits, so ignore
         // it and return a permissions error
@@ -1123,7 +1132,7 @@ mod tests {
     // Check that the `set_tid_address` system call is working correctly.
     backend_test!(set_tid_address, F, {
         type MemLayout = M4K;
-        const MEM_BYTES: usize = MemLayout::TOTAL_BYTES;
+        const MEM_BYTES: usize = MemLayout::TOTAL_BYTES.get();
 
         let mut machine_state =
             MachineState::<MemLayout, TestCacheConfig, Interpreted<MemLayout, F>, F>::new(
@@ -1375,7 +1384,7 @@ mod tests {
 
         let mut do_ignore = |signal: Signal| {
             // Write the initial stack pointer and program counter.
-            let stack_top = M4K::TOTAL_BYTES as u64;
+            let stack_top = M4K::TOTAL_BYTES.get() as u64;
             machine_state.core.hart.xregisters.write(sp, stack_top);
             let init_pc = 0;
             machine_state.core.hart.pc.write(init_pc);

--- a/src/riscv/lib/src/pvm/linux/memory.rs
+++ b/src/riscv/lib/src/pvm/linux/memory.rs
@@ -16,6 +16,7 @@
 //! - `stack_guard_start+PAGE_SIZE..MC::TOTAL_BYTES` is the stack area
 
 use std::num::NonZeroU64;
+use std::num::NonZeroUsize;
 
 use super::SupervisorState;
 use super::addr::PageAligned;
@@ -71,6 +72,8 @@ impl<M: ManagerBase> SupervisorState<M> {
     /// Handle `mprotect` system call.
     ///
     /// See: <https://man7.org/linux/man-pages/man2/mprotect.2.html>
+    ///
+    /// A length of 0 means no protections need to be changed.
     pub(super) fn handle_mprotect<MC>(
         &mut self,
         core: &mut MachineCoreState<MC, M>,
@@ -82,8 +85,10 @@ impl<M: ManagerBase> SupervisorState<M> {
         MC: MemoryConfig,
         M: ManagerReadWrite,
     {
-        core.main_memory
-            .protect_pages(addr.to_machine_address(), length as usize, perms)?;
+        if let Some(length) = NonZeroUsize::new(length as usize) {
+            core.main_memory
+                .protect_pages(addr.to_machine_address(), length, perms)?;
+        }
 
         // Return 0 to indicate success.
         Ok(0)
@@ -122,13 +127,13 @@ impl<M: ManagerBase> SupervisorState<M> {
             Backend::File => return Err(Error::NoSystemCall),
         }
 
+        // TODO: RV-561: use u64 everywhere in the PVM
+        let length: NonZeroUsize = length.try_into().expect("expect length to fit into usize");
+
         let res_addr: VirtAddr = match flags.addr_hint {
-            AddressHint::Hint => core.main_memory.allocate_and_protect_pages(
-                None,
-                length.get() as usize,
-                perms,
-                false,
-            )?,
+            AddressHint::Hint => core
+                .main_memory
+                .allocate_and_protect_pages(None, length, perms, false)?,
 
             AddressHint::Fixed { allow_replace } => {
                 if !addr.is_aligned(PAGE_SIZE) {
@@ -137,7 +142,7 @@ impl<M: ManagerBase> SupervisorState<M> {
 
                 core.main_memory.allocate_and_protect_pages(
                     Some(addr.to_machine_address()),
-                    length.get() as usize,
+                    length,
                     perms,
                     allow_replace,
                 )?
@@ -155,14 +160,21 @@ impl<M: ManagerBase> SupervisorState<M> {
         &mut self,
         core: &mut MachineCoreState<MC, M>,
         addr: u64,
-        length: u64,
+        // while not explicitly required to be non-zero, this does partially match the
+        // linux implementation which requires both page-aligned addresses and length > 0
+        //
+        // see <https://github.com/torvalds/linux/blob/50c19e20ed2ef359cf155a39c8462b0a6351b9fa/mm/vma.c#L1573>
+        length: NonZeroU64,
     ) -> Result<u64, Error>
     where
         MC: MemoryConfig,
         M: ManagerReadWrite,
     {
+        // TODO: RV-561: use u64 everywhere in the PVM
+        let length: NonZeroUsize = length.try_into().expect("expect length to fit into usize");
+
         core.main_memory
-            .deallocate_and_protect_pages(addr, length as usize)
+            .deallocate_and_protect_pages(addr, length)
             .map_err(|_| Error::InvalidArgument)?;
 
         Ok(0)

--- a/src/riscv/lib/src/pvm/linux/signals.rs
+++ b/src/riscv/lib/src/pvm/linux/signals.rs
@@ -766,7 +766,8 @@ where
         const ECALL: u32 = 0b1110011;
 
         const RESTORER_FUNCTION: [u32; 2] = [LOAD_SIGRETURN, ECALL];
-        const RESTORER_LENGTH: usize = size_of_val(&RESTORER_FUNCTION);
+        const RESTORER_LENGTH: NonZeroUsize = NonZeroUsize::new(size_of_val(&RESTORER_FUNCTION))
+            .expect("size of `RESTORER_FUNCTION` is greater than zero");
 
         // Ensure the restorer is in its own page
         let address = address
@@ -789,7 +790,10 @@ where
         // Make the restorer page R+X
         self.machine_state.core.main_memory.protect_pages(
             address.to_machine_address(),
-            PAGE_SIZE.get() as usize,
+            // TODO: RV-561: use u64 everywhere in the PVM
+            PAGE_SIZE
+                .try_into()
+                .expect("`PAGE_SIZE` fits into usize width"),
             Permissions {
                 read: true,
                 exec: true,
@@ -797,7 +801,7 @@ where
             },
         )?;
 
-        let restorer_end = address + RESTORER_LENGTH as u64;
+        let restorer_end = address + RESTORER_LENGTH.get() as u64;
 
         // Store where the restorer is kept so that the signal handlers can find it
         self.machine_state
@@ -847,7 +851,7 @@ mod tests {
             .unwrap();
 
         // Write the initial stack pointer and program counter.
-        let stack_top = M1M::TOTAL_BYTES as u64;
+        let stack_top = M1M::TOTAL_BYTES.get() as u64;
         pvm.machine_state.core.hart.xregisters.write(sp, stack_top);
         let init_pc = 10;
         pvm.machine_state.core.hart.pc.write(init_pc);
@@ -927,7 +931,7 @@ mod tests {
             .unwrap();
 
         // Write the initial stack pointer and program counter.
-        let stack_top = M1M::TOTAL_BYTES as u64;
+        let stack_top = M1M::TOTAL_BYTES.get() as u64;
         pvm.machine_state.core.hart.xregisters.write(sp, stack_top);
         let init_pc = 10;
         pvm.machine_state.core.hart.pc.write(init_pc);


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

- relates to RV-561
- part of RV-760

# What

Enforce all lengths in the memory trait are non-zero. 

# Why

This change makes it simpler to land the future `MemoryPermissionsListener` trait - as non-zero ranges are simpler to deal with.

# How

For now, make the lengths `NonZeroUsize`. These will in future be converted to `NonZeroU64` when RV-561 is tackled fully. (unlike the partial implementation seen in #384)

# Manually Testing

```
make all
```


# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
