### PR TITLE
chore: fix typos

### DIFF
--- a/scripts/test-status.sh
+++ b/scripts/test-status.sh
@@ -57,8 +57,8 @@ done
 
 echo "[INFO]: found ${#working[@]} tested instructions"
 
-# Examing ignored test requirements
-echo "[INFO]: examing ignored tests"
+# Examining ignored test requirements
+echo "[INFO]: examining ignored tests"
 
 for t in "${ignored[@]}"; do
   echo -en "$(basename "$t")\t\t"

--- a/src/riscv/lib/src/instruction_context.rs
+++ b/src/riscv/lib/src/instruction_context.rs
@@ -49,7 +49,7 @@ pub type IcbFnResult<I> = <I as ICB>::IResult<ProgramCounterUpdate<<I as ICB>::X
 #[expect(clippy::upper_case_acronyms, reason = "ICB looks cooler than Icb")]
 pub(crate) trait ICB
 where
-    // These contraints let us tie a type-equality knot.
+    // These constraints let us tie a type-equality knot.
     //
     // We want to allow handling of arbitrary value types via [`StateContext`]'s associated type
     // `Value`, whilst adding functionality on a subset of those values (e.g. 64-bit and 32-bit

--- a/src/riscv/lib/src/interpreter/atomics.rs
+++ b/src/riscv/lib/src/interpreter/atomics.rs
@@ -595,7 +595,7 @@ pub fn run_x64_atomic_store<I: ICB>(
     run_atomic_store::<I, i64>(icb, rs1, rs2, rd)
 }
 
-// Reservation Set Helper Functionss
+// Reservation Set Helper Functions
 
 /// Raise an [`Exception::StoreAMOAccessFault`] error if `address` is not aligned to the width
 /// encoded by `V`.

--- a/src/riscv/lib/src/interpreter/integer.rs
+++ b/src/riscv/lib/src/interpreter/integer.rs
@@ -1250,7 +1250,7 @@ mod tests {
         );
     });
 
-    backend_test!(test_bitwise_intruction, F, {
+    backend_test!(test_bitwise_instruction, F, {
         proptest!(|(val1 in any::<u64>(), val2 in any::<u64>())| {
             let mut state = MachineCoreState::<M4K, F>::new();
 

--- a/src/riscv/lib/src/jit/builder/control_flow_graph.rs
+++ b/src/riscv/lib/src/jit/builder/control_flow_graph.rs
@@ -299,7 +299,7 @@ enum EdgeClass {
 
 // By convention, test modules are at the end of the file.
 //
-// We don't put the conditional compilaton attribute here to avoid issues with Clippy. Instead, we
+// We don't put the conditional compilation attribute here to avoid issues with Clippy. Instead, we
 // put it into the module file itself. Clippy doesn't look at the module declaration in the parent
 // file to determine whether the module is test-only or not. That means some non-test lints would
 // trigger in the tests module.

--- a/src/riscv/lib/src/jit/builder/graph_walker.rs
+++ b/src/riscv/lib/src/jit/builder/graph_walker.rs
@@ -134,7 +134,7 @@ mod tests {
             Ok(())
         }
 
-        // We have moved out the body into a separate function to avoid formating problems with the
+        // We have moved out the body into a separate function to avoid formatting problems with the
         // macro.
         proptest!(|(graph in graph())| {
             inner(graph)?;

--- a/src/riscv/lib/src/jit/builder/typed.rs
+++ b/src/riscv/lib/src/jit/builder/typed.rs
@@ -30,7 +30,7 @@ use perfect_derive::perfect_derive;
 /// Cranelift IR type
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Type {
-    /// Basic Cranelift type (e.g. intergers)
+    /// Basic Cranelift type (e.g. integers)
     Basic(CraneliftType),
 
     /// Target-dependent pointer type

--- a/src/riscv/lib/src/jit/state_access/stack.rs
+++ b/src/riscv/lib/src/jit/state_access/stack.rs
@@ -4,7 +4,7 @@
 
 //! Loading and storing of temporary values to/from the stack.
 //!
-//! Certain information is occassionally required to be on the stack, when executing
+//! Certain information is occasionally required to be on the stack, when executing
 //! a JIT-compiled block.
 //!
 //! See [`crate::jit::state_access`] for examples.

--- a/src/riscv/lib/src/machine_state/block_cache.rs
+++ b/src/riscv/lib/src/machine_state/block_cache.rs
@@ -44,11 +44,11 @@
 //! instruction cache, could be completely different to those stored in
 //! the block cache, for the same physical address.
 //!
-//! This can occur due to the differring nature of cache entries between
+//! This can occur due to the differing nature of cache entries between
 //! the instruction & block cache: entries in the instruction cache are
 //! 1 instruction per slot, whereas in the block cache it's instead a
 //! block (a sequence of instructions) per slot. Therefore, an entry
-//! getting overriden in the instruction/block cache at address *A*, does
+//! getting overridden in the instruction/block cache at address *A*, does
 //! not invalidate all instructions in the block cache that correspond
 //! to *A*, as they could also exist in blocks at nearby preceding
 //! addresses.

--- a/src/riscv/lib/src/machine_state/block_cache/block/dispatch.rs
+++ b/src/riscv/lib/src/machine_state/block_cache/block/dispatch.rs
@@ -28,7 +28,7 @@ use crate::state_backend::owned_backend::Owned;
 /// Internally, this may be interpreted, just-in-time compiled, or do
 /// additional work over just execution.
 ///
-/// The first and last parameters must be thin-references, for ABI-compatability reasons.
+/// The first and last parameters must be thin-references, for ABI-compatibility reasons.
 pub type DispatchFn<C, D, MC> = unsafe extern "C" fn(
     &mut C,
     &mut MachineCoreState<MC, Owned>,
@@ -266,7 +266,7 @@ impl<MC: MemoryConfig> DispatchCompiler<MC> for InlineCompiler<MC> {
                 // case for both `Jitted` and `Jitted::BlockBuilder` which are both Sized.
                 //
                 // See <https://doc.rust-lang.org/std/primitive.fn.html#abi-compatibility> for more
-                // information on ABI compatability.
+                // information on ABI compatibility.
                 unsafe { std::mem::transmute::<JitFn<MC>, DispatchFn<C, Self, MC>>(jitfn) }
             }
             None => C::run_block_not_compiled,
@@ -348,7 +348,7 @@ impl<MC: MemoryConfig + Send> OutlineCompiler<MC> {
                         // case for both `Jitted` and `Jitted::BlockBuilder` which are both Sized.
                         //
                         // See <https://doc.rust-lang.org/std/primitive.fn.html#abi-compatibility> for more
-                        // information on ABI compatability.
+                        // information on ABI compatibility.
                         msg.fun.store(jitfn as usize, Ordering::Release);
                     };
                 }

--- a/src/riscv/lib/src/machine_state/memory/state.rs
+++ b/src/riscv/lib/src/machine_state/memory/state.rs
@@ -406,7 +406,7 @@ pub mod tests {
         }
     });
 
-    backend_test!(test_endianess, F, {
+    backend_test!(test_endianness, F, {
         let mut memory = <<M4K as MemoryConfig>::State<F>>::new();
 
         memory

--- a/src/riscv/lib/src/parser.rs
+++ b/src/riscv/lib/src/parser.rs
@@ -516,7 +516,7 @@ pub const fn parse_uncompressed_instruction(instr: u32) -> Instr {
     use Instr::*;
     // RV64I (Chapter 5.4) and RV64C (Chapter 16.7) describe the code points associated
     // with HINT instructions. We do not implement any HINT logic, but decode all these
-    // as `Hint` or `HintCompresssed` opcodes, which we translate to NOPs in `machine_state`.
+    // as `Hint` or `HintCompressed` opcodes, which we translate to NOPs in `machine_state`.
     use XRegisterParsed::*;
     match opcode(instr) {
         // R-type instructions

--- a/src/riscv/lib/src/parser/instruction.rs
+++ b/src/riscv/lib/src/parser/instruction.rs
@@ -440,12 +440,12 @@ pub enum Instr {
     Auipc(NonZeroRdUJTypeArgs),
 
     // RV64I jump instructions
-    /// `JAL` (note: uncompressed variant) - Instruction mis-aligned will
+    /// `JAL` (note: uncompressed variant) - Instruction misaligned will
     /// never be thrown because we allow C extension
     ///
     /// Always returns the target address (current program counter + imm)
     Jal(UJTypeArgs),
-    /// `JALR` (note: uncompressed variant) - Instruction mis-aligned will
+    /// `JALR` (note: uncompressed variant) - Instruction misaligned will
     /// never be thrown because we allow C extension
     ///
     /// Always returns the target address (val(rs1) + imm)

--- a/src/riscv/lib/src/pvm/linux.rs
+++ b/src/riscv/lib/src/pvm/linux.rs
@@ -1008,7 +1008,7 @@ impl<M: ManagerBase> SupervisorState<M> {
         // In jstz this is only used to set the maximum size of the process stack to infinity. In
         // other programs, it can be used to set limits for system resources. Allowing programs to
         // set these values to extreme values would inflate proof size, so is undesirable.
-        // Futhermore, a privileged process (such as the supervisor implemented in this PVM) has
+        // Furthermore, a privileged process (such as the supervisor implemented in this PVM) has
         // the ability to set these limits to arbitrary values.
         // So it does! By using its own predefined limits and returning EPERM.
 

--- a/src/riscv/lib/src/pvm/linux/parameters.rs
+++ b/src/riscv/lib/src/pvm/linux/parameters.rs
@@ -125,7 +125,7 @@ pub(crate) const RLIMIT_NPROC: u64 = 1;
 
 /// Hard limit on the number of file descriptors that a system call can work with
 ///
-/// We also use this constant to implictly limit how much memory can be associated with a system
+/// We also use this constant to implicitly limit how much memory can be associated with a system
 /// call. For example, `ppoll` takes a pointer to an array of `struct pollfd`. If we don't limit
 /// the length of that array, then we might read an arbitrary amount of memory. This impacts the
 /// proof size dramatically as everything read would also be in the proof.

--- a/src/riscv/lib/src/pvm/linux/signals.rs
+++ b/src/riscv/lib/src/pvm/linux/signals.rs
@@ -852,7 +852,7 @@ mod tests {
         let init_pc = 10;
         pvm.machine_state.core.hart.pc.write(init_pc);
 
-        // The address of a psuedo handler.
+        // The address of a pseudo handler.
         let handler_address = VirtAddr::new(42);
 
         // Instruction to return from a function.

--- a/src/riscv/lib/src/state_backend.rs
+++ b/src/riscv/lib/src/state_backend.rs
@@ -148,7 +148,7 @@ pub trait ManagerBase: Sized {
     /// [enriched]: EnrichedValue
     type EnrichedCell<V: EnrichedValue>;
 
-    /// The root manager may either be itself, or occassionally the manager that this manager
+    /// The root manager may either be itself, or occasionally the manager that this manager
     /// wraps.
     ///
     /// For example, the [`Ref`] backend is often use to wrap the [`Owned`] backend to gain access
@@ -282,7 +282,7 @@ pub trait ManagerDeserialise: ManagerBase {
         decoder: D,
     ) -> Result<Self::Region<T, LEN>, DecodeError>;
 
-    /// Deserialise the dyanmic region.
+    /// Deserialise the dynamic region.
     fn deserialise_dyn_region<const LEN: usize, D: Decoder>(
         decoder: D,
     ) -> Result<Self::DynRegion<LEN>, DecodeError>;

--- a/src/riscv/lib/src/state_backend/proof_backend/proof.rs
+++ b/src/riscv/lib/src/state_backend/proof_backend/proof.rs
@@ -347,7 +347,7 @@ mod tests {
     use crate::storage::Hash;
 
     /// Utility struct that computes the bounds of a [`MerkleProof`] serialisation
-    /// based on total number of nodes in the tree and total size of raw data in the leafs.
+    /// based on total number of nodes in the tree and total size of raw data in the leaves.
     struct SerialisationBound {
         nodes_count: u64,
         content_size: u64,

--- a/src/riscv/lib/src/state_backend/proof_backend/proof/deserialiser.rs
+++ b/src/riscv/lib/src/state_backend/proof_backend/proof/deserialiser.rs
@@ -504,8 +504,8 @@ mod tests {
         assert!(comp_fn.is_err_and(|e| matches!(e, ProofError::BadNumberOfBranches { .. })));
 
         // First 2 children of root are ok in shape (blinded) but the total number of children does not correspond
-        // Ideally, we would like to have expected: 2, got: 5, but the implemenetation for `ProofTreeDeserialiser`
-        // does not track this information (the original number of chilren)
+        // Ideally, we would like to have expected: 2, got: 5, but the implementation for `ProofTreeDeserialiser`
+        // does not track this information (the original number of children)
         let comp_fn =
             computation_i16::<ProofTreeDeserialiser>(ProofTree::Present(&bad_shape_2).into());
         assert!(comp_fn.is_err_and(|e| {

--- a/src/riscv/lib/src/state_backend/proof_backend/tree.rs
+++ b/src/riscv/lib/src/state_backend/proof_backend/tree.rs
@@ -161,7 +161,7 @@ pub fn impl_modify_map_collect<
             },
             ProcessEvents::Collect(node_data, count) => {
                 // We need to reconstruct a subtree which is made of `count` children
-                // No panic: We are guaranted count < done.len() since every Collect(size)
+                // No panic: We are guaranteed count < done.len() since every Collect(size)
                 // corresponds to size nodes pushed to Done-queue
                 let children = done.split_off(done.len() - count);
                 done.push(collect(node_data, children)?);

--- a/src/riscv/lib/src/state_backend/verify_backend.rs
+++ b/src/riscv/lib/src/state_backend/verify_backend.rs
@@ -381,7 +381,7 @@ impl<const LEAF_SIZE: usize> PageId<LEAF_SIZE> {
 
     const LEAF_MASK: usize = !(Self::LEAF_SIZE - 1);
 
-    /// Construct a page idetifier from an address.
+    /// Construct a page identifier from an address.
     pub fn from_address(address: usize) -> Self {
         PageId(address & Self::LEAF_MASK)
     }

--- a/src/riscv/lib/src/storage.rs
+++ b/src/riscv/lib/src/storage.rs
@@ -43,7 +43,7 @@ pub enum StorageError {
     #[error("Data for hash {0} not found")]
     NotFound(String),
 
-    #[error("Commited chunk {0} not found")]
+    #[error("Committed chunk {0} not found")]
     ChunkNotFound(String),
 }
 

--- a/tools/sandbox/src/memory_config.rs
+++ b/tools/sandbox/src/memory_config.rs
@@ -24,7 +24,7 @@ impl FromStr for MemoryConfigValue {
             "4g" => Ok(MemoryConfigValue::M4G),
             "16g" => Ok(MemoryConfigValue::M16G),
             "64g" => Ok(MemoryConfigValue::M64G),
-            cfg => Err(format!("Unsupported memory configuation: {cfg}")),
+            cfg => Err(format!("Unsupported memory configuration: {cfg}")),
         }
     }
 }


### PR DESCRIPTION
I used [typos](https://github.com/crate-ci/typos) to squash some typos.