### PR TITLE
feat(data): add partial vector data structure

### DIFF
--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -10,5 +10,6 @@ pub mod hash;
 pub mod merkle_proof;
 pub mod merkle_tree;
 pub mod mode;
+pub mod partial_vec;
 pub mod serialisation;
 pub mod tree;

--- a/data/src/partial_vec.rs
+++ b/data/src/partial_vec.rs
@@ -1,0 +1,439 @@
+// SPDX-FileCopyrightText: 2026 TriliTech <contact@trili.tech>
+//
+// SPDX-License-Identifier: MIT
+
+//! Like [`Vec`] but not continuously defined
+//!
+//! # Structure
+//!
+//! A [`PartialVec`] is a binary tree where leaves are either defined data or undefined gaps.
+//! This allows efficient representation of sparse data without allocating memory for gaps.
+//!
+//! ```text
+//! Logical view:    [a][b][c][ ? ][ ? ][ ? ][ ? ][d][e][f]
+//!                   0  1  2   3    4    5    6   7  8  9
+//!                  |_______|___________________|_________|
+//!                   defined      undefined       defined
+//!
+//! Tree structure:
+//!
+//!                        Concatenated
+//!                         (len: 10)
+//!                        /          \
+//!                Concatenated       Defined
+//!                 (len: 7)          [d,e,f]
+//!                /        \
+//!           Defined     Undefined
+//!           [a,b,c]      (len: 4)
+//! ```
+//!
+//! Unlike a `BTreeMap<usize, T>`, this structure is optimized for range queries making it
+//! memory-efficient for sparse but clustered data.
+
+use std::ops::Range;
+
+/// Partial vector that may not be defined for certain ranges
+///
+/// This data type can be seen as an alternative to `BTreeMap<usize, T>` which provides a more
+/// memory-efficient representation for when there are many adjacent keys and the primary query
+/// mechanism is using ranges.
+#[derive(Debug, Clone)]
+pub enum PartialVec<T> {
+    /// Undefined vector of a certain width
+    Undefined {
+        /// How many elements are undefined
+        length: usize,
+    },
+
+    /// Defined vector of a certain width
+    Defined {
+        /// Elements that define the range
+        data: Vec<T>,
+    },
+
+    /// Concatenation of two partial vectors
+    Concatenated {
+        /// Combined width of both vectors
+        ///
+        /// This is not the number of defined items.
+        node_width: usize,
+
+        /// First partial vector
+        left: Box<Self>,
+
+        /// Second partial vector
+        right: Box<Self>,
+    },
+}
+
+impl<T> PartialVec<T> {
+    /// Create a vector of defined data.
+    pub fn defined(data: Vec<T>) -> Self {
+        Self::Defined { data }
+    }
+
+    /// Create a vector of undefined data with the provided length.
+    pub fn undefined(length: usize) -> Self {
+        Self::Undefined { length }
+    }
+
+    /// Retrieve the width of the partial vector.
+    ///
+    /// This is not the number of defined elements, but the total number of elements represented by
+    /// the partial vector - defined or undefined.
+    /// In other words, `PartialVec::undefined(10).width() == 10`.
+    fn width(&self) -> usize {
+        match self {
+            Self::Undefined { length } => *length,
+            Self::Defined { data } => data.len(),
+            Self::Concatenated { node_width, .. } => *node_width,
+        }
+    }
+
+    /// Define a range within the partial vector.
+    ///
+    /// Existing data is overwritten if it overlaps the newly defined range.
+    pub fn define(&mut self, offset: usize, new_data: Vec<T>) {
+        let mut work = vec![(self, offset, new_data)];
+
+        while let Some((target, offset, mut new_data)) = work.pop() {
+            // If there is nothing left to insert, we might as well stop.
+            if new_data.is_empty() {
+                break;
+            }
+
+            match target {
+                Self::Concatenated {
+                    left,
+                    right,
+                    node_width,
+                } => {
+                    let new_data_end = offset + new_data.len();
+
+                    // Inserting may extend the range represented by the node.
+                    *node_width = std::cmp::max(*node_width, new_data_end);
+
+                    // When the offset is larger than what the left node stores, then we can safely
+                    // delegate all the work to the right node.
+                    // This case also handles when we want to define something beyond the current
+                    // node's width. In that scenario, we descend into the right node.
+                    if offset >= left.width() {
+                        let new_offset = offset - left.width();
+                        work.push((right, new_offset, new_data));
+                        continue;
+                    }
+
+                    // When the inserted range fits entirely within the left node, we can focus on
+                    // the left node only.
+                    if new_data_end <= left.width() {
+                        work.push((left, offset, new_data));
+                        continue;
+                    }
+
+                    // At this point we know that the inserted range overlaps with both the left and
+                    // right nodes. So we divide the insertion vector accordingly.
+                    let left_overlap_tail = left.width() - offset;
+                    let new_right_data = new_data.split_off(left_overlap_tail);
+
+                    work.push((left, offset, new_data));
+                    work.push((right, 0, new_right_data));
+                }
+
+                Self::Undefined { length } => {
+                    let new_data_end = offset + new_data.len();
+
+                    let undefined_prefix_len = offset;
+                    let undefined_suffix_len = length.saturating_sub(new_data_end);
+
+                    // This is the "center" node. We prepend and append undefined nodes as needed.
+                    // We don't need to worry about merging adjacent nodes, as this node is either
+                    // the root or the right-most node in a concatenation. The `Concatenated` case
+                    // deals with this for us.
+                    let mut new_data_node = Self::defined(new_data);
+
+                    // If the insertion does not happen at the beginning, then we keep a portion of
+                    // the undefined range. The length of the existing undefined range is not
+                    // considered, as we are only interested in filling the gap.
+                    if undefined_prefix_len > 0 {
+                        let prefix = Self::undefined(undefined_prefix_len);
+                        new_data_node = Self::Concatenated {
+                            node_width: prefix.width() + new_data_node.width(),
+                            left: Box::new(prefix),
+                            right: Box::new(new_data_node),
+                        };
+                    }
+
+                    // If the tail of the inserted range does not extend beyond the existing
+                    // undefined range, then the portion of the undefined range that covers that bit
+                    // needs to be kept.
+                    if undefined_suffix_len > 0 {
+                        let suffix = Self::undefined(undefined_suffix_len);
+                        new_data_node = Self::Concatenated {
+                            node_width: new_data_node.width() + suffix.width(),
+                            left: Box::new(new_data_node),
+                            right: Box::new(suffix),
+                        };
+                    }
+
+                    *target = new_data_node;
+                }
+
+                Self::Defined { data } => {
+                    // When inserting beyond what is currently present, there needs to be an
+                    // undefined gap between the existing range and the new range. This makes it a
+                    // slightly special case which is best handled separately.
+                    if offset > data.len() {
+                        let gap = offset - data.len();
+
+                        let new_data_node = Self::defined(new_data);
+                        let new_node = Self::Concatenated {
+                            node_width: gap + new_data_node.width(),
+                            left: Box::new(Self::undefined(gap)),
+                            right: Box::new(new_data_node),
+                        };
+
+                        // Taking the data lets us reuse the allocation. `Default for Vec` (like
+                        // `Vec::new`) does not allocate any memory, so this is rather efficient.
+                        // The alternative is a bit of unsafe code which doesn't seem worth the
+                        // trade-off right now.
+                        let data = std::mem::take(data);
+
+                        *target = Self::Concatenated {
+                            node_width: data.len() + new_node.width(),
+                            left: Box::new(Self::defined(data)),
+                            right: Box::new(new_node),
+                        };
+
+                        continue;
+                    }
+
+                    let new_data_end = offset + new_data.len();
+
+                    // When we start inserting within the defined range, but the new data extends
+                    // beyond the existing range, we can truncate and append in place.
+                    // We can do the extension because there are no adjacent entries to worry about.
+                    // The `Concatenated` case handles that.
+                    if new_data_end >= data.len() {
+                        // Truncation leaves the capacity unchanged.
+                        data.truncate(offset);
+
+                        // Using `append` to avoid the iterator intermediary.
+                        data.append(&mut new_data);
+
+                        continue;
+                    }
+
+                    // At this point we know that the newly inserted data fits entirely within the
+                    // existing defined entry.
+                    for (dst, src) in data[offset..new_data_end].iter_mut().zip(new_data) {
+                        // We replace the existing data this way to not require `T: Copy`.
+                        *dst = src;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Mark everything beyond `keep_length` as undefined.
+    pub fn truncate(&mut self, mut keep_length: usize) {
+        // The borrow checker is unfortunately a little in the way in this method. Please see the
+        // `PartialVec::Concatenated` case below for more information.
+        let mut target: *mut Self = self;
+
+        loop {
+            // SAFETY: Dereferencing `target` is safe because we have not aliased the pointer.
+            match unsafe { &mut *target } {
+                Self::Concatenated {
+                    left,
+                    right,
+                    node_width,
+                } => {
+                    *node_width = keep_length.min(*node_width);
+
+                    // In case the left node will be fully kept, we can just move on to the right
+                    // node.
+                    if keep_length > left.width() {
+                        target = right.as_mut();
+                        keep_length -= left.width();
+
+                        continue;
+                    }
+
+                    // We only need to keep the left portion.
+                    let new_target = std::mem::take(left.as_mut());
+
+                    // SAFETY: `left` and `right` are no longer used at this point. So technically
+                    // `target` is an exclusive reference. The borrow checker is not able to detect
+                    // this though, so we must resort to unsafe code.
+                    // The old value is dropped as it is returned from the replace call.
+                    unsafe { target.replace(new_target) };
+                }
+
+                Self::Undefined { length } => {
+                    *length = keep_length.min(*length);
+                    break;
+                }
+
+                Self::Defined { data } => {
+                    data.truncate(keep_length);
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Fetch the entries of the partial vector that make up the provided range.
+    pub fn range(&self, mut range: Range<usize>) -> impl Iterator<Item = RangeEntry<T>> {
+        let mut work = vec![self];
+
+        std::iter::from_fn(move || {
+            while !range.is_empty() {
+                let Some(node) = work.pop() else {
+                    // If we ran out of things to do, but the range is not empty yet, then the partial
+                    // vector is implicitly undefined for the rest of the queried range.
+                    let entry = RangeEntry::Undefined {
+                        length: range.len(),
+                    };
+
+                    // We must drain the range to prevent further iterations.
+                    range = 0..0;
+
+                    return Some(entry);
+                };
+
+                if node.width() <= range.start {
+                    // This branch happens in two cases:
+                    // - top-level undefined, defined or concatenation node before the query range
+                    // - when we split up a concatenation of two partial vectors, but the left
+                    //   vector is before the query range
+
+                    range.start -= node.width();
+                    range.end -= node.width();
+
+                    continue;
+                }
+
+                match node {
+                    Self::Concatenated { left, right, .. } => {
+                        // These nodes need to be traversed next. Otherwise we'll violate the
+                        // left-to-right traversal order which is assumed in this function.
+                        // After: left -> right -> rest...
+                        work.push(right.as_ref());
+                        work.push(left.as_ref());
+                    }
+
+                    Self::Undefined { length } => {
+                        // The overlap needs to be capped by the query range as the overlap could
+                        // otherwise be larger than the query range.
+                        let overlap = range.len().min(length - range.start);
+
+                        range.end = range.len() - overlap;
+                        range.start = 0;
+
+                        return Some(RangeEntry::Undefined { length: overlap });
+                    }
+
+                    Self::Defined { data } => {
+                        let chunk = &data[range.start..range.end.min(data.len())];
+
+                        range.end = range.len() - chunk.len();
+                        range.start = 0;
+
+                        return Some(RangeEntry::Defined { data: chunk });
+                    }
+                }
+            }
+
+            None
+        })
+    }
+
+    /// Retrieve chunks that make up a continuous range.
+    ///
+    /// If there are gaps in the range, `None` is returned.
+    pub fn continuous_defined_range(&self, range: Range<usize>) -> Option<Vec<&[T]>> {
+        self.range(range)
+            .map(|chunk| match chunk {
+                RangeEntry::Undefined { .. } => None,
+                RangeEntry::Defined { data, .. } => Some(data),
+            })
+            .collect::<Option<Vec<_>>>()
+    }
+
+    /// Retrieve defined entries in the given range.
+    ///
+    /// The returned iterator yields tuples of `(offset, defined_data)` where `offset` is the offset
+    /// within the queried range.
+    pub fn defined_range(&self, range: Range<usize>) -> impl Iterator<Item = (usize, &[T])> {
+        let mut start = 0;
+        self.range(range).filter_map(move |chunk| match chunk {
+            RangeEntry::Undefined { length } => {
+                start += length;
+                None
+            }
+
+            RangeEntry::Defined { data } => {
+                let item = (start, data);
+                start += data.len();
+                Some(item)
+            }
+        })
+    }
+
+    /// Check if the range is continuously defined.
+    ///
+    /// In other words, `self.continuous_range(range)` would succeed (return `Some`).
+    pub fn is_all_defined(&self, range: Range<usize>) -> bool {
+        self.range(range)
+            .all(|chunk| matches!(chunk, RangeEntry::Defined { .. }))
+    }
+
+    /// Check if the range is at least partially defined.
+    ///
+    /// In other words, `self.range(range)` contains at least one defined entry.
+    pub fn is_any_defined(&self, range: Range<usize>) -> bool {
+        self.range(range)
+            .any(|chunk| matches!(chunk, RangeEntry::Defined { .. }))
+    }
+
+    /// Is nothing in the partial vector defined?
+    pub fn is_all_undefined(&self) -> bool {
+        self.range(0..self.width())
+            .all(|chunk| matches!(chunk, RangeEntry::Undefined { .. }))
+    }
+}
+
+impl<T> Default for PartialVec<T> {
+    fn default() -> Self {
+        Self::undefined(0)
+    }
+}
+
+/// Entry within a partial vector
+#[derive(Debug, Clone)]
+pub enum RangeEntry<'a, T> {
+    /// Undefined entry of a certain length
+    Undefined { length: usize },
+
+    /// Defined entry with data
+    Defined { data: &'a [T] },
+}
+
+impl<'a, T> RangeEntry<'a, T> {
+    /// Check if the entry is empty.
+    pub fn is_empty(&self) -> bool {
+        self.width() == 0
+    }
+
+    /// Get the number of elements that this entry represents, regardless of whether they are
+    /// defined or not.
+    pub fn width(&self) -> usize {
+        match self {
+            RangeEntry::Undefined { length, .. } => *length,
+            RangeEntry::Defined { data, .. } => data.len(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/data/src/partial_vec/tests.rs
+++ b/data/src/partial_vec/tests.rs
@@ -1,0 +1,514 @@
+// SPDX-FileCopyrightText: 2026 TriliTech <contact@trili.tech>
+//
+// SPDX-License-Identifier: MIT
+
+//! Tests for [`PartialVec`]
+
+use proptest::arbitrary::any;
+use proptest::collection::vec;
+use proptest::prelude::Strategy;
+use proptest::proptest;
+
+use crate::partial_vec::PartialVec;
+use crate::partial_vec::RangeEntry;
+
+/// Strategy to generate random byte vectors of limited length
+fn data_vec() -> impl Strategy<Value = Vec<u8>> {
+    vec(any::<u8>(), 0..1024)
+}
+
+proptest! {
+    /// Defining a range anywhere should never fail.
+    #[test]
+    fn insert_randomly(init_len: usize, init_data in vec((any::<usize>(), data_vec()), ..1024)) {
+        let mut vec = PartialVec::undefined(init_len);
+
+        for (index, data) in init_data {
+            vec.define(index, data);
+        }
+    }
+
+    /// It should be able to extend a partially defined vector by defining more at the end.
+    #[test]
+    fn insert_end(init_len: usize, data in vec(data_vec(), ..1024)){
+        let mut added_so_far = init_len;
+        let mut vec = PartialVec::undefined(init_len);
+
+        for chunk in data {
+            let chunk_len = chunk.len();
+            vec.define(added_so_far, chunk.clone());
+
+            let values = vec.continuous_defined_range(added_so_far..added_so_far + chunk_len).unwrap();
+            let values = values.into_iter().flatten().copied().collect::<Vec<_>>();
+            assert_eq!(values, chunk);
+
+            added_so_far += chunk_len;
+        }
+    }
+}
+
+/// Ensure defining continuous ranges can be recovered.
+#[test]
+fn get_continuous() {
+    let mut vec = PartialVec::undefined(1024);
+
+    vec.define(10, Vec::from_iter(0..10));
+    vec.define(20, Vec::from_iter(10..20));
+
+    assert!(vec.is_any_defined(10..20));
+    assert!(vec.is_all_defined(10..20));
+
+    let values = vec
+        .continuous_defined_range(10..30)
+        .unwrap()
+        .into_iter()
+        .flatten()
+        .copied()
+        .collect::<Vec<_>>();
+    assert_eq!(values, Vec::from_iter(0..20));
+}
+
+/// Ensure defining ranges with gaps behaves correctly and is reflected in queries.
+#[test]
+fn get_with_gaps() {
+    let mut vec = PartialVec::undefined(1024);
+
+    // Don't define index 3
+    vec.define(1, vec!["a", "b"]);
+    vec.define(4, vec!["c", "d"]);
+
+    assert_eq!(vec.continuous_defined_range(1..6), None);
+
+    assert!(vec.is_any_defined(1..6));
+    assert!(!vec.is_all_defined(1..6));
+
+    // This vector tracks which indices are defined in the range.
+    // We use `None` as an initial value to detect whether we covered the entire range by setting
+    // each entry to `Some(_)`. E.g. if there are `None`s in the vector, we made a mistake.
+    let mut defined = vec![None; 5];
+
+    // Iterate through the retrieved range and populate the `defined` vector.
+    vec.range(1..6).fold(defined.as_mut_slice(), |acc, item| {
+        match item {
+            RangeEntry::Undefined { length, .. } => {
+                acc[..length].fill(Some(false));
+            }
+
+            RangeEntry::Defined { data, .. } => {
+                acc[..data.len()].fill(Some(true));
+            }
+        }
+
+        &mut acc[item.width()..]
+    });
+
+    assert_eq!(defined, vec![
+        Some(true),
+        Some(true),
+        Some(false),
+        Some(true),
+        Some(true)
+    ]);
+}
+
+/// Check if `is_all_defined` works in various scenarios where there are no gaps
+#[test]
+fn is_all_defined_basic() {
+    let mut vec = PartialVec::undefined(1024);
+
+    vec.define(10, Vec::from_iter(0u8..20));
+
+    // Fully within the defined range
+    assert!(vec.is_all_defined(10..30));
+    assert!(vec.is_all_defined(15..25));
+    assert!(vec.is_all_defined(10..20));
+
+    // Overlapping with undefined at the start
+    assert!(!vec.is_all_defined(5..15));
+
+    // Overlapping with undefined at the end
+    assert!(!vec.is_all_defined(25..35));
+
+    // Entirely in undefined region
+    assert!(!vec.is_all_defined(0..5));
+    assert!(!vec.is_all_defined(100..200));
+
+    // Empty range is vacuously continuously defined
+    assert!(vec.is_all_defined(0..0));
+    assert!(vec.is_all_defined(50..50));
+}
+
+/// Check if `is_all_defined` works in various scenarios where there are gaps.
+#[test]
+fn is_all_defined_with_gaps() {
+    let mut vec = PartialVec::undefined(1024);
+
+    // Create two defined regions with a gap
+    vec.define(10, Vec::from_iter(0u8..10)); // 10..20
+    vec.define(30, Vec::from_iter(0u8..10)); // 30..40
+
+    // Each region individually
+    assert!(vec.is_all_defined(10..20));
+    assert!(vec.is_all_defined(30..40));
+
+    // Spanning the gap
+    assert!(!vec.is_all_defined(10..40));
+    assert!(!vec.is_all_defined(15..35));
+
+    // Just the gap
+    assert!(!vec.is_all_defined(20..30));
+}
+
+/// Check if `is_all_defined` works when there are adjacent defined regions.
+#[test]
+fn is_all_defined_adjacent_regions() {
+    let mut vec = PartialVec::undefined(1024);
+
+    // Create adjacent defined regions (no gap)
+    vec.define(10, Vec::from_iter(0u8..10)); // 10..20
+    vec.define(20, Vec::from_iter(0u8..10)); // 20..30
+
+    // Each region individually
+    assert!(vec.is_all_defined(10..20));
+    assert!(vec.is_all_defined(20..30));
+
+    // Spanning both regions
+    assert!(vec.is_all_defined(10..30));
+    assert!(vec.is_all_defined(15..25));
+}
+
+/// Check that `is_any_defined` works in various scenarios without gaps.
+#[test]
+fn is_any_defined_basic() {
+    let mut vec = PartialVec::undefined(1024);
+
+    vec.define(10, Vec::from_iter(0u8..10)); // 10..20
+
+    // Fully within the defined range
+    assert!(vec.is_any_defined(10..20));
+    assert!(vec.is_any_defined(12..18));
+
+    // Overlapping with defined at the start
+    assert!(vec.is_any_defined(5..15));
+
+    // Overlapping with defined at the end
+    assert!(vec.is_any_defined(15..25));
+
+    // Entirely in undefined region
+    assert!(!vec.is_any_defined(0..5));
+    assert!(!vec.is_any_defined(100..200));
+
+    // Empty range has no defined entries
+    assert!(!vec.is_any_defined(0..0));
+    assert!(!vec.is_any_defined(15..15));
+}
+
+/// Check that `is_any_defined` works in various scenarios with gaps.
+#[test]
+fn is_any_defined_with_gaps() {
+    let mut vec = PartialVec::undefined(1024);
+
+    // Create two defined regions with a gap
+    vec.define(10, Vec::from_iter(0u8..10)); // 10..20
+    vec.define(30, Vec::from_iter(0u8..10)); // 30..40
+
+    // Each region individually
+    assert!(vec.is_any_defined(10..20));
+    assert!(vec.is_any_defined(30..40));
+
+    // Spanning both regions and the gap
+    assert!(vec.is_any_defined(10..40));
+    assert!(vec.is_any_defined(15..35));
+
+    // Just the gap (no defined data)
+    assert!(!vec.is_any_defined(20..30));
+    assert!(!vec.is_any_defined(22..28));
+}
+
+/// Check that truncation works correctly on a fully defined vector.
+#[test]
+fn truncate_defined_vector() {
+    let mut vec = PartialVec::defined(vec![1, 2, 3, 4, 5]);
+
+    vec.truncate(3);
+
+    let values = vec
+        .continuous_defined_range(0..3)
+        .unwrap()
+        .into_iter()
+        .flatten()
+        .copied()
+        .collect::<Vec<_>>();
+    assert_eq!(values, vec![1, 2, 3]);
+}
+
+/// Check that truncating to zero on a defined vector works correctly.
+#[test]
+fn truncate_to_zero_defined() {
+    let mut vec = PartialVec::defined(vec![1, 2, 3, 4, 5]);
+
+    vec.truncate(0);
+
+    // After truncating to 0, the vector should have no defined data
+    assert!(!vec.is_any_defined(0..5));
+}
+
+/// Check that truncating an undefined vector works correctly.
+#[test]
+fn truncate_undefined_vector() {
+    let mut vec: PartialVec<u8> = PartialVec::undefined(10);
+    vec.truncate(5);
+
+    // After truncating, the undefined region should be 5 elements
+    assert!(!vec.is_any_defined(0..5));
+
+    // Check that the vector reports length 5
+    let entries: Vec<_> = vec.range(0..5).collect();
+    assert_eq!(entries.len(), 1);
+    match entries[0] {
+        RangeEntry::Undefined { length } => assert_eq!(length, 5),
+        _ => panic!("Expected undefined entry"),
+    }
+}
+
+/// Check that truncating a vector with undefined followed by defined data works correctly.
+#[test]
+fn truncate_concatenated_with_undefined_left() {
+    let mut vec: PartialVec<u8> = PartialVec::undefined(5);
+    vec.define(5, vec![1, 2, 3]);
+
+    vec.truncate(3);
+
+    // After truncation, we should have only 3 undefined elements
+    let entries: Vec<_> = vec.range(0..3).collect();
+    assert_eq!(entries.len(), 1);
+    match &entries[0] {
+        RangeEntry::Undefined { length } => assert_eq!(*length, 3),
+        _ => panic!("Expected undefined entry"),
+    }
+}
+
+/// Check that in-place replacement within an existing defined range works correctly.
+///
+/// This tests the case where new data fits entirely within an existing defined entry,
+/// replacing elements without extending the range.
+#[test]
+fn define_inplace_replacement() {
+    let mut vec = PartialVec::defined(vec![1, 2, 3, 4, 5]);
+
+    // Replace elements at indices 1 and 2 (values 2, 3) with 10, 20
+    vec.define(1, vec![10, 20]);
+
+    let values = vec
+        .continuous_defined_range(0..5)
+        .unwrap()
+        .into_iter()
+        .flatten()
+        .copied()
+        .collect::<Vec<_>>();
+    assert_eq!(values, vec![1, 10, 20, 4, 5]);
+}
+
+/// Check that in-place replacement at the start of a defined range works.
+#[test]
+fn define_inplace_replacement_at_start() {
+    let mut vec = PartialVec::defined(vec![1, 2, 3, 4, 5]);
+
+    // Replace first two elements
+    vec.define(0, vec![10, 20]);
+
+    let values = vec
+        .continuous_defined_range(0..5)
+        .unwrap()
+        .into_iter()
+        .flatten()
+        .copied()
+        .collect::<Vec<_>>();
+    assert_eq!(values, vec![10, 20, 3, 4, 5]);
+}
+
+/// Check that defining data spanning both left and right nodes works correctly.
+///
+/// This tests the cross-boundary insertion case where the inserted range overlaps
+/// with both left and right children of a Concatenated node.
+#[test]
+fn define_spanning_left_and_right() {
+    let mut vec: PartialVec<u8> = PartialVec::undefined(10);
+
+    // Now create a structure with defined regions on both sides
+    vec.define(0, vec![1, 2, 3]); // Left side: indices 0-2
+    vec.define(7, vec![7, 8, 9]); // Right side: indices 7-9
+
+    // Now define data that spans across the middle, overlapping both regions
+    // This should trigger the cross-boundary insertion code path
+    vec.define(2, vec![20, 30, 40, 50, 60]);
+
+    // Check that we can read back the defined portions as expected
+    let values = vec
+        .continuous_defined_range(0..10)
+        .unwrap()
+        .into_iter()
+        .flatten()
+        .copied()
+        .collect::<Vec<_>>();
+    assert_eq!(values, vec![1, 2, 20, 30, 40, 50, 60, 7, 8, 9]);
+}
+
+/// Check that defining data across a Defined+Undefined boundary triggers the optimization.
+///
+/// This tests the special case in define() where the left child is Defined
+/// and the right child is Undefined, allowing in-place extension.
+#[test]
+fn define_across_defined_undefined_boundary() {
+    // Create structure: Defined[1,2,3] ++ Undefined(5)
+    // by starting with undefined and defining at offset 0
+    let mut vec: PartialVec<u8> = PartialVec::undefined(8);
+    vec.define(0, vec![1, 2, 3]);
+
+    // Now we have a Concatenated node: Defined[1,2,3] (left) ++ Undefined(5) (right)
+    // Define data starting within the defined region and extending into undefined.
+    // This should trigger the optimization path at lines 217-226.
+    vec.define(1, vec![10, 20, 30, 40]);
+
+    // Check that we can read back the defined portions
+    // The result should be [1, 10, 20, 30, 40] at indices 0-4
+    let values = vec
+        .continuous_defined_range(0..5)
+        .unwrap()
+        .into_iter()
+        .flatten()
+        .copied()
+        .collect::<Vec<_>>();
+    assert_eq!(values, vec![1, 10, 20, 30, 40]);
+}
+
+/// Check truncation when keep_length is greater than left node width.
+///
+/// This tests the case where truncation needs to continue into the right child
+/// of a Concatenated node.
+#[test]
+fn truncate_into_right_child() {
+    // Create a Concatenated structure by starting with undefined and defining data.
+    // This creates: Undefined(3) ++ Defined[1,2,3,4,5]
+    let mut vec: PartialVec<u8> = PartialVec::undefined(3);
+    vec.define(3, vec![1, 2, 3, 4, 5]);
+
+    // Truncate to 5 elements - this should keep the left node (3 undefined)
+    // and continue into the right node (keeping 2 defined elements)
+    vec.truncate(5);
+
+    // Verify that indices 0-2 are undefined
+    assert!(!vec.is_all_defined(0..3));
+
+    // Verify that indices 3-4 are defined
+    let values = vec
+        .continuous_defined_range(3..5)
+        .unwrap()
+        .into_iter()
+        .flatten()
+        .copied()
+        .collect::<Vec<_>>();
+    assert_eq!(values, vec![1, 2]);
+
+    // Verify that elements beyond 5 are gone
+    assert!(!vec.is_any_defined(5..8));
+}
+
+/// Check that `defined_range` returns only defined entries with correct offsets.
+#[test]
+fn defined_range_basic() {
+    let mut vec: PartialVec<u8> = PartialVec::undefined(20);
+
+    vec.define(5, vec![1, 2, 3]); // indices 5-7
+    vec.define(12, vec![4, 5, 6]); // indices 12-14
+
+    // Query a range that includes both defined regions and gaps
+    let entries: Vec<_> = vec.defined_range(0..20).collect();
+
+    assert_eq!(entries.len(), 2);
+
+    // First defined region starts at offset 5 in the queried range
+    assert_eq!(entries[0].0, 5);
+    assert_eq!(entries[0].1, &[1, 2, 3]);
+
+    // Second defined region starts at offset 12 in the queried range
+    assert_eq!(entries[1].0, 12);
+    assert_eq!(entries[1].1, &[4, 5, 6]);
+}
+
+/// Check that `defined_range` works with partial overlaps.
+#[test]
+fn defined_range_partial_overlap() {
+    let mut vec: PartialVec<u8> = PartialVec::undefined(20);
+
+    vec.define(5, vec![1, 2, 3, 4, 5]); // indices 5-9
+
+    // Query a range that partially overlaps the defined region
+    let entries: Vec<_> = vec.defined_range(7..15).collect();
+
+    assert_eq!(entries.len(), 1);
+    // The defined data starts at offset 0 in the queried range (7..15)
+    // and contains elements from index 7 and 8 of the original vec
+    assert_eq!(entries[0].0, 0);
+    assert_eq!(entries[0].1, &[3, 4, 5]);
+}
+
+/// Check that `defined_range` returns no entries when there is no defined data.
+#[test]
+fn defined_range_no_defined_data() {
+    let vec: PartialVec<u8> = PartialVec::undefined(20);
+    let entries: Vec<_> = vec.defined_range(0..20).collect();
+    assert!(entries.is_empty());
+}
+
+/// Check that `is_all_undefined` returns true for a fully undefined vector.
+#[test]
+fn is_undefined_empty() {
+    let vec: PartialVec<u8> = PartialVec::undefined(100);
+    assert!(vec.is_all_undefined());
+}
+
+/// Check that `is_all_undefined` returns true for a zero-length vector.
+#[test]
+fn is_undefined_zero_length() {
+    let vec: PartialVec<u8> = PartialVec::undefined(0);
+    assert!(vec.is_all_undefined());
+}
+
+/// Check that `is_all_undefined` returns false when there is defined data.
+#[test]
+fn is_undefined_with_defined_data() {
+    let mut vec: PartialVec<u8> = PartialVec::undefined(100);
+    vec.define(50, vec![1, 2, 3]);
+    assert!(!vec.is_all_undefined());
+}
+
+/// Check that `is_all_undefined` returns false for a fully defined vector.
+#[test]
+fn is_undefined_fully_defined() {
+    let vec = PartialVec::defined(vec![1u8, 2, 3, 4, 5]);
+    assert!(!vec.is_all_undefined());
+}
+
+/// Check that `RangeEntry::is_empty` works correctly.
+#[test]
+fn range_entry_is_empty() {
+    // Create a vector with defined and undefined regions
+    let mut vec: PartialVec<u8> = PartialVec::undefined(10);
+    vec.define(3, vec![1, 2, 3]);
+
+    // Get entries from the range and check is_empty on them
+    let entries: Vec<_> = vec.range(0..10).collect();
+
+    // We should have: undefined (0..3), defined (3..6), undefined (6..10)
+    assert_eq!(entries.len(), 3);
+
+    // All entries should be non-empty since they have length > 0
+    for entry in &entries {
+        assert!(!entry.is_empty());
+    }
+
+    // Test with an empty range - should produce no entries
+    let empty_entries: Vec<_> = vec.range(0..0).collect();
+    assert!(empty_entries.is_empty());
+}


### PR DESCRIPTION
Part of RV-861

# What

Introduces a partial vector data structure that lets you define arbitrary parts of a large space (`0..=usize::MAX`).

# Why

I found this data structure to be very useful in implementing the byte array state component (#732). It was also handy in making `DataSpace` more space efficient during proof generation (#736).

# How

I added lots of commentary within the data structure module. Please let me know what you think is missing.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.