### PR TITLE
feat(pvm-storage): enable option to use `PersistenceLayer` in pvm storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2475,6 +2475,7 @@ version = "0.0.0"
 dependencies = [
  "arbitrary-int",
  "bincode",
+ "cfg-if",
  "cranelift",
  "cranelift-jit",
  "cranelift-module",

--- a/pvm/Cargo.toml
+++ b/pvm/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 [dependencies]
 arbitrary-int.workspace = true
 bincode.workspace = true
+cfg-if.workspace = true
 cranelift.workspace = true
 cranelift-jit.workspace = true
 cranelift-module.workspace = true

--- a/pvm/src/pvm/node_pvm.rs
+++ b/pvm/src/pvm/node_pvm.rs
@@ -24,7 +24,6 @@ use octez_riscv_data::mode::Normal;
 use octez_riscv_data::mode::Provable;
 use octez_riscv_data::mode::Prove;
 use octez_riscv_data::mode::Verify;
-use octez_riscv_data::store::BlobStore;
 use octez_riscv_durable_storage::registry::CloneRegistryMode;
 use perfect_derive::perfect_derive;
 use thiserror::Error;
@@ -327,7 +326,7 @@ pub struct PvmStorage<BS> {
     repo: Repo<BS>,
 }
 
-impl<BS: BlobStore> PvmStorage<BS> {
+impl<BS: PersistentBlobStore> PvmStorage<BS> {
     pub fn close(self) {
         self.repo.close()
     }
@@ -342,9 +341,7 @@ impl<BS: BlobStore> PvmStorage<BS> {
         let pvm = self.repo.checkout_serialised(id)?;
         Ok(NodePvm::wrap(pvm))
     }
-}
 
-impl<BS: PersistentBlobStore> PvmStorage<BS> {
     /// Load or create new repo at `path`.
     pub fn load(path: impl AsRef<Path>) -> Result<Self, PvmStorageError> {
         let repo = Repo::load(path)?;

--- a/pvm/src/storage.rs
+++ b/pvm/src/storage.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 mod chunked_io;
+pub mod rocksdb_store;
 
 use std::io;
 use std::io::Write;
@@ -25,6 +26,7 @@ use octez_riscv_data::store::BlobStore;
 use octez_riscv_data::store::BlobStoreError;
 use octez_riscv_data::store::fold::BlobStoreFold;
 use octez_riscv_data::store::unfold::BlobStoreUnfold;
+use octez_riscv_durable_storage::errors::OperationalError;
 use thiserror::Error;
 
 const CHUNK_SIZE: usize = 4096;
@@ -43,6 +45,9 @@ pub enum StorageError {
     #[error("Invalid repo")]
     InvalidRepo,
 
+    #[error("RocksDBStore error: {0:?}")]
+    RocksDBError(#[from] OperationalError),
+
     #[error("Committed chunk {0} not found")]
     ChunkNotFound(String),
 
@@ -53,8 +58,8 @@ pub enum StorageError {
     UnfoldError(#[from] UnfoldError),
 }
 
-/// A subtrait for `BlobStore` to provide extra functionality required by the PVM storage to export
-/// PVM snapshots.
+/// A subtrait for `BlobStore` to provide extra functionality required by the PVM storage to
+/// persist and export PVM snapshots.
 pub trait PersistentBlobStore: BlobStore {
     /// Initialise a store. Either create a new directory if `path` does not exist or initialise in
     /// an existing directory.
@@ -63,6 +68,13 @@ pub trait PersistentBlobStore: BlobStore {
     fn init_from_path(path: impl AsRef<Path>) -> Result<Self, StorageError>
     where
         Self: Sized;
+
+    /// Some implementations do not automatically persist all the blobs; when the blob store is
+    /// dropped, they will be lost. Calling this method will take a 'snapshot' of the state of the
+    /// blob store which is persistent at the `path` the store was created from.
+    ///
+    /// This will be a no-op in implementations where it is uneccessary.
+    fn persist(&self) -> Result<(), StorageError>;
 
     /// Copy a specific blob across to a different store. While this should be functionally
     /// equivalent to using `blob_get` followed by `blob_set` to copy the blob across, it could in
@@ -125,6 +137,11 @@ impl PersistentBlobStore for Store {
         Ok(Store {
             path: path.into_boxed_path(),
         })
+    }
+
+    fn persist(&self) -> Result<(), StorageError> {
+        // With `Store` the blobs are automatically persisted, so this is a no-op.
+        Ok(())
     }
 
     fn export_blob(&self, other: &mut Self, hash: Hash) -> Result<(), StorageError> {
@@ -208,6 +225,9 @@ impl<BS: PersistentBlobStore> Repo<BS> {
             self.backend.export_blob(&mut other, chunk)?;
         }
         self.backend.export_blob(&mut other, id)?;
+
+        other.persist()?;
+
         Ok(())
     }
 
@@ -227,15 +247,15 @@ impl<BS: PersistentBlobStore> Repo<BS> {
         let source = BlobStoreUnfold::new(Arc::clone(&self.backend), id);
         let state = State::unfold(source)?;
 
-        let other = Self::init_empty(path)?;
-        let builder = BlobStoreFold::from(Arc::new(other));
+        let other = Arc::new(Self::init_empty(path)?);
+        let builder = BlobStoreFold::from(Arc::clone(&other));
         state.fold(builder)?;
+
+        other.persist()?;
 
         Ok(())
     }
-}
 
-impl<BS: BlobStore> Repo<BS> {
     pub fn new(store: BS) -> Self {
         Repo {
             backend: Arc::new(store),
@@ -259,6 +279,8 @@ impl<BS: BlobStore> Repo<BS> {
         let hashed_commit_bytes = HashedData::from_data(commit_bytes);
         self.backend.blob_set(&hashed_commit_bytes)?;
 
+        self.backend.persist()?;
+
         Ok(hashed_commit_bytes.hash())
     }
 
@@ -275,6 +297,8 @@ impl<BS: BlobStore> Repo<BS> {
         let hashed_commit_bytes = HashedData::from_data(commit_bytes);
         self.backend.blob_set(&hashed_commit_bytes)?;
 
+        self.backend.persist()?;
+
         Ok(hashed_commit_bytes.hash())
     }
 
@@ -284,8 +308,11 @@ impl<BS: BlobStore> Repo<BS> {
         subject: &impl Foldable<BlobStoreFold<BS>>,
     ) -> Result<Hash, StorageError> {
         let builder = BlobStoreFold::from(Arc::clone(&self.backend));
+        let hash = subject.fold(builder)?;
 
-        Ok(subject.fold(builder)?)
+        self.backend.persist()?;
+
+        Ok(hash)
     }
 
     /// Checkout the bytes committed under `id`, if the commit exists.

--- a/pvm/src/storage/rocksdb_store.rs
+++ b/pvm/src/storage/rocksdb_store.rs
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2026 Trilitech <contact@trili.tech>
+//
+// SPDX-License-Identifier: MIT
+
+#![cfg(feature = "rocksdb")]
+
+//! Implementation of `BlobStore` that can persist to disk using RocksDB.
+
+use std::path::Path;
+use std::path::PathBuf;
+
+use octez_riscv_data::hash;
+use octez_riscv_data::store::BlobStore;
+use octez_riscv_data::store::BlobStoreError;
+use octez_riscv_durable_storage::errors::Error;
+use octez_riscv_durable_storage::errors::InvalidArgumentError;
+use octez_riscv_durable_storage::persistence_layer::PersistenceLayer;
+use octez_riscv_durable_storage::repo::DirectoryManager;
+use octez_riscv_durable_storage::storage::KeyValueStore;
+use octez_riscv_durable_storage::storage::PersistentKeyValueStore;
+
+use super::PersistentBlobStore;
+use super::StorageError;
+
+/// An on-disk blob store implementation that uses RocksDB. Basically a fairly simple wrapper
+/// around the persistence layer implemented in the durable storage crate.
+///
+/// Does not behave exactly like `Store` in terms of persistence; when it is dropped, the
+/// persistence layer deletes its main 'temporary' directory, so in order to make blobs persistent
+/// beyond dropping this struct you must call the `persist` method.
+pub struct RocksDBStore {
+    inner: PersistenceLayer,
+    persist_path: PathBuf,
+    tmp_commit_path: PathBuf,
+}
+
+fn from_durable_storage_error(key: hash::Hash, e: Error) -> BlobStoreError {
+    match e {
+        Error::InvalidArgument(InvalidArgumentError::KeyNotFound) => BlobStoreError::NotFound(key),
+        _ => BlobStoreError::Custom(Box::new(e)),
+    }
+}
+
+impl BlobStore for RocksDBStore {
+    fn blob_get(&self, key: hash::Hash) -> Result<impl AsRef<[u8]>, BlobStoreError> {
+        self.inner
+            .blob_get(key)
+            .map_err(|e| from_durable_storage_error(key, e))
+    }
+
+    fn blob_set<Data: AsRef<[u8]>>(
+        &self,
+        blob: &hash::HashedData<Data>,
+    ) -> Result<(), BlobStoreError> {
+        self.inner
+            .blob_set(blob.hash(), blob.data())
+            .map_err(|e| BlobStoreError::Custom(Box::new(e)))
+    }
+
+    fn blob_delete(&self, key: hash::Hash) -> Result<(), BlobStoreError> {
+        self.inner
+            .blob_delete(key)
+            .map_err(|e| BlobStoreError::Custom(Box::new(e)))
+    }
+}
+
+impl PersistentBlobStore for RocksDBStore {
+    fn init_from_path(path: impl AsRef<Path>) -> Result<Self, StorageError>
+    where
+        Self: Sized,
+    {
+        let repo = DirectoryManager::new(path.as_ref())?;
+        let tempdir = repo.temp_database_dir()?;
+
+        let persist_path = PathBuf::from(path.as_ref()).join("committed");
+        let tmp_commit_path = PathBuf::from(path.as_ref()).join("tmp");
+
+        let inner = if persist_path.exists() {
+            PersistenceLayer::checkout_from_path(persist_path.as_path(), tempdir)
+        } else {
+            PersistenceLayer::new(&repo)
+        }?;
+
+        Ok(Self {
+            inner,
+            persist_path,
+            tmp_commit_path,
+        })
+    }
+
+    // TODO (TZX-130): fix the trait to be more compatible with the persistence layer, removing the
+    // need for this slightly hacky approach.
+    fn persist(&self) -> Result<(), StorageError> {
+        self.inner.commit_to_path(self.tmp_commit_path.as_path())?;
+
+        if self.persist_path.as_path().exists() {
+            std::fs::remove_dir_all(self.persist_path.as_path())?;
+        }
+        std::fs::rename(&self.tmp_commit_path, &self.persist_path)?;
+
+        Ok(())
+    }
+}

--- a/pvm/tests/test_pvm_storage.rs
+++ b/pvm/tests/test_pvm_storage.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: MIT
 
+#![cfg(test)]
+
 use std::fs::File;
 
 use octez_riscv::machine_state::memory::M1M;
@@ -12,7 +14,6 @@ use octez_riscv::pvm::node_pvm::NodePvm;
 use octez_riscv::pvm::node_pvm::PvmStorage;
 use octez_riscv::storage::Repo;
 use octez_riscv::storage::StorageError;
-use octez_riscv::storage::Store;
 use octez_riscv_data::hash::Hash;
 use octez_riscv_data::mode::Normal;
 use octez_riscv_data::store::BlobStoreError;
@@ -21,191 +22,236 @@ use proptest::prelude::*;
 use proptest::strategy::ValueTree;
 use proptest::test_runner::TestRunner;
 
-#[test]
-fn test_repo() {
-    let mut runner = TestRunner::default();
+macro_rules! repo_test {
+    (
+        $ty_name:ident,
+        $(#[$attr:meta])*
+        fn $fn_name:ident() $body:block
+    ) => {
+        paste::paste! {
+            $(#[$attr])*
+            #[test]
+            fn $fn_name() {
+                fn inner<$ty_name: octez_riscv::storage::PersistentBlobStore>() $body
+                inner::<octez_riscv::storage::Store>();
+            }
 
-    let tmp_dir = TestableTmpdir::new();
-    let mut test_data = Vec::new();
-
-    // Create a new repo, commit 5 times and check that all 5 commits can
-    // be checked out
-    let repo = Repo::<Store>::load(tmp_dir.path()).unwrap();
-    for _ in 0..5 {
-        let data = prop::collection::vec(any::<u8>(), 0..100)
-            .new_tree(&mut runner)
-            .unwrap()
-            .current();
-        let commit_id = repo.commit(&data).unwrap();
-        test_data.push((commit_id, data));
+            $(#[$attr])*
+            #[cfg(feature = "rocksdb")]
+            #[test]
+            fn [<$fn_name _rocksdb>]() {
+                fn inner<$ty_name: octez_riscv::storage::PersistentBlobStore>() $body
+                inner::<octez_riscv::storage::rocksdb_store::RocksDBStore>();
+            }
+        }
     }
-    for (commit_id, bytes) in test_data.iter() {
-        let checked_out_data = repo.checkout(commit_id).unwrap();
-        assert_eq!(checked_out_data, *bytes);
-    }
-    repo.close();
-
-    // Reload the repo and check that all previous commits can be checked out
-    let repo = Repo::<Store>::load(tmp_dir.path()).unwrap();
-    for (commit_id, bytes) in test_data.iter() {
-        let checked_out_data = repo.checkout(commit_id).unwrap();
-        assert_eq!(checked_out_data, *bytes);
-    }
-
-    // Make 5 additional commits and check that all 10 commits can be checked out
-    for _ in 0..5 {
-        let data = prop::collection::vec(any::<u8>(), 0..100)
-            .new_tree(&mut runner)
-            .unwrap()
-            .current();
-        let commit_id = repo.commit(&data).unwrap();
-        test_data.push((commit_id, data));
-    }
-    for (commit_id, bytes) in test_data.iter() {
-        let checked_out_data = repo.checkout(commit_id).unwrap();
-        assert_eq!(checked_out_data, *bytes);
-    }
-
-    // Check that an unknown commit returns a `NotFound` error
-    let unknown_hash: Hash = [0u8; Hash::DIGEST_SIZE].into();
-    assert!(matches!(
-        repo.checkout(&unknown_hash),
-        Err(StorageError::BlobStore(BlobStoreError::NotFound(_)))
-    ));
-
-    // Check that exporting a snapshot creates a new repo which contains
-    // the requested commit
-    let snapshot_dir = TestableTmpdir::new();
-    let (export_hash, export_data) = &test_data[0];
-    repo.export_snapshot_chunked(*export_hash, snapshot_dir.path())
-        .unwrap();
-    let snapshot_repo = Repo::<Store>::load(snapshot_dir.path()).unwrap();
-    let checked_out_data = snapshot_repo.checkout(export_hash).unwrap();
-    assert_eq!(checked_out_data, *export_data);
 }
 
-#[test]
-fn test_repo_serialised() {
-    let mut runner = TestRunner::default();
+repo_test!(
+    TestStore,
+    fn test_repo() {
+        let mut runner = TestRunner::default();
 
-    let tmp_dir = TestableTmpdir::new();
-    let mut test_data = Vec::new();
+        let tmp_dir = TestableTmpdir::new();
+        let mut test_data = Vec::new();
 
-    // Create a new repo, commit 5 times and check that all 5 commits can
-    // be checked out
-    let repo = Repo::<Store>::load(tmp_dir.path()).unwrap();
-    for _ in 0..5 {
-        let data = prop::collection::vec(any::<u8>(), 0..100)
-            .new_tree(&mut runner)
-            .unwrap()
-            .current();
-        let commit_id = repo.commit_serialised(&data).unwrap();
-        test_data.push((commit_id, data));
+        // Create a new repo, commit 5 times and check that all 5 commits can
+        // be checked out
+        let repo = Repo::<TestStore>::load(tmp_dir.path()).unwrap();
+        for _ in 0..5 {
+            let data = prop::collection::vec(any::<u8>(), 0..100)
+                .new_tree(&mut runner)
+                .unwrap()
+                .current();
+            let commit_id = repo.commit(&data).unwrap();
+            test_data.push((commit_id, data));
+        }
+        for (commit_id, bytes) in test_data.iter() {
+            let checked_out_data = repo.checkout(commit_id).unwrap();
+            assert_eq!(checked_out_data, *bytes);
+        }
+        repo.close();
+
+        // Reload the repo and check that all previous commits can be checked out
+        let repo = Repo::<TestStore>::load(tmp_dir.path()).unwrap();
+        for (commit_id, bytes) in test_data.iter() {
+            let checked_out_data = repo.checkout(commit_id).unwrap();
+            assert_eq!(checked_out_data, *bytes);
+        }
+
+        // Make 5 additional commits and check that all 10 commits can be checked out
+        for _ in 0..5 {
+            let data = prop::collection::vec(any::<u8>(), 0..100)
+                .new_tree(&mut runner)
+                .unwrap()
+                .current();
+            let commit_id = repo.commit(&data).unwrap();
+            test_data.push((commit_id, data));
+        }
+        for (commit_id, bytes) in test_data.iter() {
+            let checked_out_data = repo.checkout(commit_id).unwrap();
+            assert_eq!(checked_out_data, *bytes);
+        }
+
+        // Check that an unknown commit returns a `NotFound` error
+        let unknown_hash: Hash = [0u8; Hash::DIGEST_SIZE].into();
+        assert!(matches!(
+            repo.checkout(&unknown_hash),
+            Err(StorageError::BlobStore(BlobStoreError::NotFound(_)))
+        ));
+
+        // Check that exporting a snapshot creates a new repo which contains
+        // the requested commit
+        let snapshot_dir = TestableTmpdir::new();
+        let (export_hash, export_data) = &test_data[0];
+        repo.export_snapshot_chunked(*export_hash, snapshot_dir.path())
+            .unwrap();
+        let snapshot_repo = Repo::<TestStore>::load(snapshot_dir.path()).unwrap();
+        let checked_out_data = snapshot_repo.checkout(export_hash).unwrap();
+        assert_eq!(checked_out_data, *export_data);
     }
-    for (commit_id, bytes) in test_data.iter() {
-        let checked_out_data: Vec<u8> = repo.checkout_serialised(commit_id).unwrap();
-        assert_eq!(checked_out_data, *bytes);
-    }
-    repo.close();
+);
 
-    // Reload the repo and check that all previous commits can be checked out
-    let repo = Repo::<Store>::load(tmp_dir.path()).unwrap();
-    for (commit_id, bytes) in test_data.iter() {
-        let checked_out_data: Vec<u8> = repo.checkout_serialised(commit_id).unwrap();
-        assert_eq!(checked_out_data, *bytes);
-    }
+repo_test!(
+    TestStore,
+    fn test_repo_serialised() {
+        let mut runner = TestRunner::default();
 
-    // Make 5 additional commits and check that all 10 commits can be checked out
-    for _ in 0..5 {
-        let data = prop::collection::vec(any::<u8>(), 0..100)
-            .new_tree(&mut runner)
-            .unwrap()
-            .current();
-        let commit_id = repo.commit_serialised(&data).unwrap();
-        test_data.push((commit_id, data));
-    }
-    for (commit_id, bytes) in test_data.iter() {
-        let checked_out_data: Vec<u8> = repo.checkout_serialised(commit_id).unwrap();
-        assert_eq!(checked_out_data, *bytes);
-    }
+        let tmp_dir = TestableTmpdir::new();
+        let mut test_data = Vec::new();
 
-    // Check that an unknown commit returns a `NotFound` error
-    let unknown_hash: Hash = [0u8; Hash::DIGEST_SIZE].into();
-    assert!(matches!(
-        repo.checkout_serialised::<Vec<u8>>(&unknown_hash),
-        Err(StorageError::BlobStore(BlobStoreError::NotFound(_)))
-    ));
+        // Create a new repo, commit 5 times and check that all 5 commits can
+        // be checked out
+        let repo = Repo::<TestStore>::load(tmp_dir.path()).unwrap();
+        for _ in 0..5 {
+            let data = prop::collection::vec(any::<u8>(), 0..100)
+                .new_tree(&mut runner)
+                .unwrap()
+                .current();
+            let commit_id = repo.commit_serialised(&data).unwrap();
+            test_data.push((commit_id, data));
+        }
+        for (commit_id, bytes) in test_data.iter() {
+            let checked_out_data: Vec<u8> = repo.checkout_serialised(commit_id).unwrap();
+            assert_eq!(checked_out_data, *bytes);
+        }
 
-    // Check that exporting a snapshot creates a new repo which contains
-    // the requested commit
-    let snapshot_dir = TestableTmpdir::new();
-    let (export_hash, export_data) = &test_data[0];
-    repo.export_snapshot_chunked(*export_hash, snapshot_dir.path())
-        .unwrap();
-    let snapshot_repo = Repo::<Store>::load(snapshot_dir.path()).unwrap();
-    let checked_out_data: Vec<u8> = snapshot_repo.checkout_serialised(export_hash).unwrap();
-    assert_eq!(checked_out_data, *export_data);
-}
+        repo.close();
+
+        // Reload the repo and check that all previous commits can be checked out
+        let repo = Repo::<TestStore>::load(tmp_dir.path()).unwrap();
+
+        for (commit_id, bytes) in test_data.iter() {
+            let checked_out_data: Vec<u8> = repo.checkout_serialised(commit_id).unwrap();
+            assert_eq!(checked_out_data, *bytes);
+        }
+
+        // Make 5 additional commits and check that all 10 commits can be checked out
+        for _ in 0..5 {
+            let data = prop::collection::vec(any::<u8>(), 0..100)
+                .new_tree(&mut runner)
+                .unwrap()
+                .current();
+            let commit_id = repo.commit_serialised(&data).unwrap();
+            test_data.push((commit_id, data));
+        }
+        for (commit_id, bytes) in test_data.iter() {
+            let checked_out_data: Vec<u8> = repo.checkout_serialised(commit_id).unwrap();
+            assert_eq!(checked_out_data, *bytes);
+        }
+
+        // Check that an unknown commit returns a `NotFound` error
+        let unknown_hash: Hash = [0u8; Hash::DIGEST_SIZE].into();
+        assert!(matches!(
+            repo.checkout_serialised::<Vec<u8>>(&unknown_hash),
+            Err(StorageError::BlobStore(BlobStoreError::NotFound(_)))
+        ));
+
+        // Check that exporting a snapshot creates a new repo which contains
+        // the requested commit
+        let snapshot_dir = TestableTmpdir::new();
+        let (export_hash, export_data) = &test_data[0];
+        repo.export_snapshot_chunked(*export_hash, snapshot_dir.path())
+            .unwrap();
+        let snapshot_repo = Repo::<TestStore>::load(snapshot_dir.path()).unwrap();
+        let checked_out_data: Vec<u8> = snapshot_repo.checkout_serialised(export_hash).unwrap();
+        assert_eq!(checked_out_data, *export_data);
+    }
+);
 
 type TestPvm = Pvm<M1M, EmptyPageCache, DurableStorageDummy, Normal>;
 
-#[test]
-fn test_repo_folding() {
-    let tmp_dir = TestableTmpdir::new();
-    let repo = Repo::<Store>::load(tmp_dir.path()).unwrap();
+repo_test!(
+    TestStore,
+    fn test_repo_folding() {
+        let tmp_dir = TestableTmpdir::new();
+        let repo = Repo::<TestStore>::load(tmp_dir.path()).unwrap();
 
-    let empty_pvm = TestPvm::default();
-    let hash = repo.commit_folded(&empty_pvm).unwrap();
-    let checked_out = repo.checkout_folded::<TestPvm>(&hash).unwrap();
+        let empty_pvm = TestPvm::default();
+        let hash = repo.commit_folded(&empty_pvm).unwrap();
 
-    // We use `assert!` to avoid very verbose test failures
-    assert!(empty_pvm == checked_out);
+        repo.close();
 
-    let snapshot_dir = TestableTmpdir::new();
-    repo.export_snapshot_folded::<TestPvm>(hash, &snapshot_dir.path())
-        .unwrap();
+        let repo = Repo::<TestStore>::load(tmp_dir.path()).unwrap();
+        let checked_out = repo.checkout_folded::<TestPvm>(&hash).unwrap();
 
-    let snapshot_repo = Repo::<Store>::load(snapshot_dir.path()).unwrap();
-    let checked_out_from_snapshot = snapshot_repo.checkout_folded::<TestPvm>(&hash).unwrap();
+        // We use `assert!` to avoid very verbose test failures
+        assert!(empty_pvm == checked_out);
 
-    assert!(empty_pvm == checked_out_from_snapshot);
-}
+        let snapshot_dir = TestableTmpdir::new();
+        repo.export_snapshot_folded::<TestPvm>(hash, snapshot_dir.path())
+            .unwrap();
+
+        let snapshot_repo = Repo::<TestStore>::load(snapshot_dir.path()).unwrap();
+        let checked_out_from_snapshot = snapshot_repo.checkout_folded::<TestPvm>(&hash).unwrap();
+
+        assert!(empty_pvm == checked_out_from_snapshot);
+    }
+);
 
 // Mirrors `src/lib_riscv/pvm/test/test_storage.ml`
-#[test]
-fn test_pvm_storage() {
-    let tmp_dir = TestableTmpdir::new();
-    let empty = NodePvm::empty();
-    let mut repo = PvmStorage::<Store>::load(tmp_dir.path()).unwrap();
-    let id = repo.commit(&empty).unwrap();
-    let checked_out_empty = repo.checkout(&id).unwrap();
-    assert_eq!(empty, checked_out_empty);
-    let id2 = repo.commit(&empty).unwrap();
-    assert_eq!(id, id2);
-    repo.close()
-}
+repo_test!(
+    TestStore,
+    fn test_pvm_storage() {
+        let tmp_dir = TestableTmpdir::new();
+        let empty = NodePvm::empty();
+        let mut repo = PvmStorage::<TestStore>::load(tmp_dir.path()).unwrap();
+        let id = repo.commit(&empty).unwrap();
+        let checked_out_empty = repo.checkout(&id).unwrap();
+        assert_eq!(empty, checked_out_empty);
+        let id2 = repo.commit(&empty).unwrap();
+        assert_eq!(id, id2);
+        repo.close()
+    }
+);
 
-#[test]
-fn test_invalid_repo() {
-    // Error if we try to initialise a repo with a path that is a file, not a directory.
-    let tmp_dir = TestableTmpdir::new();
-    let tmp_file_path = tmp_dir.path().join("blah");
-    let _tmp_file = File::create(tmp_file_path.as_path()).unwrap();
-    let load_result = Repo::<Store>::load(tmp_file_path.as_path());
+repo_test!(
+    TestStore,
+    fn test_invalid_repo() {
+        // Error if we try to initialise a repo with a path that is a file, not a directory.
+        let tmp_dir = TestableTmpdir::new();
+        let tmp_file_path = tmp_dir.path().join("blah");
+        let _tmp_file = File::create(tmp_file_path.as_path()).unwrap();
+        let load_result = Repo::<TestStore>::load(tmp_file_path.as_path());
 
-    assert!(matches!(load_result, Err(StorageError::InvalidRepo)));
+        println!("{:?}", load_result.as_ref().err());
+        assert!(matches!(
+            load_result,
+            Err(StorageError::InvalidRepo | StorageError::RocksDBError(_))
+        ));
 
-    // Error if we try to export a snapshot to non-empty directory.
-    let tmp_dir_2 = TestableTmpdir::new();
-    let repo = Repo::<Store>::load(tmp_dir_2.path()).unwrap();
+        // Error if we try to export a snapshot to non-empty directory.
+        let tmp_dir_2 = TestableTmpdir::new();
+        let repo = Repo::<TestStore>::load(tmp_dir_2.path()).unwrap();
 
-    let data = vec![];
-    let id = repo.commit(&data).unwrap();
-    let export_result = repo.export_snapshot_chunked(id, tmp_dir.path());
+        let data = vec![];
+        let id = repo.commit(&data).unwrap();
+        let export_result = repo.export_snapshot_chunked(id, tmp_dir.path());
 
-    assert!(matches!(export_result, Err(StorageError::InvalidRepo)));
+        assert!(matches!(export_result, Err(StorageError::InvalidRepo)));
 
-    // Error if we try to export a snapshot to a path that is a file, not a directory.
-    let export_result = repo.export_snapshot_chunked(id, tmp_file_path);
-    assert!(matches!(export_result, Err(StorageError::InvalidRepo)));
-}
+        // Error if we try to export a snapshot to a path that is a file, not a directory.
+        let export_result = repo.export_snapshot_chunked(id, tmp_file_path);
+        assert!(matches!(export_result, Err(StorageError::InvalidRepo)));
+    }
+);


### PR DESCRIPTION
Closes TZX-72
Closes TZX-73

# What

This PR adds a feature flag `rocksdb` that allows the PVM storage to use the persistence layer (without changing the chunking or folding logic at all).

# Why

For now we want the option of using the persistence layer for benchmarking, in future we may switch to using it for all PVM commits.

# How

We add a module `storage::rocksdb_store` that contains a wrapper around the persistence layer. This wrapper type implements `BlobStore` and `PersistentBlobStore` meaning it can be used by the PVM storage as a drop-in replacement for the existing `Store`.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
