### PR TITLE
refactor(blob-store): blob store error type

### DIFF
--- a/data/src/store.rs
+++ b/data/src/store.rs
@@ -15,32 +15,45 @@ use bytes::Bytes;
 use crate::hash::Hash;
 use crate::hash::HashedData;
 
+/// Error type for errors that can occur in any `BlobStore` implementation, including a `Custom`
+/// variant to allow different implementations to include their own specific errors.
+#[derive(Debug, thiserror::Error)]
+pub enum BlobStoreError {
+    #[error("Blob not found in store: {0}")]
+    NotFound(Hash),
+
+    #[error("Store-specific error: {0}")]
+    Custom(Box<dyn std::error::Error + Send + Sync>),
+}
+
 /// Content addressable store that can contain arbitrary blobs of data indexed by their hashes.
 pub trait BlobStore {
-    type Error: std::error::Error + 'static;
-
-    /// Retrieve a blob from its hash. If a hash is not found that must be somehow represented with
-    /// the `Error` return type.
-    fn blob_get(&self, key: Hash) -> Result<impl AsRef<[u8]>, Self::Error>;
+    /// Retrieve a blob from its hash. Will return `BlobStoreError::NotFound` if the hash is not
+    /// present in the store.
+    fn blob_get(&self, key: Hash) -> Result<impl AsRef<[u8]>, BlobStoreError>;
 
     /// Store a blob under its hash; should be a no-op if it is already present.
-    fn blob_set<Data: AsRef<[u8]>>(&self, blob: &HashedData<Data>) -> Result<(), Self::Error>;
+    fn blob_set<Data: AsRef<[u8]>>(&self, blob: &HashedData<Data>) -> Result<(), BlobStoreError>;
 
     /// Remove an item from the store; should be a no-op if it is already absent.
-    fn blob_delete(&self, key: Hash) -> Result<(), Self::Error>;
+    fn blob_delete(&self, key: Hash) -> Result<(), BlobStoreError>;
 }
 
 /// Basic implementation of the `BlobStore` trait for use in tests and any other time we don't want
 /// to persist data to disk.
 pub struct InMemoryBlobStore(RwLock<HashMap<Hash, Bytes>>);
 
+/// Error type for errors that are specific to the `InMemoryBlobStore`.
 #[derive(Debug, thiserror::Error)]
 pub enum InMemoryError {
-    #[error("Blob not found in store: {0}")]
-    NotFound(Hash),
-
     #[error("RwLock in blob store was poisoned.")]
     LockPoisoned,
+}
+
+impl From<InMemoryError> for BlobStoreError {
+    fn from(e: InMemoryError) -> Self {
+        Self::Custom(Box::new(e))
+    }
 }
 
 #[cfg(test)]
@@ -51,23 +64,21 @@ impl InMemoryBlobStore {
 }
 
 impl BlobStore for InMemoryBlobStore {
-    type Error = InMemoryError;
-
-    fn blob_get(&self, key: Hash) -> Result<impl AsRef<[u8]>, Self::Error> {
+    fn blob_get(&self, key: Hash) -> Result<impl AsRef<[u8]>, BlobStoreError> {
         let store = self.0.read().map_err(|_| InMemoryError::LockPoisoned)?;
         match store.get(&key) {
             Some(blob) => Ok(blob.clone()),
-            None => Err(InMemoryError::NotFound(key)),
+            None => Err(BlobStoreError::NotFound(key)),
         }
     }
 
-    fn blob_set<Data: AsRef<[u8]>>(&self, blob: &HashedData<Data>) -> Result<(), Self::Error> {
+    fn blob_set<Data: AsRef<[u8]>>(&self, blob: &HashedData<Data>) -> Result<(), BlobStoreError> {
         let mut store = self.0.write().map_err(|_| InMemoryError::LockPoisoned)?;
         store.insert(blob.hash(), Bytes::copy_from_slice(blob.data()));
         Ok(())
     }
 
-    fn blob_delete(&self, key: Hash) -> Result<(), Self::Error> {
+    fn blob_delete(&self, key: Hash) -> Result<(), BlobStoreError> {
         let mut store = self.0.write().map_err(|_| InMemoryError::LockPoisoned)?;
         store.remove(&key);
         Ok(())

--- a/data/src/store/fold.rs
+++ b/data/src/store/fold.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use derive_more::From;
 
 use super::BlobStore;
+use super::BlobStoreError;
 use crate::foldable::Fold;
 use crate::foldable::FoldLeaf;
 use crate::foldable::Foldable;
@@ -32,11 +33,11 @@ pub struct BlobStoreFold<BS> {
 pub struct BlobStoreNodeFold<BS: BlobStore> {
     store: Arc<BS>,
     bytes: Vec<u8>,
-    error: Option<BS::Error>,
+    error: Option<BlobStoreError>,
 }
 
 impl<BS: BlobStore> Fold for BlobStoreFold<BS> {
-    type Folded = Result<Hash, BS::Error>;
+    type Folded = Result<Hash, BlobStoreError>;
 
     type NodeFold = BlobStoreNodeFold<BS>;
 
@@ -50,7 +51,7 @@ impl<BS: BlobStore> Fold for BlobStoreFold<BS> {
 }
 
 impl<BS: BlobStore> FoldLeaf for BlobStoreFold<BS> {
-    fn fold_leaf_raw(self, bytes: &[u8]) -> Result<Hash, BS::Error> {
+    fn fold_leaf_raw(self, bytes: &[u8]) -> Result<Hash, BlobStoreError> {
         let hashed = HashedData::from_data(bytes);
         self.store.blob_set(&hashed)?;
         Ok(hashed.hash())
@@ -76,7 +77,7 @@ impl<BS: BlobStore> NodeFold for BlobStoreNodeFold<BS> {
         };
     }
 
-    fn done(self) -> Result<Hash, BS::Error> {
+    fn done(self) -> Result<Hash, BlobStoreError> {
         if let Some(e) = self.error {
             Err(e)
         } else {
@@ -101,12 +102,19 @@ mod tests {
     use crate::hash::HashedData;
     use crate::mode::Normal;
     use crate::store::BlobStore;
+    use crate::store::BlobStoreError;
     use crate::store::InMemoryBlobStore;
 
     #[derive(Debug, thiserror::Error)]
     enum TestError {
         #[error("Test error")]
         TestError,
+    }
+
+    impl From<TestError> for BlobStoreError {
+        fn from(e: TestError) -> Self {
+            Self::Custom(Box::new(e))
+        }
     }
 
     struct ErroringBlobStore {
@@ -124,22 +132,23 @@ mod tests {
     }
 
     impl BlobStore for ErroringBlobStore {
-        type Error = TestError;
-
-        fn blob_get(&self, key: Hash) -> Result<impl AsRef<[u8]>, Self::Error> {
+        fn blob_get(&self, key: Hash) -> Result<impl AsRef<[u8]>, BlobStoreError> {
             Ok(self.inner.blob_get(key).unwrap())
         }
 
-        fn blob_set<Data: AsRef<[u8]>>(&self, blob: &HashedData<Data>) -> Result<(), Self::Error> {
+        fn blob_set<Data: AsRef<[u8]>>(
+            &self,
+            blob: &HashedData<Data>,
+        ) -> Result<(), BlobStoreError> {
             if blob.hash() == self.error_hash {
-                Err(TestError::TestError)
+                Err(TestError::TestError)?
             } else {
                 self.inner.blob_set(blob).unwrap();
                 Ok(())
             }
         }
 
-        fn blob_delete(&self, key: Hash) -> Result<(), Self::Error> {
+        fn blob_delete(&self, key: Hash) -> Result<(), BlobStoreError> {
             self.inner.blob_delete(key).unwrap();
             Ok(())
         }

--- a/pvm/src/storage.rs
+++ b/pvm/src/storage.rs
@@ -19,6 +19,7 @@ use octez_riscv_data::hash::HashError;
 use octez_riscv_data::hash::HashedData;
 use octez_riscv_data::serialisation;
 use octez_riscv_data::store::BlobStore;
+use octez_riscv_data::store::BlobStoreError;
 use thiserror::Error;
 
 const CHUNK_SIZE: usize = 4096;
@@ -120,24 +121,30 @@ impl Store {
 }
 
 impl BlobStore for Store {
-    type Error = StorageError;
-
-    fn blob_get(&self, key: Hash) -> Result<impl AsRef<[u8]>, Self::Error> {
-        self.load(&key)
+    fn blob_get(&self, hash: Hash) -> Result<impl AsRef<[u8]>, BlobStoreError> {
+        let file_name = self.path_of_hash(&hash);
+        std::fs::read(file_name).map_err(|e| {
+            if e.kind() == io::ErrorKind::NotFound {
+                BlobStoreError::NotFound(hash)
+            } else {
+                BlobStoreError::Custom(Box::new(e))
+            }
+        })
     }
 
-    fn blob_set<Data: AsRef<[u8]>>(&self, blob: &HashedData<Data>) -> Result<(), Self::Error> {
+    fn blob_set<Data: AsRef<[u8]>>(&self, blob: &HashedData<Data>) -> Result<(), BlobStoreError> {
         let file_name = self.path_of_hash(&blob.hash());
-        self.write_data_if_new(file_name, blob.data())?;
+        self.write_data_if_new(file_name, blob.data())
+            .map_err(|e| BlobStoreError::Custom(Box::new(e)))?;
         Ok(())
     }
 
-    fn blob_delete(&self, key: Hash) -> Result<(), Self::Error> {
+    fn blob_delete(&self, key: Hash) -> Result<(), BlobStoreError> {
         let file_name = self.path_of_hash(&key);
         match std::fs::remove_file(file_name) {
             Ok(_) => Ok(()),
             Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
-            Err(e) => Err(StorageError::IoError(e)),
+            Err(e) => Err(BlobStoreError::Custom(Box::new(e))),
         }
     }
 }
@@ -232,8 +239,8 @@ mod tests {
     use octez_riscv_data::hash::Hash;
     use octez_riscv_data::hash::HashedData;
     use octez_riscv_data::store::BlobStore;
+    use octez_riscv_data::store::BlobStoreError;
 
-    use super::StorageError;
     use super::Store;
 
     #[test]
@@ -256,7 +263,9 @@ mod tests {
         store.blob_delete(hash1).unwrap();
 
         match store.blob_get(hash1) {
-            Err(StorageError::NotFound(hash)) => assert_eq!(hash, hash1.to_string()),
+            Err(BlobStoreError::NotFound(hash)) => {
+                assert_eq!(hash, hash1)
+            }
             _ => panic!("Expected `NotFound` error"),
         };
 


### PR DESCRIPTION
Part of TZX-86.

# What

Switch from an associated error type in the `BlobStore` trait to a dedicated `BlobStoreError` enum representing the common errors that a blob store may experience (with a `Custom` variant for other errors associated with specific implementations).

# Why

This is an approach that is easier to integrate into other error types such as the existing `StorageError` in the PVM storage module, which will happen in a follow up PR.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
