### PR TITLE
feat(Merkle): partially implement `Verify` mode

### DIFF
--- a/data/src/components/bytes.rs
+++ b/data/src/components/bytes.rs
@@ -979,7 +979,7 @@ impl<'normal> ProveImpl<'normal> {
 }
 
 /// [`crate::mode::Verify`] mode implementation for the [`Bytes`] component
-#[perfect_derive(Clone)]
+#[perfect_derive(Clone, Debug)]
 struct VerifyImpl {
     original_length: Partial<usize>,
     length: Partial<usize>,

--- a/data/src/merkle_proof.rs
+++ b/data/src/merkle_proof.rs
@@ -23,7 +23,7 @@ use crate::hash::PartialHashFold;
 
 /// Possible outcomes when parsing a node or a leaf from a Merkle proof
 /// where the leaf is assumed to have type `T`.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Partial<T> {
     /// The leaf or node is absent from the proof.
     Absent,

--- a/durable-storage/src/avl/resolver.rs
+++ b/durable-storage/src/avl/resolver.rs
@@ -574,10 +574,16 @@ impl<R: Resolver<LazyTreeId, Tree<LazyNodeId>>> Resolver<ProveTreeId, Tree<Prove
 ///
 /// Absent nodes are not a valid variant as they indicate a bad proof: any node accessed during
 /// validation should be present or blinded from being accessed in the proof.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum VerifyNodeId {
     Present(Arc<Node<VerifyTreeId, Verify>>),
     Blinded(Hash),
+}
+
+impl From<Node<VerifyTreeId, Verify>> for VerifyNodeId {
+    fn from(node: Node<VerifyTreeId, Verify>) -> Self {
+        VerifyNodeId::Present(Arc::new(node))
+    }
 }
 
 impl FromProof for VerifyNodeId {
@@ -596,7 +602,7 @@ impl FromProof for VerifyNodeId {
 }
 
 /// Identifier for a tree resolved in [`Verify`] mode.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum VerifyTreeId {
     Present(Tree<VerifyNodeId>),
     Blinded(Hash),
@@ -616,7 +622,16 @@ impl FromProof for VerifyTreeId {
     }
 }
 
+// TODO: RV-895, RV-963: Required by the bounds in `Tree::upsert` and
+// `Tree::replace_with_successor`, may cause issues with round-trip verification.
+impl Default for VerifyTreeId {
+    fn default() -> Self {
+        Self::Present(Tree::default())
+    }
+}
+
 /// Adapter that projects in-memory AVL identifiers into verify-mode values.
+#[derive(Debug)]
 pub struct VerifyResolver;
 
 impl Resolver<VerifyNodeId, Node<VerifyTreeId, Verify>> for VerifyResolver {
@@ -772,15 +787,6 @@ mod tests {
 
         fn delete(&self, key: impl AsRef<[u8]>) -> Result<(), OperationalError> {
             self.inner.delete(key)
-        }
-    }
-
-    /// `Node::new` requires `TreeId: Default`. In production, a `VerifyTreeId` is only
-    /// created by deserialising a proof, never by defaulting, but tests need a way to
-    /// construct leaf nodes directly.
-    impl Default for VerifyTreeId {
-        fn default() -> Self {
-            Self::Absent
         }
     }
 

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -23,10 +23,13 @@ use octez_riscv_data::hash::Hash;
 use octez_riscv_data::mode::Modal;
 use octez_riscv_data::mode::Mode;
 use octez_riscv_data::mode::Normal;
+use octez_riscv_data::mode::Verify;
 use perfect_derive::perfect_derive;
 
 use crate::avl::resolver::LazyNodeId;
 use crate::avl::resolver::LazyResolver;
+use crate::avl::resolver::VerifyNodeId;
+use crate::avl::resolver::VerifyResolver;
 use crate::avl::tree::Tree;
 use crate::commit::CommitId;
 use crate::errors::Error;
@@ -186,6 +189,53 @@ impl MerkleLayerMode for Normal {
     }
 }
 
+impl MerkleLayerMode for Verify {
+    fn try_clone_with<KV: KeyValueStore>(
+        this: &MerkleLayer<KV, Self>,
+        _persistence: Arc<KV>,
+    ) -> MerkleLayer<KV, Self> {
+        MerkleLayer {
+            inner: VerifyImpl {
+                tree: this.inner.tree.clone(),
+                resolver: VerifyResolver,
+            },
+        }
+    }
+
+    fn hash<KV>(_this: &MerkleLayer<KV, Self>) -> Hash {
+        unimplemented!("Blocked by RV-961")
+    }
+
+    fn delete<KV: KeyValueStore>(
+        this: &mut MerkleLayer<KV, Self>,
+        key: &Key,
+    ) -> Result<(), OperationalError> {
+        this.inner.tree.delete(key, &mut this.inner.resolver)?;
+        Ok(())
+    }
+
+    fn set<KV: KeyValueStore>(
+        this: &mut MerkleLayer<KV, Self>,
+        key: &Key,
+        data: &[u8],
+    ) -> Result<(), OperationalError> {
+        this.inner.tree.set(key, data, &mut this.inner.resolver)?;
+        Ok(())
+    }
+
+    fn write<KV: KeyValueStore>(
+        this: &mut MerkleLayer<KV, Self>,
+        key: &Key,
+        offset: usize,
+        data: &[u8],
+    ) -> Result<(), Error> {
+        this.inner
+            .tree
+            .write(key, offset, data, &mut this.inner.resolver)?;
+        Ok(())
+    }
+}
+
 struct MerkleLayerTemplate<KV>(PhantomData<KV>, Infallible);
 
 impl<KV> Modal for MerkleLayerTemplate<KV> {
@@ -193,7 +243,7 @@ impl<KV> Modal for MerkleLayerTemplate<KV> {
 
     type Prove<'normal> = Infallible;
 
-    type Verify = Infallible;
+    type Verify = VerifyImpl;
 }
 
 #[derive(Debug)]
@@ -279,10 +329,19 @@ impl<KV> NormalImpl<KV> {
     }
 }
 
+#[derive(Debug)]
+struct VerifyImpl {
+    tree: Tree<VerifyNodeId>,
+    resolver: VerifyResolver,
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use octez_riscv_data::components::bytes::Bytes;
     use octez_riscv_data::mode::Normal;
+    use octez_riscv_data::mode::Verify;
     use proptest::prelude::*;
     use proptest::prop_assert_eq;
     use proptest::proptest;
@@ -292,9 +351,12 @@ mod tests {
     use crate::avl::resolver::ArcTreeId;
     use crate::avl::resolver::LazyNodeId;
     use crate::avl::resolver::LazyTreeId;
+    use crate::avl::resolver::VerifyNodeId;
+    use crate::avl::resolver::VerifyResolver;
     use crate::avl::tree::Tree;
     use crate::errors::OperationalError;
     use crate::key::Key;
+    use crate::merkle_layer::VerifyImpl;
     use crate::storage::KeyValueStore;
     use crate::storage::TestKeyValueStore;
     use crate::storage::TestRepo;
@@ -313,6 +375,22 @@ mod tests {
         /// Returns an immutable reference to the data stored for a given [Key].
         pub fn get(&mut self, key: &Key) -> Result<Option<&Bytes<Normal>>, OperationalError> {
             self.inner.tree.get(key, &self.inner.resolver)
+        }
+    }
+
+    impl<KV> MerkleLayer<KV, Verify> {
+        fn get(&self, key: &Key) -> Result<Option<&Bytes<Verify>>, OperationalError> {
+            self.inner.tree.get(key, &self.inner.resolver)
+        }
+
+        /// Construct a Verify-mode MerkleLayer from a deserialised tree.
+        pub(crate) fn from_verify_tree(tree: Tree<VerifyNodeId>) -> Self {
+            MerkleLayer {
+                inner: VerifyImpl {
+                    tree,
+                    resolver: VerifyResolver,
+                },
+            }
         }
     }
 
@@ -1295,5 +1373,98 @@ mod tests {
 
         let root_hash = merkle_layer.hash();
         assert_eq!(*commit_id.as_hash(), root_hash);
+    }
+
+    #[test]
+    fn test_verify_delete() {
+        let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
+
+        let mut ml: MerkleLayer<TestKeyValueStore, Verify> =
+            MerkleLayer::from_verify_tree(Tree::default());
+        ml.delete(&key)
+            .expect("deleting a key that doesn't exist should succeed");
+
+        ml.set(&key, b"delete")
+            .expect("setting node should succeed");
+        ml.delete(&key).expect("delete should succeed");
+
+        let got = ml
+            .get(&key)
+            .expect("The node should be retrieved successfully.");
+        assert!(got.is_none(), "data should not exist after deletion");
+    }
+
+    #[test]
+    fn test_verify_multiple_keys() {
+        let keys = [Key::new(&[0]), Key::new(&[1]), Key::new(&[2])]
+            .map(|r| r.expect("Size less than KEY_MAX_SIZE"));
+        let data: [&[u8]; 3] = [b"too cold", b"too hot", b"just right"];
+
+        let mut ml: MerkleLayer<TestKeyValueStore, Verify> =
+            MerkleLayer::from_verify_tree(Tree::default());
+        for (key, datum) in keys.iter().zip(data.iter()) {
+            ml.set(key, datum).expect("setting node should succeed");
+        }
+
+        for (key, datum) in keys.iter().zip(data.iter()) {
+            let got = ml
+                .get(key)
+                .expect("The node should be retrieved successfully.")
+                .expect("data should exist");
+            assert_eq!(got, datum);
+        }
+    }
+
+    #[test]
+    fn test_verify_try_clone_with_cow() {
+        let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
+
+        let mut ml: MerkleLayer<TestKeyValueStore, Verify> =
+            MerkleLayer::from_verify_tree(Tree::default());
+        let cow_data = "🐮<(verify a moo!)";
+        ml.set(&key, cow_data.as_bytes())
+            .expect("setting node should succeed");
+
+        let (_keepalive, repo) = setup_repo();
+        let kv: Arc<TestKeyValueStore> = TestKeyValueStore::new(&repo)
+            .expect("Creating a persistence layer should succeed")
+            .into();
+
+        let mut ml2 = ml.try_clone_with(kv);
+        let cow_data2 = "🐮<(mooify a moo!)";
+        ml2.set(&key, cow_data2.as_bytes())
+            .expect("setting node should succeed");
+
+        // Original should be unchanged.
+        let got_original = ml
+            .get(&key)
+            .expect("The node should be retrieved successfully.")
+            .expect("data should exist");
+        assert_eq!(got_original, &cow_data.as_bytes().to_vec());
+
+        // Clone should have the new value.
+        let got_clone = ml2
+            .get(&key)
+            .expect("The node should be retrieved successfully.")
+            .expect("data should exist");
+        assert_eq!(got_clone, &cow_data2.as_bytes().to_vec());
+    }
+
+    #[test]
+    fn test_verify_write_partial() {
+        let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
+
+        let mut ml: MerkleLayer<TestKeyValueStore, Verify> =
+            MerkleLayer::from_verify_tree(Tree::default());
+        ml.set(&key, b"partial")
+            .expect("setting node should succeed");
+        ml.write(&key, 4, b"ying").expect("write should succeed");
+
+        let got = ml
+            .get(&key)
+            .expect("The node should be retrieved successfully.")
+            .expect("The data should exist");
+
+        assert_eq!(got, b"partying");
     }
 }


### PR DESCRIPTION
Part of RV-959

# What
Implements (most of) Verify mode for the Merkle layer

# Why
We want to move towards Verify and Prove mode implementations up to the Registry. This is a prerequisite.

# How
 - Introduces `VerifyImpl` and `MerkleLayer<KV, Verify>::from_verify_tree`
 - Fills in 'impl MerkleLayerMode for Verify', delegating to `MerkleLayerMode`
 - Moves the `VerifyTreeId::Default` impl and makes default trees present. This makes sense to me as nodes that are created or rebalanced must be present, but is worth revisiting during implementation of the round-trip tests.
 
 Doesn't implement proof parsing yet, which needs RV-958 and will allow construction of a `Verify` Merkle layer in production.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
