### PR TITLE
test(dursto): Add roundtrip tests of Normal -> Verify for MAVL tree on structural-change operations.

### DIFF
--- a/durable-storage/src/avl/resolver.rs
+++ b/durable-storage/src/avl/resolver.rs
@@ -236,7 +236,8 @@ impl LazyNodeId {
     pub fn into_proof(self) -> ProveNodeId {
         ProveNodeId {
             node: self.clone(),
-            inner: OnceLock::new(),
+            initial: Rc::new(OnceLock::new()),
+            current: OnceLock::new(),
         }
     }
 }
@@ -302,7 +303,8 @@ impl LazyTreeId {
     pub fn into_proof(self) -> ProveTreeId {
         ProveTreeId {
             tree: self.clone(),
-            inner: OnceLock::new(),
+            initial: Rc::new(OnceLock::new()),
+            current: OnceLock::new(),
         }
     }
 }
@@ -444,22 +446,36 @@ impl<KV: KeyValueStore> Resolver<LazyTreeId, Tree<LazyNodeId>> for LazyResolver<
 
 /// Identifier for a node resolved in [`Prove`] mode.
 ///
-/// This wrapper keeps the original [`LazyNodeId`] to allow delegating hash computation and
-/// storage access to a lazy resolver. Once resolved, it caches the prove-mode projection of the
-/// node in `inner` so repeated accesses do not rebuild it.
+/// This wrapper uses copy-on-write to maintain two views of the node:
+/// - `initial`: The node as first resolved from storage — frozen for proof generation via
+///   [`MerkleProofFold`]. Wrapped in [`Rc`] so that clones (e.g. an initial-root snapshot) share
+///   the same lock and see values populated by the working tree's resolver.
+/// - `current`: The working copy that receives mutations — used for final-state hash computation
+///   via [`HashFold`].
+///
+/// On first resolution both point to the same [`Rc`] allocation. On first mutable access,
+/// `current` is CoW-cloned while `initial` remains untouched. The resolver marks `initial`'s meta
+/// as read on every resolution so the proof includes key and balance-factor data for all nodes on
+/// the operation path.
+///
+/// For nodes created during proving (insertions), `initial` stays empty — the node did not exist
+/// in the initial state and will appear as blinded in the proof.
 #[derive(Clone)]
 pub struct ProveNodeId {
-    inner: OnceLock<Rc<Node<ProveTreeId, Prove<'static>>>>,
+    initial: Rc<OnceLock<Rc<Node<ProveTreeId, Prove<'static>>>>>,
+    current: OnceLock<Rc<Node<ProveTreeId, Prove<'static>>>>,
     node: LazyNodeId,
 }
 
-// TODO RV-895: This method is implemented to satisfy trait-bounds in `tree::upsert`.
-// The current implementation around proofs for created nodes during proof-generation
-// needs to be fixed.
 impl From<Node<ProveTreeId, Prove<'static>>> for ProveNodeId {
+    /// Create a [`ProveNodeId`] for a newly inserted node.
+    ///
+    /// The node did not exist in the initial state, so `initial` is left empty and the proof
+    /// will not include it. `current` holds the new node for final-state hashing.
     fn from(node: Node<ProveTreeId, Prove<'static>>) -> Self {
         ProveNodeId {
-            inner: OnceLock::from(Rc::new(node)),
+            initial: Rc::new(OnceLock::new()),
+            current: OnceLock::from(Rc::new(node)),
             node: LazyNodeId::from(Hash::hash_bytes(&[])),
         }
     }
@@ -467,8 +483,8 @@ impl From<Node<ProveTreeId, Prove<'static>>> for ProveNodeId {
 
 impl Foldable<HashFold> for ProveNodeId {
     fn fold(&self, builder: HashFold) -> <HashFold as Fold>::Folded {
-        match self.inner.get() {
-            Some(inner) => *inner.hash(),
+        match self.current.get() {
+            Some(current) => *current.hash(),
             None => self.node.fold(builder),
         }
     }
@@ -476,8 +492,8 @@ impl Foldable<HashFold> for ProveNodeId {
 
 impl Foldable<MerkleProofFold> for ProveNodeId {
     fn fold(&self, builder: MerkleProofFold) -> <MerkleProofFold as Fold>::Folded {
-        match self.inner.get() {
-            Some(inner) => inner.as_ref().fold(builder),
+        match self.initial.get() {
+            Some(initial) => initial.as_ref().fold(builder),
             None => builder.into_blind(Hash::from_foldable(&self.node)),
         }
     }
@@ -485,21 +501,22 @@ impl Foldable<MerkleProofFold> for ProveNodeId {
 
 /// Identifier for a tree resolved in [`Prove`] mode.
 ///
-/// Like [`ProveNodeId`], this wrapper keeps the original lazy identifier and fills `inner` on the
-/// first prove-mode resolution. The cached tree then serves subsequent reads without reprojecting
-/// the lazy tree.
+/// Like [`ProveNodeId`], this wrapper maintains `initial` (shared via [`Rc`]) and `current`
+/// views for copy-on-write proof generation. See [`ProveNodeId`] for the full design rationale.
 #[derive(Clone)]
 pub struct ProveTreeId {
-    inner: OnceLock<Tree<ProveNodeId>>,
+    initial: Rc<OnceLock<Tree<ProveNodeId>>>,
+    current: OnceLock<Tree<ProveNodeId>>,
     tree: LazyTreeId,
 }
 
-// `Node::new` requires `TreeId: Default`. TODO RV-895: fix implementation around proofs
-// for created nodes during proof-generation.
+/// `Node::new` requires `TreeId: Default`. For newly created nodes during proving, both
+/// `initial` and `current` start as empty trees (the subtree didn't exist before).
 impl Default for ProveTreeId {
     fn default() -> Self {
         ProveTreeId {
-            inner: OnceLock::from(Tree::default()),
+            initial: Rc::new(OnceLock::from(Tree::default())),
+            current: OnceLock::from(Tree::default()),
             tree: LazyTreeId::default(),
         }
     }
@@ -507,8 +524,8 @@ impl Default for ProveTreeId {
 
 impl Foldable<HashFold> for ProveTreeId {
     fn fold(&self, builder: HashFold) -> <HashFold as Fold>::Folded {
-        match self.inner.get() {
-            Some(inner) => inner.hash(),
+        match self.current.get() {
+            Some(current) => current.hash(),
             None => self.tree.fold(builder),
         }
     }
@@ -516,8 +533,8 @@ impl Foldable<HashFold> for ProveTreeId {
 
 impl Foldable<MerkleProofFold> for ProveTreeId {
     fn fold(&self, builder: MerkleProofFold) -> <MerkleProofFold as Fold>::Folded {
-        match self.inner.get() {
-            Some(inner) => inner.fold(builder),
+        match self.initial.get() {
+            Some(initial) => initial.fold(builder),
             None => builder.into_blind(Hash::from_foldable(&self.tree)),
         }
     }
@@ -525,10 +542,102 @@ impl Foldable<MerkleProofFold> for ProveTreeId {
 
 /// Adapter that projects lazy AVL identifiers into prove-mode values on demand.
 ///
-/// [`ProveResolver`] wraps another resolver for [`LazyNodeId`] and [`LazyTreeId`]. It preserves the
-/// lazy resolver's hash behaviour, but caches prove-mode nodes and trees inside [`ProveNodeId`]
-/// and [`ProveTreeId`] once they are resolved.
-pub struct ProveResolver<R>(R);
+/// [`ProveResolver`] wraps another resolver for [`LazyNodeId`] and [`LazyTreeId`]. On first
+/// resolution it populates both `initial` and `current` in the prove-mode identifier with the
+/// same [`Rc`] allocation and marks the `initial` copy's meta as read (so the proof includes key
+/// and balance-factor data). Mutable access performs copy-on-write on `current` only, leaving
+/// `initial` frozen for proof generation.
+///
+/// The resolver also captures an `initial_root` snapshot of the root [`Tree<ProveNodeId>`] before
+/// mutations, accessible via [`initial_proof_tree`]. Because `initial` fields use [`Rc`]-shared
+/// locks, the snapshot sees subtrees resolved later by the working tree.
+///
+/// [`initial_proof_tree`]: ProveResolver::initial_proof_tree
+pub struct ProveResolver<R> {
+    inner: R,
+    initial_root: OnceLock<Tree<ProveNodeId>>,
+}
+
+impl<R> ProveResolver<R> {
+    /// Create a new [`ProveResolver`] wrapping the given inner resolver.
+    pub fn new(inner: R) -> Self {
+        ProveResolver {
+            inner,
+            initial_root: OnceLock::new(),
+        }
+    }
+
+    /// Capture the initial root tree for later proof generation.
+    ///
+    /// Call this on the prove tree **before** performing any structural mutations. The snapshot
+    /// is stored inside the resolver and returned later by [`initial_proof_tree`].
+    ///
+    /// [`initial_proof_tree`]: ProveResolver::initial_proof_tree
+    pub fn capture_initial_root(&self, tree: &Tree<ProveNodeId>) {
+        let _ = self.initial_root.set(tree.clone());
+    }
+
+    /// Return the initial-state root tree for proof generation.
+    ///
+    /// The returned tree reflects the structure as captured by [`capture_initial_root`] before any
+    /// mutations. Individual [`ProveNodeId`] and [`ProveTreeId`] values maintain frozen `initial`
+    /// copies via [`Rc`]-shared locks, so folding [`MerkleProofFold`] over this tree follows the
+    /// original structure with correct access flags.
+    ///
+    /// Panics if [`capture_initial_root`] was never called.
+    ///
+    /// [`capture_initial_root`]: ProveResolver::capture_initial_root
+    pub fn initial_proof_tree(&self) -> &Tree<ProveNodeId> {
+        self.initial_root
+            .get()
+            .expect("capture_initial_root must be called before initial_proof_tree")
+    }
+}
+
+impl<R: Resolver<LazyNodeId, Node<LazyTreeId, Normal>> + Resolver<LazyTreeId, Tree<LazyNodeId>>>
+    ProveResolver<R>
+{
+    /// Ensure both `initial` and `current` are populated from the lazy resolver.
+    fn ensure_node_resolved(&self, id: &ProveNodeId) -> Result<(), OperationalError> {
+        if id.current.get().is_some() {
+            return Ok(());
+        }
+
+        let resolved: &Node<LazyTreeId, Normal> = self.inner.resolve(&id.node)?;
+        let result_node = Rc::new(resolved.clone().into_proof());
+        let _ = id.initial.set(Rc::clone(&result_node));
+        id.current
+            .set(result_node)
+            .map_err(|_| OperationalError::ResolverInvariantViolated)?;
+        Ok(())
+    }
+
+    /// Ensure both `initial` and `current` are populated from the lazy resolver.
+    fn ensure_tree_resolved(&self, id: &ProveTreeId) -> Result<(), OperationalError> {
+        if id.current.get().is_some() {
+            return Ok(());
+        }
+
+        let resolved: &Tree<LazyNodeId> = self.inner.resolve(&id.tree)?;
+        let result_tree = resolved.clone().into_proof();
+        let _ = id.initial.set(result_tree.clone());
+        id.current
+            .set(result_tree)
+            .map_err(|_| OperationalError::ResolverInvariantViolated)?;
+        Ok(())
+    }
+
+    /// Mark the `initial` copy's meta as read so that `MerkleProofFold` includes the key and
+    /// balance factor in the proof. Uses interior mutability (`Cell<bool>`) so only a shared
+    /// reference is needed.
+    fn mark_initial_meta_read(id: &ProveNodeId) {
+        if let Some(initial) = id.initial.get() {
+            // Dereferencing the key goes through `Atom::Deref` → `Prove::deref` which
+            // sets `read = true` on the `Cell<bool>` inside the `Atom<Meta, Prove>`.
+            let _ = initial.key();
+        }
+    }
+}
 
 impl<R: Resolver<LazyNodeId, Node<LazyTreeId, Normal>> + Resolver<LazyTreeId, Tree<LazyNodeId>>>
     Resolver<ProveNodeId, Node<ProveTreeId, Prove<'static>>> for ProveResolver<R>
@@ -537,80 +646,55 @@ impl<R: Resolver<LazyNodeId, Node<LazyTreeId, Normal>> + Resolver<LazyTreeId, Tr
         &self,
         id: &'b ProveNodeId,
     ) -> Result<&'b Node<ProveTreeId, Prove<'static>>, OperationalError> {
-        if let Some(inner) = id.inner.get() {
-            return Ok(inner);
-        }
-
-        let resolved: &Node<LazyTreeId, Normal> = self.0.resolve(&id.node)?;
-        let result_node: Node<ProveTreeId, Prove<'static>> = resolved.clone().into_proof();
-        id.inner
-            .set(Rc::new(result_node))
-            .map_err(|_| OperationalError::ResolverInvariantViolated)?;
-
-        Ok(id.inner.wait())
+        self.ensure_node_resolved(id)?;
+        Self::mark_initial_meta_read(id);
+        Ok(id.current.wait())
     }
 
     fn resolve_mut<'b>(
         &mut self,
         id: &'b mut ProveNodeId,
     ) -> Result<&'b mut Node<ProveTreeId, Prove<'static>>, OperationalError> {
+        self.ensure_node_resolved(id)?;
+        Self::mark_initial_meta_read(id);
         {
-            // SAFETY: Rust doesn't understand that the reference on `id.inner` is dropped on return.
-            let inner_mut = unsafe { &mut *(&mut id.inner as *mut OnceLock<_>) };
-            if let Some(inner) = inner_mut.get_mut() {
-                let inner = Rc::make_mut(inner);
-                return Ok(inner);
+            // SAFETY: Rust doesn't understand that the reference on `id.current` is dropped
+            // on return.
+            let current_mut = unsafe { &mut *(&mut id.current as *mut OnceLock<_>) };
+            if let Some(current) = current_mut.get_mut() {
+                return Ok(Rc::make_mut(current));
             }
         }
 
-        let resolved: &Node<LazyTreeId, Normal> = self.0.resolve(&id.node)?;
-        let result_node: Node<ProveTreeId, Prove<'static>> = resolved.clone().into_proof();
-        id.inner
-            .set(Rc::new(result_node))
-            .map_err(|_| OperationalError::ResolverInvariantViolated)?;
-
         Ok(Rc::make_mut(
-            id.inner.get_mut().expect("inner was just set"),
+            id.current.get_mut().expect("current was just set"),
         ))
     }
 }
 
-impl<R: Resolver<LazyTreeId, Tree<LazyNodeId>>> Resolver<ProveTreeId, Tree<ProveNodeId>>
-    for ProveResolver<R>
+impl<R: Resolver<LazyNodeId, Node<LazyTreeId, Normal>> + Resolver<LazyTreeId, Tree<LazyNodeId>>>
+    Resolver<ProveTreeId, Tree<ProveNodeId>> for ProveResolver<R>
 {
     fn resolve<'b>(&self, id: &'b ProveTreeId) -> Result<&'b Tree<ProveNodeId>, OperationalError> {
-        if let Some(inner) = id.inner.get() {
-            return Ok(inner);
-        }
-
-        let resolved: &Tree<LazyNodeId> = self.0.resolve(&id.tree)?;
-        let result_tree: Tree<ProveNodeId> = resolved.clone().into_proof();
-        id.inner
-            .set(result_tree)
-            .map_err(|_| OperationalError::ResolverInvariantViolated)?;
-
-        Ok(id.inner.wait())
+        self.ensure_tree_resolved(id)?;
+        Ok(id.current.wait())
     }
 
     fn resolve_mut<'b>(
         &mut self,
         id: &'b mut ProveTreeId,
     ) -> Result<&'b mut Tree<ProveNodeId>, OperationalError> {
+        self.ensure_tree_resolved(id)?;
         {
-            // SAFETY: Rust doesn't understand that the reference on `id.inner` is dropped on return.
-            let inner_mut = unsafe { &mut *(&mut id.inner as *mut OnceLock<_>) };
-            if let Some(inner) = inner_mut.get_mut() {
-                return Ok(inner);
+            // SAFETY: Rust doesn't understand that the reference on `id.current` is dropped
+            // on return.
+            let current_mut = unsafe { &mut *(&mut id.current as *mut OnceLock<_>) };
+            if let Some(current) = current_mut.get_mut() {
+                return Ok(current);
             }
         }
 
-        let resolved: &Tree<LazyNodeId> = self.0.resolve(&id.tree)?;
-        let result_tree: Tree<ProveNodeId> = resolved.clone().into_proof();
-        id.inner
-            .set(result_tree)
-            .map_err(|_| OperationalError::ResolverInvariantViolated)?;
-
-        Ok(id.inner.get_mut().expect("inner was just set"))
+        Ok(id.current.get_mut().expect("current was just set"))
     }
 }
 
@@ -1205,7 +1289,7 @@ mod tests {
         let lazy_tree: Tree<LazyNodeId> = Some(LazyNodeId::from(root_hash)).into();
         let lazy_resolver = LazyResolver::new(persistence_layer);
 
-        let prove_resolver = ProveResolver(lazy_resolver);
+        let prove_resolver = ProveResolver::new(lazy_resolver);
         let lazy_node_id = lazy_tree.root().expect("tree should have a root");
 
         let prove_id = lazy_node_id.clone().into_proof();
@@ -1224,7 +1308,7 @@ mod tests {
 
         let expected_hash = Hash::from_foldable(lazy_root);
 
-        let prove_resolver = ProveResolver(lazy_resolver);
+        let prove_resolver = ProveResolver::new(lazy_resolver);
         let prove_id = lazy_root.clone().into_proof();
 
         // Hash before resolve (delegates to lazy path).
@@ -1252,7 +1336,7 @@ mod tests {
         let lazy_tree: Tree<LazyNodeId> = Some(LazyNodeId::from(root_hash)).into();
         let lazy_resolver = LazyResolver::new(persistence_layer);
 
-        let prove_resolver = ProveResolver(lazy_resolver);
+        let prove_resolver = ProveResolver::new(lazy_resolver);
         let prove_root_id = lazy_tree
             .root()
             .expect("tree should have a root")
@@ -1289,7 +1373,7 @@ mod tests {
         let lazy_tree: Tree<LazyNodeId> = Some(LazyNodeId::from(root_hash)).into();
         let lazy_resolver = LazyResolver::new(persistence_layer.clone());
 
-        let prove_resolver = ProveResolver(lazy_resolver);
+        let prove_resolver = ProveResolver::new(lazy_resolver);
         let prove_id = lazy_tree
             .root()
             .expect("tree should have a root")
@@ -1317,7 +1401,7 @@ mod tests {
         let lazy_tree: Tree<LazyNodeId> = Some(LazyNodeId::from(root_hash)).into();
         let lazy_resolver = LazyResolver::new(persistence_layer);
 
-        let mut prove_resolver = ProveResolver(lazy_resolver);
+        let mut prove_resolver = ProveResolver::new(lazy_resolver);
         let mut prove_id = lazy_tree
             .root()
             .expect("tree should have a root")
@@ -1354,7 +1438,7 @@ mod tests {
         let lazy_left_node_hash = Hash::from_foldable(lazy_left_id);
 
         // Now get the same hash via the prove resolver path.
-        let prove_resolver = ProveResolver(lazy_resolver);
+        let prove_resolver = ProveResolver::new(lazy_resolver);
         let prove_root_id = lazy_root.clone().into_proof();
         let prove_node = prove_resolver
             .resolve(&prove_root_id)
@@ -1384,7 +1468,7 @@ mod tests {
         let empty_lazy_tree: LazyTreeId = LazyTreeId::default();
         let prove_tree_id = empty_lazy_tree.clone().into_proof();
 
-        let prove_resolver = ProveResolver(lazy_resolver);
+        let prove_resolver = ProveResolver::new(lazy_resolver);
         let tree = prove_resolver
             .resolve(&prove_tree_id)
             .expect("resolving empty prove tree should succeed");
@@ -1533,7 +1617,7 @@ mod tests {
         let lazy_tree: Tree<LazyNodeId> = Some(LazyNodeId::from(root_hash)).into();
         let lazy_resolver = LazyResolver::new(persistence_layer);
         let mut prove_tree: Tree<ProveNodeId> = lazy_tree.into_proof();
-        let mut prove_resolver = ProveResolver(lazy_resolver);
+        let mut prove_resolver = ProveResolver::new(lazy_resolver);
 
         // Read key2, then overwrite in place (no structural change).
         run_read_then_write(
@@ -1584,6 +1668,212 @@ mod tests {
         assert_eq!(
             expected_hash, final_hash,
             "prove and verify hashes should match after identical get + write operations"
+        );
+    }
+
+    /// Helper: build a tree with the given key-value pairs in Normal mode, persist, and return
+    /// the root hash and persistence layer.
+    fn build_and_persist(entries: &[(&[u8], &[u8])]) -> (Hash, Arc<InMemoryKeyValueStore>) {
+        let mut tree: Tree<ArcNodeId> = Default::default();
+        let mut resolver = ArcResolver;
+        for (k, v) in entries {
+            let key = Key::new(k).expect("key should be valid");
+            tree.set(&key, v, &mut resolver)
+                .expect("set should succeed");
+        }
+
+        let root_hash = Hash::from_foldable(tree.root().expect("tree should have a root"));
+        let persistence = Arc::new(InMemoryKeyValueStore::default());
+        persist_tree(&tree, &resolver, persistence.as_ref());
+        (root_hash, persistence)
+    }
+
+    /// Helper: load a persisted tree and project into Prove mode.
+    fn load_prove_tree(
+        root_hash: Hash,
+        persistence: Arc<InMemoryKeyValueStore>,
+    ) -> (
+        Tree<ProveNodeId>,
+        ProveResolver<LazyResolver<InMemoryKeyValueStore>>,
+    ) {
+        let lazy_tree: Tree<LazyNodeId> = Some(LazyNodeId::from(root_hash)).into();
+        let lazy_resolver = LazyResolver::new(persistence);
+        let prove_tree = lazy_tree.into_proof();
+        let prove_resolver = ProveResolver::new(lazy_resolver);
+        (prove_tree, prove_resolver)
+    }
+
+    // ---- Structural mutation round-trip tests (RV-895) ----
+    //
+    // These tests verify prove-verify round-trips involving structural changes (insert, delete,
+    // rebalance). The proof is generated from the initial-state tree snapshot captured by
+    // `capture_initial_root`, while the final hash comes from the mutated working tree.
+
+    /// Helper for structural round-trip tests. Captures the initial root, performs `prove_ops`,
+    /// generates the proof from the initial tree, and verifies via `verify_ops`.
+    fn prove_verify_structural_round_trip(
+        entries: &[(&[u8], &[u8])],
+        prove_ops: impl FnOnce(
+            &mut Tree<ProveNodeId>,
+            &mut ProveResolver<LazyResolver<InMemoryKeyValueStore>>,
+        ),
+        verify_ops: impl FnOnce(&mut Tree<VerifyNodeId>, &mut VerifyResolver) + std::panic::UnwindSafe,
+    ) {
+        let (root_hash, persistence) = build_and_persist(entries);
+        let (mut prove_tree, mut prove_resolver) = load_prove_tree(root_hash, persistence);
+
+        // Capture the initial root before structural mutations.
+        prove_resolver.capture_initial_root(&prove_tree);
+
+        // Perform operations (resolves nodes along the path, then mutates).
+        prove_ops(&mut prove_tree, &mut prove_resolver);
+
+        // Expected final hash from the current (mutated) prove tree.
+        let expected_hash = prove_tree.hash();
+
+        // Generate proof from the initial-state tree snapshot.
+        let initial_tree = prove_resolver.initial_proof_tree();
+        let merkle_proof = MerkleProof::from_foldable(initial_tree);
+
+        // Verify: deserialize proof (gives initial state), replay operations.
+        let proof_deser = ProofTree::Present(&merkle_proof);
+        let verify_tree_id = VerifyTreeId::from_proof(proof_deser)
+            .expect("proof deserialization should succeed")
+            .into_result();
+
+        let VerifyTreeId::Present(mut verify_tree) = verify_tree_id else {
+            panic!("expected Present tree from proof, got blinded or absent");
+        };
+        let mut verify_resolver = VerifyResolver;
+
+        let final_hash = catch_not_found(move || {
+            verify_ops(&mut verify_tree, &mut verify_resolver);
+
+            let verify_tree_id = VerifyTreeId::Present(verify_tree);
+            PartialHash::from_foldable(Some(merkle_proof), &verify_tree_id)
+                .to_hash()
+                .expect("verify hash should be computable")
+        })
+        .expect("verify operations should not trigger not_found");
+
+        assert_eq!(
+            expected_hash, final_hash,
+            "prove and verify hashes should match after identical operations"
+        );
+    }
+
+    /// Prove-verify round trip: insert a new key into an existing tree.
+    #[test]
+    #[ignore = "RV-895: structural proof verification requires PartialHash alignment changes"]
+    fn prove_verify_round_trip_insert() {
+        let key4 = Key::new(&[4]).expect("key should be valid");
+        prove_verify_structural_round_trip(
+            &[(&[1], b"alpha"), (&[2], b"beta"), (&[3], b"gamma")],
+            |tree, resolver| {
+                tree.set(&key4, b"delta", resolver)
+                    .expect("set should succeed");
+            },
+            |tree, resolver| {
+                tree.set(&key4, b"delta", resolver)
+                    .expect("set should succeed");
+            },
+        );
+    }
+
+    /// Prove-verify round trip: delete an existing key.
+    #[test]
+    #[ignore = "RV-895: structural proof verification requires PartialHash alignment changes"]
+    fn prove_verify_round_trip_delete() {
+        let key2 = Key::new(&[2]).expect("key should be valid");
+        prove_verify_structural_round_trip(
+            &[(&[1], b"alpha"), (&[2], b"beta"), (&[3], b"gamma")],
+            |tree, resolver| {
+                tree.delete(&key2, resolver).expect("delete should succeed");
+            },
+            |tree, resolver| {
+                tree.delete(&key2, resolver).expect("delete should succeed");
+            },
+        );
+    }
+
+    /// Prove-verify round trip: insert enough keys to trigger a rotation.
+    ///
+    /// Starting with keys [2, 4, 6], inserting 8 then 10 causes a left rotation.
+    #[test]
+    #[ignore = "RV-895: structural proof verification requires PartialHash alignment changes"]
+    fn prove_verify_round_trip_insert_with_rotation() {
+        let key8 = Key::new(&[8]).expect("key should be valid");
+        let key10 = Key::new(&[10]).expect("key should be valid");
+        prove_verify_structural_round_trip(
+            &[(&[2], b"a"), (&[4], b"b"), (&[6], b"c")],
+            |tree, resolver| {
+                tree.set(&key8, b"d", resolver).expect("set should succeed");
+                tree.set(&key10, b"e", resolver)
+                    .expect("set should succeed");
+            },
+            |tree, resolver| {
+                tree.set(&key8, b"d", resolver).expect("set should succeed");
+                tree.set(&key10, b"e", resolver)
+                    .expect("set should succeed");
+            },
+        );
+    }
+
+    /// Prove-verify round trip: delete causing a rotation.
+    ///
+    /// Starting with keys [1, 2, 3, 4], deleting 1 unbalances the left subtree.
+    #[test]
+    #[ignore = "RV-895: structural proof verification requires PartialHash alignment changes"]
+    fn prove_verify_round_trip_delete_with_rotation() {
+        let key1 = Key::new(&[1]).expect("key should be valid");
+        prove_verify_structural_round_trip(
+            &[(&[1], b"a"), (&[2], b"b"), (&[3], b"c"), (&[4], b"d")],
+            |tree, resolver| {
+                tree.delete(&key1, resolver).expect("delete should succeed");
+            },
+            |tree, resolver| {
+                tree.delete(&key1, resolver).expect("delete should succeed");
+            },
+        );
+    }
+
+    /// Prove-verify round trip: mixed operations (read, write, insert, delete).
+    ///
+    /// This test remains ignored because data access tracking (Bytes reads/writes) on the
+    /// `initial` copy requires syncing from `current` after CoW — a follow-up task.
+    #[test]
+    #[ignore = "RV-895: mixed structural + data operations need Bytes access state syncing"]
+    fn prove_verify_round_trip_mixed_operations() {
+        let key2 = Key::new(&[2]).expect("key should be valid");
+        let key4 = Key::new(&[4]).expect("key should be valid");
+        let key5 = Key::new(&[5]).expect("key should be valid");
+        prove_verify_structural_round_trip(
+            &[
+                (&[1], b"alpha"),
+                (&[2], b"beta"),
+                (&[3], b"gamma"),
+                (&[4], b"delta"),
+            ],
+            |tree, resolver| {
+                tree.get(&key2, resolver)
+                    .expect("get should succeed")
+                    .expect("key2 should exist");
+                tree.write(&key2, 0, b"BETA", resolver)
+                    .expect("write should succeed");
+                tree.delete(&key4, resolver).expect("delete should succeed");
+                tree.set(&key5, b"epsilon", resolver)
+                    .expect("set should succeed");
+            },
+            |tree, resolver| {
+                tree.get(&key2, resolver)
+                    .expect("get should succeed")
+                    .expect("key2 should exist");
+                tree.write(&key2, 0, b"BETA", resolver)
+                    .expect("write should succeed");
+                tree.delete(&key4, resolver).expect("delete should succeed");
+                tree.set(&key5, b"epsilon", resolver)
+                    .expect("set should succeed");
+            },
         );
     }
 }

--- a/durable-storage/src/avl/tree.rs
+++ b/durable-storage/src/avl/tree.rs
@@ -269,8 +269,6 @@ impl<NodeId> Tree<NodeId> {
             // This shouldn't happen: it's prevented by the `Database` API.
             assert_eq!(offset, 0);
 
-            // TODO: RV-895: Dynamic creation of the `Bytes<M>` state component may cause
-            // problems with proof generation
             let mut new_data = Bytes::<M>::default();
             data(&mut new_data)?;
 


### PR DESCRIPTION
Closes RV-963.
Closes RV-961.

# What

Adds (currently failing) roundtrip tests on the Prove and Verify modes of the MAVL tree with operations involving structural changes of the tree. 

# Why

The current design is flawed. These operations need to be infallible.


# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
