### PR TITLE
feat(pvm-storage): chunked io using `BlobStore`

### DIFF
--- a/pvm/src/pvm/node_pvm.rs
+++ b/pvm/src/pvm/node_pvm.rs
@@ -24,6 +24,7 @@ use octez_riscv_data::mode::Normal;
 use octez_riscv_data::mode::Provable;
 use octez_riscv_data::mode::Prove;
 use octez_riscv_data::mode::Verify;
+use octez_riscv_data::store::BlobStore;
 use octez_riscv_durable_storage::registry::CloneRegistryMode;
 use perfect_derive::perfect_derive;
 use thiserror::Error;
@@ -46,6 +47,7 @@ use crate::pvm::hooks::PvmHooks;
 use crate::state_backend::proof_backend::proof::Proof;
 use crate::state_backend::verify_backend::ProofVerificationFailure;
 use crate::storage;
+use crate::storage::PersistentBlobStore;
 use crate::storage::Repo;
 
 #[derive(Error, Debug)]
@@ -321,17 +323,11 @@ pub enum PvmStorageError {
     PvmError(#[from] PvmError),
 }
 
-pub struct PvmStorage {
-    repo: Repo,
+pub struct PvmStorage<BS> {
+    repo: Repo<BS>,
 }
 
-impl PvmStorage {
-    /// Load or create new repo at `path`.
-    pub fn load(path: impl AsRef<Path>) -> Result<PvmStorage, PvmStorageError> {
-        let repo = Repo::load(path)?;
-        Ok(PvmStorage { repo })
-    }
-
+impl<BS: BlobStore> PvmStorage<BS> {
     pub fn close(self) {
         self.repo.close()
     }
@@ -346,6 +342,14 @@ impl PvmStorage {
         let pvm = self.repo.checkout_serialised(id)?;
         Ok(NodePvm::wrap(pvm))
     }
+}
+
+impl<BS: PersistentBlobStore> PvmStorage<BS> {
+    /// Load or create new repo at `path`.
+    pub fn load(path: impl AsRef<Path>) -> Result<Self, PvmStorageError> {
+        let repo = Repo::load(path)?;
+        Ok(Self { repo })
+    }
 
     /// A snapshot is a new repo to which only `id` has been committed.
     pub fn export_snapshot(
@@ -353,6 +357,6 @@ impl PvmStorage {
         id: &Hash,
         path: impl AsRef<Path>,
     ) -> Result<(), PvmStorageError> {
-        Ok(self.repo.export_snapshot(id, path)?)
+        Ok(self.repo.export_snapshot_chunked(id, path)?)
     }
 }

--- a/pvm/src/storage.rs
+++ b/pvm/src/storage.rs
@@ -15,7 +15,6 @@ use bincode::Encode;
 use bincode::error::DecodeError;
 use bincode::error::EncodeError;
 use octez_riscv_data::hash::Hash;
-use octez_riscv_data::hash::HashError;
 use octez_riscv_data::hash::HashedData;
 use octez_riscv_data::serialisation;
 use octez_riscv_data::store::BlobStore;
@@ -38,14 +37,34 @@ pub enum StorageError {
     #[error("Invalid repo")]
     InvalidRepo,
 
-    #[error("Hashing error")]
-    HashError(#[from] HashError),
-
-    #[error("Data for hash {0} not found")]
-    NotFound(String),
-
     #[error("Committed chunk {0} not found")]
     ChunkNotFound(String),
+
+    #[error("Blob store error")]
+    BlobStore(#[from] BlobStoreError),
+}
+
+/// A subtrait for `BlobStore` to provide extra functionality required by the PVM storage to export
+/// PVM snapshots.
+pub trait PersistentBlobStore: BlobStore {
+    /// Initialise a store. Either create a new directory if `path` does not exist or initialise in
+    /// an existing directory.
+    ///
+    /// Should throw [`StorageError::InvalidRepo`] if `path` is a file.
+    fn init_from_path(path: impl AsRef<Path>) -> Result<Self, StorageError>
+    where
+        Self: Sized;
+
+    /// Copy a specific blob across to a different store. While this should be functionally
+    /// equivalent to using `blob_get` followed by `blob_set` to copy the blob across, it could in
+    /// many impls be more efficient (especially for large blobs) by using `std::fs::copy` or
+    /// equivalent instead.
+    fn export_blob(&self, other: &mut Self, hash: &Hash) -> Result<(), StorageError> {
+        let blob = self.blob_get(*hash)?;
+        other.blob_set(&HashedData::from_data(blob.as_ref()))?;
+
+        Ok(())
+    }
 }
 
 #[derive(Debug, PartialEq)]
@@ -54,21 +73,6 @@ pub struct Store {
 }
 
 impl Store {
-    /// Initialise a store. Either create a new directory if `path` does not
-    /// exist or initialise in an existing directory.
-    /// Throws `StorageError::InvalidRepo` if `path` is a file.
-    pub fn init(path: impl AsRef<Path>) -> Result<Self, StorageError> {
-        let path = path.as_ref().to_path_buf();
-        if !path.exists() {
-            std::fs::create_dir(&path)?;
-        } else if path.metadata()?.is_file() {
-            return Err(StorageError::InvalidRepo);
-        }
-        Ok(Store {
-            path: path.into_boxed_path(),
-        })
-    }
-
     fn file_name_of_hash(hash: &Hash) -> String {
         hex::encode(hash)
     }
@@ -98,23 +102,25 @@ impl Store {
         self.write_data_if_new(file_name, data)?;
         Ok(hash)
     }
+}
 
-    /// Load data corresponding to `hash`, if found.
-    pub fn load(&self, hash: &Hash) -> Result<Vec<u8>, StorageError> {
-        let file_name = self.path_of_hash(hash);
-        std::fs::read(file_name).map_err(|e| {
-            if e.kind() == io::ErrorKind::NotFound {
-                StorageError::NotFound(hex::encode(hash))
-            } else {
-                StorageError::IoError(e)
-            }
+impl PersistentBlobStore for Store {
+    fn init_from_path(path: impl AsRef<Path>) -> Result<Self, StorageError> {
+        let path = path.as_ref().to_path_buf();
+        if !path.exists() {
+            std::fs::create_dir(&path)?;
+        } else if path.metadata()?.is_file() {
+            return Err(StorageError::InvalidRepo);
+        }
+
+        Ok(Store {
+            path: path.into_boxed_path(),
         })
     }
 
-    /// Copy the data corresponding to `hash` to `path`.
-    pub fn copy(&self, hash: &Hash, path: impl AsRef<Path>) -> Result<(), StorageError> {
+    fn export_blob(&self, other: &mut Self, hash: &Hash) -> Result<(), StorageError> {
         let source_path = self.path_of_hash(hash);
-        let target_path = path.as_ref().join(Self::file_name_of_hash(hash));
+        let target_path = other.path_of_hash(hash);
         std::fs::copy(source_path, target_path)?;
         Ok(())
     }
@@ -150,61 +156,115 @@ impl BlobStore for Store {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct Repo {
-    backend: Store,
+pub struct Repo<BS> {
+    backend: BS,
 }
 
-impl Repo {
+impl<BS: PersistentBlobStore> Repo<BS> {
     /// Load or create new repo at `path`.
-    pub fn load(path: impl AsRef<Path>) -> Result<Repo, StorageError> {
+    pub fn load(path: impl AsRef<Path>) -> Result<Self, StorageError> {
         Ok(Repo {
-            backend: Store::init(path)?,
+            backend: BS::init_from_path(path)?,
         })
+    }
+
+    /// A snapshot is a new repo to which only `id` has been committed. This method exports an `id`
+    /// assuming that it represents a Merkle tree of uniform depth one (the result of using
+    /// `commit_serialised`, which chunks the serialisation).
+    pub fn export_snapshot_chunked(
+        &self,
+        id: &Hash,
+        path: impl AsRef<Path>,
+    ) -> Result<(), StorageError> {
+        // Only export a snapshot to a new or empty directory
+        let path = path.as_ref();
+        if !path.exists() || path.read_dir()?.next().is_none() {
+            std::fs::create_dir_all(path)?;
+        } else {
+            return Err(StorageError::InvalidRepo);
+        };
+        let mut other = BS::init_from_path(path)?;
+        let bytes = self.backend.blob_get(*id)?;
+        let commit: Vec<Hash> = serialisation::deserialise(bytes.as_ref())?;
+        for chunk in commit {
+            self.backend.export_blob(&mut other, &chunk)?;
+        }
+        self.backend.export_blob(&mut other, id)?;
+        Ok(())
+    }
+
+    /// A snapshot is a new repo to which only `id` has been committed. This method exports an `id`
+    /// which represents any Merkle tree structure.
+    ///
+    /// Currently unimplemented.
+    ///
+    /// TODO (TZX-121)
+    pub fn export_snapshot_folded(
+        &self,
+        _id: &Hash,
+        _path: impl AsRef<Path>,
+    ) -> Result<(), StorageError> {
+        todo!()
+    }
+}
+
+impl<BS: BlobStore> Repo<BS> {
+    pub fn new(store: BS) -> Self {
+        Repo { backend: store }
     }
 
     pub fn close(self) {}
 
-    /// Create a new commit for `bytes` and  return the commit id.
-    pub fn commit(&mut self, bytes: &[u8]) -> Result<Hash, StorageError> {
+    /// Create a new commit for `bytes` and return the commit id.
+    pub fn commit(&self, bytes: &[u8]) -> Result<Hash, StorageError> {
         let mut commit = Vec::with_capacity(bytes.len().div_ceil(CHUNK_SIZE) * Hash::DIGEST_SIZE);
 
         for chunk in bytes.chunks(CHUNK_SIZE) {
-            let chunk_hash = self.backend.store(chunk)?;
-            commit.push(chunk_hash);
+            let hashed_chunk = HashedData::from_data(chunk);
+            self.backend.blob_set(&hashed_chunk)?;
+            commit.push(hashed_chunk.hash());
         }
 
         // A commit contains the list of all chunks needed to reconstruct `data`.
         let commit_bytes = serialisation::serialise(&commit)?;
-        self.backend.store(&commit_bytes)
+        let hashed_commit_bytes = HashedData::from_data(commit_bytes);
+        self.backend.blob_set(&hashed_commit_bytes)?;
+
+        Ok(hashed_commit_bytes.hash())
     }
 
     /// Commit something serialisable and return the commit ID.
-    pub fn commit_serialised(&mut self, subject: &impl Encode) -> Result<Hash, StorageError> {
+    pub fn commit_serialised(&self, subject: &impl Encode) -> Result<Hash, StorageError> {
         let chunk_hashes = {
-            let mut writer = chunked_io::ChunkWriter::new(&mut self.backend);
+            let mut writer = chunked_io::ChunkWriter::new(&self.backend);
             serialisation::serialise_into(subject, &mut writer)?;
             writer.finalise()?
         };
 
         // A commit contains the list of all chunks needed to reconstruct the underlying data.
         let commit_bytes = serialisation::serialise(&chunk_hashes)?;
-        self.backend.store(&commit_bytes)
+        let hashed_commit_bytes = HashedData::from_data(commit_bytes);
+        self.backend.blob_set(&hashed_commit_bytes)?;
+
+        Ok(hashed_commit_bytes.hash())
     }
 
     /// Checkout the bytes committed under `id`, if the commit exists.
     pub fn checkout(&self, id: &Hash) -> Result<Vec<u8>, StorageError> {
-        let bytes = self.backend.load(id)?;
-        let commit: Vec<Hash> = serialisation::deserialise(&bytes)?;
+        let bytes = self.backend.blob_get(*id)?;
+
+        let commit: Vec<Hash> = serialisation::deserialise(bytes.as_ref())?;
         let mut bytes = Vec::new();
+
         for hash in commit {
-            let mut chunk = self.backend.load(&hash).map_err(|e| {
-                if let StorageError::NotFound(hash) = e {
-                    StorageError::ChunkNotFound(hash)
+            let chunk = self.backend.blob_get(hash).map_err(|e| {
+                if let BlobStoreError::NotFound(hash) = e {
+                    StorageError::ChunkNotFound(hash.to_string())
                 } else {
-                    e
+                    StorageError::BlobStore(e)
                 }
             })?;
-            bytes.append(&mut chunk);
+            bytes.extend_from_slice(chunk.as_ref());
         }
         Ok(bytes)
     }
@@ -213,24 +273,6 @@ impl Repo {
     pub fn checkout_serialised<S: Decode<()>>(&self, id: &Hash) -> Result<S, StorageError> {
         let mut reader = chunked_io::ChunkedReader::new(&self.backend, id)?;
         Ok(serialisation::deserialise_from(&mut reader)?)
-    }
-
-    /// A snapshot is a new repo to which only `id` has been committed.
-    pub fn export_snapshot(&self, id: &Hash, path: impl AsRef<Path>) -> Result<(), StorageError> {
-        // Only export a snapshot to a new or empty directory
-        let path = path.as_ref();
-        if !path.exists() || path.read_dir()?.next().is_none() {
-            std::fs::create_dir_all(path)?;
-        } else {
-            return Err(StorageError::InvalidRepo);
-        };
-        let bytes = self.backend.load(id)?;
-        let commit: Vec<Hash> = serialisation::deserialise(&bytes)?;
-        for chunk in commit {
-            self.backend.copy(&chunk, path)?;
-        }
-        self.backend.copy(id, path)?;
-        Ok(())
     }
 }
 
@@ -241,12 +283,13 @@ mod tests {
     use octez_riscv_data::store::BlobStore;
     use octez_riscv_data::store::BlobStoreError;
 
+    use super::PersistentBlobStore;
     use super::Store;
 
     #[test]
     fn blob_store_test() {
         let tmp_dir = tempfile::tempdir().unwrap();
-        let store = Store::init(tmp_dir.path()).unwrap();
+        let store = Store::init_from_path(tmp_dir.path()).unwrap();
 
         let data1: &[u8] = &[3, 4, 5, 6, 8];
         let data2: &[u8] = b"Hi";

--- a/pvm/src/storage/chunked_io.rs
+++ b/pvm/src/storage/chunked_io.rs
@@ -6,24 +6,26 @@ use std::cmp;
 use std::collections::VecDeque;
 use std::io;
 use std::io::Cursor;
+use std::io::Write;
 
 use octez_riscv_data::hash::Hash;
+use octez_riscv_data::hash::HashedData;
 use octez_riscv_data::serialisation::deserialise;
+use octez_riscv_data::store::BlobStore;
 
 use super::CHUNK_SIZE;
 use super::StorageError;
-use super::Store;
 
-/// Simple writer that stores data in chunks of size [`CHUNK_SIZE`]
-pub struct ChunkWriter<'a> {
-    store: &'a mut Store,
+/// Simple writer that stores data in chunks of size [`CHUNK_SIZE`] in any [`BlobStore`].
+pub struct ChunkWriter<'a, BS> {
+    store: &'a BS,
     hashes: Vec<Hash>,
     buffer: Vec<u8>,
 }
 
-impl<'a> ChunkWriter<'a> {
-    /// Create a new writer that writes the chunks to the given [`Store`].
-    pub fn new(store: &'a mut Store) -> Self {
+impl<'a, BS: BlobStore> ChunkWriter<'a, BS> {
+    /// Create a new writer that writes the chunks to the given [`BlobStore`].
+    pub fn new(store: &'a BS) -> Self {
         Self {
             store,
             hashes: Vec::new(),
@@ -43,14 +45,15 @@ impl<'a> ChunkWriter<'a> {
 
     /// Write a chunk to the store.
     fn flush_buffer(&mut self) -> Result<(), StorageError> {
-        let chunk_hash = self.store.store(self.buffer.as_slice())?;
-        self.hashes.push(chunk_hash);
+        let hashed = HashedData::from_data(&self.buffer);
+        self.store.blob_set(&hashed)?;
+        self.hashes.push(hashed.hash());
         self.buffer.clear();
         Ok(())
     }
 }
 
-impl io::Write for ChunkWriter<'_> {
+impl<BS: BlobStore> Write for ChunkWriter<'_, BS> {
     fn write(&mut self, mut data: &[u8]) -> io::Result<usize> {
         let ret = data.len();
 
@@ -78,17 +81,17 @@ impl io::Write for ChunkWriter<'_> {
 }
 
 /// Just like [`ChunkWriter`], but for reading.
-pub struct ChunkedReader<'a> {
-    store: &'a Store,
+pub struct ChunkedReader<'a, BS> {
+    store: &'a BS,
     hashes: VecDeque<Hash>,
     buffer: Cursor<Vec<u8>>,
 }
 
-impl<'a> ChunkedReader<'a> {
-    /// Create a new reader that pulls the chunks from the given [`Store`].
-    pub fn new(store: &'a Store, hash: &Hash) -> Result<Self, StorageError> {
-        let raw_hashes = store.load(hash)?;
-        let hashes = deserialise(raw_hashes.as_slice())?;
+impl<'a, BS: BlobStore> ChunkedReader<'a, BS> {
+    /// Create a new reader that pulls the chunks from the given [`BlobStore`].
+    pub fn new(store: &'a BS, hash: &Hash) -> Result<Self, StorageError> {
+        let raw_hashes = store.blob_get(*hash)?;
+        let hashes = deserialise(raw_hashes.as_ref())?;
         Ok(Self {
             store,
             hashes,
@@ -102,13 +105,17 @@ impl<'a> ChunkedReader<'a> {
             return Ok(());
         };
 
-        self.buffer = Cursor::new(self.store.load(&hash)?);
+        let bytes = self.store.blob_get(hash)?;
+
+        self.buffer.get_mut().clear();
+        self.buffer.get_mut().extend_from_slice(bytes.as_ref());
+        self.buffer.set_position(0);
 
         Ok(())
     }
 }
 
-impl io::Read for ChunkedReader<'_> {
+impl<BS: BlobStore> io::Read for ChunkedReader<'_, BS> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if self.buffer.position() as usize >= self.buffer.get_ref().len() {
             self.next_chunk().map_err(io::Error::other)?;

--- a/pvm/tests/test_pvm_storage.rs
+++ b/pvm/tests/test_pvm_storage.rs
@@ -8,7 +8,9 @@ use octez_riscv::pvm::node_pvm::NodePvm;
 use octez_riscv::pvm::node_pvm::PvmStorage;
 use octez_riscv::storage::Repo;
 use octez_riscv::storage::StorageError;
+use octez_riscv::storage::Store;
 use octez_riscv_data::hash::Hash;
+use octez_riscv_data::store::BlobStoreError;
 use proptest::prelude::*;
 use proptest::strategy::ValueTree;
 use proptest::test_runner::TestRunner;
@@ -22,7 +24,7 @@ fn test_repo() {
 
     // Create a new repo, commit 5 times and check that all 5 commits can
     // be checked out
-    let mut repo = Repo::load(tmp_dir.path()).unwrap();
+    let repo = Repo::<Store>::load(tmp_dir.path()).unwrap();
     for _ in 0..5 {
         let data = prop::collection::vec(any::<u8>(), 0..100)
             .new_tree(&mut runner)
@@ -38,7 +40,7 @@ fn test_repo() {
     repo.close();
 
     // Reload the repo and check that all previous commits can be checked out
-    let mut repo = Repo::load(tmp_dir.path()).unwrap();
+    let repo = Repo::<Store>::load(tmp_dir.path()).unwrap();
     for (commit_id, bytes) in test_data.iter() {
         let checked_out_data = repo.checkout(commit_id).unwrap();
         assert_eq!(checked_out_data, *bytes);
@@ -62,15 +64,16 @@ fn test_repo() {
     let unknown_hash: Hash = [0u8; Hash::DIGEST_SIZE].into();
     assert!(matches!(
         repo.checkout(&unknown_hash),
-        Err(StorageError::NotFound(_))
+        Err(StorageError::BlobStore(BlobStoreError::NotFound(_)))
     ));
 
     // Check that exporting a snapshot creates a new repo which contains
     // the requested commit
     let snapshot_dir = tempfile::tempdir().unwrap();
     let (export_hash, export_data) = &test_data[0];
-    repo.export_snapshot(export_hash, &snapshot_dir).unwrap();
-    let snapshot_repo = Repo::load(tmp_dir.path()).unwrap();
+    repo.export_snapshot_chunked(export_hash, &snapshot_dir)
+        .unwrap();
+    let snapshot_repo = Repo::<Store>::load(snapshot_dir.path()).unwrap();
     let checked_out_data = snapshot_repo.checkout(export_hash).unwrap();
     assert_eq!(checked_out_data, *export_data);
 
@@ -87,7 +90,7 @@ fn test_repo_serialised() {
 
     // Create a new repo, commit 5 times and check that all 5 commits can
     // be checked out
-    let mut repo = Repo::load(tmp_dir.path()).unwrap();
+    let repo = Repo::<Store>::load(tmp_dir.path()).unwrap();
     for _ in 0..5 {
         let data = prop::collection::vec(any::<u8>(), 0..100)
             .new_tree(&mut runner)
@@ -103,7 +106,7 @@ fn test_repo_serialised() {
     repo.close();
 
     // Reload the repo and check that all previous commits can be checked out
-    let mut repo = Repo::load(tmp_dir.path()).unwrap();
+    let repo = Repo::<Store>::load(tmp_dir.path()).unwrap();
     for (commit_id, bytes) in test_data.iter() {
         let checked_out_data: Vec<u8> = repo.checkout_serialised(commit_id).unwrap();
         assert_eq!(checked_out_data, *bytes);
@@ -127,15 +130,16 @@ fn test_repo_serialised() {
     let unknown_hash: Hash = [0u8; Hash::DIGEST_SIZE].into();
     assert!(matches!(
         repo.checkout_serialised::<Vec<u8>>(&unknown_hash),
-        Err(StorageError::NotFound(_))
+        Err(StorageError::BlobStore(BlobStoreError::NotFound(_)))
     ));
 
     // Check that exporting a snapshot creates a new repo which contains
     // the requested commit
     let snapshot_dir = tempfile::tempdir().unwrap();
     let (export_hash, export_data) = &test_data[0];
-    repo.export_snapshot(export_hash, &snapshot_dir).unwrap();
-    let snapshot_repo = Repo::load(tmp_dir.path()).unwrap();
+    repo.export_snapshot_chunked(export_hash, &snapshot_dir)
+        .unwrap();
+    let snapshot_repo = Repo::<Store>::load(snapshot_dir.path()).unwrap();
     let checked_out_data: Vec<u8> = snapshot_repo.checkout_serialised(export_hash).unwrap();
     assert_eq!(checked_out_data, *export_data);
 
@@ -148,7 +152,7 @@ fn test_repo_serialised() {
 fn test_pvm_storage() {
     let tmp_dir = tempfile::tempdir().unwrap();
     let empty = NodePvm::empty();
-    let mut repo = PvmStorage::load(tmp_dir.path()).unwrap();
+    let mut repo = PvmStorage::<Store>::load(tmp_dir.path()).unwrap();
     let id = repo.commit(&empty).unwrap();
     let checked_out_empty = repo.checkout(&id).unwrap();
     assert_eq!(empty, checked_out_empty);
@@ -164,19 +168,19 @@ fn test_invalid_repo() {
     let tmp_file_path = tmp_dir.path().join("blah");
     let _tmp_file = File::create(&tmp_file_path).unwrap();
     assert!(matches!(
-        Repo::load(tmp_file_path),
+        Repo::<Store>::load(tmp_file_path),
         Err(StorageError::InvalidRepo)
     ));
 
     // Error if we try to export a snapshot to non-empty directory.
     let tmp_dir_2 = tempfile::tempdir().unwrap();
-    let mut repo = Repo::load(tmp_dir_2.path()).unwrap();
+    let repo = Repo::<Store>::load(tmp_dir_2.path()).unwrap();
 
     let data = vec![];
     let id = repo.commit(&data).unwrap();
 
     assert!(matches!(
-        repo.export_snapshot(&id, tmp_dir.path()),
+        repo.export_snapshot_chunked(&id, tmp_dir.path()),
         Err(StorageError::InvalidRepo)
     ));
 }


### PR DESCRIPTION
Part of TZX-86.

# What

Modify the 'chunked IO' methods `commit_serialised` and `checkout_serialised` that are currently used for PVM storage so that they can run against any implementation of the `BlobStore` trait.

We also add an extension to that trait, `ExportStore`, that allows copying blobs from one store into another at a given filesystem path. This is needed to implement the `export_snapshot` method. Having this extra trait will make it easier to switch to using the durable-storage persistence-layer, as that can easily be made to implement `ExportStore` on top of `BlobStore`.

# Why

We want to benchmark the existing (chunked) commit and checkout as well as the new (folded) methods. If both approaches can be run against an arbitrary `BlobStore` it makes the benchmarking much easier.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
