### PR TITLE
feat(pvm-storage): new commit, checkout and export, with end-to-end test

### DIFF
--- a/data/src/foldable.rs
+++ b/data/src/foldable.rs
@@ -196,10 +196,10 @@ pub enum UnfoldError {
     UnexpectedNode,
 
     #[error("Component specific error: {0}")]
-    OfComponent(Box<dyn std::error::Error>),
+    OfComponent(Box<dyn std::error::Error + Send + Sync>),
 
     #[error("Source specific error: {0}")]
-    OfSource(Box<dyn std::error::Error>),
+    OfSource(Box<dyn std::error::Error + Send + Sync>),
 }
 
 /// Implementing types describe 'source' data structures than can be deserialised or extracted in a

--- a/data/src/store/unfold.rs
+++ b/data/src/store/unfold.rs
@@ -24,10 +24,10 @@ pub struct BlobStoreUnfold<BS> {
     hash: Hash,
 }
 
-// TODO TZX-86: cfg annotation will be removed as part of wiring up the new PVM commit and checkout
-#[cfg(test)]
 impl<BS> BlobStoreUnfold<BS> {
-    fn new(store: Arc<BS>, hash: Hash) -> Self {
+    /// To construct a source for blob-store unfolding we need a cloneable reference to a store
+    /// together with a `hash` (the root hash of the tree, to start from) in the store.
+    pub fn new(store: Arc<BS>, hash: Hash) -> Self {
         Self { store, hash }
     }
 }

--- a/pvm/src/machine_state/memory/protection.rs
+++ b/pvm/src/machine_state/memory/protection.rs
@@ -21,6 +21,9 @@ use octez_riscv_data::components::vector::Vector;
 use octez_riscv_data::components::vector::VectorMode;
 use octez_riscv_data::foldable::Fold;
 use octez_riscv_data::foldable::Foldable;
+use octez_riscv_data::foldable::Unfold;
+use octez_riscv_data::foldable::UnfoldError;
+use octez_riscv_data::foldable::Unfoldable;
 use octez_riscv_data::merkle_proof::Deserialiser;
 use octez_riscv_data::merkle_proof::FromProof;
 use octez_riscv_data::merkle_proof::Suspended;
@@ -171,5 +174,12 @@ where
 impl FromProof for PagePermissions<Verify> {
     fn from_proof<D: Deserialiser>(proof: D) -> SuspendedResult<D, Self> {
         Vector::from_proof(proof).map(|result| result.map(|pages| Self { pages }))
+    }
+}
+
+impl Unfoldable for PagePermissions<Normal> {
+    fn unfold<U: Unfold>(src: U) -> Result<Self, UnfoldError> {
+        let pages = Vector::<Atom<bool, Normal>, Normal>::unfold(src)?;
+        Ok(Self { pages })
     }
 }

--- a/pvm/src/pvm/durable_storage.rs
+++ b/pvm/src/pvm/durable_storage.rs
@@ -10,6 +10,9 @@ use octez_riscv_data::clone::CloneState;
 use octez_riscv_data::foldable::Fold;
 use octez_riscv_data::foldable::Foldable;
 use octez_riscv_data::foldable::NodeFold;
+use octez_riscv_data::foldable::Unfold;
+use octez_riscv_data::foldable::UnfoldError;
+use octez_riscv_data::foldable::Unfoldable;
 use octez_riscv_data::merkle_proof::DeserialiserNode;
 use octez_riscv_data::merkle_proof::FromProof;
 use octez_riscv_data::mode::Mode;
@@ -66,6 +69,12 @@ impl FromProof for DurableStorageDummy {
     ) -> octez_riscv_data::merkle_proof::SuspendedResult<Proof, Self> {
         let node = proof.into_node()?;
         node.done(Self)
+    }
+}
+
+impl Unfoldable for DurableStorageDummy {
+    fn unfold<U: Unfold>(_src: U) -> Result<Self, UnfoldError> {
+        Ok(Self)
     }
 }
 

--- a/pvm/src/pvm/node_pvm.rs
+++ b/pvm/src/pvm/node_pvm.rs
@@ -352,11 +352,7 @@ impl<BS: PersistentBlobStore> PvmStorage<BS> {
     }
 
     /// A snapshot is a new repo to which only `id` has been committed.
-    pub fn export_snapshot(
-        &self,
-        id: &Hash,
-        path: impl AsRef<Path>,
-    ) -> Result<(), PvmStorageError> {
+    pub fn export_snapshot(&self, id: Hash, path: impl AsRef<Path>) -> Result<(), PvmStorageError> {
         Ok(self.repo.export_snapshot_chunked(id, path)?)
     }
 }

--- a/pvm/src/storage.rs
+++ b/pvm/src/storage.rs
@@ -9,16 +9,22 @@ use std::io;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use bincode::Decode;
 use bincode::Encode;
 use bincode::error::DecodeError;
 use bincode::error::EncodeError;
+use octez_riscv_data::foldable::Foldable;
+use octez_riscv_data::foldable::UnfoldError;
+use octez_riscv_data::foldable::Unfoldable;
 use octez_riscv_data::hash::Hash;
 use octez_riscv_data::hash::HashedData;
 use octez_riscv_data::serialisation;
 use octez_riscv_data::store::BlobStore;
 use octez_riscv_data::store::BlobStoreError;
+use octez_riscv_data::store::fold::BlobStoreFold;
+use octez_riscv_data::store::unfold::BlobStoreUnfold;
 use thiserror::Error;
 
 const CHUNK_SIZE: usize = 4096;
@@ -42,6 +48,9 @@ pub enum StorageError {
 
     #[error("Blob store error")]
     BlobStore(#[from] BlobStoreError),
+
+    #[error("Unfold error")]
+    UnfoldError(#[from] UnfoldError),
 }
 
 /// A subtrait for `BlobStore` to provide extra functionality required by the PVM storage to export
@@ -59,8 +68,8 @@ pub trait PersistentBlobStore: BlobStore {
     /// equivalent to using `blob_get` followed by `blob_set` to copy the blob across, it could in
     /// many impls be more efficient (especially for large blobs) by using `std::fs::copy` or
     /// equivalent instead.
-    fn export_blob(&self, other: &mut Self, hash: &Hash) -> Result<(), StorageError> {
-        let blob = self.blob_get(*hash)?;
+    fn export_blob(&self, other: &mut Self, hash: Hash) -> Result<(), StorageError> {
+        let blob = self.blob_get(hash)?;
         other.blob_set(&HashedData::from_data(blob.as_ref()))?;
 
         Ok(())
@@ -118,9 +127,9 @@ impl PersistentBlobStore for Store {
         })
     }
 
-    fn export_blob(&self, other: &mut Self, hash: &Hash) -> Result<(), StorageError> {
-        let source_path = self.path_of_hash(hash);
-        let target_path = other.path_of_hash(hash);
+    fn export_blob(&self, other: &mut Self, hash: Hash) -> Result<(), StorageError> {
+        let source_path = self.path_of_hash(&hash);
+        let target_path = other.path_of_hash(&hash);
         std::fs::copy(source_path, target_path)?;
         Ok(())
     }
@@ -157,15 +166,31 @@ impl BlobStore for Store {
 
 #[derive(Debug, PartialEq)]
 pub struct Repo<BS> {
-    backend: BS,
+    backend: Arc<BS>,
 }
 
 impl<BS: PersistentBlobStore> Repo<BS> {
     /// Load or create new repo at `path`.
     pub fn load(path: impl AsRef<Path>) -> Result<Self, StorageError> {
         Ok(Repo {
-            backend: BS::init_from_path(path)?,
+            backend: Arc::new(BS::init_from_path(path)?),
         })
+    }
+
+    /// Makes sure an empty directory exists at the path, suitable for a new `Repo`, and
+    /// initialises a blob store there.
+    ///
+    /// If this is not possible (the directory isn't empty or is a file), we return
+    /// `Err(StorageError::InvalidRepo)`.
+    fn init_empty(path: impl AsRef<Path>) -> Result<BS, StorageError> {
+        let path = path.as_ref();
+
+        if path.exists() && (path.metadata()?.is_file() || path.read_dir()?.next().is_some()) {
+            return Err(StorageError::InvalidRepo);
+        }
+
+        std::fs::create_dir_all(path)?;
+        BS::init_from_path(path)
     }
 
     /// A snapshot is a new repo to which only `id` has been committed. This method exports an `id`
@@ -173,21 +198,14 @@ impl<BS: PersistentBlobStore> Repo<BS> {
     /// `commit_serialised`, which chunks the serialisation).
     pub fn export_snapshot_chunked(
         &self,
-        id: &Hash,
+        id: Hash,
         path: impl AsRef<Path>,
     ) -> Result<(), StorageError> {
-        // Only export a snapshot to a new or empty directory
-        let path = path.as_ref();
-        if !path.exists() || path.read_dir()?.next().is_none() {
-            std::fs::create_dir_all(path)?;
-        } else {
-            return Err(StorageError::InvalidRepo);
-        };
-        let mut other = BS::init_from_path(path)?;
-        let bytes = self.backend.blob_get(*id)?;
+        let mut other = Self::init_empty(path)?;
+        let bytes = self.backend.blob_get(id)?;
         let commit: Vec<Hash> = serialisation::deserialise(bytes.as_ref())?;
         for chunk in commit {
-            self.backend.export_blob(&mut other, &chunk)?;
+            self.backend.export_blob(&mut other, chunk)?;
         }
         self.backend.export_blob(&mut other, id)?;
         Ok(())
@@ -196,21 +214,32 @@ impl<BS: PersistentBlobStore> Repo<BS> {
     /// A snapshot is a new repo to which only `id` has been committed. This method exports an `id`
     /// which represents any Merkle tree structure.
     ///
-    /// Currently unimplemented.
-    ///
-    /// TODO (TZX-121)
-    pub fn export_snapshot_folded(
+    /// TODO (TZX-126): Improve this so that it doesn't need to deserialise the whole state being
+    /// snapshotted.
+    pub fn export_snapshot_folded<State>(
         &self,
-        _id: &Hash,
-        _path: impl AsRef<Path>,
-    ) -> Result<(), StorageError> {
-        todo!()
+        id: Hash,
+        path: impl AsRef<Path>,
+    ) -> Result<(), StorageError>
+    where
+        State: Foldable<BlobStoreFold<BS>> + Unfoldable,
+    {
+        let source = BlobStoreUnfold::new(Arc::clone(&self.backend), id);
+        let state = State::unfold(source)?;
+
+        let other = Self::init_empty(path)?;
+        let builder = BlobStoreFold::from(Arc::new(other));
+        state.fold(builder)?;
+
+        Ok(())
     }
 }
 
 impl<BS: BlobStore> Repo<BS> {
     pub fn new(store: BS) -> Self {
-        Repo { backend: store }
+        Repo {
+            backend: Arc::new(store),
+        }
     }
 
     pub fn close(self) {}
@@ -236,7 +265,7 @@ impl<BS: BlobStore> Repo<BS> {
     /// Commit something serialisable and return the commit ID.
     pub fn commit_serialised(&self, subject: &impl Encode) -> Result<Hash, StorageError> {
         let chunk_hashes = {
-            let mut writer = chunked_io::ChunkWriter::new(&self.backend);
+            let mut writer = chunked_io::ChunkWriter::new(self.backend.as_ref());
             serialisation::serialise_into(subject, &mut writer)?;
             writer.finalise()?
         };
@@ -247,6 +276,16 @@ impl<BS: BlobStore> Repo<BS> {
         self.backend.blob_set(&hashed_commit_bytes)?;
 
         Ok(hashed_commit_bytes.hash())
+    }
+
+    /// Commit something foldable and return the commit ID.
+    pub fn commit_folded(
+        &self,
+        subject: &impl Foldable<BlobStoreFold<BS>>,
+    ) -> Result<Hash, StorageError> {
+        let builder = BlobStoreFold::from(Arc::clone(&self.backend));
+
+        Ok(subject.fold(builder)?)
     }
 
     /// Checkout the bytes committed under `id`, if the commit exists.
@@ -271,8 +310,15 @@ impl<BS: BlobStore> Repo<BS> {
 
     /// Checkout something deserialisable from the store.
     pub fn checkout_serialised<S: Decode<()>>(&self, id: &Hash) -> Result<S, StorageError> {
-        let mut reader = chunked_io::ChunkedReader::new(&self.backend, id)?;
+        let mut reader = chunked_io::ChunkedReader::new(self.backend.as_ref(), id)?;
         Ok(serialisation::deserialise_from(&mut reader)?)
+    }
+
+    /// Checkout something unfoldable from the store.
+    pub fn checkout_folded<S: Unfoldable>(&self, id: &Hash) -> Result<S, StorageError> {
+        let source = BlobStoreUnfold::new(Arc::clone(&self.backend), *id);
+
+        Ok(S::unfold(source)?)
     }
 }
 

--- a/pvm/tests/test_pvm_storage.rs
+++ b/pvm/tests/test_pvm_storage.rs
@@ -4,13 +4,19 @@
 
 use std::fs::File;
 
+use octez_riscv::machine_state::memory::M1M;
+use octez_riscv::machine_state::page_cache::EmptyPageCache;
+use octez_riscv::pvm::Pvm;
+use octez_riscv::pvm::durable_storage::DurableStorageDummy;
 use octez_riscv::pvm::node_pvm::NodePvm;
 use octez_riscv::pvm::node_pvm::PvmStorage;
 use octez_riscv::storage::Repo;
 use octez_riscv::storage::StorageError;
 use octez_riscv::storage::Store;
 use octez_riscv_data::hash::Hash;
+use octez_riscv_data::mode::Normal;
 use octez_riscv_data::store::BlobStoreError;
+use octez_riscv_test_utils::TestableTmpdir;
 use proptest::prelude::*;
 use proptest::strategy::ValueTree;
 use proptest::test_runner::TestRunner;
@@ -19,7 +25,7 @@ use proptest::test_runner::TestRunner;
 fn test_repo() {
     let mut runner = TestRunner::default();
 
-    let tmp_dir = tempfile::tempdir().unwrap();
+    let tmp_dir = TestableTmpdir::new();
     let mut test_data = Vec::new();
 
     // Create a new repo, commit 5 times and check that all 5 commits can
@@ -69,23 +75,20 @@ fn test_repo() {
 
     // Check that exporting a snapshot creates a new repo which contains
     // the requested commit
-    let snapshot_dir = tempfile::tempdir().unwrap();
+    let snapshot_dir = TestableTmpdir::new();
     let (export_hash, export_data) = &test_data[0];
-    repo.export_snapshot_chunked(export_hash, &snapshot_dir)
+    repo.export_snapshot_chunked(*export_hash, snapshot_dir.path())
         .unwrap();
     let snapshot_repo = Repo::<Store>::load(snapshot_dir.path()).unwrap();
     let checked_out_data = snapshot_repo.checkout(export_hash).unwrap();
     assert_eq!(checked_out_data, *export_data);
-
-    tmp_dir.close().unwrap();
-    snapshot_dir.close().unwrap()
 }
 
 #[test]
 fn test_repo_serialised() {
     let mut runner = TestRunner::default();
 
-    let tmp_dir = tempfile::tempdir().unwrap();
+    let tmp_dir = TestableTmpdir::new();
     let mut test_data = Vec::new();
 
     // Create a new repo, commit 5 times and check that all 5 commits can
@@ -135,22 +138,43 @@ fn test_repo_serialised() {
 
     // Check that exporting a snapshot creates a new repo which contains
     // the requested commit
-    let snapshot_dir = tempfile::tempdir().unwrap();
+    let snapshot_dir = TestableTmpdir::new();
     let (export_hash, export_data) = &test_data[0];
-    repo.export_snapshot_chunked(export_hash, &snapshot_dir)
+    repo.export_snapshot_chunked(*export_hash, snapshot_dir.path())
         .unwrap();
     let snapshot_repo = Repo::<Store>::load(snapshot_dir.path()).unwrap();
     let checked_out_data: Vec<u8> = snapshot_repo.checkout_serialised(export_hash).unwrap();
     assert_eq!(checked_out_data, *export_data);
+}
 
-    tmp_dir.close().unwrap();
-    snapshot_dir.close().unwrap()
+type TestPvm = Pvm<M1M, EmptyPageCache, DurableStorageDummy, Normal>;
+
+#[test]
+fn test_repo_folding() {
+    let tmp_dir = TestableTmpdir::new();
+    let repo = Repo::<Store>::load(tmp_dir.path()).unwrap();
+
+    let empty_pvm = TestPvm::default();
+    let hash = repo.commit_folded(&empty_pvm).unwrap();
+    let checked_out = repo.checkout_folded::<TestPvm>(&hash).unwrap();
+
+    // We use `assert!` to avoid very verbose test failures
+    assert!(empty_pvm == checked_out);
+
+    let snapshot_dir = TestableTmpdir::new();
+    repo.export_snapshot_folded::<TestPvm>(hash, &snapshot_dir.path())
+        .unwrap();
+
+    let snapshot_repo = Repo::<Store>::load(snapshot_dir.path()).unwrap();
+    let checked_out_from_snapshot = snapshot_repo.checkout_folded::<TestPvm>(&hash).unwrap();
+
+    assert!(empty_pvm == checked_out_from_snapshot);
 }
 
 // Mirrors `src/lib_riscv/pvm/test/test_storage.ml`
 #[test]
 fn test_pvm_storage() {
-    let tmp_dir = tempfile::tempdir().unwrap();
+    let tmp_dir = TestableTmpdir::new();
     let empty = NodePvm::empty();
     let mut repo = PvmStorage::<Store>::load(tmp_dir.path()).unwrap();
     let id = repo.commit(&empty).unwrap();
@@ -164,23 +188,24 @@ fn test_pvm_storage() {
 #[test]
 fn test_invalid_repo() {
     // Error if we try to initialise a repo with a path that is a file, not a directory.
-    let tmp_dir = tempfile::tempdir().unwrap();
+    let tmp_dir = TestableTmpdir::new();
     let tmp_file_path = tmp_dir.path().join("blah");
-    let _tmp_file = File::create(&tmp_file_path).unwrap();
-    assert!(matches!(
-        Repo::<Store>::load(tmp_file_path),
-        Err(StorageError::InvalidRepo)
-    ));
+    let _tmp_file = File::create(tmp_file_path.as_path()).unwrap();
+    let load_result = Repo::<Store>::load(tmp_file_path.as_path());
+
+    assert!(matches!(load_result, Err(StorageError::InvalidRepo)));
 
     // Error if we try to export a snapshot to non-empty directory.
-    let tmp_dir_2 = tempfile::tempdir().unwrap();
+    let tmp_dir_2 = TestableTmpdir::new();
     let repo = Repo::<Store>::load(tmp_dir_2.path()).unwrap();
 
     let data = vec![];
     let id = repo.commit(&data).unwrap();
+    let export_result = repo.export_snapshot_chunked(id, tmp_dir.path());
 
-    assert!(matches!(
-        repo.export_snapshot_chunked(&id, tmp_dir.path()),
-        Err(StorageError::InvalidRepo)
-    ));
+    assert!(matches!(export_result, Err(StorageError::InvalidRepo)));
+
+    // Error if we try to export a snapshot to a path that is a file, not a directory.
+    let export_result = repo.export_snapshot_chunked(id, tmp_file_path);
+    assert!(matches!(export_result, Err(StorageError::InvalidRepo)));
 }


### PR DESCRIPTION
Closes TZX-121.
Part of TZX-86.

# What

An end-to-end test that creates a (small) empty PVM, commits it to the PVM storage, checks it out, exports it and checks out the exported copy, checking that the round trip gives the same state. This isn't intended to be an exhaustive test at all, more of a quick check that everything is plumbed together and basically works.

This includes two very simple `Unfoldable` implementations that were missing (probably due to PRs on using `Vector` that merged since the original work on unfold). It also adds three new methods to `Repo`:

- `commit_folded` (analogous to `commit_serialised` for something that is `Foldable<BlobStoreFold<BS>>`),
- `checkout_folded` (analogous to `checkout_serialised` for any type that is `Unfoldable`),
- and `export_snapshot_folded` which uses the 'quick-fix' implementation described in TZX-121. 

# Why

Want to check everything actually works with the new folding approach. And we need to be able to export snapshots, even if it's a bit clunky in this first version.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
