### PR TITLE
fix: ignore RUSTSEC-2026-0098/RUSTSEC-2026-0099

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,6 +1,7 @@
 [advisories]
 ignore = [
-  # The affected dependency is only used in the dependency cone of `kernel-bench-utils`.
-  # We don't make use of it in the main PVM library.
-  "RUSTSEC-2026-0049",
+  # The affected dependencies are only used in the dependency cone of
+  # `kernel-bench-utils`. We don't make use of them in the main PVM library.
+  "RUSTSEC-2026-0098",
+  "RUSTSEC-2026-0099",
 ]


### PR DESCRIPTION
No ticket

# What
Adds two new security advisories to the ignored set

# Why
They are causing CI to fail on `main`, but are only used in benchmark utils.

See #928 for a full explanation.

# Manually Testing

```
make audit
```

# Regressions
Two new advisories ignored

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
