### PR TITLE
Implement `Verify` mode for `Database`

### DIFF
--- a/data/src/components/bytes.rs
+++ b/data/src/components/bytes.rs
@@ -214,6 +214,28 @@ impl Bytes<Verify> {
         }
     }
 
+    /// Returns the given range as a contiguous byte slice.
+    ///
+    /// Panics (via [`not_found`]) if the range extends beyond the length, or is not fully
+    /// contained within a single defined entry, indicating the Merkle proof did not include the
+    /// data required for this access.
+    pub fn partial_slice(&self, range: Range<usize>) -> &[u8] {
+        if range.is_empty() {
+            return &[];
+        }
+        if range.start >= self.len() {
+            // SAFETY: called only in `Verify` mode
+            unsafe { not_found() }
+        }
+        match self.bytes.data.contiguous_range(range) {
+            Some(slice) => slice,
+            None => {
+                // SAFETY: called only in `Verify` mode
+                unsafe { not_found() }
+            }
+        }
+    }
+
     /// Zero-initialise all undefined bytes in the given range.
     pub(crate) fn zero_init_range(&mut self, range: Range<usize>) {
         let mut offset = range.start;

--- a/data/src/components/bytes/tests.rs
+++ b/data/src/components/bytes/tests.rs
@@ -27,6 +27,8 @@ use crate::mode::Normal;
 use crate::mode::Provable;
 use crate::mode::Prove;
 use crate::mode::Verify;
+use crate::mode::utils::assert_eq_found;
+use crate::mode::utils::assert_not_found;
 use crate::mode_test;
 use crate::serialisation::serialise;
 
@@ -546,6 +548,102 @@ fn proof_round_trip() {
             prop_assert_eq!(after_normal_hash, after_verify_hash);
         }
     });
+}
+
+// `partial_slice` of an empty range, even when the underlying region is undefined.
+#[test]
+fn partial_slice_empty_range() {
+    let bytes = Bytes::<Verify>::absent(10);
+    assert_eq_found!(bytes.partial_slice(0..0), [].as_slice());
+    assert_eq_found!(bytes.partial_slice(5..5), [].as_slice());
+}
+
+// `partial_slice` at the exact boundaries of a defined entry within a partial state.
+#[test]
+fn partial_slice_entry_boundaries() {
+    let mut bytes = Bytes::<Verify>::absent(20);
+    bytes.write(5, &[1, 2, 3, 4, 5]);
+
+    // Exact match for the entry's range.
+    assert_eq_found!(bytes.partial_slice(5..10), [1, 2, 3, 4, 5].as_slice());
+    // Sub-ranges fully contained inside the entry.
+    assert_eq_found!(bytes.partial_slice(6..9), [2, 3, 4].as_slice());
+    assert_eq_found!(bytes.partial_slice(5..6), [1].as_slice());
+    assert_eq_found!(bytes.partial_slice(9..10), [5].as_slice());
+}
+
+// `partial_slice` when the range is fully contained within a single defined entry.
+#[test]
+fn partial_slice_fully_defined() {
+    // `Bytes::<Verify>::new` lays out the whole length as a single contiguous defined entry.
+    let mut bytes = Bytes::<Verify>::new(20);
+    bytes.write(
+        0,
+        &[
+            10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11,
+        ],
+    );
+
+    assert_eq_found!(
+        bytes.partial_slice(0..20),
+        [
+            10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11
+        ]
+        .as_slice()
+    );
+    assert_eq_found!(bytes.partial_slice(5..10), [60, 70, 80, 90, 100].as_slice());
+    assert_eq_found!(bytes.partial_slice(0..1), [10].as_slice());
+    assert_eq_found!(bytes.partial_slice(19..20), [11].as_slice());
+}
+
+// `partial_slice` when the requested range extends past the byte array's length.
+#[test]
+fn partial_slice_range_exceeds_length() {
+    let bytes = Bytes::<Verify>::new(10);
+    assert_not_found!(bytes.partial_slice(0..11));
+    assert_not_found!(bytes.partial_slice(5..15));
+    assert_not_found!(bytes.partial_slice(10..11));
+    // Empty ranges always succeed, even when out-of-bounds: this matches `slice[len..len]` in std
+    // and lets callers that already validated their bounds (e.g. via `min(len, ..)`) ask for a
+    // zero-length read at the end without tripping `not_found`.
+    assert_eq_found!(bytes.partial_slice(11..11), [].as_slice());
+}
+
+// `partial_slice` when the range crosses a gap between two separately defined entries.
+#[test]
+fn partial_slice_range_spans_gap() {
+    let mut bytes = Bytes::<Verify>::absent(20);
+    // Define [0, 3) and [10, 13), leaving an undefined gap at [3, 10).
+    bytes.write(0, &[1, 2, 3]);
+    bytes.write(10, &[4, 5, 6]);
+
+    assert_not_found!(bytes.partial_slice(2..11));
+    assert_not_found!(bytes.partial_slice(0..13));
+    assert_not_found!(bytes.partial_slice(3..10));
+}
+
+// `partial_slice` when the range straddles a defined/undefined boundary.
+#[test]
+fn partial_slice_range_straddles_boundary() {
+    let mut bytes = Bytes::<Verify>::absent(20);
+    bytes.write(5, &[1, 2, 3, 4, 5]);
+
+    // Starts in undefined, ends in defined.
+    assert_not_found!(bytes.partial_slice(3..7));
+    // Starts in defined, ends in undefined.
+    assert_not_found!(bytes.partial_slice(7..12));
+    // Starts before and ends after the defined region.
+    assert_not_found!(bytes.partial_slice(0..15));
+}
+
+// `partial_slice` when no part of the requested range is defined.
+#[test]
+fn partial_slice_range_undefined() {
+    // `absent` leaves the underlying `PartialVec` empty, so any non-empty range is undefined.
+    let bytes = Bytes::<Verify>::absent(10);
+    assert_not_found!(bytes.partial_slice(0..1));
+    assert_not_found!(bytes.partial_slice(0..10));
+    assert_not_found!(bytes.partial_slice(3..7));
 }
 
 #[test]

--- a/data/src/partial_vec.rs
+++ b/data/src/partial_vec.rs
@@ -366,7 +366,7 @@ impl<T> PartialVec<T> {
     ///
     /// Returns `None` if the range spans multiple entries, includes any undefined data, or is empty
     /// and out-of-bounds.
-    pub fn contiguous_range(&self, range: Range<usize>) -> Option<&[T]> {
+    pub(crate) fn contiguous_range(&self, range: Range<usize>) -> Option<&[T]> {
         let idx = self
             .entries
             .partition_point(|entry| entry.end() < range.end);

--- a/durable-storage/src/avl/node.rs
+++ b/durable-storage/src/avl/node.rs
@@ -134,6 +134,36 @@ impl<TreeId, M: Mode> Node<TreeId, M> {
 }
 
 impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
+    /// The data stored in a [`Node`] within the subtree of this [`Node`] with a given [`Key`] .
+    pub(super) fn get<'a, NodeId>(
+        mut node: &'a NodeId,
+        key: &Key,
+        resolver: &impl AvlResolver<NodeId, TreeId, M>,
+    ) -> Result<Option<&'a Bytes<M>>, OperationalError>
+    where
+        NodeId: 'a,
+        TreeId: 'a,
+    {
+        loop {
+            let resolved_node = resolver.resolve(node)?;
+            match resolved_node.key().cmp(key) {
+                Ordering::Equal => return Ok(Some(&resolved_node.data)),
+                Ordering::Greater => {
+                    let Some(left) = resolved_node.left_ref(resolver)?.root() else {
+                        return Ok(None);
+                    };
+                    node = left;
+                }
+                Ordering::Less => {
+                    let Some(right) = resolved_node.right_ref(resolver)?.root() else {
+                        return Ok(None);
+                    };
+                    node = right;
+                }
+            }
+        }
+    }
+
     /// Create a new leaf [`Node`] from the given key and data.
     pub(crate) fn new(key: Key, data: impl Into<Bytes<M>>) -> Self
     where
@@ -712,36 +742,6 @@ impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
 
 #[cfg(test)]
 impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
-    /// The data stored in a [`Node`] within the subtree of this [`Node`] with a given [`Key`] .
-    pub(super) fn get<'a, NodeId>(
-        mut node: &'a NodeId,
-        key: &Key,
-        resolver: &impl AvlResolver<NodeId, TreeId, M>,
-    ) -> Result<Option<&'a Bytes<M>>, OperationalError>
-    where
-        NodeId: 'a,
-        TreeId: 'a,
-    {
-        loop {
-            let resolved_node = resolver.resolve(node)?;
-            match resolved_node.key().cmp(key) {
-                Ordering::Equal => return Ok(Some(resolved_node.data())),
-                Ordering::Greater => {
-                    let Some(left) = resolved_node.left_ref(resolver)?.root() else {
-                        return Ok(None);
-                    };
-                    node = left;
-                }
-                Ordering::Less => {
-                    let Some(right) = resolved_node.right_ref(resolver)?.root() else {
-                        return Ok(None);
-                    };
-                    node = right;
-                }
-            }
-        }
-    }
-
     /// Returns true if the balance factors stored in the [`Node`]'s subtree are correct.
     pub(super) fn has_correct_balance_factors<NodeId>(
         &self,

--- a/durable-storage/src/avl/tree.rs
+++ b/durable-storage/src/avl/tree.rs
@@ -146,6 +146,19 @@ impl<NodeId> Tree<NodeId> {
     }
 
     #[inline]
+    /// The data stored in a [`Node`] in the [`Tree`] with a given [`Key`].
+    pub(crate) fn get<'a, TreeId: 'a, M: BytesMode + AtomMode>(
+        &'a self,
+        key: &Key,
+        resolver: &impl AvlResolver<NodeId, TreeId, M>,
+    ) -> Result<Option<&'a Bytes<M>>, OperationalError> {
+        let Some(node) = self.root() else {
+            return Ok(None);
+        };
+        Node::get(node, key, resolver)
+    }
+
+    #[inline]
     /// Set the value of the [`Node`] with a given key.
     ///
     /// Returns true if the [`Tree`] has grown in size.
@@ -481,19 +494,6 @@ mod tests {
     use crate::key::Key;
 
     impl<NodeId> Tree<NodeId> {
-        #[inline]
-        /// The data stored in a [`Node`] in the [`Tree`] with a given [`Key`].
-        pub fn get<'a, TreeId: 'a, M: BytesMode + AtomMode>(
-            &'a self,
-            key: &Key,
-            resolver: &impl AvlResolver<NodeId, TreeId, M>,
-        ) -> Result<Option<&'a Bytes<M>>, OperationalError> {
-            let Some(node) = self.root() else {
-                return Ok(None);
-            };
-            Node::get(node, key, resolver)
-        }
-
         /// Asserts that the [`Tree`] is a valid AVL tree
         pub(crate) fn check<TreeId, M: BytesMode + AtomMode>(
             &self,

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -12,6 +12,8 @@ pub(crate) mod value_ref;
 
 use std::convert::Infallible;
 use std::marker::PhantomData;
+use std::ops::Index;
+use std::ops::Range;
 use std::sync::Arc;
 
 use bytes::BufMut;
@@ -22,6 +24,7 @@ use octez_riscv_data::hash::HashFold;
 use octez_riscv_data::mode::Modal;
 use octez_riscv_data::mode::Mode;
 use octez_riscv_data::mode::Normal;
+use octez_riscv_data::mode::Verify;
 use tezos_smart_rollup_constants::core::MAX_FILE_CHUNK_SIZE;
 use tokio::runtime::Handle;
 
@@ -32,6 +35,7 @@ use crate::errors::Error;
 use crate::errors::InvalidArgumentError;
 use crate::errors::OperationalError;
 use crate::key::Key;
+use crate::merkle_layer::MerkleLayer;
 use crate::merkle_worker::BackgroundKeyValueStore;
 use crate::merkle_worker::BackgroundPersistentKeyValueStore;
 use crate::merkle_worker::MerkleWorker;
@@ -289,7 +293,7 @@ impl<KV> Modal for DatabaseTemplate<KV> {
 
     type Prove<'normal> = Infallible;
 
-    type Verify = Infallible;
+    type Verify = VerifyImpl<KV>;
 }
 
 /// Modes that support the operational API exposed by [`Database`].
@@ -380,6 +384,79 @@ struct NormalImpl<KV> {
     merkle: MerkleWorker<KV>,
 }
 
+/// Verify-mode implementation for the [`Database`].
+struct VerifyImpl<KV> {
+    merkle: MerkleLayer<KV, Verify>,
+}
+
+impl DatabaseMode for Verify {
+    fn get<KV: BackgroundKeyValueStore>(
+        this: &Database<KV, Self>,
+        key: &Key,
+    ) -> Result<impl ValueRef, Error> {
+        // Wraps the return type of [`MerkleLayer::get`] to allow returning the data as an
+        // [`impl ValueRef`] without allocating.
+        struct Wrapper<'a>(&'a octez_riscv_data::components::bytes::Bytes<Verify>);
+
+        impl Index<Range<usize>> for Wrapper<'_> {
+            type Output = [u8];
+
+            fn index(&self, range: Range<usize>) -> &[u8] {
+                // TODO RV-993: Reading data which is contained in multiple adjacent entries will
+                // yield `not_found`.
+                self.0.partial_slice(range)
+            }
+        }
+
+        impl ValueRef for Wrapper<'_> {
+            fn len(&self) -> usize {
+                self.0.len()
+            }
+        }
+
+        let value = this
+            .inner
+            .merkle
+            .get(key)?
+            .ok_or(InvalidArgumentError::KeyNotFound)?;
+
+        Ok(Wrapper(value))
+    }
+
+    fn set<KV: BackgroundKeyValueStore>(
+        this: &mut Database<KV, Self>,
+        key: Key,
+        data: Bytes,
+    ) -> Result<(), Error> {
+        this.inner.merkle.set(&key, &data)?;
+        Ok(())
+    }
+
+    fn write<KV: BackgroundKeyValueStore>(
+        this: &mut Database<KV, Self>,
+        key: Key,
+        offset: usize,
+        data: Bytes,
+    ) -> Result<usize, Error> {
+        let written = data.len();
+        this.inner.merkle.write(&key, offset, &data)?;
+        Ok(written)
+    }
+
+    fn delete<KV: BackgroundKeyValueStore>(
+        this: &mut Database<KV, Self>,
+        key: Key,
+    ) -> Result<(), OperationalError> {
+        this.inner.merkle.delete(&key)
+    }
+
+    fn hash<KV: BackgroundKeyValueStore>(
+        this: &Database<KV, Self>,
+    ) -> Result<Hash, OperationalError> {
+        Ok(this.inner.merkle.hash())
+    }
+}
+
 #[cfg(test)]
 impl<KV: BackgroundKeyValueStore, M: DatabaseMode> Database<KV, M> {
     /// Assert that a database contains the expected value for a given key.
@@ -399,6 +476,7 @@ mod tests {
 
     use bytes::Bytes;
     use octez_riscv_data::mode::Normal;
+    use octez_riscv_data::mode::Verify;
     use proptest::prelude::*;
     use proptest::prop_assert_eq;
     use proptest::proptest;
@@ -407,11 +485,13 @@ mod tests {
 
     use super::Database;
     use super::DatabaseMode;
+    use crate::avl::tree::Tree;
     use crate::database::MAX_VALUE_SIZE;
     use crate::errors::Error;
     use crate::errors::InvalidArgumentError;
     use crate::key::KEY_MAX_SIZE;
     use crate::key::Key;
+    use crate::merkle_layer::MerkleLayer;
     use crate::merkle_worker::BackgroundKeyValueStore;
     use crate::merkle_worker::BackgroundPersistentKeyValueStore;
     use crate::storage::TestKeyValueStoreSetup;
@@ -422,6 +502,14 @@ mod tests {
         repo: &KV::Repo,
     ) -> Database<KV, Normal> {
         Database::try_new(handle, repo).expect("Creating a test database should succeed")
+    }
+
+    fn new_verify_database<KV>() -> Database<KV, Verify> {
+        Database {
+            inner: super::VerifyImpl {
+                merkle: MerkleLayer::from_verify_tree(Tree::default()),
+            },
+        }
     }
 
     fn new_persistent_database<KV>() -> (
@@ -1252,5 +1340,105 @@ mod tests {
             "Appending zero bytes to maximum length value does not change size"
         );
         assert_eq!(MAX_VALUE_SIZE, database.value_length(&key).unwrap());
+    });
+
+    kv_test!(test_verify_database_delete, KV: BackgroundKeyValueStore, {
+        let mut database = new_verify_database::<KV>();
+        let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
+
+        database
+            .set(key.clone(), Bytes::copy_from_slice(&[]))
+            .expect("Verify mode does not return `OperationError`s");
+        assert!(
+            database
+                .exists(&key)
+                .expect("Verify mode does not return `OperationError`s")
+        );
+
+        database
+            .delete(key.clone())
+            .expect("Verify mode does not return `OperationError`s");
+        assert!(
+            !database
+                .exists(&key)
+                .expect("Verify mode does not return `OperationError`s")
+        );
+
+        // Deleting a non-existent key should also succeed.
+        let nonexistent_key = Key::new(&[2]).expect("Size less than KEY_MAX_SIZE");
+        assert!(
+            !database
+                .exists(&nonexistent_key)
+                .expect("Verify mode does not return `OperationError`s")
+        );
+        database
+            .delete(nonexistent_key)
+            .expect("Verify mode does not return `OperationError`s");
+    });
+
+    kv_test!(test_verify_database_set_and_read, KV: BackgroundKeyValueStore, {
+        proptest!(|(data in prop::collection::vec(any::<u8>(), 0..200))| {
+            let mut database = new_verify_database::<KV>();
+            let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
+
+            database
+                .set(key.clone(), Bytes::copy_from_slice(&data))
+                .expect("Verify mode does not return `OperationError`s");
+
+            let result = database
+                .read_bytes(&key, 0, data.len())
+                .expect("Verify mode does not return `OperationError`s");
+            prop_assert_eq!(result.as_ref(), data.as_slice());
+        });
+    });
+
+    kv_test!(test_verify_database_value_length, KV: BackgroundKeyValueStore, {
+        proptest!(|(data in prop::collection::vec(any::<u8>(), 0..200))| {
+            let mut database = new_verify_database::<KV>();
+            let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
+
+            database
+                .set(key.clone(), Bytes::copy_from_slice(&data))
+                .expect("Verify mode does not return `OperationError`s");
+
+            prop_assert_eq!(
+                database
+                    .value_length(&key)
+                    .expect("Verify mode does not return `OperationError`s"),
+                data.len()
+            );
+        });
+    });
+
+    kv_test!(test_verify_database_write_partial, KV: BackgroundKeyValueStore, {
+        proptest!(|(
+            initial in prop::collection::vec(any::<u8>(), 1..200),
+            patch in prop::collection::vec(any::<u8>(), 0..200),
+            offset_frac in 0_usize..=100,
+        )| {
+            let offset = offset_frac * initial.len() / 100;
+            let patch_len = patch.len().min(initial.len() - offset);
+            let patch = &patch[..patch_len];
+
+            let mut database = new_verify_database::<KV>();
+            let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
+
+            database
+                .set(key.clone(), Bytes::copy_from_slice(&initial))
+                .expect("Verify mode does not return `OperationError`s");
+
+            let written = database
+                .write(key.clone(), offset, Bytes::copy_from_slice(patch))
+                .expect("Verify mode does not return `OperationError`s");
+            prop_assert_eq!(written, patch_len);
+
+            let result = database
+                .read_bytes(&key, 0, initial.len())
+                .expect("Verify mode does not return `OperationError`s");
+
+            let mut expected = initial.clone();
+            expected[offset..offset + patch_len].copy_from_slice(patch);
+            prop_assert_eq!(result.as_ref(), expected.as_slice());
+        });
     });
 }

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -20,6 +20,7 @@ use std::convert::Infallible;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
+use octez_riscv_data::components::bytes::Bytes;
 use octez_riscv_data::hash::Hash;
 use octez_riscv_data::mode::Modal;
 use octez_riscv_data::mode::Mode;
@@ -392,6 +393,13 @@ struct VerifyImpl {
     resolver: VerifyResolver,
 }
 
+impl<KV> MerkleLayer<KV, Verify> {
+    /// Returns an immutable reference to the data stored for a given [Key].
+    pub(crate) fn get(&self, key: &Key) -> Result<Option<&Bytes<Verify>>, OperationalError> {
+        self.inner.tree.get(key, &self.inner.resolver)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -451,10 +459,6 @@ mod tests {
     }
 
     impl<KV> MerkleLayer<KV, Verify> {
-        fn get(&self, key: &Key) -> Result<Option<&Bytes<Verify>>, OperationalError> {
-            self.inner.tree.get(key, &self.inner.resolver)
-        }
-
         /// Construct a Verify-mode MerkleLayer from a deserialised tree.
         pub(crate) fn from_verify_tree(tree: Tree<VerifyNodeId>) -> Self {
             MerkleLayer {


### PR DESCRIPTION
Part of RV-964

# What
Implements `DatabaseMode` for `Verify`

# Why
Part of hooking up `Verify` mode to the `Registry` level

# How
- Promotes `data` and  `get` to non-test functionality
- Passes off each call to the `MerkleLayer` equivalent

`DatabaseMode::hash` is added, but still calls an unimplemented method. I'll change this PR to mark RV-964 as closed when RV-959 is.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
