### PR TITLE
feat(durable): restrict max io bounds to MAX_FILE_CHUNK_SIZE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2556,6 +2556,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tezos-smart-rollup-constants",
  "thiserror 2.0.18",
  "tokio",
  "trait-set",

--- a/durable-storage/Cargo.toml
+++ b/durable-storage/Cargo.toml
@@ -22,6 +22,7 @@ perfect-derive.workspace = true
 octez-riscv-data.workspace = true
 rand.workspace = true
 tempfile.workspace = true
+tezos-smart-rollup-constants.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 trait-set.workspace = true

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -19,6 +19,7 @@ use octez_riscv_data::hash::HashFold;
 use octez_riscv_data::mode::Modal;
 use octez_riscv_data::mode::Mode;
 use octez_riscv_data::mode::Normal;
+use tezos_smart_rollup_constants::core::MAX_FILE_CHUNK_SIZE;
 use tokio::runtime::Handle;
 
 use crate::commit::CommitId;
@@ -149,6 +150,7 @@ impl<KV: BackgroundKeyValueStore, M: DatabaseMode> Database<KV, M> {
     /// Returns the number of bytes read.
     ///
     /// Fails if:
+    ///  - The number of bytes to read is larger than [`MAX_FILE_CHUNK_SIZE`].
     ///  - The key does not exist.
     ///  - The offset is larger than the length of the associated value.
     pub fn read(&self, key: &Key, offset: usize, mut output: impl BufMut) -> Result<usize, Error> {
@@ -163,6 +165,7 @@ impl<KV: BackgroundKeyValueStore, M: DatabaseMode> Database<KV, M> {
     /// reading.
     ///
     /// Fails if:
+    ///  - The number of bytes to read is larger than [`MAX_FILE_CHUNK_SIZE`].
     ///  - The key does not exist.
     ///  - The offset is larger than the length of the associated value.
     pub fn read_bytes(
@@ -171,6 +174,10 @@ impl<KV: BackgroundKeyValueStore, M: DatabaseMode> Database<KV, M> {
         offset: usize,
         max_bytes: usize,
     ) -> Result<impl AsRef<[u8]>, Error> {
+        if max_bytes > MAX_FILE_CHUNK_SIZE {
+            Err(InvalidArgumentError::IoRequestTooLarge)?;
+        }
+
         let value = self.get(key)?;
         let value_length = value.as_ref().len();
         if offset > value_length {
@@ -200,7 +207,14 @@ impl<KV: BackgroundKeyValueStore, M: DatabaseMode> Database<KV, M> {
 
     /// Inserts the value associated with the provided key, replacing any data already associated
     /// with the key.
+    ///
+    /// Fails if:
+    ///  - The number of bytes to write is larger than [`MAX_FILE_CHUNK_SIZE`].
     pub fn set(&mut self, key: Key, data: Bytes) -> Result<(), Error> {
+        if data.len() > MAX_FILE_CHUNK_SIZE {
+            Err(InvalidArgumentError::IoRequestTooLarge)?;
+        }
+
         M::set(self, key, data)
     }
 
@@ -212,10 +226,15 @@ impl<KV: BackgroundKeyValueStore, M: DatabaseMode> Database<KV, M> {
     /// them more expensive.
     ///
     /// Fails if:
+    ///  - The number of bytes to write is larger than [`MAX_FILE_CHUNK_SIZE`].
     ///  - The offset is non-zero and the key does not exist.
     ///  - The offset is larger than the length of the associated value.
     ///  - The offset plus the length of the data would overflow.
     pub fn write(&mut self, key: Key, offset: usize, data: Bytes) -> Result<usize, Error> {
+        if data.len() > MAX_FILE_CHUNK_SIZE {
+            Err(InvalidArgumentError::IoRequestTooLarge)?;
+        }
+
         M::write(self, key, offset, data)
     }
 
@@ -427,7 +446,7 @@ mod tests {
         use crate::errors::InvalidArgumentError;
 
         assert!(matches!(
-            database.read(key, 0, Vec::new()),
+            database.read_bytes(key, 0, 0),
             Err(Error::InvalidArgument(InvalidArgumentError::KeyNotFound))
         ));
     }
@@ -896,7 +915,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_database_read_bytes_io_too_large() {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
@@ -918,7 +936,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_database_read_io_too_large() {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
@@ -1029,7 +1046,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_database_write_io_too_large() {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
@@ -1118,7 +1134,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_database_set_io_too_large() {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -365,6 +365,7 @@ mod tests {
     use proptest::prelude::*;
     use proptest::prop_assert_eq;
     use proptest::proptest;
+    use tezos_smart_rollup_constants::core::MAX_FILE_CHUNK_SIZE;
     use tokio::runtime::Handle;
 
     use super::Database;
@@ -894,6 +895,53 @@ mod tests {
         assert_eq!(read_data_before, read_data);
     }
 
+    #[test]
+    #[ignore]
+    fn test_database_read_bytes_io_too_large() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("Creating a Tokio runtime should succeed");
+        let handle = runtime.handle();
+        let (_keepalive, repo) = setup_repo();
+        let database = new_database(handle, repo);
+
+        let key = Key::new(&[]).expect("Size less than KEY_MAX_SIZE");
+
+        // The io request is too large - this takes priority
+        // even though the key does not exist
+        assert!(matches!(
+            database.read_bytes(&key, 5, MAX_FILE_CHUNK_SIZE + 1),
+            Err(Error::InvalidArgument(
+                InvalidArgumentError::IoRequestTooLarge
+            ))
+        ));
+    }
+
+    #[test]
+    #[ignore]
+    fn test_database_read_io_too_large() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("Creating a Tokio runtime should succeed");
+        let handle = runtime.handle();
+        let (_keepalive, repo) = setup_repo();
+        let database = new_database(handle, repo);
+
+        let key = Key::new(&[]).expect("Size less than KEY_MAX_SIZE");
+        let mut read_data: Vec<u8> = vec![42; MAX_FILE_CHUNK_SIZE + 1];
+        let read_data_before = read_data.clone();
+
+        // The io request is too large - this takes priority
+        // even though the key does not exist
+        assert!(matches!(
+            database.read(&key, 5, read_data.as_mut_slice()),
+            Err(Error::InvalidArgument(
+                InvalidArgumentError::IoRequestTooLarge
+            ))
+        ));
+        assert_eq!(read_data_before, read_data);
+    }
+
     proptest! {
         #[test]
         fn test_database_value_length(keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..KEY_MAX_SIZE), 0..100),
@@ -981,6 +1029,30 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
+    fn test_database_write_io_too_large() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("Creating a Tokio runtime should succeed");
+        let handle = runtime.handle();
+        let (_keepalive, repo) = setup_repo();
+        let mut database = new_database(handle, repo);
+
+        let key = Key::new(&[]).expect("Size less than KEY_MAX_SIZE");
+        let data = Bytes::copy_from_slice(vec![0; MAX_FILE_CHUNK_SIZE + 1].as_slice());
+
+        let res = database.write(key.clone(), 1, data);
+
+        // even though the offset is too large, the io error takes priority
+        assert!(matches!(
+            res,
+            Err(Error::InvalidArgument(
+                InvalidArgumentError::IoRequestTooLarge
+            ))
+        ));
+    }
+
+    #[test]
     fn test_database_write_no_truncation() {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
@@ -1043,5 +1115,28 @@ mod tests {
 
         assert!(database.set(key.clone(), data.clone()).is_ok());
         assert!(database.write(key.clone(), data.len() + 1, data).is_err());
+    }
+
+    #[test]
+    #[ignore]
+    fn test_database_set_io_too_large() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("Creating a Tokio runtime should succeed");
+        let handle = runtime.handle();
+        let (_keepalive, repo) = setup_repo();
+        let mut database = new_database(handle, repo);
+
+        let key = Key::new(&[]).expect("Size less than KEY_MAX_SIZE");
+        let data = Bytes::copy_from_slice(vec![0; MAX_FILE_CHUNK_SIZE + 1].as_slice());
+
+        let res = database.set(key.clone(), data);
+
+        assert!(matches!(
+            res,
+            Err(Error::InvalidArgument(
+                InvalidArgumentError::IoRequestTooLarge
+            ))
+        ));
     }
 }

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -867,7 +867,10 @@ mod tests {
         let key = Key::new(&[]).expect("Size less than KEY_MAX_SIZE");
 
         // The key doesn't exist
-        assert!(database.read_bytes(&key, 0, 1).is_err());
+        assert!(matches!(
+            database.read_bytes(&key, 0, 1),
+            Err(Error::InvalidArgument(InvalidArgumentError::KeyNotFound))
+        ));
     }
 
     #[test]
@@ -884,7 +887,10 @@ mod tests {
         let read_data_before = read_data;
 
         // The key doesn't exist
-        assert!(database.read(&key, 0, read_data.as_mut_slice()).is_err());
+        assert!(matches!(
+            database.read(&key, 0, read_data.as_mut_slice()),
+            Err(Error::InvalidArgument(InvalidArgumentError::KeyNotFound))
+        ));
         assert_eq!(read_data_before, read_data);
     }
 

--- a/durable-storage/src/errors.rs
+++ b/durable-storage/src/errors.rs
@@ -135,6 +135,9 @@ pub enum InvalidArgumentError {
     #[error("Key is too long")]
     KeyTooLong,
 
+    #[error("IO requests cannot be larger than MAX_FILE_CHUNK_SIZE")]
+    IoRequestTooLarge,
+
     #[error("Value offset too large")]
     OffsetTooLarge,
 

--- a/durable-storage/tests/integration_test.rs
+++ b/durable-storage/tests/integration_test.rs
@@ -11,6 +11,7 @@ use octez_riscv_durable_storage::registry::Registry;
 use proptest::prelude::*;
 use proptest::proptest;
 use proptest::sample::Index;
+use tezos_smart_rollup_constants::core::MAX_FILE_CHUNK_SIZE;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "rocksdb")] {
@@ -292,13 +293,22 @@ fn test_durable_storage_inner(operations: Vec<Operation>) {
 
                 let data = Bytes::copy_from_slice(&bytes);
 
-                registry
+                let result = registry
                     .database_mut(index)
                     .expect("The index is in bounds")
-                    .set(key.clone(), data)
-                    .expect("Setting should succeed");
+                    .set(key.clone(), data);
 
-                golden[index].seen.insert(key, bytes.clone());
+                if bytes.len() <= MAX_FILE_CHUNK_SIZE {
+                    assert!(
+                        result.is_ok(),
+                        "Set should have succeeded but failed: {:?}",
+                        result.err()
+                    );
+
+                    golden[index].seen.insert(key, bytes.clone());
+                } else {
+                    assert!(result.is_err(), "Set should have failed but succeeded");
+                }
             }
             Operation::Write(key, offset, bytes) => {
                 let data = Bytes::copy_from_slice(&bytes);
@@ -310,13 +320,16 @@ fn test_durable_storage_inner(operations: Vec<Operation>) {
                     .write(key.clone(), offset, data);
 
                 let should_succeed = if let Some(map_value) = golden[index].seen.get_mut(&key) {
-                    if offset > map_value.len() || offset.checked_add(bytes.len()).is_none() {
+                    if offset > map_value.len()
+                        || offset.checked_add(bytes.len()).is_none()
+                        || bytes.len() > MAX_FILE_CHUNK_SIZE
+                    {
                         false
                     } else {
                         update_value(map_value, offset, bytes);
                         true
                     }
-                } else if offset > 0 {
+                } else if offset > 0 || bytes.len() > MAX_FILE_CHUNK_SIZE {
                     false
                 } else {
                     golden[index].seen.insert(key, bytes);
@@ -355,7 +368,7 @@ fn test_durable_storage_inner(operations: Vec<Operation>) {
                 }
 
                 if let Some(map_value) = golden[index].seen.get(&key) {
-                    if offset > map_value.len() {
+                    if offset > map_value.len() || len > MAX_FILE_CHUNK_SIZE {
                         assert!(result.is_err());
                     } else {
                         let expected_len = std::cmp::min(len, map_value.len() - offset);


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

Part of RV-960

# What

Restrict the sizes of reads/writes to durable storage to `MAX_FILE_CHUNK_SIZE` (2KiB) at a time.

# Why

This restriction matches that of irmin-durable storage. The intent is to put a limit on how big a NDS proof can be.

*NB* while WASM-pvm allows reading of values to/from memory larger than this (up to 4KiB), we place the lower restriction for now, as this reduces the maximum WASM part of the proof, for successful r/w to storage, but up 2KiB. Values larger than this (e.g. for writes), would result in a larger WASM proof, but a much smaller NDS proof (as the write fails early).

We _may_ consider raising this restriction to 4KiB (matching the size of PAGES in the Bytes component) if we are sufficiently confident in the proof size restrictions.

# How

Check the size of IO _first_ when reading/writing - before checking anything else.

# Manually Testing

```
make all
```

If you checkout the second commit, the following tests should fail. They are enabled and pass in the third commit
```
λ cargo nextest run -p octez-riscv-durable-storage --no-fail-fast --run-ignored only
────────────
     Summary [   0.028s] 4 tests run: 0 passed, 4 failed, 100 skipped
        FAIL [   0.022s] octez-riscv-durable-storage database::tests::test_database_read_io_too_large
        FAIL [   0.023s] octez-riscv-durable-storage database::tests::test_database_read_bytes_io_too_large
        FAIL [   0.023s] octez-riscv-durable-storage database::tests::test_database_write_io_too_large
        FAIL [   0.024s] octez-riscv-durable-storage database::tests::test_database_set_io_too_large
```


# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
