### PR TITLE
chore: ignore RUSTSEC-2026-0104

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -4,4 +4,5 @@ ignore = [
   # `kernel-bench-utils`. We don't make use of them in the main PVM library.
   "RUSTSEC-2026-0098",
   "RUSTSEC-2026-0099",
+  "RUSTSEC-2026-0104",
 ]


### PR DESCRIPTION
# What

Ignores RUSTSEC-2026-0104 for `cargo audit`

# Why

Same as the already ignored advisories, this only affects `kernel-bench-utils`. Fixes [failing CI](https://github.com/tezos/riscv-pvm/actions/runs/24770210410/job/72474418448).

# Manually Testing

```
cargo audit
```

# Tasks for the Author

- [ ] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [ ] Eliminate dead code and other spurious artefacts introduced in your changes.
- [ ] Document new public functions, methods and types.
- [ ] Make sure the documentation for updated functions, methods, and types is correct.
- [ ] Add tests for bugs that have been fixed.
- [ ] [Explain changes](#regressions) to regression test captures when applicable.
- [ ] Write commit messages in agreement with our guidelines.
- [ ] Self-review your changes to ensure they are high-quality.
- [ ] Complete all of the above before assigning this MR to reviewers.
