### PR TITLE
feat(durable): limit value sizes to 64MiB

### DIFF
--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -35,6 +35,10 @@ use crate::storage::KeyValueStore;
 use crate::storage::PersistentKeyValueStore;
 use crate::storage::StoreOptions;
 
+/// The maximum possible length of a value in durable storage.
+pub const MAX_VALUE_SIZE: usize =
+    const { 64_usize.checked_shl(20).expect("usize overflow on 64MiB") };
+
 /// An isolated key-space, independent from other [`Database`]s, on which database operations can
 /// be performed, e.g. read, write, delete.
 ///
@@ -215,6 +219,13 @@ impl<KV: BackgroundKeyValueStore, M: DatabaseMode> Database<KV, M> {
             Err(InvalidArgumentError::IoRequestTooLarge)?;
         }
 
+        const {
+            assert!(
+                MAX_FILE_CHUNK_SIZE <= MAX_VALUE_SIZE,
+                "It must not be possible to set a value larger than MAX_VALUE_SIZE in one go."
+            )
+        };
+
         M::set(self, key, data)
     }
 
@@ -388,6 +399,7 @@ mod tests {
     use tokio::runtime::Handle;
 
     use super::Database;
+    use crate::database::MAX_VALUE_SIZE;
     use crate::errors::Error;
     use crate::errors::InvalidArgumentError;
     use crate::key::KEY_MAX_SIZE;
@@ -1153,5 +1165,92 @@ mod tests {
                 InvalidArgumentError::IoRequestTooLarge
             ))
         ));
+    }
+
+    #[test]
+    #[ignore]
+    fn test_database_write_value_too_large() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("Creating a Tokio runtime should succeed");
+        let handle = runtime.handle();
+        let (_keepalive, repo) = setup_repo();
+        let mut database = new_database(handle, repo);
+
+        let can_write = 100;
+
+        let key = Key::new(&[]).expect("Size less than KEY_MAX_SIZE");
+        let bytes = Bytes::from(vec![42; MAX_VALUE_SIZE - can_write]);
+
+        <Normal as super::DatabaseMode>::set(&mut database, key.clone(), bytes)
+            .expect("Setting should succeed (bypassing API layer)");
+
+        let value_len = database
+            .value_length(&key)
+            .expect("The key was written to previously");
+
+        // Check all writes that would cause the value size to grow too large fail
+        // the choice of '50' is arbitrary - mainly just chose something to prevent
+        // the test running too long
+        for buffer_size in ((can_write + 1)..MAX_FILE_CHUNK_SIZE)
+            .step_by(50)
+            .chain([MAX_FILE_CHUNK_SIZE])
+        {
+            let bytes = Bytes::from(vec![15; buffer_size]);
+            let result = database.write(key.clone(), value_len, bytes);
+
+            assert!(
+                matches!(
+                    result,
+                    Err(Error::InvalidArgument(
+                        InvalidArgumentError::ValueSizeTooLarge
+                    ))
+                ),
+                "Write would cause value to exceed MAX_VALUE_SIZE"
+            );
+
+            assert_eq!(
+                value_len,
+                database.value_length(&key).unwrap(),
+                "Value size must not have changed"
+            );
+        }
+
+        // Double check writing more than MAX_FILE_CHUNK_SIZE triggers IoRequestTooLarge
+        let bytes = Bytes::from(vec![15; MAX_FILE_CHUNK_SIZE + 1]);
+        let result = database.write(key.clone(), value_len, bytes);
+
+        assert!(
+            matches!(
+                result,
+                Err(Error::InvalidArgument(
+                    InvalidArgumentError::IoRequestTooLarge
+                ))
+            ),
+            "Write would cause value to exceed MAX_VALUE_SIZE"
+        );
+
+        // Check that writing up to MAX_VALUE_SIZE is ok
+        let bytes = Bytes::from(vec![15; can_write]);
+        let wrote = database
+            .write(key.clone(), value_len, bytes)
+            .expect("Writing up to allowed value size succeeds");
+
+        assert_eq!(
+            wrote, can_write,
+            "Write increasing value_length up to MAX_VALUE_SIZE succeeds"
+        );
+        assert_eq!(MAX_VALUE_SIZE, database.value_length(&key).unwrap());
+
+        // Ensure we can still append 'zero bytes' to end of value
+        let wrote = database
+            .write(key.clone(), MAX_VALUE_SIZE, Bytes::new())
+            .expect("Appending zero bytes to value of max allowed size should succeed");
+
+        assert_eq!(
+            wrote, 0,
+            "Appending zero bytes to maximum length value does not change size"
+        );
+        assert_eq!(MAX_VALUE_SIZE, database.value_length(&key).unwrap());
     }
 }

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -238,12 +238,17 @@ impl<KV: BackgroundKeyValueStore, M: DatabaseMode> Database<KV, M> {
     ///
     /// Fails if:
     ///  - The number of bytes to write is larger than [`MAX_FILE_CHUNK_SIZE`].
+    ///  - The size of the value after the write would exceed [`MAX_VALUE_SIZE]`.
     ///  - The offset is non-zero and the key does not exist.
     ///  - The offset is larger than the length of the associated value.
     ///  - The offset plus the length of the data would overflow.
     pub fn write(&mut self, key: Key, offset: usize, data: Bytes) -> Result<usize, Error> {
         if data.len() > MAX_FILE_CHUNK_SIZE {
             Err(InvalidArgumentError::IoRequestTooLarge)?;
+        }
+
+        if offset.saturating_add(data.len()) > MAX_VALUE_SIZE {
+            Err(InvalidArgumentError::ValueSizeTooLarge)?;
         }
 
         M::write(self, key, offset, data)
@@ -1168,7 +1173,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_database_write_value_too_large() {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()

--- a/durable-storage/src/errors.rs
+++ b/durable-storage/src/errors.rs
@@ -141,6 +141,9 @@ pub enum InvalidArgumentError {
     #[error("Value offset too large")]
     OffsetTooLarge,
 
+    #[error("Maximum value size exceeded")]
+    ValueSizeTooLarge,
+
     #[error("Registry resize can only change size by one")]
     RegistryResizeTooLarge,
 


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

- Part of RV-960

# What

Limits sizes of values in durable storage to 64MiB

# Why

Large enough to allow all reasonable kernels to be stored in a single slot (e.g. jstz is 18M) - but small enough to not eat up all memory in one go/cause issues with rocksdb.

# How

- `set` is covered as `MAX_FILE_CHUNK_SIZE < MAX_VALUE_SIZE`
- `write`: ensure that `offset + data.len() =< MAX_VALUE_SIZE` *NB* if `data.len()` is too large `IoRequestTooLarge` is still the preferred error.

# Manually Testing

```
make all
```

checkout the first commit and run:
```
λ cargo nextest run -p octez-riscv-durable-storage --run-ignored only
```
The new test  `test_database_write_value_too_large` will fail. This test is enabled in the second commit.

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
