### PR TITLE
feat(dursto): migrate prove-verify round-trip to merkle-layer

### DIFF
--- a/durable-storage/src/avl/resolver.rs
+++ b/durable-storage/src/avl/resolver.rs
@@ -760,14 +760,8 @@ mod tests {
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering;
 
-    use octez_riscv_data::components::atom::AtomMode;
     use octez_riscv_data::components::bytes::Bytes;
-    use octez_riscv_data::components::bytes::BytesMode;
     use octez_riscv_data::hash::Hash;
-    use octez_riscv_data::hash::PartialHash;
-    use octez_riscv_data::merkle_proof::FromProof;
-    use octez_riscv_data::merkle_proof::proof_tree::MerkleProof;
-    use octez_riscv_data::merkle_proof::proof_tree::ProofTree;
     use octez_riscv_data::mode::Normal;
     use octez_riscv_data::mode::Verify;
     use octez_riscv_data::mode::utils::NotFound;
@@ -794,10 +788,8 @@ mod tests {
     use crate::storage::KeyValueStore;
     use crate::storage::Storable;
     use crate::storage::StoreOptions;
-    use crate::storage::TestKeyValueStore;
     use crate::storage::in_memory::InMemoryKeyValueStore;
     use crate::storage::in_memory::InMemoryRepo;
-    use crate::storage::setup_repo;
 
     /// A wrapper around an in-memory key-value store that counts the number of `blob_get` calls.
     #[derive(Debug, Default)]
@@ -1470,128 +1462,5 @@ mod tests {
             .expect("should resolve to a verify tree");
 
         assert!(resolved.root().is_some(), "tree should have a root");
-    }
-
-    /// Read `key` from `tree`, assert the contents match `expected`, then overwrite at
-    /// `offset` with `new_data`.
-    ///
-    /// Shared across the Prove and Verify halves of
-    /// [`prove_verify_round_trip_get_and_write`] so both modes execute byte-for-byte
-    /// identical operations.
-    // TODO RV-969: rewrite in terms of an `OperationStream`.
-    fn run_read_then_write<NodeId, TreeId, M, Res>(
-        tree: &mut Tree<NodeId>,
-        resolver: &mut Res,
-        key: &Key,
-        expected: &[u8],
-        offset: usize,
-        new_data: &[u8],
-    ) where
-        NodeId: Clone + From<Node<TreeId, M>>,
-        TreeId: Default,
-        M: BytesMode + AtomMode,
-        Res: AvlResolver<NodeId, TreeId, M>,
-    {
-        let data: &Bytes<M> = tree
-            .get(key, resolver)
-            .expect("get should succeed")
-            .expect("key should exist");
-        let mut buf = vec![0u8; data.len()];
-        data.read(0, &mut buf);
-        assert_eq!(&buf, expected, "read should observe the expected bytes");
-
-        tree.write(key, offset, new_data, resolver)
-            .expect("write should succeed");
-    }
-
-    /// Build a three-node tree, persist it, then run a round-trip through Prove and Verify
-    /// modes using only read (`get`) and in-place write operations (no structural changes).
-    ///
-    /// TODO: RV-969: Rewrite operations to use OperationStream.
-    #[test]
-    fn prove_verify_round_trip_get_and_write() {
-        let key1 = Key::new(&[1]).expect("key should be valid");
-        let key2 = Key::new(&[2]).expect("key should be valid");
-        let key3 = Key::new(&[3]).expect("key should be valid");
-
-        // Shared operation parameters replayed across Prove and Verify modes.
-        let initial_data: &[u8] = b"beta";
-        let write_offset: usize = 0;
-        let overwrite_data: &[u8] = b"BETA";
-
-        // ---- Normal: build a three-node tree and persist ----
-        let mut tree: Tree<ArcNodeId> = Default::default();
-        let mut resolver = ArcResolver;
-        tree.set(&key1, b"alpha", &mut resolver)
-            .expect("set should succeed");
-        tree.set(&key2, b"beta", &mut resolver)
-            .expect("set should succeed");
-        tree.set(&key3, b"gamma", &mut resolver)
-            .expect("set should succeed");
-
-        let root_hash = Hash::from_foldable(tree.root().expect("tree should have a root node"));
-
-        let (_keepalive, repo) = setup_repo();
-        let persistence_layer = Arc::new(
-            TestKeyValueStore::new(&repo).expect("creating persistence layer should succeed"),
-        );
-        persist_tree(&tree, &resolver, persistence_layer.as_ref());
-
-        // ---- Prove: load, project, do get + write ----
-        let lazy_tree: Tree<LazyNodeId> = Some(LazyNodeId::from(root_hash)).into();
-        let lazy_resolver = LazyResolver::new(persistence_layer);
-        let mut prove_tree: Tree<ProveNodeId> = lazy_tree.into_proof();
-        let mut prove_resolver = ProveResolver(lazy_resolver);
-
-        // Read key2, then overwrite in place (no structural change).
-        run_read_then_write(
-            &mut prove_tree,
-            &mut prove_resolver,
-            &key2,
-            initial_data,
-            write_offset,
-            overwrite_data,
-        );
-
-        // Expected final hash (from prove-mode tree after operations)
-        let expected_hash = prove_tree.hash();
-
-        // ---- Generate proof ----
-        let merkle_proof = MerkleProof::from_foldable(&prove_tree);
-
-        // ---- Verify: deserialize proof, replay operations ----
-        let proof_deser = ProofTree::Present(&merkle_proof);
-        let verify_tree_id = VerifyTreeId::from_proof(proof_deser)
-            .expect("proof deserialization should succeed")
-            .into_result();
-
-        let VerifyTreeId::Present(mut verify_tree) = verify_tree_id else {
-            panic!("expected Present tree from proof, got {verify_tree_id:#?}");
-        };
-        let mut verify_resolver = VerifyResolver;
-
-        let final_hash = catch_not_found(move || {
-            // Replay the identical read + write against the verify tree.
-            run_read_then_write(
-                &mut verify_tree,
-                &mut verify_resolver,
-                &key2,
-                initial_data,
-                write_offset,
-                overwrite_data,
-            );
-
-            // Compute verify hash
-            let verify_tree_id = VerifyTreeId::Present(verify_tree);
-            PartialHash::from_foldable(Some(merkle_proof), &verify_tree_id)
-                .to_hash()
-                .expect("verify hash should be computable")
-        })
-        .expect("verify operations should not trigger not_found");
-
-        assert_eq!(
-            expected_hash, final_hash,
-            "prove and verify hashes should match after identical get + write operations"
-        );
     }
 }

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -397,12 +397,14 @@ mod tests {
     use std::sync::Arc;
 
     use octez_riscv_data::components::bytes::Bytes;
+    use octez_riscv_data::hash::PartialHash;
     use octez_riscv_data::merkle_proof::FromProof;
     use octez_riscv_data::merkle_proof::proof_tree::MerkleProof;
     use octez_riscv_data::merkle_proof::proof_tree::ProofTree;
     use octez_riscv_data::mode::Normal;
     use octez_riscv_data::mode::Prove;
     use octez_riscv_data::mode::Verify;
+    use octez_riscv_data::mode::utils::catch_not_found;
     use proptest::prelude::*;
     use proptest::prop_assert_eq;
     use proptest::proptest;
@@ -1720,5 +1722,86 @@ mod tests {
         };
 
         assert_eq!(normal_hash, prove_ml.hash());
+    });
+
+    kv_test!(test_prove_verify_round_trip_write, KV, {
+        let keys = [Key::new(&[1]), Key::new(&[2]), Key::new(&[3])]
+            .map(|r| r.expect("key should be valid"));
+
+        // ---- Normal: build a three-node tree ----
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut normal_ml = new_merkle_layer::<KV>(&repo);
+        normal_ml
+            .set(&keys[0], b"alpha")
+            .expect("set should succeed");
+        normal_ml
+            .set(&keys[1], b"beta")
+            .expect("set should succeed");
+        normal_ml
+            .set(&keys[2], b"gamma")
+            .expect("set should succeed");
+
+        let initial_hash = normal_ml.hash();
+
+        // ---- Prove: read key then overwrite it ----
+        let prove_tree = normal_ml.inner.tree.into_proof();
+        let mut prove_ml: MerkleLayer<KV, Prove<'static>> = MerkleLayer {
+            inner: ProveImpl {
+                tree: prove_tree,
+                resolver: ProveResolver::new(LazyResolver::new(
+                    normal_ml.inner.persistence.clone(),
+                )),
+            },
+        };
+
+        let data = prove_ml
+            .get(&keys[1])
+            .expect("get should succeed")
+            .expect("key should exist");
+        assert_eq!(data, b"beta");
+
+        prove_ml
+            .write(&keys[1], 0, b"BETA")
+            .expect("write should succeed");
+
+        let expected_hash = prove_ml.hash();
+        assert_ne!(initial_hash, expected_hash, "write should change the hash");
+
+        // ---- Generate proof ----
+        let merkle_proof = MerkleProof::from_foldable(&prove_ml.inner.tree);
+
+        // ---- Verify: deserialize proof, replay identical ops ----
+        let verify_tree_id = VerifyTreeId::from_proof(ProofTree::Present(&merkle_proof))
+            .expect("proof deserialization should succeed")
+            .into_result();
+
+        let VerifyTreeId::Present(verify_tree) = verify_tree_id else {
+            panic!("expected Present tree from proof");
+        };
+
+        let mut verify_ml: MerkleLayer<KV, Verify> = MerkleLayer::from_verify_tree(verify_tree);
+
+        let final_hash = catch_not_found(move || {
+            let data = verify_ml
+                .get(&keys[1])
+                .expect("get should succeed")
+                .expect("key should be present in proof");
+            assert_eq!(data, b"beta", "verify should see initial data");
+
+            verify_ml
+                .write(&keys[1], 0, b"BETA")
+                .expect("write should succeed");
+
+            let verify_tree_id = VerifyTreeId::Present(verify_ml.inner.tree);
+            PartialHash::from_foldable(Some(merkle_proof), &verify_tree_id)
+                .to_hash()
+                .expect("verify hash should be computable")
+        })
+        .expect("verify operations should not trigger not_found");
+
+        assert_eq!(
+            expected_hash, final_hash,
+            "prove and verify hashes should match after identical get + write operations"
+        );
     });
 }


### PR DESCRIPTION
Part of RV-957.

# What

Migrate the existing prove-verify round-trip test from resolver.rs to
merkle_layer.rs.

# Why

The proof no longer builds directly over the tree level.


# Manually Testing

```
make all
```

# Regressions

<!--
    Explain changes to regression test captures. If there are no changes to these, delete this
    section.
-->

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
