### PR TITLE
feat(dursto): Add access-tracking to the ProveResolver.

### DIFF
--- a/durable-storage/src/avl/resolver.rs
+++ b/durable-storage/src/avl/resolver.rs
@@ -27,6 +27,8 @@
 //! [`Tree`]: crate::avl::tree::Tree
 //! [`Node`]: crate::avl::node::Node
 
+use std::cell::RefCell;
+use std::collections::BTreeSet;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -465,6 +467,17 @@ impl From<Node<ProveTreeId, Prove<'static>>> for ProveNodeId {
     }
 }
 
+/// Access the cached prove-mode node, if populated.
+///
+/// Used by the `MerkleLayer`-level fold to extract per-field read flags from a node that
+/// was resolved during the proof step.
+impl ProveNodeId {
+    #[expect(dead_code, reason = "used by MerkleLayer fold in follow-up commit")]
+    pub(crate) fn cached_node(&self) -> Option<&Node<ProveTreeId, Prove<'static>>> {
+        self.inner.get().map(|rc| rc.as_ref())
+    }
+}
+
 impl Foldable<HashFold> for ProveNodeId {
     fn fold(&self, builder: HashFold) -> <HashFold as Fold>::Folded {
         match self.inner.get() {
@@ -523,18 +536,80 @@ impl Foldable<MerkleProofFold> for ProveTreeId {
     }
 }
 
+/// State of the [`ProveResolver`] that tracks which nodes and trees have been
+/// accessed in the initial tree via the corresponding resolution methods
+#[derive(Default, Debug)]
+struct AccessedItems {
+    /// Hashes of nodes that have been accessed
+    nodes: BTreeSet<Hash>,
+
+    /// Hashes of trees that have been accessed
+    trees: BTreeSet<Hash>,
+}
+
 /// Adapter that projects lazy AVL identifiers into prove-mode values on demand.
 ///
 /// [`ProveResolver`] wraps another resolver for [`LazyNodeId`] and [`LazyTreeId`]. It preserves the
 /// lazy resolver's hash behaviour, but caches prove-mode nodes and trees inside [`ProveNodeId`]
 /// and [`ProveTreeId`] once they are resolved.
 #[derive(Debug)]
-pub struct ProveResolver<R>(R);
+pub(crate) struct ProveResolver<R> {
+    /// Inner resolver that is used for [`LazyNodeId`] and [`LazyTreeId`]
+    inner: R,
+
+    /// Inner state for access tracking
+    accessed_items: RefCell<AccessedItems>,
+}
 
 impl<R> ProveResolver<R> {
-    /// Create a new prove-mode resolver wrapping the given resolver.
-    pub(crate) fn new(resolver: R) -> Self {
-        Self(resolver)
+    /// Start the prove resolution process.
+    pub(crate) fn start(inner: R) -> Self {
+        Self {
+            inner,
+            accessed_items: RefCell::default(),
+        }
+    }
+
+    /// Whether a node with the given hash was accessed during the proof step.
+    #[expect(dead_code, reason = "used by MerkleLayer fold in follow-up commit")]
+    pub(crate) fn was_node_accessed(&self, hash: &Hash) -> bool {
+        self.accessed_items.borrow().nodes.contains(hash)
+    }
+
+    /// Whether a tree with the given hash was accessed during the proof step.
+    #[expect(dead_code, reason = "used by MerkleLayer fold in follow-up commit")]
+    pub(crate) fn was_tree_accessed(&self, hash: &Hash) -> bool {
+        self.accessed_items.borrow().trees.contains(hash)
+    }
+
+    /// Track node access and resolve the underlying lazy node in one step.
+    fn resolve_and_track_node<'a>(
+        &self,
+        id: &'a LazyNodeId,
+    ) -> Result<&'a Node<LazyTreeId, Normal>, OperationalError>
+    where
+        R: Resolver<LazyNodeId, Node<LazyTreeId, Normal>>,
+    {
+        self.accessed_items
+            .borrow_mut()
+            .nodes
+            .insert(Hash::from_foldable(id));
+        self.inner.resolve(id)
+    }
+
+    /// Track tree access and resolve the underlying lazy tree in one step.
+    fn resolve_and_track_tree<'a>(
+        &self,
+        id: &'a LazyTreeId,
+    ) -> Result<&'a Tree<LazyNodeId>, OperationalError>
+    where
+        R: Resolver<LazyTreeId, Tree<LazyNodeId>>,
+    {
+        self.accessed_items
+            .borrow_mut()
+            .trees
+            .insert(Hash::from_foldable(id));
+        self.inner.resolve(id)
     }
 }
 
@@ -549,7 +624,7 @@ impl<R: Resolver<LazyNodeId, Node<LazyTreeId, Normal>> + Resolver<LazyTreeId, Tr
             return Ok(inner);
         }
 
-        let resolved: &Node<LazyTreeId, Normal> = self.0.resolve(&id.node)?;
+        let resolved = self.resolve_and_track_node(&id.node)?;
         let result_node: Node<ProveTreeId, Prove<'static>> = resolved.clone().into_proof();
         id.inner
             .set(Rc::new(result_node))
@@ -566,12 +641,11 @@ impl<R: Resolver<LazyNodeId, Node<LazyTreeId, Normal>> + Resolver<LazyTreeId, Tr
             // SAFETY: Rust doesn't understand that the reference on `id.inner` is dropped on return.
             let inner_mut = unsafe { &mut *(&mut id.inner as *mut OnceLock<_>) };
             if let Some(inner) = inner_mut.get_mut() {
-                let inner = Rc::make_mut(inner);
-                return Ok(inner);
+                return Ok(Rc::make_mut(inner));
             }
         }
 
-        let resolved: &Node<LazyTreeId, Normal> = self.0.resolve(&id.node)?;
+        let resolved = self.resolve_and_track_node(&id.node)?;
         let result_node: Node<ProveTreeId, Prove<'static>> = resolved.clone().into_proof();
         id.inner
             .set(Rc::new(result_node))
@@ -591,7 +665,7 @@ impl<R: Resolver<LazyTreeId, Tree<LazyNodeId>>> Resolver<ProveTreeId, Tree<Prove
             return Ok(inner);
         }
 
-        let resolved: &Tree<LazyNodeId> = self.0.resolve(&id.tree)?;
+        let resolved = self.resolve_and_track_tree(&id.tree)?;
         let result_tree: Tree<ProveNodeId> = resolved.clone().into_proof();
         id.inner
             .set(result_tree)
@@ -612,7 +686,7 @@ impl<R: Resolver<LazyTreeId, Tree<LazyNodeId>>> Resolver<ProveTreeId, Tree<Prove
             }
         }
 
-        let resolved: &Tree<LazyNodeId> = self.0.resolve(&id.tree)?;
+        let resolved = self.resolve_and_track_tree(&id.tree)?;
         let result_tree: Tree<ProveNodeId> = resolved.clone().into_proof();
         id.inner
             .set(result_tree)
@@ -1205,7 +1279,7 @@ mod tests {
         let lazy_tree: Tree<LazyNodeId> = Some(LazyNodeId::from(root_hash)).into();
         let lazy_resolver = LazyResolver::new(persistence_layer);
 
-        let prove_resolver = ProveResolver(lazy_resolver);
+        let prove_resolver = ProveResolver::start(lazy_resolver);
         let lazy_node_id = lazy_tree.root().expect("tree should have a root");
 
         let prove_id = lazy_node_id.clone().into_proof();
@@ -1224,7 +1298,7 @@ mod tests {
 
         let expected_hash = Hash::from_foldable(lazy_root);
 
-        let prove_resolver = ProveResolver(lazy_resolver);
+        let prove_resolver = ProveResolver::start(lazy_resolver);
         let prove_id = lazy_root.clone().into_proof();
 
         // Hash before resolve (delegates to lazy path).
@@ -1252,7 +1326,7 @@ mod tests {
         let lazy_tree: Tree<LazyNodeId> = Some(LazyNodeId::from(root_hash)).into();
         let lazy_resolver = LazyResolver::new(persistence_layer);
 
-        let prove_resolver = ProveResolver(lazy_resolver);
+        let prove_resolver = ProveResolver::start(lazy_resolver);
         let prove_root_id = lazy_tree
             .root()
             .expect("tree should have a root")
@@ -1289,7 +1363,7 @@ mod tests {
         let lazy_tree: Tree<LazyNodeId> = Some(LazyNodeId::from(root_hash)).into();
         let lazy_resolver = LazyResolver::new(persistence_layer.clone());
 
-        let prove_resolver = ProveResolver(lazy_resolver);
+        let prove_resolver = ProveResolver::start(lazy_resolver);
         let prove_id = lazy_tree
             .root()
             .expect("tree should have a root")
@@ -1317,7 +1391,7 @@ mod tests {
         let lazy_tree: Tree<LazyNodeId> = Some(LazyNodeId::from(root_hash)).into();
         let lazy_resolver = LazyResolver::new(persistence_layer);
 
-        let mut prove_resolver = ProveResolver(lazy_resolver);
+        let mut prove_resolver = ProveResolver::start(lazy_resolver);
         let mut prove_id = lazy_tree
             .root()
             .expect("tree should have a root")
@@ -1354,7 +1428,7 @@ mod tests {
         let lazy_left_node_hash = Hash::from_foldable(lazy_left_id);
 
         // Now get the same hash via the prove resolver path.
-        let prove_resolver = ProveResolver(lazy_resolver);
+        let prove_resolver = ProveResolver::start(lazy_resolver);
         let prove_root_id = lazy_root.clone().into_proof();
         let prove_node = prove_resolver
             .resolve(&prove_root_id)
@@ -1384,7 +1458,7 @@ mod tests {
         let empty_lazy_tree: LazyTreeId = LazyTreeId::default();
         let prove_tree_id = empty_lazy_tree.clone().into_proof();
 
-        let prove_resolver = ProveResolver(lazy_resolver);
+        let prove_resolver = ProveResolver::start(lazy_resolver);
         let tree = prove_resolver
             .resolve(&prove_tree_id)
             .expect("resolving empty prove tree should succeed");

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -201,7 +201,7 @@ impl MerkleLayerMode for Prove<'static> {
         MerkleLayer {
             inner: ProveImpl {
                 tree: this.inner.tree.clone(),
-                resolver: ProveResolver::new(LazyResolver::new(persistence)),
+                resolver: ProveResolver::start(LazyResolver::new(persistence)),
             },
         }
     }
@@ -1440,7 +1440,7 @@ mod tests {
         let mut ml: MerkleLayer<KV, Prove<'static>> = MerkleLayer {
             inner: ProveImpl {
                 tree: Tree::default(),
-                resolver: ProveResolver::new(LazyResolver::new(persistence)),
+                resolver: ProveResolver::start(LazyResolver::new(persistence)),
             },
         };
         ml.delete(&key)
@@ -1468,7 +1468,7 @@ mod tests {
         let mut ml: MerkleLayer<KV, Prove<'static>> = MerkleLayer {
             inner: ProveImpl {
                 tree: Tree::default(),
-                resolver: ProveResolver::new(LazyResolver::new(persistence)),
+                resolver: ProveResolver::start(LazyResolver::new(persistence)),
             },
         };
         for (key, datum) in keys.iter().zip(data.iter()) {
@@ -1494,7 +1494,7 @@ mod tests {
         let mut ml: MerkleLayer<KV, Prove<'static>> = MerkleLayer {
             inner: ProveImpl {
                 tree: Tree::default(),
-                resolver: ProveResolver::new(LazyResolver::new(persistence)),
+                resolver: ProveResolver::start(LazyResolver::new(persistence)),
             },
         };
         let cow_data = "🐮<(prove a moo!)";
@@ -1536,7 +1536,7 @@ mod tests {
         let mut ml: MerkleLayer<KV, Prove<'static>> = MerkleLayer {
             inner: ProveImpl {
                 tree: Tree::default(),
-                resolver: ProveResolver::new(LazyResolver::new(persistence)),
+                resolver: ProveResolver::start(LazyResolver::new(persistence)),
             },
         };
         ml.set(&key, b"partial")
@@ -1575,7 +1575,7 @@ mod tests {
         let prove_ml: MerkleLayer<KV, Prove<'static>> = MerkleLayer {
             inner: ProveImpl {
                 tree: prove_tree,
-                resolver: ProveResolver::new(LazyResolver::new(
+                resolver: ProveResolver::start(LazyResolver::new(
                     normal_ml.inner.persistence.clone(),
                 )),
             },
@@ -1715,7 +1715,7 @@ mod tests {
         let prove_ml: MerkleLayer<KV, Prove<'static>> = MerkleLayer {
             inner: ProveImpl {
                 tree: prove_tree,
-                resolver: ProveResolver::new(LazyResolver::new(
+                resolver: ProveResolver::start(LazyResolver::new(
                     normal_ml.inner.persistence.clone(),
                 )),
             },
@@ -1748,7 +1748,7 @@ mod tests {
         let mut prove_ml: MerkleLayer<KV, Prove<'static>> = MerkleLayer {
             inner: ProveImpl {
                 tree: prove_tree,
-                resolver: ProveResolver::new(LazyResolver::new(
+                resolver: ProveResolver::start(LazyResolver::new(
                     normal_ml.inner.persistence.clone(),
                 )),
             },


### PR DESCRIPTION
Part of RV-957.

# What

Add access tracking to the ProveResolver, as part of the refactor of prove and verify modes for the MAVL tree.

# Why

The MerkleProofFold implementation over the Merkle Layer will use to check how the initial tree has been accessed as it is traversed.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
