### PR TITLE
test(dursto): run in-memory Database and Registry tests across backends when `rocksdb` is on

### DIFF
--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 Trilitech <contact@trili.tech>
+// SPDX-FileCopyrightText: 2026 Nomadic Labs <contact@nomadic-labs.com>
 //
 // SPDX-License-Identifier: MIT
 
@@ -404,17 +405,25 @@ mod tests {
     use tokio::runtime::Handle;
 
     use super::Database;
+    #[cfg(feature = "rocksdb")]
+    use super::DatabaseMode;
     use crate::database::MAX_VALUE_SIZE;
     use crate::errors::Error;
     use crate::errors::InvalidArgumentError;
     use crate::key::KEY_MAX_SIZE;
     use crate::key::Key;
-    use crate::storage::TestKeyValueStore;
+    use crate::merkle_worker::BackgroundKeyValueStore;
+    #[cfg(feature = "rocksdb")]
     use crate::storage::TestRepo;
+    use crate::storage::kv_test;
+    #[cfg(feature = "rocksdb")]
     use crate::storage::setup_repo;
 
-    fn new_database(handle: &Handle, repo: TestRepo) -> Database<TestKeyValueStore, Normal> {
-        Database::try_new(handle, &repo).expect("Creating a test database should succeed")
+    fn new_database<KV: BackgroundKeyValueStore>(
+        handle: &Handle,
+        repo: &KV::Repo,
+    ) -> Database<KV, Normal> {
+        Database::try_new(handle, repo).expect("Creating a test database should succeed")
     }
 
     #[cfg(feature = "rocksdb")]
@@ -440,8 +449,8 @@ mod tests {
     }
 
     #[cfg(feature = "rocksdb")]
-    fn insert_entries(
-        database: &mut PersistentDatabase,
+    fn insert_entries<KV: BackgroundKeyValueStore, M: DatabaseMode>(
+        database: &mut Database<KV, M>,
         entries: Vec<(Vec<u8>, Vec<u8>)>,
     ) -> std::collections::HashMap<Key, Bytes> {
         let mut expected = std::collections::HashMap::new();
@@ -496,19 +505,19 @@ mod tests {
                 checked_out.assert_database_value(&key, value.as_ref());
             }
         }
+    }
 
-        #[test]
-        fn test_database_delete(
+    kv_test!(test_database_delete, KV: BackgroundKeyValueStore, {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .build()
+            .expect("Creating a Tokio runtime should succeed");
+        let handle = runtime.handle();
+        let (_keepalive, repo) = KV::setup_repo();
+        proptest!(|(
             keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..=KEY_MAX_SIZE), 0..100),
-            data in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..200), 0..100),
-        ) {
-            let runtime = tokio::runtime::Builder::new_multi_thread()
-                .build()
-                .expect("Creating a Tokio runtime should succeed");
-            let handle = runtime.handle();
-
-            let (_keepalive, repo) = setup_repo();
-            let mut database = new_database(handle, repo);
+            data in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..200), 0..100)
+        )| {
+            let mut database = new_database::<KV>(handle, &repo);
 
             for (key, data) in keys.iter().zip(data.iter()) {
                 let key = Key::new(key).expect("Size less than KEY_MAX_SIZE");
@@ -523,11 +532,10 @@ mod tests {
                 assert_ne!(before, after);
                 prop_assert!(!database.exists(&key).expect("There should be no other `PersistenceLayerError`s"));
             }
-        }
-    }
+        });
+    });
 
-    #[test]
-    fn test_database_delete_nonexistent() {
+    kv_test!(test_database_delete_nonexistent, KV: BackgroundKeyValueStore, {
         // Receiving the hash requires a separate worker thread
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(1)
@@ -535,8 +543,8 @@ mod tests {
             .expect("Creating a Tokio runtime should succeed");
         let handle = runtime.handle();
 
-        let (_keepalive, repo) = setup_repo();
-        let mut database = new_database(handle, repo);
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut database = new_database::<KV>(handle, &repo);
 
         database
             .set(
@@ -559,7 +567,7 @@ mod tests {
         // Ensure the root hash is unchanged
         let after = database.hash().expect("Hash should be calculated");
         assert_eq!(before, after);
-    }
+    });
 
     #[cfg(feature = "rocksdb")]
     #[test]
@@ -670,17 +678,17 @@ mod tests {
         ));
     }
 
-    proptest! {
-        #[test]
-        fn test_database_exists(keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..KEY_MAX_SIZE), 0..100),
-                                data in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..200), 0..100), ) {
-
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .build()
-                .expect("Creating a Tokio runtime should succeed");
-            let handle = runtime.handle();
-            let (_keepalive, repo) = setup_repo();
-            let mut database = new_database(handle, repo);
+    kv_test!(test_database_exists, KV: BackgroundKeyValueStore, {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("Creating a Tokio runtime should succeed");
+        let handle = runtime.handle();
+        let (_keepalive, repo) = KV::setup_repo();
+        proptest!(|(
+            keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..KEY_MAX_SIZE), 0..100),
+            data in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..200), 0..100)
+        )| {
+            let mut database = new_database::<KV>(handle, &repo);
 
             let mut seen = HashSet::new();
 
@@ -697,20 +705,22 @@ mod tests {
                     .expect("Writing should succeed");
                 prop_assert!(database.exists(&key).expect("There should be no other `PersistenceLayerError`s"));
             }
-        }
+        });
+    });
 
-        #[test]
-        fn test_database_hash(keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..=KEY_MAX_SIZE), 0..100),
-                              data in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..200), 0..100), ) {
-
-            // Needs a thread for sending and a thread for receiving
-            let runtime = tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(2)
-                .build()
-                .expect("Creating a Tokio runtime should succeed");
-            let handle = runtime.handle();
-            let (_keepalive, repo) = setup_repo();
-            let mut database = new_database(handle, repo);
+    kv_test!(test_database_hash, KV: BackgroundKeyValueStore, {
+        // Needs a thread for sending and a thread for receiving
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .build()
+            .expect("Creating a Tokio runtime should succeed");
+        let handle = runtime.handle();
+        let (_keepalive, repo) = KV::setup_repo();
+        proptest!(|(
+            keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..=KEY_MAX_SIZE), 0..100),
+            data in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..200), 0..100)
+        )| {
+            let mut database = new_database::<KV>(handle, &repo);
 
             let mut seen = HashSet::new();
 
@@ -733,19 +743,18 @@ mod tests {
                     prop_assert_ne!(before, after);
                 }
             }
-        }
-    }
+        });
+    });
 
-    #[test]
-    fn test_database_hash_revert() {
+    kv_test!(test_database_hash_revert, KV: BackgroundKeyValueStore, {
         // Needs a thread for sending and a thread for receiving
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(2)
             .build()
             .expect("Creating a Tokio runtime should succeed");
         let handle = runtime.handle();
-        let (_keepalive, repo) = setup_repo();
-        let mut database = new_database(handle, repo);
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut database = new_database::<KV>(handle, &repo);
 
         let key = Key::new(&[0]).expect("Size less than KEY_MAX_SIZE");
         let original_data = [1, 2, 3];
@@ -772,18 +781,19 @@ mod tests {
             .expect("Writing should succeed");
         let reverted = database.hash().expect("Hash should be calculated");
         assert_eq!(before, reverted);
-    }
+    });
 
-    proptest! {
-        #[test]
-        fn test_database_read(keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..KEY_MAX_SIZE), 0..100),
-                              data in prop::collection::vec(prop::collection::vec(any::<u8>(), 3..100), 0..100), ) {
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .build()
-                .expect("Creating a Tokio runtime should succeed");
-            let handle = runtime.handle();
-            let (_keepalive, repo) = setup_repo();
-            let mut database = new_database(handle, repo);
+    kv_test!(test_database_read, KV: BackgroundKeyValueStore, {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("Creating a Tokio runtime should succeed");
+        let handle = runtime.handle();
+        let (_keepalive, repo) = KV::setup_repo();
+        proptest!(|(
+            keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..KEY_MAX_SIZE), 0..100),
+            data in prop::collection::vec(prop::collection::vec(any::<u8>(), 3..100), 0..100)
+        )| {
+            let mut database = new_database::<KV>(handle, &repo);
 
             for (key, data) in keys.iter().zip(data.iter()) {
                 let key = Key::new(key).expect("Size less than KEY_MAX_SIZE");
@@ -846,19 +856,20 @@ mod tests {
                 prop_assert_eq!(read, small_buffer.len());
                 prop_assert_eq!(&small_buffer, &data[0..3]);
             }
-        }
-    }
+        });
+    });
 
-    proptest! {
-        #[test]
-        fn test_database_read_bytes(keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..KEY_MAX_SIZE), 0..100),
-                                    data in prop::collection::vec(prop::collection::vec(any::<u8>(), 3..100), 0..100), ) {
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .build()
-                .expect("Creating a Tokio runtime should succeed");
-            let handle = runtime.handle();
-            let (_keepalive, repo) = setup_repo();
-            let mut database = new_database(handle, repo);
+    kv_test!(test_database_read_bytes, KV: BackgroundKeyValueStore, {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("Creating a Tokio runtime should succeed");
+        let handle = runtime.handle();
+        let (_keepalive, repo) = KV::setup_repo();
+        proptest!(|(
+            keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..KEY_MAX_SIZE), 0..100),
+            data in prop::collection::vec(prop::collection::vec(any::<u8>(), 3..100), 0..100)
+        )| {
+            let mut database = new_database::<KV>(handle, &repo);
 
             for (key, data) in keys.iter().zip(data.iter()) {
                 let key = Key::new(key).expect("Size less than KEY_MAX_SIZE");
@@ -889,17 +900,16 @@ mod tests {
                     .expect("A partial read should succeed");
                 prop_assert_eq!(result.as_ref(), &data[data.len() - 1..]);
             }
-        }
-    }
+        });
+    });
 
-    #[test]
-    fn test_database_read_bytes_no_key() {
+    kv_test!(test_database_read_bytes_no_key, KV: BackgroundKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("Creating a Tokio runtime should succeed");
         let handle = runtime.handle();
-        let (_keepalive, repo) = setup_repo();
-        let database = new_database(handle, repo);
+        let (_keepalive, repo) = KV::setup_repo();
+        let database = new_database::<KV>(handle, &repo);
 
         let key = Key::new(&[]).expect("Size less than KEY_MAX_SIZE");
 
@@ -908,16 +918,15 @@ mod tests {
             database.read_bytes(&key, 0, 1),
             Err(Error::InvalidArgument(InvalidArgumentError::KeyNotFound))
         ));
-    }
+    });
 
-    #[test]
-    fn test_database_read_no_key() {
+    kv_test!(test_database_read_no_key, KV: BackgroundKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("Creating a Tokio runtime should succeed");
         let handle = runtime.handle();
-        let (_keepalive, repo) = setup_repo();
-        let database = new_database(handle, repo);
+        let (_keepalive, repo) = KV::setup_repo();
+        let database = new_database::<KV>(handle, &repo);
 
         let key = Key::new(&[]).expect("Size less than KEY_MAX_SIZE");
         let mut read_data: [u8; 100] = [42; 100];
@@ -929,16 +938,15 @@ mod tests {
             Err(Error::InvalidArgument(InvalidArgumentError::KeyNotFound))
         ));
         assert_eq!(read_data_before, read_data);
-    }
+    });
 
-    #[test]
-    fn test_database_read_bytes_io_too_large() {
+    kv_test!(test_database_read_bytes_io_too_large, KV: BackgroundKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("Creating a Tokio runtime should succeed");
         let handle = runtime.handle();
-        let (_keepalive, repo) = setup_repo();
-        let database = new_database(handle, repo);
+        let (_keepalive, repo) = KV::setup_repo();
+        let database = new_database::<KV>(handle, &repo);
 
         let key = Key::new(&[]).expect("Size less than KEY_MAX_SIZE");
 
@@ -950,16 +958,15 @@ mod tests {
                 InvalidArgumentError::IoRequestTooLarge
             ))
         ));
-    }
+    });
 
-    #[test]
-    fn test_database_read_io_too_large() {
+    kv_test!(test_database_read_io_too_large, KV: BackgroundKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("Creating a Tokio runtime should succeed");
         let handle = runtime.handle();
-        let (_keepalive, repo) = setup_repo();
-        let database = new_database(handle, repo);
+        let (_keepalive, repo) = KV::setup_repo();
+        let database = new_database::<KV>(handle, &repo);
 
         let key = Key::new(&[]).expect("Size less than KEY_MAX_SIZE");
         let mut read_data: Vec<u8> = vec![42; MAX_FILE_CHUNK_SIZE + 1];
@@ -974,19 +981,19 @@ mod tests {
             ))
         ));
         assert_eq!(read_data_before, read_data);
-    }
+    });
 
-    proptest! {
-        #[test]
-        fn test_database_value_length(keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..KEY_MAX_SIZE), 0..100),
-                                      data in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..100), 0..100), ) {
-
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .build()
-                .expect("Creating a Tokio runtime should succeed");
-            let handle = runtime.handle();
-            let (_keepalive, repo) = setup_repo();
-            let mut database = new_database(handle, repo);
+    kv_test!(test_database_value_length, KV: BackgroundKeyValueStore, {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("Creating a Tokio runtime should succeed");
+        let handle = runtime.handle();
+        let (_keepalive, repo) = KV::setup_repo();
+        proptest!(|(
+            keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..KEY_MAX_SIZE), 0..100),
+            data in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..100), 0..100)
+        )| {
+            let mut database = new_database::<KV>(handle, &repo);
 
             for (key, data) in keys.iter().zip(data.iter()) {
                 let key = Key::new(key).expect("Size less than KEY_MAX_SIZE");
@@ -1002,22 +1009,22 @@ mod tests {
                     data.len()
                 );
             }
-        }
-    }
+        });
+    });
 
-    proptest! {
-        #[test]
-        fn test_database_write(keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..KEY_MAX_SIZE), 0..10),
-                               offsets in prop::collection::vec(0..10usize, 0..10),
-                               initial_data in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..200), 0..10),
-                               patch in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..200), 0..10), ) {
-
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .build()
-                .expect("Creating a Tokio runtime should succeed");
-            let handle = runtime.handle();
-            let (_keepalive, repo) = setup_repo();
-            let mut database = new_database(handle, repo);
+    kv_test!(test_database_write, KV: BackgroundKeyValueStore, {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("Creating a Tokio runtime should succeed");
+        let handle = runtime.handle();
+        let (_keepalive, repo) = KV::setup_repo();
+        proptest!(|(
+            keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..KEY_MAX_SIZE), 0..10),
+            offsets in prop::collection::vec(0..10usize, 0..10),
+            initial_data in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..200), 0..10),
+            patch in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..200), 0..10)
+        )| {
+            let mut database = new_database::<KV>(handle, &repo);
 
             for (((key, offset), initial_data), patch) in keys.iter().zip(offsets.iter()).zip(initial_data.iter()).zip(patch.iter()) {
                 let key = Key::new(key).expect("Size less than KEY_MAX_SIZE");
@@ -1036,17 +1043,16 @@ mod tests {
                     prop_assert_eq!(database.value_length(&key).unwrap(), expected_length);
                 }
             }
-        }
-    }
+        });
+    });
 
-    #[test]
-    fn test_database_write_new_nonzero_offset() {
+    kv_test!(test_database_write_new_nonzero_offset, KV: BackgroundKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("Creating a Tokio runtime should succeed");
         let handle = runtime.handle();
-        let (_keepalive, repo) = setup_repo();
-        let mut database = new_database(handle, repo);
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut database = new_database::<KV>(handle, &repo);
 
         let key = Key::new(&[]).expect("Size less than KEY_MAX_SIZE");
         let data = Bytes::copy_from_slice(&[]);
@@ -1060,16 +1066,15 @@ mod tests {
             ),
             "Values that don't exist are implicitly zero in size when written. Got {res:?}"
         );
-    }
+    });
 
-    #[test]
-    fn test_database_write_io_too_large() {
+    kv_test!(test_database_write_io_too_large, KV: BackgroundKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("Creating a Tokio runtime should succeed");
         let handle = runtime.handle();
-        let (_keepalive, repo) = setup_repo();
-        let mut database = new_database(handle, repo);
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut database = new_database::<KV>(handle, &repo);
 
         let key = Key::new(&[]).expect("Size less than KEY_MAX_SIZE");
         let data = Bytes::copy_from_slice(vec![0; MAX_FILE_CHUNK_SIZE + 1].as_slice());
@@ -1083,16 +1088,15 @@ mod tests {
                 InvalidArgumentError::IoRequestTooLarge
             ))
         ));
-    }
+    });
 
-    #[test]
-    fn test_database_write_no_truncation() {
+    kv_test!(test_database_write_no_truncation, KV: BackgroundKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("Creating a Tokio runtime should succeed");
         let handle = runtime.handle();
-        let (_keepalive, repo) = setup_repo();
-        let mut database = new_database(handle, repo);
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut database = new_database::<KV>(handle, &repo);
 
         let key = Key::new(&[]).expect("Size less than KEY_MAX_SIZE");
         let data = Bytes::from("a long value");
@@ -1109,16 +1113,15 @@ mod tests {
         let mut output = vec![0; data.len()];
         assert!(database.read(&key, 0, output.as_mut_slice()).is_ok());
         assert_eq!(output.as_slice(), "nother value".as_bytes());
-    }
+    });
 
-    #[test]
-    fn test_database_write_offset_append() {
+    kv_test!(test_database_write_offset_append, KV: BackgroundKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("Creating a Tokio runtime should succeed");
         let handle = runtime.handle();
-        let (_keepalive, repo) = setup_repo();
-        let mut database = new_database(handle, repo);
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut database = new_database::<KV>(handle, &repo);
 
         let key = Key::new(&[]).expect("Size less than KEY_MAX_SIZE");
         let data = Bytes::copy_from_slice(&[1, 2, 3]);
@@ -1132,32 +1135,30 @@ mod tests {
         let mut output = vec![0; 2 * data.len()];
         assert!(database.read(&key, 0, output.as_mut_slice()).is_ok());
         assert_eq!(output.as_slice(), [1, 2, 3, 1, 2, 3]);
-    }
+    });
 
-    #[test]
-    fn test_database_write_oversized_offset() {
+    kv_test!(test_database_write_oversized_offset, KV: BackgroundKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("Creating a Tokio runtime should succeed");
         let handle = runtime.handle();
-        let (_keepalive, repo) = setup_repo();
-        let mut database = new_database(handle, repo);
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut database = new_database::<KV>(handle, &repo);
 
         let key = Key::new(&[]).expect("Size less than KEY_MAX_SIZE");
         let data = Bytes::copy_from_slice(&[]);
 
         assert!(database.set(key.clone(), data.clone()).is_ok());
         assert!(database.write(key.clone(), data.len() + 1, data).is_err());
-    }
+    });
 
-    #[test]
-    fn test_database_set_io_too_large() {
+    kv_test!(test_database_set_io_too_large, KV: BackgroundKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("Creating a Tokio runtime should succeed");
         let handle = runtime.handle();
-        let (_keepalive, repo) = setup_repo();
-        let mut database = new_database(handle, repo);
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut database = new_database::<KV>(handle, &repo);
 
         let key = Key::new(&[]).expect("Size less than KEY_MAX_SIZE");
         let data = Bytes::copy_from_slice(vec![0; MAX_FILE_CHUNK_SIZE + 1].as_slice());
@@ -1170,16 +1171,15 @@ mod tests {
                 InvalidArgumentError::IoRequestTooLarge
             ))
         ));
-    }
+    });
 
-    #[test]
-    fn test_database_write_value_too_large() {
+    kv_test!(test_database_write_value_too_large, KV: BackgroundKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("Creating a Tokio runtime should succeed");
         let handle = runtime.handle();
-        let (_keepalive, repo) = setup_repo();
-        let mut database = new_database(handle, repo);
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut database = new_database::<KV>(handle, &repo);
 
         let can_write = 100;
 
@@ -1256,5 +1256,5 @@ mod tests {
             "Appending zero bytes to maximum length value does not change size"
         );
         assert_eq!(MAX_VALUE_SIZE, database.value_length(&key).unwrap());
-    }
+    });
 }

--- a/durable-storage/src/registry.rs
+++ b/durable-storage/src/registry.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Trilitech <contact@trili.tech>
+// SPDX-FileCopyrightText: 2026 Nomadic Labs <contact@nomadic-labs.com>
 //
 // SPDX-License-Identifier: MIT
 
@@ -403,16 +404,19 @@ pub(super) mod tests {
     use crate::errors::Error;
     use crate::errors::InvalidArgumentError;
     use crate::key::Key;
-    use crate::storage::TestKeyValueStore;
-    use crate::storage::TestRepo;
-    use crate::storage::setup_repo;
+    use crate::merkle_worker::BackgroundKeyValueStore;
+    use crate::storage::kv_test;
 
-    pub(super) fn setup_registry(repo: TestRepo) -> Registry<TestKeyValueStore, Normal> {
+    pub(super) fn setup_registry<KV: BackgroundKeyValueStore>(
+        repo: KV::Repo,
+    ) -> Registry<KV, Normal> {
         Registry::new(repo).expect("Registry should be created")
     }
 
-    pub(super) fn setup_size_2_registry(repo: TestRepo) -> Registry<TestKeyValueStore, Normal> {
-        let mut registry = setup_registry(repo);
+    pub(super) fn setup_size_2_registry<KV: BackgroundKeyValueStore>(
+        repo: KV::Repo,
+    ) -> Registry<KV, Normal> {
+        let mut registry = setup_registry::<KV>(repo);
         registry
             .resize_tick(1)
             .expect("Growing the registry should succeed.");
@@ -424,8 +428,8 @@ pub(super) mod tests {
         registry
     }
 
-    fn seed_copy_move(
-        registry: &mut Registry<TestKeyValueStore, Normal>,
+    fn seed_copy_move<KV: BackgroundKeyValueStore>(
+        registry: &mut Registry<KV, Normal>,
         src_index: usize,
         dst_index: usize,
     ) -> ([(Key, &'static [u8]); 2], Key) {
@@ -456,8 +460,8 @@ pub(super) mod tests {
         (src_pairs, key_c)
     }
 
-    fn assert_pairs_present(
-        registry: &Registry<TestKeyValueStore, Normal>,
+    fn assert_pairs_present<KV: BackgroundKeyValueStore>(
+        registry: &Registry<KV, Normal>,
         db_index: usize,
         pairs: &[(Key, &'static [u8])],
     ) {
@@ -475,8 +479,8 @@ pub(super) mod tests {
         }
     }
 
-    fn assert_pairs_absent(
-        registry: &Registry<TestKeyValueStore, Normal>,
+    fn assert_pairs_absent<KV: BackgroundKeyValueStore>(
+        registry: &Registry<KV, Normal>,
         db_index: usize,
         pairs: &[(Key, &'static [u8])],
     ) {
@@ -490,8 +494,8 @@ pub(super) mod tests {
         }
     }
 
-    pub(super) fn populate_database_with_key_value(
-        registry: &mut Registry<TestKeyValueStore, Normal>,
+    pub(super) fn populate_database_with_key_value<KV: BackgroundKeyValueStore>(
+        registry: &mut Registry<KV, Normal>,
         db_index: usize,
         key_bytes: &[u8],
         value: &[u8],
@@ -502,17 +506,15 @@ pub(super) mod tests {
             .expect("Writing to database should succeed");
     }
 
-    #[test]
-    fn test_new() {
-        let (_keepalive, repo) = setup_repo();
-        let registry = setup_registry(repo);
+    kv_test!(test_new, KV: BackgroundKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+        let registry = setup_registry::<KV>(repo);
         assert!(registry.is_empty());
-    }
+    });
 
-    #[test]
-    fn test_resize() {
-        let (_keepalive, repo) = setup_repo();
-        let mut registry = setup_registry(repo);
+    kv_test!(test_resize, KV: BackgroundKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut registry = setup_registry::<KV>(repo);
 
         while registry.len() < 4 {
             registry
@@ -529,12 +531,11 @@ pub(super) mod tests {
         assert_eq!(registry.len(), 1);
 
         assert!(registry.resize_tick(5).is_err());
-    }
+    });
 
-    #[test]
-    fn test_get_database() {
-        let (_keepalive, repo) = setup_repo();
-        let mut registry = setup_registry(repo);
+    kv_test!(test_get_database, KV: BackgroundKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut registry = setup_registry::<KV>(repo);
 
         while registry.len() < 3 {
             registry
@@ -545,23 +546,22 @@ pub(super) mod tests {
         for i in 0..3 {
             registry.database(i).expect("Database should exist.");
         }
-    }
+    });
 
-    #[test]
-    fn test_copy_database() {
-        let (_keepalive, repo) = setup_repo();
-        let mut registry = setup_size_2_registry(repo);
+    kv_test!(test_copy_database, KV: BackgroundKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut registry = setup_size_2_registry::<KV>(repo);
 
         let src_index = 0;
         let dst_index = 1;
 
-        let (src_pairs, key_c) = seed_copy_move(&mut registry, src_index, dst_index);
+        let (src_pairs, key_c) = seed_copy_move::<KV>(&mut registry, src_index, dst_index);
 
         registry
             .copy_database(src_index, dst_index)
             .expect("Copying should succeed");
 
-        assert_pairs_present(&registry, dst_index, &src_pairs);
+        assert_pairs_present::<KV>(&registry, dst_index, &src_pairs);
 
         assert!(
             !registry.databases[dst_index]
@@ -569,10 +569,9 @@ pub(super) mod tests {
                 .expect("Checking destination should succeed"),
             "Key C should not exist in destination after copy."
         );
-    }
+    });
 
-    #[test]
-    fn test_database_operations_invalid_index() {
+    kv_test!(test_database_operations_invalid_index, KV: BackgroundKeyValueStore, {
         macro_rules! assert_invalid_index_error {
             ($result:expr, $operation:expr, $direction:expr) => {
                 assert!(
@@ -589,8 +588,8 @@ pub(super) mod tests {
             };
         }
 
-        let (_keepalive, repo) = setup_repo();
-        let mut registry = setup_size_2_registry(repo);
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut registry = setup_size_2_registry::<KV>(repo);
 
         // Test copy operations with invalid indices
         assert_invalid_index_error!(registry.copy_database(0, 2), "copy", "to");
@@ -604,56 +603,53 @@ pub(super) mod tests {
 
         // Test clear operation with invalid index
         assert_invalid_index_error!(registry.clear_database(2), "clear", "");
-    }
+    });
 
-    #[test]
-    fn test_move_database() {
+    kv_test!(test_move_database, KV: BackgroundKeyValueStore, {
         // Test that the source database is emptied and the destination database
         // has all the data, and any data previously in the destination is lost.
 
-        let (_keepalive, repo) = setup_repo();
-        let mut registry = setup_size_2_registry(repo);
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut registry = setup_size_2_registry::<KV>(repo);
 
         let src_index = 1;
         let dst_index = 0;
 
-        let (src_pairs, _key_c) = seed_copy_move(&mut registry, src_index, dst_index);
+        let (src_pairs, _key_c) = seed_copy_move::<KV>(&mut registry, src_index, dst_index);
 
         registry
             .move_database(src_index, dst_index)
             .expect("Moving should succeed");
 
-        assert_pairs_present(&registry, dst_index, &src_pairs);
-        assert_pairs_absent(&registry, src_index, &src_pairs);
-    }
+        assert_pairs_present::<KV>(&registry, dst_index, &src_pairs);
+        assert_pairs_absent::<KV>(&registry, src_index, &src_pairs);
+    });
 
-    #[test]
-    fn test_database_operations_same_index() {
-        let (_keepalive, repo) = setup_repo();
-        let mut registry = setup_size_2_registry(repo);
+    kv_test!(test_database_operations_same_index, KV: BackgroundKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut registry = setup_size_2_registry::<KV>(repo);
 
-        let (src_pairs, _key_c) = seed_copy_move(&mut registry, 0, 1);
+        let (src_pairs, _key_c) = seed_copy_move::<KV>(&mut registry, 0, 1);
 
         // Test copy with same index
         registry
             .copy_database(0, 0)
             .expect("Copying to same index should succeed");
-        assert_pairs_present(&registry, 0, &src_pairs);
+        assert_pairs_present::<KV>(&registry, 0, &src_pairs);
 
         // Test move with same index
         registry
             .move_database(0, 0)
             .expect("Moving to same index should succeed");
-        assert_pairs_present(&registry, 0, &src_pairs);
-    }
+        assert_pairs_present::<KV>(&registry, 0, &src_pairs);
+    });
 
-    #[test]
-    fn test_clear_database() {
-        let (_keepalive, repo) = setup_repo();
-        let mut registry = setup_size_2_registry(repo);
+    kv_test!(test_clear_database, KV: BackgroundKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut registry = setup_size_2_registry::<KV>(repo);
 
         let db_index = 0;
-        populate_database_with_key_value(&mut registry, db_index, &[1], b"some_value");
+        populate_database_with_key_value::<KV>(&mut registry, db_index, &[1], b"some_value");
         let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
 
         registry
@@ -666,7 +662,7 @@ pub(super) mod tests {
                 .expect("Checking database should succeed"),
             "Key should not exist after clearing the database."
         );
-    }
+    });
 }
 
 #[cfg(feature = "rocksdb")]
@@ -707,7 +703,7 @@ mod rocksdb_tests {
     #[test]
     fn test_registry_commit_empty() {
         let (_keepalive, repo) = setup_repo();
-        let registry = setup_registry(repo);
+        let registry = setup_registry::<TestKeyValueStore>(repo);
 
         let expected_db_hashes: Vec<CommitId> = Vec::new();
         let expected_root = CommitId::from(Hash::hash_bytes(&[]));
@@ -721,12 +717,12 @@ mod rocksdb_tests {
     #[test]
     fn test_registry_commit_size_1() {
         let (_keepalive, repo) = setup_repo();
-        let mut registry = setup_registry(repo);
+        let mut registry = setup_registry::<TestKeyValueStore>(repo);
         registry
             .resize_tick(1)
             .expect("Growing the registry should succeed.");
 
-        populate_database_with_key_value(&mut registry, 0, &[1], b"singleton");
+        populate_database_with_key_value::<TestKeyValueStore>(&mut registry, 0, &[1], b"singleton");
 
         let expected_db_hashes: Vec<super::CommitId> = registry
             .databases
@@ -744,12 +740,12 @@ mod rocksdb_tests {
     #[test]
     fn test_committing_identical_registry_succeeds() {
         let (_keepalive, repo) = setup_repo();
-        let mut registry = setup_registry(repo);
+        let mut registry = setup_registry::<TestKeyValueStore>(repo);
         registry
             .resize_tick(1)
             .expect("Growing the registry should succeed.");
 
-        populate_database_with_key_value(&mut registry, 0, &[1], b"singleton");
+        populate_database_with_key_value::<TestKeyValueStore>(&mut registry, 0, &[1], b"singleton");
 
         let first_commit = registry.commit().expect("First commit should succeed");
         let second_commit = registry.commit().expect("Second commit should succeed");
@@ -763,10 +759,10 @@ mod rocksdb_tests {
     #[test]
     fn test_registry_commit_writes_manifest() {
         let (_keepalive, repo) = setup_repo();
-        let mut registry = setup_size_2_registry(repo);
+        let mut registry = setup_size_2_registry::<TestKeyValueStore>(repo);
 
-        populate_database_with_key_value(&mut registry, 0, &[1], b"alpha");
-        populate_database_with_key_value(&mut registry, 1, &[2], b"beta");
+        populate_database_with_key_value::<TestKeyValueStore>(&mut registry, 0, &[1], b"alpha");
+        populate_database_with_key_value::<TestKeyValueStore>(&mut registry, 1, &[2], b"beta");
 
         let expected_db_hashes: Vec<super::CommitId> = registry
             .databases
@@ -786,7 +782,7 @@ mod rocksdb_tests {
     #[test]
     fn test_registry_checkout_roundtrip_empty() {
         let (_keepalive, repo) = setup_repo();
-        let registry = setup_registry(repo.clone());
+        let registry = setup_registry::<TestKeyValueStore>(repo.clone());
 
         let root_commit = registry.commit().expect("Commit should succeed");
         let checked_out = Registry::<TestKeyValueStore, Normal>::checkout(repo, root_commit)
@@ -802,10 +798,10 @@ mod rocksdb_tests {
     #[test]
     fn test_registry_checkout_roundtrip_populated() {
         let (_keepalive, repo) = setup_repo();
-        let mut registry = setup_size_2_registry(repo.clone());
+        let mut registry = setup_size_2_registry::<TestKeyValueStore>(repo.clone());
 
-        populate_database_with_key_value(&mut registry, 0, &[1], b"alpha");
-        populate_database_with_key_value(&mut registry, 1, &[2], b"beta");
+        populate_database_with_key_value::<TestKeyValueStore>(&mut registry, 0, &[1], b"alpha");
+        populate_database_with_key_value::<TestKeyValueStore>(&mut registry, 1, &[2], b"beta");
 
         let key_a = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
         let key_b = Key::new(&[2]).expect("Size less than KEY_MAX_SIZE");
@@ -837,12 +833,12 @@ mod rocksdb_tests {
     #[test]
     fn test_registry_checkout_missing_database_commit_fails() {
         let (_keepalive, repo) = setup_repo();
-        let mut registry = setup_registry(repo.clone());
+        let mut registry = setup_registry::<TestKeyValueStore>(repo.clone());
         registry
             .resize_tick(1)
             .expect("Growing the registry should succeed.");
 
-        populate_database_with_key_value(&mut registry, 0, &[1], b"singleton");
+        populate_database_with_key_value::<TestKeyValueStore>(&mut registry, 0, &[1], b"singleton");
 
         let root_commit = registry.commit().expect("Commit should succeed");
         let manifest_path = repo.registry_commit_file(&root_commit);
@@ -861,12 +857,12 @@ mod rocksdb_tests {
     #[test]
     fn test_registry_checkout_detects_manifest_root_mismatch() {
         let (_keepalive, repo) = setup_repo();
-        let mut registry = setup_registry(repo.clone());
+        let mut registry = setup_registry::<TestKeyValueStore>(repo.clone());
         registry
             .resize_tick(1)
             .expect("Growing the registry should succeed.");
 
-        populate_database_with_key_value(&mut registry, 0, &[1], b"value");
+        populate_database_with_key_value::<TestKeyValueStore>(&mut registry, 0, &[1], b"value");
 
         let root_commit = registry.commit().expect("Commit should succeed");
         let manifest_path = repo.registry_commit_file(&root_commit);


### PR DESCRIPTION
Part of RV-972. Part of RV-975.

# What

Rewrites all the `Registry` and `Database` tests which don't rely on `PersistentKeyValueStore` using the `kv_test!` macro introduced in  #1009.

The rest of these tests will also be converted to `kv_test!` in follow-up PRs, using a test-only implementation of `PersistentKeyValueStore` for `InMemoryKeyValueStore`:

- #1020
- #1021

# Why

In order to run all tests across both the in-memory backend and the persistence layer.

# How

The changes are mostly mechanical and confined to test-only code.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
