### PR TITLE
test(dursto): run all Database tests across backends when `rocksdb` is on

### DIFF
--- a/durable-storage/benches/avl_tree.rs
+++ b/durable-storage/benches/avl_tree.rs
@@ -67,7 +67,7 @@ cfg_if::cfg_if! {
         type TestRepo = <TestKeyValueStore as KeyValueStore>::Repo;
 
         fn setup_repo() -> ((), TestRepo) {
-            ((), InMemoryRepo)
+            ((), InMemoryRepo::default())
         }
     }
 }

--- a/durable-storage/src/commit.rs
+++ b/durable-storage/src/commit.rs
@@ -11,7 +11,7 @@ use octez_riscv_data::hash::Hash;
 
 /// [`CommitId`]'s are used to generate commits & to checkout specific commits
 /// from a `DirectoryManager`.
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Encode, Decode)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Encode, Decode, Hash)]
 pub struct CommitId(Hash);
 
 impl CommitId {

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -76,7 +76,7 @@ impl<KV> Database<KV, Normal> {
     /// applied to a working copy, not to the committed state on disk.
     pub fn checkout(handle: &Handle, repo: &KV::Repo, commit_id: CommitId) -> Result<Self, Error>
     where
-        KV: BackgroundPersistentKeyValueStore<Repo = DirectoryManager>,
+        KV: BackgroundPersistentKeyValueStore,
     {
         let persistent = KV::checkout(repo, &commit_id)?;
         let persistent = Arc::new(persistent);
@@ -111,10 +111,7 @@ impl<KV> Database<KV, Normal> {
     ///
     /// The returned [`CommitId`] is derived from the Merkle root hash of the current working
     /// state. The commit can later be restored with [`Database::checkout`].
-    pub fn commit(
-        &self,
-        repo: &DirectoryManager,
-    ) -> Result<crate::commit::CommitId, OperationalError>
+    pub fn commit(&self, repo: &KV::Repo) -> Result<crate::commit::CommitId, OperationalError>
     where
         KV: PersistentKeyValueStore,
     {
@@ -379,7 +376,6 @@ struct NormalImpl<KV> {
 }
 
 #[cfg(test)]
-#[cfg(feature = "rocksdb")]
 impl<KV: BackgroundKeyValueStore, M: DatabaseMode> Database<KV, M> {
     /// Assert that a database contains the expected value for a given key.
     pub(crate) fn assert_database_value(&self, key: &Key, expected: &[u8]) {
@@ -405,7 +401,6 @@ mod tests {
     use tokio::runtime::Handle;
 
     use super::Database;
-    #[cfg(feature = "rocksdb")]
     use super::DatabaseMode;
     use crate::database::MAX_VALUE_SIZE;
     use crate::errors::Error;
@@ -413,11 +408,9 @@ mod tests {
     use crate::key::KEY_MAX_SIZE;
     use crate::key::Key;
     use crate::merkle_worker::BackgroundKeyValueStore;
-    #[cfg(feature = "rocksdb")]
-    use crate::storage::TestRepo;
+    use crate::merkle_worker::BackgroundPersistentKeyValueStore;
+    use crate::storage::TestKeyValueStoreSetup;
     use crate::storage::kv_test;
-    #[cfg(feature = "rocksdb")]
-    use crate::storage::setup_repo;
 
     fn new_database<KV: BackgroundKeyValueStore>(
         handle: &Handle,
@@ -426,29 +419,27 @@ mod tests {
         Database::try_new(handle, repo).expect("Creating a test database should succeed")
     }
 
-    #[cfg(feature = "rocksdb")]
-    type PersistentDatabase = Database<crate::persistence_layer::PersistenceLayer, Normal>;
-
-    #[cfg(feature = "rocksdb")]
-    fn new_persistent_database() -> (
+    fn new_persistent_database<KV>() -> (
         tokio::runtime::Runtime,
-        octez_riscv_test_utils::TestableTmpdir,
-        TestRepo,
-        PersistentDatabase,
-    ) {
+        KV::Keepalive,
+        KV::Repo,
+        Database<KV, Normal>,
+    )
+    where
+        KV: BackgroundKeyValueStore + TestKeyValueStoreSetup,
+    {
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(2)
             .build()
             .expect("Creating a Tokio runtime should succeed");
         let handle = runtime.handle();
-        let (keepalive, repo) = setup_repo();
+        let (keepalive, repo) = KV::setup_repo();
         let database =
             Database::try_new(handle, &repo).expect("Creating a test database should succeed");
 
         (runtime, keepalive, repo, database)
     }
 
-    #[cfg(feature = "rocksdb")]
     fn insert_entries<KV: BackgroundKeyValueStore, M: DatabaseMode>(
         database: &mut Database<KV, M>,
         entries: Vec<(Vec<u8>, Vec<u8>)>,
@@ -466,37 +457,33 @@ mod tests {
         expected
     }
 
-    #[cfg(feature = "rocksdb")]
-    fn assert_database_missing(database: &PersistentDatabase, key: &Key) {
-        use crate::errors::Error;
-        use crate::errors::InvalidArgumentError;
-
+    fn assert_database_missing<KV: BackgroundKeyValueStore, M: DatabaseMode>(
+        database: &Database<KV, M>,
+        key: &Key,
+    ) {
         assert!(matches!(
             database.read_bytes(key, 0, 0),
             Err(Error::InvalidArgument(InvalidArgumentError::KeyNotFound))
         ));
     }
 
-    #[cfg(feature = "rocksdb")]
-    proptest! {
-        #[test]
-        fn test_database_commit_and_checkout(
+    kv_test!(test_database_commit_and_checkout, KV: BackgroundPersistentKeyValueStore, {
+        let (runtime, _keepalive, repo, _database) = new_persistent_database::<KV>();
+        let handle = runtime.handle();
+        proptest!(|(
             entries in prop::collection::vec(
                 (prop::collection::vec(any::<u8>(), 1..=KEY_MAX_SIZE),
                  prop::collection::vec(any::<u8>(), 0..200)),
                 1..50,
             ),
-        ) {
-            use crate::persistence_layer::PersistenceLayer;
-
-            let (runtime, _keepalive, repo, mut database) = new_persistent_database();
-            let handle = runtime.handle();
+        )| {
+            let mut database = new_database::<KV>(handle, &repo);
             let expected = insert_entries(&mut database, entries);
 
             let expected_hash = database.hash().expect("Hash should be calculated");
             let commit_id = database.commit(&repo).expect("Commit should succeed");
 
-            let checked_out = Database::<PersistenceLayer, _>::checkout(handle, &repo, commit_id)
+            let checked_out = Database::<KV, _>::checkout(handle, &repo, commit_id)
                 .expect("Checkout should succeed");
 
             prop_assert_eq!(checked_out.hash().expect("Hash should be calculated"), expected_hash);
@@ -504,8 +491,8 @@ mod tests {
             for (key, value) in expected {
                 checked_out.assert_database_value(&key, value.as_ref());
             }
-        }
-    }
+        });
+    });
 
     kv_test!(test_database_delete, KV: BackgroundKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -569,13 +556,15 @@ mod tests {
         assert_eq!(before, after);
     });
 
-    #[cfg(feature = "rocksdb")]
-    #[test]
-    fn test_database_checkout_commit_creates_new_snapshot() {
-        use crate::persistence_layer::PersistenceLayer;
-
-        let (runtime, _keepalive, repo, mut original) = new_persistent_database();
+    kv_test!(test_database_checkout_commit_creates_new_snapshot, KV: BackgroundPersistentKeyValueStore, {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .build()
+            .expect("Creating a Tokio runtime should succeed");
         let handle = runtime.handle();
+        let (_keepalive, repo) = KV::setup_repo();
+
+        let mut original = new_database::<KV>(handle, &repo);
 
         let persisted_key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
         let derived_key = Key::new(&[2]).expect("Size less than KEY_MAX_SIZE");
@@ -586,7 +575,7 @@ mod tests {
         let original_commit = original.commit(&repo).expect("Commit should succeed");
 
         let mut checked_out =
-            Database::<PersistenceLayer, _>::checkout(handle, &repo, original_commit)
+            Database::<KV, _>::checkout(handle, &repo, original_commit)
                 .expect("Checkout should succeed");
         checked_out
             .set(persisted_key.clone(), Bytes::from_static(b"after"))
@@ -599,17 +588,17 @@ mod tests {
         assert_ne!(derived_commit, original_commit);
 
         let original_reloaded =
-            Database::<PersistenceLayer, _>::checkout(handle, &repo, original_commit)
+            Database::<KV, _>::checkout(handle, &repo, original_commit)
                 .expect("Checkout should succeed");
         original_reloaded.assert_database_value(&persisted_key, b"before");
         assert_database_missing(&original_reloaded, &derived_key);
 
         let derived_reloaded =
-            Database::<PersistenceLayer, _>::checkout(handle, &repo, derived_commit)
+            Database::<KV, _>::checkout(handle, &repo, derived_commit)
                 .expect("Checkout should succeed");
         derived_reloaded.assert_database_value(&persisted_key, b"after");
         derived_reloaded.assert_database_value(&derived_key, b"new");
-    }
+    });
 
     #[cfg(feature = "rocksdb")]
     #[test]
@@ -621,7 +610,8 @@ mod tests {
         use crate::persistence_layer::PersistenceLayer;
         use crate::persistence_layer::rocksdb_checkpoint_options;
 
-        let (runtime, _keepalive, repo, mut database) = new_persistent_database();
+        let (runtime, _keepalive, repo, mut database) =
+            new_persistent_database::<PersistenceLayer>();
         let handle = runtime.handle();
 
         let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
@@ -657,26 +647,27 @@ mod tests {
         ));
     }
 
-    #[cfg(feature = "rocksdb")]
-    #[test]
-    fn test_database_checkout_unknown_commit_fails() {
+    kv_test!(test_database_checkout_unknown_commit_fails, KV: BackgroundPersistentKeyValueStore, {
         use octez_riscv_data::hash::Hash;
 
         use crate::commit::CommitId;
-        use crate::errors::Error;
         use crate::errors::OperationalError;
-        use crate::persistence_layer::PersistenceLayer;
 
-        let (runtime, _keepalive, repo, _database) = new_persistent_database();
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .build()
+            .expect("Creating a Tokio runtime should succeed");
         let handle = runtime.handle();
+        let (_keepalive, repo) = KV::setup_repo();
+        let _database = new_database::<KV>(handle, &repo);
 
         let missing_commit = CommitId::from(Hash::hash_bytes(b"missing-commit"));
 
         assert!(matches!(
-            Database::<PersistenceLayer, _>::checkout(handle, &repo, missing_commit),
+            Database::<KV, _>::checkout(handle, &repo, missing_commit),
             Err(Error::Operational(OperationalError::CommitNotFound))
         ));
-    }
+    });
 
     kv_test!(test_database_exists, KV: BackgroundKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_current_thread()

--- a/durable-storage/src/persistence_layer.rs
+++ b/durable-storage/src/persistence_layer.rs
@@ -39,6 +39,7 @@ use rocksdb::MergeOperands;
 use rocksdb::checkpoint::Checkpoint;
 use tempfile::TempDir;
 
+use crate::commit::CommitId;
 use crate::errors::Error;
 use crate::errors::InvalidArgumentError;
 use crate::errors::OperationalError;
@@ -423,6 +424,25 @@ impl PersistentKeyValueStore for PersistenceLayer {
             .map_err(|error| OperationalError::CheckpointCreationFailed { error })
     }
 
+    fn commit(&self, repo: &DirectoryManager, id: &CommitId) -> Result<(), OperationalError> {
+        let checkpoint_path = repo.database_commit_dir(id);
+
+        // If the path already exists, we overwrite the existing commit. This is highly unlikely to
+        // happen anyway if the commits are a hash of the content.
+        if Path::exists(&checkpoint_path) {
+            std::fs::remove_dir_all(&checkpoint_path).map_err(|error| {
+                OperationalError::DirRemovalFailed {
+                    path: checkpoint_path.clone(),
+                    error,
+                }
+            })?;
+
+            log::warn!("Overwriting existing commit: {}", id.hex_encode());
+        }
+
+        self.commit_to_path(&checkpoint_path)
+    }
+
     fn checkout_from_path(
         commit_path: &Path,
         working_path: TempDir,
@@ -464,6 +484,13 @@ impl PersistentKeyValueStore for PersistenceLayer {
             db_instance: ManuallyDrop::new(database),
             _tempdir: working_path,
         })
+    }
+
+    fn checkout(repo: &DirectoryManager, id: &CommitId) -> Result<Self, OperationalError> {
+        let commit_path = repo.database_commit_dir(id);
+        let working_path = repo.temp_database_dir()?;
+
+        Self::checkout_from_path(&commit_path, working_path)
     }
 }
 

--- a/durable-storage/src/storage.rs
+++ b/durable-storage/src/storage.rs
@@ -18,7 +18,6 @@ use tempfile::TempDir;
 use crate::commit::CommitId;
 use crate::errors::Error;
 use crate::errors::OperationalError;
-use crate::repo::DirectoryManager;
 
 /// Types that implement this trait can be used as the underlying key-value store
 pub trait KeyValueStore: Sized {
@@ -71,25 +70,8 @@ pub trait PersistentKeyValueStore: KeyValueStore + Sized {
     /// Implementations will treat the path as a directory.
     fn commit_to_path(&self, path: &Path) -> Result<(), OperationalError>;
 
-    /// Write the current key-value state to disk.
-    fn commit(&self, repo: &DirectoryManager, id: &CommitId) -> Result<(), OperationalError> {
-        let checkpoint_path = repo.database_commit_dir(id);
-
-        // If the path already exists, we overwrite the existing commit. This is highly unlikely to
-        // happen anyway if the commits are a hash of the content.
-        if Path::exists(&checkpoint_path) {
-            std::fs::remove_dir_all(&checkpoint_path).map_err(|error| {
-                OperationalError::DirRemovalFailed {
-                    path: checkpoint_path.clone(),
-                    error,
-                }
-            })?;
-
-            log::warn!("Overwriting existing commit: {}", id.hex_encode());
-        }
-
-        self.commit_to_path(&checkpoint_path)
-    }
+    /// Write the current key-value state to the repository.
+    fn commit(&self, repo: &Self::Repo, id: &CommitId) -> Result<(), OperationalError>;
 
     /// Checkout the state from `source_path` but leave it untouched. Modifications to the
     /// resulting state will be reflected in `working_path`.
@@ -98,13 +80,8 @@ pub trait PersistentKeyValueStore: KeyValueStore + Sized {
         working_path: TempDir,
     ) -> Result<Self, OperationalError>;
 
-    /// Retrieve a key-value state from disk.
-    fn checkout(repo: &DirectoryManager, id: &CommitId) -> Result<Self, OperationalError> {
-        let commit_path = repo.database_commit_dir(id);
-        let working_path = repo.temp_database_dir()?;
-
-        Self::checkout_from_path(&commit_path, working_path)
-    }
+    /// Retrieve a key-value state from the repository.
+    fn checkout(repo: &Self::Repo, id: &CommitId) -> Result<Self, OperationalError>;
 }
 
 #[cfg(test)]

--- a/durable-storage/src/storage.rs
+++ b/durable-storage/src/storage.rs
@@ -121,7 +121,7 @@ cfg_if::cfg_if! {
         ///
         /// Returns `((), repo)` for signature compatibility with the `rocksdb` branch.
         pub(crate) fn setup_repo() -> ((), TestRepo) {
-            ((), in_memory::InMemoryRepo)
+            ((), in_memory::InMemoryRepo::default())
         }
     }
 }
@@ -143,7 +143,7 @@ cfg_if::cfg_if! {
             type Keepalive = ();
 
             fn setup_repo() -> ((), in_memory::InMemoryRepo) {
-                ((), in_memory::InMemoryRepo)
+                ((), in_memory::InMemoryRepo::default())
             }
         }
 

--- a/durable-storage/src/storage/in_memory.rs
+++ b/durable-storage/src/storage/in_memory.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Trilitech <contact@trili.tech>
+// SPDX-FileCopyrightText: 2026 Nomadic Labs <contact@nomadic-labs.com>
 //
 // SPDX-License-Identifier: MIT
 
@@ -18,8 +19,11 @@ use crate::errors::OperationalError;
 /// Repository used by [`InMemoryKeyValueStore`].
 ///
 /// Will never write to disk.
-#[derive(Debug, Copy, Clone)]
-pub struct InMemoryRepo;
+#[derive(Debug, Default)]
+pub struct InMemoryRepo {
+    #[cfg(test)]
+    commits: RwLock<HashMap<crate::commit::CommitId, InMemorySnapshot>>,
+}
 
 /// In-memory key-value store
 #[derive(Debug, Default)]
@@ -185,5 +189,64 @@ impl KeyValueStore for InMemoryKeyValueStore {
         store.remove(key.as_ref());
 
         Ok(())
+    }
+}
+
+/// Test-only snapshot repository for [`InMemoryRepo`]
+#[cfg(test)]
+#[derive(Debug)]
+struct InMemorySnapshot {
+    blobs: HashMap<Bytes, Bytes>,
+    values: HashMap<Bytes, BytesMut>,
+}
+
+#[cfg(test)]
+impl super::PersistentKeyValueStore for InMemoryKeyValueStore {
+    fn commit_to_path(&self, _path: &std::path::Path) -> Result<(), OperationalError> {
+        unimplemented!("In-memory store cannot commit to disk")
+    }
+
+    fn commit(
+        &self,
+        repo: &InMemoryRepo,
+        id: &crate::commit::CommitId,
+    ) -> Result<(), OperationalError> {
+        let blobs = self
+            .blobs
+            .read()
+            .map_err(|_| OperationalError::LockPoisoned)?
+            .clone();
+        let values = self
+            .values
+            .read()
+            .map_err(|_| OperationalError::LockPoisoned)?
+            .clone();
+        repo.commits
+            .write()
+            .map_err(|_| OperationalError::LockPoisoned)?
+            .insert(*id, InMemorySnapshot { blobs, values });
+        Ok(())
+    }
+
+    fn checkout_from_path(
+        _source_path: &std::path::Path,
+        _working_path: tempfile::TempDir,
+    ) -> Result<Self, OperationalError> {
+        unimplemented!("In-memory store cannot check out from disk")
+    }
+
+    fn checkout(
+        repo: &InMemoryRepo,
+        id: &crate::commit::CommitId,
+    ) -> Result<Self, OperationalError> {
+        let commits = repo
+            .commits
+            .read()
+            .map_err(|_| OperationalError::LockPoisoned)?;
+        let snapshot = commits.get(id).ok_or(OperationalError::CommitNotFound)?;
+        Ok(Self {
+            blobs: RwLock::new(snapshot.blobs.clone()),
+            values: RwLock::new(snapshot.values.clone()),
+        })
     }
 }

--- a/durable-storage/tests/integration_test.rs
+++ b/durable-storage/tests/integration_test.rs
@@ -276,7 +276,7 @@ fn test_durable_storage_inner(operations: Vec<Operation>) {
             let mut checkout_candidates: HashMap<Hash, bool> = HashMap::new();
         } else {
             use octez_riscv_durable_storage::storage::in_memory::InMemoryRepo;
-            let repo = InMemoryRepo;
+            let repo = InMemoryRepo::default();
         }
     }
 


### PR DESCRIPTION
Closes RV-971. Closes RV-975.

# What

Adds a test-only implementation of `PersistentKeyValueStore` for `InMemoryKeyValueStore`. Uses it to convert all*) remaining `Database` tests to the `kv_test` macro.

# Why

In order to run all tests across both the in-memory backend and the persistence layer.

# How

A slight refactoring was needed in production code:
- The requirement that the repo be a `DirectoryManager` for `Database` functions is relaxed so that they can be implemented with the in-memory backend repo.
- As a consequence, the `DirectoryManager`-based default implementations in `PersistentKeyValueStore` were instead moved to the implementation for `PersistenceLayer`.

In test-only code:
- `InMemoryRepo` now tracks commits. This is used for the `PersistentKeyValueStore` implementation for `InMemoryKeyValueStore`. Committing and checking out to/from a path are not supported.
- Adapting helpers and converting tests to `kv_test` is mostly mechanical.

*) The only test not be converted is `test_database_checkout_missing_root_blob_fails_operationally`, since it relies on RocksDB-specific functionality.

# Manually Testing

```
make all
```

# Regressions

<!--
    Explain changes to regression test captures. If there are no changes to these, delete this
    section.
-->

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
