### PR TITLE
test(dursto): run all Registry tests across backends when `rocksdb` is on

### DIFF
--- a/durable-storage/src/registry.rs
+++ b/durable-storage/src/registry.rs
@@ -393,13 +393,21 @@ struct NormalImpl<KV: KeyValueStore> {
 #[cfg(test)]
 pub(super) mod tests {
     use bytes::Bytes;
+    use octez_riscv_data::hash::Hash;
     use octez_riscv_data::mode::Normal;
+    use octez_riscv_data::serialisation::deserialise;
+    use octez_riscv_data::serialisation::serialise;
 
     use super::Registry;
+    use super::RegistryManifest;
+    use crate::commit::CommitId;
     use crate::errors::Error;
     use crate::errors::InvalidArgumentError;
+    use crate::errors::OperationalError;
     use crate::key::Key;
     use crate::merkle_worker::BackgroundKeyValueStore;
+    use crate::merkle_worker::BackgroundPersistentKeyValueStore;
+    use crate::repo::RegistryRepo;
     use crate::storage::kv_test;
 
     pub(super) fn setup_registry<KV: BackgroundKeyValueStore>(
@@ -658,47 +666,32 @@ pub(super) mod tests {
             "Key should not exist after clearing the database."
         );
     });
-}
 
-#[cfg(feature = "rocksdb")]
-#[cfg(test)]
-mod rocksdb_tests {
-    use octez_riscv_data::hash::Hash;
-    use octez_riscv_data::mode::Normal;
-    use octez_riscv_data::serialisation::deserialise;
-    use octez_riscv_data::serialisation::serialise;
+    impl<KV> Registry<KV, Normal>
+    where
+        KV: BackgroundPersistentKeyValueStore,
+        KV::Repo: RegistryRepo,
+    {
+        /// Read and deserialise the manifest for `commit_id`.
+        fn read_manifest(&self, commit_id: &CommitId) -> RegistryManifest {
+            let bytes = self
+                .inner
+                .repo
+                .read_registry_commit(commit_id)
+                .expect("Manifest should be readable");
+            deserialise(&bytes).expect("Manifest should be deserialisable")
+        }
 
-    use super::Registry;
-    use super::RegistryManifest;
-    use super::tests::populate_database_with_key_value;
-    use super::tests::setup_registry;
-    use super::tests::setup_size_2_registry;
-    use crate::commit::CommitId;
-    use crate::errors::Error;
-    use crate::errors::OperationalError;
-    use crate::key::Key;
-    use crate::storage::TestKeyValueStore;
-    use crate::storage::setup_repo;
-
-    impl Registry<TestKeyValueStore, Normal> {
         /// Assert that the manifest written for `commit_id` contains the expected database commit IDs.
-        fn verify_manifest(
-            &self,
-            commit_id: &super::CommitId,
-            expected_db_hashes: &[super::CommitId],
-        ) {
-            let commit_path = self.inner.repo.registry_commit_file(commit_id);
-            let commit_bytes = std::fs::read(&commit_path).expect("Manifest should be written");
-            let commit: RegistryManifest =
-                deserialise(&commit_bytes).expect("Manifest should be deserialisable");
-            assert_eq!(commit.database_hashes, expected_db_hashes);
+        fn verify_manifest(&self, commit_id: &CommitId, expected_db_hashes: &[CommitId]) {
+            let manifest = self.read_manifest(commit_id);
+            assert_eq!(manifest.database_hashes, expected_db_hashes);
         }
     }
 
-    #[test]
-    fn test_registry_commit_empty() {
-        let (_keepalive, repo) = setup_repo();
-        let registry = setup_registry::<TestKeyValueStore>(repo);
+    kv_test!(test_registry_commit_empty, KV: BackgroundPersistentKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+        let registry = setup_registry::<KV>(repo.clone());
 
         let expected_db_hashes: Vec<CommitId> = Vec::new();
         let expected_root = CommitId::from(Hash::hash_bytes(&[]));
@@ -707,19 +700,18 @@ mod rocksdb_tests {
         assert_eq!(root_commit, expected_root);
 
         registry.verify_manifest(&root_commit, &expected_db_hashes);
-    }
+    });
 
-    #[test]
-    fn test_registry_commit_size_1() {
-        let (_keepalive, repo) = setup_repo();
-        let mut registry = setup_registry::<TestKeyValueStore>(repo);
+    kv_test!(test_registry_commit_size_1, KV: BackgroundPersistentKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut registry = setup_registry::<KV>(repo.clone());
         registry
             .resize_tick(1)
             .expect("Growing the registry should succeed.");
 
-        populate_database_with_key_value::<TestKeyValueStore>(&mut registry, 0, &[1], b"singleton");
+        populate_database_with_key_value::<KV>(&mut registry, 0, &[1], b"singleton");
 
-        let expected_db_hashes: Vec<super::CommitId> = registry
+        let expected_db_hashes: Vec<CommitId> = registry
             .databases
             .iter()
             .map(|db| db.hash().unwrap().into())
@@ -730,17 +722,16 @@ mod rocksdb_tests {
         assert_eq!(root_commit, expected_root);
 
         registry.verify_manifest(&root_commit, &expected_db_hashes);
-    }
+    });
 
-    #[test]
-    fn test_committing_identical_registry_succeeds() {
-        let (_keepalive, repo) = setup_repo();
-        let mut registry = setup_registry::<TestKeyValueStore>(repo);
+    kv_test!(test_committing_identical_registry_succeeds, KV: BackgroundPersistentKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut registry = setup_registry::<KV>(repo);
         registry
             .resize_tick(1)
             .expect("Growing the registry should succeed.");
 
-        populate_database_with_key_value::<TestKeyValueStore>(&mut registry, 0, &[1], b"singleton");
+        populate_database_with_key_value::<KV>(&mut registry, 0, &[1], b"singleton");
 
         let first_commit = registry.commit().expect("First commit should succeed");
         let second_commit = registry.commit().expect("Second commit should succeed");
@@ -749,17 +740,16 @@ mod rocksdb_tests {
             first_commit, second_commit,
             "Committing identical registry states should yield the same commit ID."
         );
-    }
+    });
 
-    #[test]
-    fn test_registry_commit_writes_manifest() {
-        let (_keepalive, repo) = setup_repo();
-        let mut registry = setup_size_2_registry::<TestKeyValueStore>(repo);
+    kv_test!(test_registry_commit_writes_manifest, KV: BackgroundPersistentKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut registry = setup_size_2_registry::<KV>(repo.clone());
 
-        populate_database_with_key_value::<TestKeyValueStore>(&mut registry, 0, &[1], b"alpha");
-        populate_database_with_key_value::<TestKeyValueStore>(&mut registry, 1, &[2], b"beta");
+        populate_database_with_key_value::<KV>(&mut registry, 0, &[1], b"alpha");
+        populate_database_with_key_value::<KV>(&mut registry, 1, &[2], b"beta");
 
-        let expected_db_hashes: Vec<super::CommitId> = registry
+        let expected_db_hashes: Vec<CommitId> = registry
             .databases
             .iter()
             .map(|db| db.hash().unwrap().into())
@@ -772,15 +762,14 @@ mod rocksdb_tests {
         assert_eq!(root_commit, expected_root);
 
         registry.verify_manifest(&root_commit, &expected_db_hashes);
-    }
+    });
 
-    #[test]
-    fn test_registry_checkout_roundtrip_empty() {
-        let (_keepalive, repo) = setup_repo();
-        let registry = setup_registry::<TestKeyValueStore>(repo.clone());
+    kv_test!(test_registry_checkout_roundtrip_empty, KV: BackgroundPersistentKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+        let registry = setup_registry::<KV>(repo.clone());
 
         let root_commit = registry.commit().expect("Commit should succeed");
-        let checked_out = Registry::<TestKeyValueStore, Normal>::checkout(repo, root_commit)
+        let checked_out = Registry::<KV, Normal>::checkout(repo, root_commit)
             .expect("Checkout should succeed");
 
         assert!(checked_out.is_empty());
@@ -788,21 +777,20 @@ mod rocksdb_tests {
             CommitId::from(Hash::from_foldable(&checked_out)),
             root_commit
         );
-    }
+    });
 
-    #[test]
-    fn test_registry_checkout_roundtrip_populated() {
-        let (_keepalive, repo) = setup_repo();
-        let mut registry = setup_size_2_registry::<TestKeyValueStore>(repo.clone());
+    kv_test!(test_registry_checkout_roundtrip_populated, KV: BackgroundPersistentKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut registry = setup_size_2_registry::<KV>(repo.clone());
 
-        populate_database_with_key_value::<TestKeyValueStore>(&mut registry, 0, &[1], b"alpha");
-        populate_database_with_key_value::<TestKeyValueStore>(&mut registry, 1, &[2], b"beta");
+        populate_database_with_key_value::<KV>(&mut registry, 0, &[1], b"alpha");
+        populate_database_with_key_value::<KV>(&mut registry, 1, &[2], b"beta");
 
         let key_a = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
         let key_b = Key::new(&[2]).expect("Size less than KEY_MAX_SIZE");
 
         let root_commit = registry.commit().expect("Commit should succeed");
-        let checked_out = Registry::<TestKeyValueStore, Normal>::checkout(repo, root_commit)
+        let checked_out = Registry::<KV, Normal>::checkout(repo, root_commit)
             .expect("Checkout should succeed");
 
         assert_eq!(checked_out.len(), 2);
@@ -812,18 +800,57 @@ mod rocksdb_tests {
             CommitId::from(Hash::from_foldable(&checked_out)),
             root_commit
         );
-    }
+    });
 
-    #[test]
-    fn test_registry_checkout_missing_commit_fails() {
-        let (_keepalive, repo) = setup_repo();
+    kv_test!(test_registry_checkout_missing_commit_fails, KV: BackgroundPersistentKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
         let missing_commit = CommitId::from(Hash::hash_bytes(b"missing-registry-commit"));
 
         assert!(matches!(
-            Registry::<TestKeyValueStore, Normal>::checkout(repo, missing_commit),
+            Registry::<KV, Normal>::checkout(repo, missing_commit),
             Err(Error::Operational(OperationalError::CommitNotFound))
         ));
-    }
+    });
+
+    kv_test!(test_registry_checkout_detects_manifest_root_mismatch, KV: BackgroundPersistentKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut registry = setup_registry::<KV>(repo.clone());
+        registry
+            .resize_tick(1)
+            .expect("Growing the registry should succeed.");
+
+        populate_database_with_key_value::<KV>(&mut registry, 0, &[1], b"value");
+
+        let root_commit = registry.commit().expect("Commit should succeed");
+        let manifest = registry.read_manifest(&root_commit);
+
+        let fake_commit = CommitId::from(Hash::hash_bytes(b"fake-registry-commit"));
+        let fake_manifest_bytes =
+            serialise(&manifest).expect("Manifest should be serialisable");
+        repo.write_registry_commit(&fake_commit, &fake_manifest_bytes)
+            .expect("Writing the fake manifest should succeed");
+
+        assert!(matches!(
+            Registry::<KV, Normal>::checkout(repo, fake_commit),
+            Err(Error::Operational(OperationalError::RegistryCommitMismatch))
+        ));
+    });
+}
+
+#[cfg(feature = "rocksdb")]
+#[cfg(test)]
+mod rocksdb_tests {
+    use octez_riscv_data::mode::Normal;
+    use octez_riscv_data::serialisation::deserialise;
+
+    use super::Registry;
+    use super::RegistryManifest;
+    use super::tests::populate_database_with_key_value;
+    use super::tests::setup_registry;
+    use crate::errors::Error;
+    use crate::errors::OperationalError;
+    use crate::storage::TestKeyValueStore;
+    use crate::storage::setup_repo;
 
     #[test]
     fn test_registry_checkout_missing_database_commit_fails() {
@@ -846,34 +873,6 @@ mod rocksdb_tests {
         assert!(matches!(
             Registry::<TestKeyValueStore, Normal>::checkout(repo, root_commit),
             Err(Error::Operational(OperationalError::CommitNotFound))
-        ));
-    }
-
-    #[test]
-    fn test_registry_checkout_detects_manifest_root_mismatch() {
-        let (_keepalive, repo) = setup_repo();
-        let mut registry = setup_registry::<TestKeyValueStore>(repo.clone());
-        registry
-            .resize_tick(1)
-            .expect("Growing the registry should succeed.");
-
-        populate_database_with_key_value::<TestKeyValueStore>(&mut registry, 0, &[1], b"value");
-
-        let root_commit = registry.commit().expect("Commit should succeed");
-        let manifest_path = repo.registry_commit_file(&root_commit);
-        let manifest_bytes = std::fs::read(&manifest_path).expect("Manifest should be readable");
-        let manifest: RegistryManifest =
-            deserialise(&manifest_bytes).expect("Manifest should be deserialisable");
-
-        let fake_commit = CommitId::from(Hash::hash_bytes(b"fake-registry-commit"));
-        let fake_manifest_path = repo.registry_commit_file(&fake_commit);
-        let fake_manifest_bytes = serialise(&manifest).expect("Manifest should be serialisable");
-        std::fs::write(&fake_manifest_path, fake_manifest_bytes)
-            .expect("Writing the fake manifest should succeed");
-
-        assert!(matches!(
-            Registry::<TestKeyValueStore, Normal>::checkout(repo, fake_commit),
-            Err(Error::Operational(OperationalError::RegistryCommitMismatch))
         ));
     }
 }

--- a/durable-storage/src/registry.rs
+++ b/durable-storage/src/registry.rs
@@ -34,7 +34,7 @@ use crate::errors::InvalidArgumentError;
 use crate::errors::OperationalError;
 use crate::merkle_worker::BackgroundKeyValueStore;
 use crate::merkle_worker::BackgroundPersistentKeyValueStore;
-use crate::repo::DirectoryManager;
+use crate::repo::RegistryRepo;
 use crate::storage::KeyValueStore;
 
 pub(super) const REGISTRY_ARITY: usize = 2;
@@ -45,7 +45,8 @@ struct RegistryManifest {
     database_hashes: Vec<CommitId>,
 }
 
-/// Registry that owns a set of databases backed by a directory manager.
+/// Registry that owns a set of databases and the repository used to manage
+/// registry state.
 pub struct Registry<KV: KeyValueStore, M: Mode> {
     inner: M::Select<RegistryTemplate<KV>>,
     databases: Vector<Database<KV, M>, M>,
@@ -54,8 +55,7 @@ pub struct Registry<KV: KeyValueStore, M: Mode> {
 impl<KV: BackgroundKeyValueStore> Registry<KV, Normal> {
     /// Creates a new, empty Registry.
     ///
-    /// The registry owns a Tokio [`Runtime`] and a [`DirectoryManager`] rooted at
-    /// `base_dir`.
+    /// The registry owns a Tokio [`Runtime`] and a register state repository.
     pub fn new(repo: KV::Repo) -> Result<Self, OperationalError> {
         let runtime = Self::build_runtime()?;
 
@@ -74,13 +74,16 @@ impl<KV: BackgroundKeyValueStore> Registry<KV, Normal> {
     }
 }
 
-impl<KV: BackgroundPersistentKeyValueStore<Repo = DirectoryManager>> Registry<KV, Normal> {
+impl<KV: BackgroundPersistentKeyValueStore> Registry<KV, Normal>
+where
+    KV::Repo: RegistryRepo,
+{
     /// Restore a registry from a previously committed manifest.
     ///
     /// The restored databases are checked out from the database commits referenced by the
     /// manifest, then the reconstructed registry root is verified against the requested
     /// `commit_id`.
-    pub fn checkout(repo: DirectoryManager, commit_id: CommitId) -> Result<Self, Error> {
+    pub fn checkout(repo: KV::Repo, commit_id: CommitId) -> Result<Self, Error> {
         let manifest = Self::read_checkout_manifest(&repo, &commit_id)?;
         let runtime = Self::build_runtime()?;
         let databases = Self::checkout_databases(&runtime, &repo, &manifest.database_hashes)?;
@@ -99,24 +102,16 @@ impl<KV: BackgroundPersistentKeyValueStore<Repo = DirectoryManager>> Registry<KV
     }
 
     fn read_checkout_manifest(
-        repo: &DirectoryManager,
+        repo: &KV::Repo,
         commit_id: &CommitId,
     ) -> Result<RegistryManifest, OperationalError> {
-        let commit_path = repo.registry_commit_file(commit_id);
-        let commit_bytes = std::fs::read(&commit_path).map_err(|error| {
-            if error.kind() == std::io::ErrorKind::NotFound {
-                OperationalError::CommitNotFound
-            } else {
-                OperationalError::FileReadFailed { error }
-            }
-        })?;
-
+        let commit_bytes = repo.read_registry_commit(commit_id)?;
         deserialise(&commit_bytes).map_err(OperationalError::from)
     }
 
     fn checkout_databases(
         runtime: &Arc<Runtime>,
-        repo: &DirectoryManager,
+        repo: &KV::Repo,
         database_hashes: &[CommitId],
     ) -> Result<Vec<Database<KV, Normal>>, Error> {
         // TODO RV-946: Investigate parallelising the checkouts of individual databases.
@@ -145,9 +140,9 @@ impl<KV: BackgroundPersistentKeyValueStore<Repo = DirectoryManager>> Registry<KV
         let encoded =
             serialise(&manifest).expect("Serialising the registry manifest should not fail");
 
-        let commit_path = self.inner.repo.registry_commit_file(&registry_commit);
-        std::fs::write(&commit_path, &encoded)
-            .map_err(|error| OperationalError::FileWriteFailed { error })?;
+        self.inner
+            .repo
+            .write_registry_commit(&registry_commit, &encoded)?;
 
         Ok(registry_commit)
     }

--- a/durable-storage/src/repo.rs
+++ b/durable-storage/src/repo.rs
@@ -102,3 +102,33 @@ impl DirectoryManager {
         self.registry_commits_dir.join(id.hex_encode())
     }
 }
+
+/// Persistence interface for a [`crate::registry::Registry`] repo.
+pub trait RegistryRepo: Clone {
+    /// Read the registry manifest bytes associated with `id`.
+    ///
+    /// Fails with [`OperationalError::CommitNotFound`] if no manifest exists for `id`.
+    fn read_registry_commit(&self, id: &CommitId) -> Result<Vec<u8>, OperationalError>;
+
+    /// Write `bytes` as the registry manifest for `id`.
+    fn write_registry_commit(&self, id: &CommitId, bytes: &[u8]) -> Result<(), OperationalError>;
+}
+
+impl RegistryRepo for DirectoryManager {
+    fn read_registry_commit(&self, id: &CommitId) -> Result<Vec<u8>, OperationalError> {
+        let commit_path = self.registry_commit_file(id);
+        std::fs::read(&commit_path).map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                OperationalError::CommitNotFound
+            } else {
+                OperationalError::FileReadFailed { error }
+            }
+        })
+    }
+
+    fn write_registry_commit(&self, id: &CommitId, bytes: &[u8]) -> Result<(), OperationalError> {
+        let commit_path = self.registry_commit_file(id);
+        std::fs::write(&commit_path, bytes)
+            .map_err(|error| OperationalError::FileWriteFailed { error })
+    }
+}

--- a/durable-storage/src/storage.rs
+++ b/durable-storage/src/storage.rs
@@ -173,7 +173,10 @@ cfg_if::cfg_if! {
                     $(#[$attr])*
                     #[test]
                     fn [<$fun_name _in_memory>]() {
-                        fn inner<$ty_name: $crate::storage::TestKeyValueStoreSetup $(+ $ty_bound)?>() $body
+                        fn inner<$ty_name: $crate::storage::TestKeyValueStoreSetup $(+ $ty_bound)?>()
+                        where
+                            <$ty_name as $crate::storage::KeyValueStore>::Repo: $crate::repo::RegistryRepo,
+                        $body
                         inner::<$crate::storage::in_memory::InMemoryKeyValueStore>();
                     }
 
@@ -181,7 +184,10 @@ cfg_if::cfg_if! {
                     $(#[$attr])*
                     #[test]
                     fn [<$fun_name _rocksdb>]() {
-                        fn inner<$ty_name: $crate::storage::TestKeyValueStoreSetup $(+ $ty_bound)?>() $body
+                        fn inner<$ty_name: $crate::storage::TestKeyValueStoreSetup $(+ $ty_bound)?>()
+                        where
+                            <$ty_name as $crate::storage::KeyValueStore>::Repo: $crate::repo::RegistryRepo,
+                        $body
                         inner::<$crate::persistence_layer::PersistenceLayer>();
                     }
                 }

--- a/durable-storage/src/storage/in_memory.rs
+++ b/durable-storage/src/storage/in_memory.rs
@@ -23,6 +23,9 @@ use crate::errors::OperationalError;
 pub struct InMemoryRepo {
     #[cfg(test)]
     commits: std::sync::Arc<RwLock<HashMap<crate::commit::CommitId, InMemorySnapshot>>>,
+
+    #[cfg(test)]
+    registry_commits: std::sync::Arc<RwLock<HashMap<crate::commit::CommitId, Vec<u8>>>>,
 }
 
 /// In-memory key-value store
@@ -248,5 +251,35 @@ impl super::PersistentKeyValueStore for InMemoryKeyValueStore {
             blobs: RwLock::new(snapshot.blobs.clone()),
             values: RwLock::new(snapshot.values.clone()),
         })
+    }
+}
+
+#[cfg(test)]
+impl crate::repo::RegistryRepo for InMemoryRepo {
+    fn read_registry_commit(
+        &self,
+        id: &crate::commit::CommitId,
+    ) -> Result<Vec<u8>, OperationalError> {
+        let commits = self
+            .registry_commits
+            .read()
+            .map_err(|_| OperationalError::LockPoisoned)?;
+        commits
+            .get(id)
+            .cloned()
+            .ok_or(OperationalError::CommitNotFound)
+    }
+
+    fn write_registry_commit(
+        &self,
+        id: &crate::commit::CommitId,
+        bytes: &[u8],
+    ) -> Result<(), OperationalError> {
+        let mut commits = self
+            .registry_commits
+            .write()
+            .map_err(|_| OperationalError::LockPoisoned)?;
+        commits.insert(*id, bytes.to_vec());
+        Ok(())
     }
 }


### PR DESCRIPTION
Closes RV-972.

# What

Converts almost all `Registry` tests to the `kv_test!` macro.

# Why

In order to run all tests across both the in-memory backend and the persistence layer.

# How

In production code, the `RegistryRepo` trait is introduced, which abstracts the interface that the `Registry` expects from its `KeyValueStore::Repo`. This allows `Registry` functions to operate on a `KV::Repo` instead of directly on a `DirectoryManager`. Parts of the `Registry` functions which interact with the filesystem have been moved to the `RegistryRepo` implementation for `DirectoryManager`.

In test code, `InMemoryRepo` is extended to support registry commits and implements `RegistryRepo`. The `kv_test!` macro adds the bound `KV::Repo: RegistryRepo` to every test. This is necessary because we can't add this bound to the `Repo` associated type of `KeyValueStore` since it would mean non-test `InMemoryRepo` would need to implement `RegistryRepo`.

`Registry` test helpes are then rewritten and most tests are converted to the `kv_test!` macro. The only test which is not converted is `test_registry_checkout_missing_database_commit_fails` because it relies on access to the filesystem.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
