### PR TITLE
test(dursto): run MerkleWorker and remaining MerkleLayer tests across backends when `rocksdb` is on

### DIFF
--- a/durable-storage/src/avl/node.rs
+++ b/durable-storage/src/avl/node.rs
@@ -208,7 +208,7 @@ impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
     }
 
     /// Retrieve the value associated with this node.
-    #[cfg(all(test, feature = "rocksdb"))]
+    #[cfg(test)]
     pub(crate) fn value(&self) -> &Bytes<M> {
         &self.data
     }

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -425,6 +425,7 @@ mod tests {
     use crate::key::Key;
     use crate::merkle_layer::VerifyImpl;
     use crate::storage::KeyValueStore;
+    use crate::storage::PersistentKeyValueStore;
     use crate::storage::kv_test;
 
     impl<KV: KeyValueStore> MerkleLayer<KV, Normal> {
@@ -1217,7 +1218,6 @@ mod tests {
         });
     });
 
-    #[cfg(feature = "rocksdb")]
     #[derive(Debug, Clone)]
     enum GeneratedOperation {
         // Key, Value
@@ -1228,7 +1228,6 @@ mod tests {
         Delete([u8; 2]),
     }
 
-    #[cfg(feature = "rocksdb")]
     fn generated_operations_strategy(
         length: usize,
     ) -> impl Strategy<Value = Vec<GeneratedOperation>> {
@@ -1261,23 +1260,15 @@ mod tests {
             })
     }
 
-    #[cfg(feature = "rocksdb")]
-    proptest! {
-        #[test]
-        fn test_merkle_layer_checkout_lazy_from_commit(
-            operations in (1usize..100usize).prop_flat_map(generated_operations_strategy)
-        ) {
+    kv_test!(test_merkle_layer_checkout_lazy_from_commit, KV: PersistentKeyValueStore, {
+        proptest!(|(operations in (1usize..100usize).prop_flat_map(generated_operations_strategy))| {
             use std::collections::BTreeMap;
             use std::collections::BTreeSet;
-            use octez_riscv_test_utils::TestableTmpdir;
-            use crate::repo::DirectoryManager;
-            use crate::storage::TestKeyValueStore;
 
-            let tmpdir = TestableTmpdir::new();
-            let repo = DirectoryManager::new(tmpdir.path()).expect("Failed to create directory manager");
-            let persistence = TestKeyValueStore::new(&repo)
-                .expect("Creating a persistence layer should succeed");
-            let persistence = std::sync::Arc::new(persistence);
+            let (_keepalive, repo) = KV::setup_repo();
+            let persistence: Arc<KV> = KV::new(&repo)
+                .expect("Creating a persistence layer should succeed")
+                .into();
 
             let mut merkle_layer = MerkleLayer::new(persistence.clone());
             let mut reference: BTreeMap<Key, Vec<u8>> = BTreeMap::new();
@@ -1355,25 +1346,21 @@ mod tests {
                     (None, Some(_)) => panic!("Expected a missing key in lazy-loaded tree: {key:?}"),
                 }
             }
-        }
-    }
+        });
+    });
 
-    /// - Add some data to the Merkle layer.
-    /// - Commit the data to relevant column family
-    /// - Check whether the data is persisted.
-    /// - Check whether the hash contained in the commit id
-    ///   is the same as the root hash
-    #[cfg(feature = "rocksdb")]
-    #[test]
-    fn test_merkle_layer_commit_persists_nodes() {
-        use crate::persistence_layer::PersistenceLayer;
+    // - Add some data to the Merkle layer.
+    // - Commit the data to relevant column family
+    // - Check whether the data is persisted.
+    // - Check whether the hash contained in the commit id
+    //   is the same as the root hash
+    kv_test!(test_merkle_layer_commit_persists_nodes, KV: PersistentKeyValueStore, {
         use crate::storage::Loadable;
         use crate::storage::Storable;
         use crate::storage::StoreOptions;
-        use crate::storage::TestKeyValueStoreSetup;
 
-        let (_keepalive, repo) = PersistenceLayer::setup_repo();
-        let mut merkle_layer = new_merkle_layer::<PersistenceLayer>(&repo);
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut merkle_layer = new_merkle_layer::<KV>(&repo);
 
         let keys = [
             Key::new(&[12]).unwrap(),
@@ -1428,7 +1415,7 @@ mod tests {
 
         let root_hash = merkle_layer.hash();
         assert_eq!(*commit_id.as_hash(), root_hash);
-    }
+    });
 
     kv_test!(test_prove_delete, KV, {
         let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");

--- a/durable-storage/src/merkle_worker.rs
+++ b/durable-storage/src/merkle_worker.rs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 Trilitech <contact@trili.tech>
+// SPDX-FileCopyrightText: 2026 Nomadic Labs <contact@nomadic-labs.com>
 //
 // SPDX-License-Identifier: MIT
 
@@ -311,8 +312,7 @@ mod tests {
     use crate::key::Key;
     use crate::merkle_layer::MerkleLayer;
     use crate::merkle_worker::MerkleWorker;
-    use crate::storage::KeyValueStore;
-    use crate::storage::TestKeyValueStore;
+    use crate::storage::kv_test;
 
     fn key_strategy() -> impl Strategy<Value = Key> {
         proptest::collection::vec(proptest::arbitrary::any::<u8>(), 1..KEY_MAX_SIZE).prop_map(
@@ -347,12 +347,12 @@ mod tests {
     }
 
     impl TestCommand {
-        fn run(
+        fn run<KV: super::BackgroundPersistentKeyValueStore>(
             self,
             handle: &Handle,
-            repo: &<TestKeyValueStore as KeyValueStore>::Repo,
-            worker: &mut MerkleWorker<TestKeyValueStore>,
-            layer: &mut MerkleLayer<TestKeyValueStore, Normal>,
+            repo: &KV::Repo,
+            worker: &mut MerkleWorker<KV>,
+            layer: &mut MerkleLayer<KV, Normal>,
         ) {
             match self {
                 Self::Write { key, offset, value } => {
@@ -389,13 +389,13 @@ mod tests {
                 }
 
                 Self::Clone => {
-                    let persistence_layer = TestKeyValueStore::new(repo)
-                        .expect("Creating a persistence layer should succeed");
+                    let persistence_layer =
+                        KV::new(repo).expect("Creating a persistence layer should succeed");
                     let persistence_layer = Arc::new(persistence_layer);
                     *layer = layer.try_clone_with(persistence_layer);
 
-                    let persistence_worker = TestKeyValueStore::new(repo)
-                        .expect("Creating a persistence layer should succeed");
+                    let persistence_worker =
+                        KV::new(repo).expect("Creating a persistence layer should succeed");
                     let persistence_worker = Arc::new(persistence_worker);
                     *worker = worker
                         .clone_with(handle, persistence_worker)
@@ -451,32 +451,31 @@ mod tests {
         }
     }
 
-    #[test]
-    fn commands() {
+    kv_test!(commands, KV: super::BackgroundPersistentKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(2)
             .build()
             .expect("Creating a Tokio runtime should succeed");
         let handle = runtime.handle();
 
-        let (_keepalive, repo) = crate::storage::setup_repo();
+        let (_keepalive, repo) = KV::setup_repo();
 
         proptest::proptest!(|(commands in proptest::collection::vec(TestCommand::strategy(), 1..100))| {
-            let persistence_layer = TestKeyValueStore::new(&repo).expect("Creating a persistence layer should succeed");
+            let persistence_layer = KV::new(&repo).expect("Creating a persistence layer should succeed");
             let persistence_layer = Arc::new(persistence_layer);
             let mut merkle_layer = MerkleLayer::new(persistence_layer);
 
-            let persistence_worker = TestKeyValueStore::new(&repo).expect("Creating a persistence layer should succeed");
+            let persistence_worker = KV::new(&repo).expect("Creating a persistence layer should succeed");
             let persistence_worker = Arc::new(persistence_worker);
             let mut merkle_worker = MerkleWorker::new(handle, persistence_worker);
 
             for command in commands {
-                command.run(handle, &repo, &mut merkle_worker, &mut merkle_layer);
+                command.run::<KV>(handle, &repo, &mut merkle_worker, &mut merkle_layer);
             }
 
             let layer_hash = merkle_layer.hash();
             let worker_hash = merkle_worker.hash().unwrap();
             prop_assert_eq!(layer_hash, worker_hash);
         });
-    }
+    });
 }

--- a/durable-storage/src/storage.rs
+++ b/durable-storage/src/storage.rs
@@ -110,19 +110,6 @@ cfg_if::cfg_if! {
 
             (tmpdir, dir_manager)
         }
-    } else {
-        /// Test key-value store backend used when the `rocksdb` feature is disabled.
-        pub(crate) type TestKeyValueStore = crate::storage::in_memory::InMemoryKeyValueStore;
-
-        /// Repository type required to initialise [`TestKeyValueStore`].
-        pub(crate) type TestRepo = <TestKeyValueStore as KeyValueStore>::Repo;
-
-        /// Create a test repository for [`TestKeyValueStore`].
-        ///
-        /// Returns `((), repo)` for signature compatibility with the `rocksdb` branch.
-        pub(crate) fn setup_repo() -> ((), TestRepo) {
-            ((), in_memory::InMemoryRepo::default())
-        }
     }
 }
 


### PR DESCRIPTION
Closes RV-974. Closes RV-973.

# What

Converts the `MerkleWorker` test and all the remaining `MerkleLayer` tests to the `kv_test!` macro.

# Why

In order to run all tests across both the in-memory backend and the persistence layer.

# How

For `MerkleWorker`, `TestCommand` is adapted to work over any `BackgroundPersistentKeyValueStore`.

For the remaining `MerkleLayer` tests, changes are mostly mechanical, similar to previous `kv_test!` PRs.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
