### PR TITLE
feat(PartialVec): access without allocation

### DIFF
--- a/data/src/partial_vec.rs
+++ b/data/src/partial_vec.rs
@@ -311,7 +311,7 @@ impl<T> PartialVec<T> {
     /// Retrieve chunks that make up a continuous range.
     ///
     /// If there are gaps in the range, `None` is returned.
-    pub fn continuous_defined_range(&self, range: Range<usize>) -> Option<Vec<&[T]>> {
+    pub(crate) fn continuous_defined_range(&self, range: Range<usize>) -> Option<Vec<&[T]>> {
         self.range(range)
             .map(|chunk| match chunk {
                 RangeEntry::Undefined { .. } => None,
@@ -359,6 +359,21 @@ impl<T> PartialVec<T> {
     /// Is nothing in the partial vector defined?
     pub fn is_all_undefined(&self) -> bool {
         self.entries.iter().all(|entry| entry.data.is_empty())
+    }
+
+    /// Returns the given range as a contiguous slice if it is fully contained in a single
+    /// defined entry.
+    ///
+    /// Returns `None` if the range spans multiple entries, includes any undefined data, or is empty
+    /// and out-of-bounds.
+    pub fn contiguous_range(&self, range: Range<usize>) -> Option<&[T]> {
+        let idx = self
+            .entries
+            .partition_point(|entry| entry.end() < range.end);
+        let entry = self.entries.get(idx).filter(|e| e.start <= range.start)?;
+        let offset = range.start - entry.start;
+        let end = range.end - entry.start;
+        Some(&entry.data[offset..end])
     }
 }
 

--- a/data/src/partial_vec/tests.rs
+++ b/data/src/partial_vec/tests.rs
@@ -20,6 +20,25 @@ fn data_vec() -> impl Strategy<Value = Vec<u8>> {
 }
 
 proptest! {
+    /// `contiguous_range` returns the correct slice for any subrange of a single defined write.
+    #[test]
+    fn contiguous_range_single_write(
+        offset in 0usize..1000,
+        data in vec(any::<u8>(), 1..128),
+        a in any::<proptest::sample::Index>(),
+        b in any::<proptest::sample::Index>(),
+    ) {
+        let mut vec = PartialVec::empty();
+        vec.define(offset, data.clone());
+
+        let a = a.index(data.len() + 1);
+        let b = b.index(data.len() + 1);
+        let (lo, hi) = (a.min(b), a.max(b));
+
+        let result = vec.contiguous_range((offset + lo)..(offset + hi));
+        assert_eq!(result, Some(&data[lo..hi]));
+    }
+
     /// Defining a range anywhere should never fail.
     #[test]
     fn insert_randomly(init_data in vec((any::<usize>(), data_vec()), ..1024)) {
@@ -614,4 +633,24 @@ fn define_empty_data() {
         .copied()
         .collect::<Vec<_>>();
     assert_eq!(values, vec![1, 2, 3, 4, 5]);
+}
+
+/// Check that `contiguous_range` returns `None` for an empty range that falls outside any
+/// defined entry, and returns `Some(&[])` for an empty range that sits within a defined entry.
+#[test]
+fn contiguous_range_empty() {
+    let mut vec: PartialVec<u8> = PartialVec::empty();
+    vec.define(5, vec![1, 2, 3, 4, 5]);
+
+    // Empty and out-of-bounds: before, after, and in a gap between entries.
+    assert_eq!(vec.contiguous_range(0..0), None);
+    assert_eq!(vec.contiguous_range(20..20), None);
+
+    vec.define(20, vec![6, 7, 8]);
+    assert_eq!(vec.contiguous_range(15..15), None);
+
+    // Empty but contained in a defined entry: returns an empty slice.
+    assert_eq!(vec.contiguous_range(5..5), Some(&[][..]));
+    assert_eq!(vec.contiguous_range(7..7), Some(&[][..]));
+    assert_eq!(vec.contiguous_range(10..10), Some(&[][..]));
 }


### PR DESCRIPTION
Part of [RV-964](https://linear.app/tezos/issue/RV-964)

# What
Adds support for accessing a sub-range of a `PartialVec` without requiring access to the whole value (in case e.g. it is blinded/absent in `Verify` mode)

# Why
This is needed to implement `DatabaseMode::get` for `Verify` mode. See #1005 

# How
Small diff

More in-depth testing will be done in a later PR.

# Manually Testing

```
make all
```


# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
