### PR TITLE
feat: access data with ValueRef range

### DIFF
--- a/data/src/components/bytes.rs
+++ b/data/src/components/bytes.rs
@@ -9,6 +9,7 @@
 use std::borrow::Borrow;
 use std::cell::Cell;
 use std::cell::RefCell;
+use std::ops::Index;
 use std::ops::Range;
 
 use bincode::BorrowDecode;
@@ -266,6 +267,14 @@ impl Bytes<Normal> {
 impl Borrow<[u8]> for Bytes<Normal> {
     fn borrow(&self) -> &[u8] {
         &self.bytes
+    }
+}
+
+impl Index<Range<usize>> for Bytes<Normal> {
+    type Output = [u8];
+
+    fn index(&self, range: Range<usize>) -> &[u8] {
+        &self.bytes[range]
     }
 }
 

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -8,6 +8,8 @@
 //! This module provides a database type to unify operations between the Merkle layer and the
 //! key-value store.
 
+pub(crate) mod value_ref;
+
 use std::convert::Infallible;
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -24,6 +26,8 @@ use tezos_smart_rollup_constants::core::MAX_FILE_CHUNK_SIZE;
 use tokio::runtime::Handle;
 
 use crate::commit::CommitId;
+use crate::database::value_ref::AsRefValueRef;
+use crate::database::value_ref::ValueRef;
 use crate::errors::Error;
 use crate::errors::InvalidArgumentError;
 use crate::errors::OperationalError;
@@ -184,7 +188,7 @@ impl<KV: BackgroundKeyValueStore, M: DatabaseMode> Database<KV, M> {
         }
 
         let value = self.get(key)?;
-        let value_length = value.as_ref().len();
+        let value_length = value.len();
         if offset > value_length {
             Err(InvalidArgumentError::OffsetTooLarge)?;
         }
@@ -197,9 +201,9 @@ impl<KV: BackgroundKeyValueStore, M: DatabaseMode> Database<KV, M> {
             inner: T,
         }
 
-        impl<T: AsRef<[u8]>> AsRef<[u8]> for Wrapper<T> {
+        impl<T: ValueRef> AsRef<[u8]> for Wrapper<T> {
             fn as_ref(&self) -> &[u8] {
-                &self.inner.as_ref()[self.offset..self.end]
+                &self.inner[self.offset..self.end]
             }
         }
 
@@ -260,14 +264,14 @@ impl<KV: BackgroundKeyValueStore, M: DatabaseMode> Database<KV, M> {
     /// Fails if:
     ///  - The key does not exist in the database.
     pub fn value_length(&self, key: &Key) -> Result<usize, Error> {
-        Ok(self.get(key)?.as_ref().len())
+        Ok(self.get(key)?.len())
     }
 
     /// Retrieve the value associated with the provided key.
     ///
     /// Fails if:
     ///  - The key does not exist in the database.
-    fn get(&self, key: &Key) -> Result<impl AsRef<[u8]>, Error> {
+    fn get(&self, key: &Key) -> Result<impl ValueRef, Error> {
         M::get(self, key)
     }
 }
@@ -323,15 +327,16 @@ pub trait DatabaseMode: Mode {
     fn get<KV: BackgroundKeyValueStore>(
         this: &Database<KV, Self>,
         key: &Key,
-    ) -> Result<impl AsRef<[u8]>, Error>;
+    ) -> Result<impl ValueRef, Error>;
 }
 
 impl DatabaseMode for Normal {
     fn get<KV: BackgroundKeyValueStore>(
         this: &Database<KV, Self>,
         key: &Key,
-    ) -> Result<impl AsRef<[u8]>, Error> {
-        this.inner.persistent.get(key.as_ref())
+    ) -> Result<impl ValueRef, Error> {
+        let as_ref = this.inner.persistent.get(key.as_ref())?;
+        Ok(AsRefValueRef(as_ref))
     }
 
     fn set<KV: BackgroundKeyValueStore>(

--- a/durable-storage/src/database/value_ref.rs
+++ b/durable-storage/src/database/value_ref.rs
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Trilitech <contact@trili.tech>
+//
+// SPDX-License-Identifier: MIT
+
+use std::ops::Index;
+use std::ops::Range;
+
+use octez_riscv_data::mode::Normal;
+
+/// Borrowed view of a value that can be sub-sliced by range.
+pub trait ValueRef: Index<Range<usize>, Output = [u8]> {
+    /// Returns the length in bytes of the underlying value.
+    fn len(&self) -> usize;
+
+    /// Returns `true` if the underlying value has length zero.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Adapter that promotes an [`AsRef<[u8]>`] value into a [`ValueRef`].
+pub(crate) struct AsRefValueRef<T>(pub(crate) T);
+
+impl<T: AsRef<[u8]>> Index<Range<usize>> for AsRefValueRef<T> {
+    type Output = [u8];
+
+    fn index(&self, range: Range<usize>) -> &[u8] {
+        &self.0.as_ref()[range]
+    }
+}
+
+impl<T: AsRef<[u8]>> ValueRef for AsRefValueRef<T> {
+    fn len(&self) -> usize {
+        self.0.as_ref().len()
+    }
+}
+
+impl ValueRef for octez_riscv_data::components::bytes::Bytes<Normal> {
+    fn len(&self) -> usize {
+        self.len()
+    }
+}


### PR DESCRIPTION
Part of RV-964

# What
Adds a new trait for accessing a sub-range of a referenced value. Implementing this on mode-aware types will allow us to access parts of the data which is present in proofs without accessing the parts that are not.

# Why
Needed for #1005 , to allow accessing ranges of the data in the Merkle layer.


# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
