### PR TITLE
feat(dursto): Add deletion tracking

### DIFF
--- a/durable-storage/src/avl/node.rs
+++ b/durable-storage/src/avl/node.rs
@@ -94,8 +94,8 @@ impl<TreeId, M: Mode> Node<TreeId, M> {
         self.hash = OnceLock::new();
     }
 
-    #[inline]
     /// A mutable reference to the left branch.
+    #[inline]
     pub(super) fn left_mut<NodeId>(
         &mut self,
         resolver: &mut impl TreeResolver<NodeId, TreeId>,
@@ -104,8 +104,8 @@ impl<TreeId, M: Mode> Node<TreeId, M> {
         resolver.resolve_mut(&mut self.left)
     }
 
-    #[inline]
     /// An immutable reference to the left branch.
+    #[inline]
     pub(super) fn left_ref<NodeId>(
         &self,
         resolver: &impl TreeResolver<NodeId, TreeId>,
@@ -113,8 +113,8 @@ impl<TreeId, M: Mode> Node<TreeId, M> {
         resolver.resolve(&self.left)
     }
 
-    #[inline]
     /// A mutable reference to the right branch.
+    #[inline]
     pub(super) fn right_mut<NodeId>(
         &mut self,
         resolver: &mut impl TreeResolver<NodeId, TreeId>,
@@ -123,8 +123,8 @@ impl<TreeId, M: Mode> Node<TreeId, M> {
         resolver.resolve_mut(&mut self.right)
     }
 
-    #[inline]
     /// An immutable reference to the right branch.
+    #[inline]
     pub(super) fn right_ref<NodeId>(
         &self,
         resolver: &impl TreeResolver<NodeId, TreeId>,
@@ -189,27 +189,33 @@ impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
         self.hash.get_or_init(|| Hash::from_foldable(self))
     }
 
+    /// The metadata of this [`Node`].
     #[inline]
+    pub(crate) fn meta(&self) -> &Atom<Meta, M> {
+        &self.meta
+    }
+
     /// The difference in heights between child branches.
+    #[inline]
     pub(crate) fn balance_factor(&self) -> i64 {
         self.meta.balance_factor
     }
 
-    #[inline]
     /// A mutable reference to the difference in heights between child branches.
+    #[inline]
     pub(super) fn balance_factor_mut(&mut self) -> &mut i64 {
         &mut self.meta.balance_factor
     }
 
-    #[inline]
     /// The [`Key`] used for determining the [`Node`].
+    #[inline]
     pub(crate) fn key(&self) -> &Key {
         &self.meta.key
     }
 
     /// Retrieve the value associated with this node.
-    #[cfg(test)]
-    pub(crate) fn value(&self) -> &Bytes<M> {
+    #[inline]
+    pub(crate) fn data(&self) -> &Bytes<M> {
         &self.data
     }
 
@@ -706,12 +712,6 @@ impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
 
 #[cfg(test)]
 impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
-    #[inline]
-    /// The data stored in the [`Node`].
-    pub(crate) fn data(&self) -> &Bytes<M> {
-        &self.data
-    }
-
     /// The data stored in a [`Node`] within the subtree of this [`Node`] with a given [`Key`] .
     pub(super) fn get<'a, NodeId>(
         mut node: &'a NodeId,

--- a/durable-storage/src/avl/resolver.rs
+++ b/durable-storage/src/avl/resolver.rs
@@ -28,11 +28,15 @@
 //! [`Node`]: crate::avl::node::Node
 
 use std::cell::RefCell;
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+use std::ops::Deref;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::OnceLock;
 
+use octez_riscv_data::components::atom::Atom;
+use octez_riscv_data::components::bytes::Bytes;
 use octez_riscv_data::foldable::Fold;
 use octez_riscv_data::foldable::Foldable;
 use octez_riscv_data::hash::Hash;
@@ -54,6 +58,7 @@ use trait_set::trait_set;
 
 use super::node::Node;
 use super::tree::Tree;
+use crate::avl::node::Meta;
 use crate::errors::OperationalError;
 use crate::storage::KeyValueStore;
 use crate::storage::Loadable;
@@ -235,10 +240,11 @@ impl LazyNodeId {
     /// The returned [`ProveNodeId`] keeps the original lazy identifier for hash lookups and
     /// storage-backed resolution, while leaving its prove-mode cache empty until a
     /// [`ProveResolver`] materialises the node.
-    pub fn into_proof(self) -> ProveNodeId {
+    pub(crate) fn into_proof<R>(self, resolver: &ProveResolver<R>) -> ProveNodeId {
         ProveNodeId {
             node: self.clone(),
             inner: OnceLock::new(),
+            deleted_nodes: resolver.deleted_nodes.clone(),
         }
     }
 }
@@ -453,6 +459,26 @@ impl<KV: KeyValueStore> Resolver<LazyTreeId, Tree<LazyNodeId>> for LazyResolver<
 pub struct ProveNodeId {
     inner: OnceLock<Rc<Node<ProveTreeId, Prove<'static>>>>,
     node: LazyNodeId,
+    deleted_nodes: Rc<RefCell<BTreeMap<Hash, DeletedNodeFields>>>,
+}
+
+impl Drop for ProveNodeId {
+    fn drop(&mut self) {
+        // Nodes that were resolved during the step carry a prove-mode projection that needs
+        // to be available for the `MerkleLayer`-level fold after the step finishes. Non-resolved
+        // nodes are not relevant for the fold.
+        let Some(inner) = self.inner.get() else {
+            return;
+        };
+        let hash = Hash::from_foldable(&self.node);
+        let node = inner.as_ref();
+        let fields = DeletedNodeFields {
+            meta: node.meta().clone(),
+            data: node.data().clone(),
+        };
+
+        self.deleted_nodes.borrow_mut().insert(hash, fields);
+    }
 }
 
 // TODO RV-895: This method is implemented to satisfy trait-bounds in `tree::upsert`.
@@ -463,15 +489,16 @@ impl From<Node<ProveTreeId, Prove<'static>>> for ProveNodeId {
         ProveNodeId {
             inner: OnceLock::from(Rc::new(node)),
             node: LazyNodeId::from(Hash::hash_bytes(&[])),
+            deleted_nodes: Rc::new(RefCell::new(BTreeMap::new())),
         }
     }
 }
 
-/// Access the cached prove-mode node, if populated.
-///
-/// Used by the `MerkleLayer`-level fold to extract per-field read flags from a node that
-/// was resolved during the proof step.
 impl ProveNodeId {
+    /// Access the cached prove-mode node, if populated.
+    ///
+    /// Used by the `MerkleLayer`-level fold to extract per-field read flags from a node that
+    /// was resolved during the proof step.
     #[expect(dead_code, reason = "used by MerkleLayer fold in follow-up commit")]
     pub(crate) fn cached_node(&self) -> Option<&Node<ProveTreeId, Prove<'static>>> {
         self.inner.get().map(|rc| rc.as_ref())
@@ -527,6 +554,13 @@ impl Foldable<HashFold> for ProveTreeId {
     }
 }
 
+impl ProveTreeId {
+    #[expect(dead_code, reason = "used by CachedOnlyResolver in follow-up commit")]
+    pub(crate) fn inner(&self) -> Option<&Tree<ProveNodeId>> {
+        self.inner.get()
+    }
+}
+
 impl Foldable<MerkleProofFold> for ProveTreeId {
     fn fold(&self, builder: MerkleProofFold) -> <MerkleProofFold as Fold>::Folded {
         match self.inner.get() {
@@ -534,6 +568,17 @@ impl Foldable<MerkleProofFold> for ProveTreeId {
             None => builder.into_blind(Hash::from_foldable(&self.tree)),
         }
     }
+}
+
+/// Captured prove-mode fields of a node unlinked from the working tree during a step.
+///
+/// Only `meta` and `data` carry the per-field read flags consumed by the
+/// `MerkleLayer`-level fold; subtree IDs and the hash cache are unnecessary.
+#[derive(Debug)]
+#[expect(dead_code, reason = "used by MerkleLayer fold in follow-up commit")]
+pub(crate) struct DeletedNodeFields {
+    pub(crate) meta: Atom<Meta, Prove<'static>>,
+    pub(crate) data: Bytes<Prove<'static>>,
 }
 
 /// State of the [`ProveResolver`] that tracks which nodes and trees have been
@@ -559,6 +604,10 @@ pub(crate) struct ProveResolver<R> {
 
     /// Inner state for access tracking
     accessed_items: RefCell<AccessedItems>,
+
+    /// Prove-mode projections of nodes unlinked from the working tree during the step, keyed by
+    /// their initial-tree hash. Consumed by the `MerkleLayer`-level fold.
+    deleted_nodes: Rc<RefCell<BTreeMap<Hash, DeletedNodeFields>>>,
 }
 
 impl<R> ProveResolver<R> {
@@ -567,6 +616,7 @@ impl<R> ProveResolver<R> {
         Self {
             inner,
             accessed_items: RefCell::default(),
+            deleted_nodes: Rc::new(RefCell::new(BTreeMap::new())),
         }
     }
 
@@ -580,6 +630,13 @@ impl<R> ProveResolver<R> {
     #[expect(dead_code, reason = "used by MerkleLayer fold in follow-up commit")]
     pub(crate) fn was_tree_accessed(&self, hash: &Hash) -> bool {
         self.accessed_items.borrow().trees.contains(hash)
+    }
+
+    /// Prove-mode projections of nodes unlinked from the working tree during the step, keyed by
+    /// their initial-tree hash.
+    #[expect(dead_code, reason = "used by MerkleLayer fold in follow-up commit")]
+    pub(crate) fn deleted_nodes(&self) -> impl Deref<Target = BTreeMap<Hash, DeletedNodeFields>> {
+        self.deleted_nodes.borrow()
     }
 
     /// Track node access and resolve the underlying lazy node in one step.
@@ -666,7 +723,7 @@ impl<R: Resolver<LazyTreeId, Tree<LazyNodeId>>> Resolver<ProveTreeId, Tree<Prove
         }
 
         let resolved = self.resolve_and_track_tree(&id.tree)?;
-        let result_tree: Tree<ProveNodeId> = resolved.clone().into_proof();
+        let result_tree: Tree<ProveNodeId> = resolved.clone().into_proof(self);
         id.inner
             .set(result_tree)
             .map_err(|_| OperationalError::ResolverInvariantViolated)?;
@@ -687,7 +744,7 @@ impl<R: Resolver<LazyTreeId, Tree<LazyNodeId>>> Resolver<ProveTreeId, Tree<Prove
         }
 
         let resolved = self.resolve_and_track_tree(&id.tree)?;
-        let result_tree: Tree<ProveNodeId> = resolved.clone().into_proof();
+        let result_tree: Tree<ProveNodeId> = resolved.clone().into_proof(self);
         id.inner
             .set(result_tree)
             .map_err(|_| OperationalError::ResolverInvariantViolated)?;
@@ -1282,7 +1339,7 @@ mod tests {
         let prove_resolver = ProveResolver::start(lazy_resolver);
         let lazy_node_id = lazy_tree.root().expect("tree should have a root");
 
-        let prove_id = lazy_node_id.clone().into_proof();
+        let prove_id = lazy_node_id.clone().into_proof(&prove_resolver);
 
         prove_resolver
             .resolve(&prove_id)
@@ -1299,7 +1356,7 @@ mod tests {
         let expected_hash = Hash::from_foldable(lazy_root);
 
         let prove_resolver = ProveResolver::start(lazy_resolver);
-        let prove_id = lazy_root.clone().into_proof();
+        let prove_id = lazy_root.clone().into_proof(&prove_resolver);
 
         // Hash before resolve (delegates to lazy path).
         let hash_before = Hash::from_foldable(&prove_id);
@@ -1331,7 +1388,7 @@ mod tests {
             .root()
             .expect("tree should have a root")
             .clone()
-            .into_proof();
+            .into_proof(&prove_resolver);
 
         // Resolve root node.
         let prove_node = prove_resolver
@@ -1368,7 +1425,7 @@ mod tests {
             .root()
             .expect("tree should have a root")
             .clone()
-            .into_proof();
+            .into_proof(&prove_resolver);
 
         prove_resolver
             .resolve(&prove_id)
@@ -1396,7 +1453,7 @@ mod tests {
             .root()
             .expect("tree should have a root")
             .clone()
-            .into_proof();
+            .into_proof(&prove_resolver);
 
         let node = prove_resolver
             .resolve_mut(&mut prove_id)
@@ -1429,7 +1486,7 @@ mod tests {
 
         // Now get the same hash via the prove resolver path.
         let prove_resolver = ProveResolver::start(lazy_resolver);
-        let prove_root_id = lazy_root.clone().into_proof();
+        let prove_root_id = lazy_root.clone().into_proof(&prove_resolver);
         let prove_node = prove_resolver
             .resolve(&prove_root_id)
             .expect("resolve should succeed");

--- a/durable-storage/src/avl/tree.rs
+++ b/durable-storage/src/avl/tree.rs
@@ -37,6 +37,7 @@ use super::resolver::VerifyNodeId;
 use crate::avl::resolver::AvlResolver;
 use crate::avl::resolver::LazyNodeId;
 use crate::avl::resolver::NodeResolver;
+use crate::avl::resolver::ProveResolver;
 use crate::errors::Error;
 use crate::errors::InvalidArgumentError;
 use crate::errors::OperationalError;
@@ -55,8 +56,8 @@ impl Tree<LazyNodeId> {
     /// Converts the [`Tree`] to [`Prove`] mode.
     ///
     /// [`Prove`]: octez_riscv_data::mode::Prove
-    pub fn into_proof(self) -> Tree<ProveNodeId> {
-        Tree(self.0.map(|id| id.into_proof()))
+    pub(crate) fn into_proof<R>(self, resolver: &ProveResolver<R>) -> Tree<ProveNodeId> {
+        Tree(self.0.map(|id| id.into_proof(resolver)))
     }
 }
 

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -1410,7 +1410,7 @@ mod tests {
             assert_eq!(node.hash(), loaded_node.hash());
             assert_eq!(node.balance_factor(), loaded_node.balance_factor());
             assert_eq!(node.key(), loaded_node.key());
-            assert_eq!(node.value(), loaded_node.value());
+            assert_eq!(node.data(), loaded_node.data());
         }
 
         let root_hash = merkle_layer.hash();
@@ -1558,13 +1558,14 @@ mod tests {
             .expect("setting node should succeed");
 
         // `Prove` mode
-        let prove_tree = normal_ml.inner.tree.into_proof();
+        let resolver = LazyResolver::new(normal_ml.inner.persistence.clone());
+        let resolver = ProveResolver::start(resolver);
+        let prove_tree = normal_ml.inner.tree.into_proof(&resolver);
+
         let prove_ml: MerkleLayer<KV, Prove<'static>> = MerkleLayer {
             inner: ProveImpl {
                 tree: prove_tree,
-                resolver: ProveResolver::start(LazyResolver::new(
-                    normal_ml.inner.persistence.clone(),
-                )),
+                resolver,
             },
         };
 
@@ -1698,13 +1699,14 @@ mod tests {
 
         let normal_hash = normal_ml.hash();
 
-        let prove_tree = normal_ml.inner.tree.into_proof();
+        let resolver = LazyResolver::new(normal_ml.inner.persistence.clone());
+        let resolver = ProveResolver::start(resolver);
+        let prove_tree = normal_ml.inner.tree.into_proof(&resolver);
+
         let prove_ml: MerkleLayer<KV, Prove<'static>> = MerkleLayer {
             inner: ProveImpl {
                 tree: prove_tree,
-                resolver: ProveResolver::start(LazyResolver::new(
-                    normal_ml.inner.persistence.clone(),
-                )),
+                resolver,
             },
         };
 
@@ -1731,13 +1733,14 @@ mod tests {
         let initial_hash = normal_ml.hash();
 
         // ---- Prove: read key then overwrite it ----
-        let prove_tree = normal_ml.inner.tree.into_proof();
+        let resolver = LazyResolver::new(normal_ml.inner.persistence.clone());
+        let resolver = ProveResolver::start(resolver);
+        let prove_tree = normal_ml.inner.tree.into_proof(&resolver);
+
         let mut prove_ml: MerkleLayer<KV, Prove<'static>> = MerkleLayer {
             inner: ProveImpl {
                 tree: prove_tree,
-                resolver: ProveResolver::start(LazyResolver::new(
-                    normal_ml.inner.persistence.clone(),
-                )),
+                resolver,
             },
         };
 


### PR DESCRIPTION
Part of RV-957. 

# What

This is a precursor to #1004 . It introduces a way for the Merkle Layer to keep track of deleted nodes during a proof. 

# Why

Deleted nodes still need to have presence in the initial tree. Once deleted, we cannot track their presence.

# How

We introduce an additional operation to the `Drop` of any `ProveNodeId`, by preserving it in the `ProveResolver::deleted_nodes` field. 

# Manually Testing

```
make all
```


# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
