### PR TITLE
fix(durable): restore `impl Clone for InMemoryRepo`

### DIFF
--- a/durable-storage/src/storage/in_memory.rs
+++ b/durable-storage/src/storage/in_memory.rs
@@ -19,10 +19,10 @@ use crate::errors::OperationalError;
 /// Repository used by [`InMemoryKeyValueStore`].
 ///
 /// Will never write to disk.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct InMemoryRepo {
     #[cfg(test)]
-    commits: RwLock<HashMap<crate::commit::CommitId, InMemorySnapshot>>,
+    commits: std::sync::Arc<RwLock<HashMap<crate::commit::CommitId, InMemorySnapshot>>>,
 }
 
 /// In-memory key-value store


### PR DESCRIPTION
`KV::Repo: Clone` is required by the octez integration. Slight revert on a change introduced by #1020

<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

- Relates to RV-960

# What

Restore `impl Clone for InMemoryRepo` - which was removed accidentally by #1020 

# Why

It's required by the `octez` integration. Namely, we require `KV::Clone` to implement `TryClone` for the `SafePointer`. `DirectlyManager` is also `Clone` - and, outside of a field used only present in tests, there's no good reason for `InMemoryRepo` to still be Clone.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
