### PR TITLE
Coalesce PartialVec range

### DIFF
--- a/data/src/components/bytes.rs
+++ b/data/src/components/bytes.rs
@@ -218,9 +218,9 @@ impl Bytes<Verify> {
 
     /// Returns the given range as a contiguous byte slice.
     ///
-    /// Panics (via [`not_found`]) if the range extends beyond the length, or is not fully
-    /// contained within a single defined entry, indicating the Merkle proof did not include the
-    /// data required for this access.
+    /// Panics (via [`not_found`]) if the range extends beyond the length, or includes any
+    /// undefined data, indicating the Merkle proof did not include the data required for this
+    /// access.
     pub fn partial_slice(&self, range: Range<usize>) -> &[u8] {
         if range.is_empty() {
             return &[];

--- a/data/src/partial_vec.rs
+++ b/data/src/partial_vec.rs
@@ -231,6 +231,7 @@ impl<T> PartialVec<T> {
         let mut start_idx = self
             .entries
             .partition_point(|entry| entry.end() <= new_entry.start);
+        let initial_idx = start_idx;
 
         while !new_entry.data.is_empty() {
             // Insert or merge the new entry at the current index.
@@ -238,6 +239,43 @@ impl<T> PartialVec<T> {
             self.insert_entry(start_idx, &mut new_entry);
             start_idx += 1;
         }
+
+        self.coalesce_adjacent(
+            initial_idx.saturating_sub(1),
+            (start_idx + 1).min(self.entries.len()),
+        );
+    }
+
+    /// Merge any consecutive entries in `[from, to_exclusive)` whose ranges touch.
+    ///
+    /// Entries outside that window are assumed to already satisfy the no-adjacency invariant.
+    ///
+    /// Merging leaves emptied entries scattered through the window, but the `swap` below pushes
+    /// them all past `write_ptr` so a single `drain` at the end cleans them up.
+    fn coalesce_adjacent(&mut self, from: usize, to_exclusive: usize) {
+        let to = to_exclusive.min(self.entries.len());
+        if from + 1 >= to {
+            return;
+        }
+
+        let mut write_ptr = from;
+        let mut read_ptr = from + 1;
+
+        while read_ptr < to {
+            if self.entries[write_ptr].end() == self.entries[read_ptr].start {
+                let mut absorbed = std::mem::take(&mut self.entries[read_ptr].data);
+                self.entries[write_ptr].data.append(&mut absorbed);
+            } else {
+                // Keeps emptied entries behind `write_ptr`; see the partition note above.
+                write_ptr += 1;
+                if write_ptr != read_ptr {
+                    self.entries.swap(write_ptr, read_ptr);
+                }
+            }
+            read_ptr += 1;
+        }
+
+        self.entries.drain(write_ptr + 1..to);
     }
 
     /// Mark everything beyond `keep_length` as undefined.
@@ -361,12 +399,12 @@ impl<T> PartialVec<T> {
         self.entries.iter().all(|entry| entry.data.is_empty())
     }
 
-    /// Returns the given range as a contiguous slice if it is fully contained in a single
-    /// defined entry.
+    /// Returns the given range as a contiguous slice if every position in it is defined.
     ///
-    /// Returns `None` if the range spans multiple entries, includes any undefined data, or is empty
-    /// and out-of-bounds.
+    /// Returns `None` if the range includes any undefined data, or is empty and out-of-bounds.
     pub(crate) fn contiguous_range(&self, range: Range<usize>) -> Option<&[T]> {
+        // Relies on `define` coalescing touching entries, so any fully-defined range lives in a
+        // single entry.
         let idx = self
             .entries
             .partition_point(|entry| entry.end() < range.end);

--- a/data/src/partial_vec/tests.rs
+++ b/data/src/partial_vec/tests.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeMap;
 use proptest::arbitrary::any;
 use proptest::collection::vec;
 use proptest::prelude::Strategy;
+use proptest::prop_assert;
 use proptest::proptest;
 
 use crate::partial_vec::PartialVec;
@@ -46,6 +47,22 @@ proptest! {
 
         for (index, data) in init_data {
             vec.define(index, data);
+        }
+    }
+
+    /// After any sequence of `define` calls, no two consecutive entries should be touching:
+    /// `entries[i].end()` must be strictly less than `entries[i + 1].start`.
+    #[test]
+    fn entries_never_touching(init_data in vec((any::<usize>(), data_vec()), ..1024)) {
+        let mut vec: PartialVec<u8> = PartialVec::empty();
+
+        for (index, data) in init_data {
+            vec.define(index, data);
+        }
+
+        for pair in vec.entries.windows(2) {
+            // `DefinedEntry::end` is an exclusive end of the contained range.
+            prop_assert!(pair[0].end() < pair[1].start);
         }
     }
 
@@ -653,4 +670,129 @@ fn contiguous_range_empty() {
     assert_eq!(vec.contiguous_range(5..5), Some(&[][..]));
     assert_eq!(vec.contiguous_range(7..7), Some(&[][..]));
     assert_eq!(vec.contiguous_range(10..10), Some(&[][..]));
+}
+
+/// Two writes that meet exactly should collapse into a single defined entry.
+#[test]
+fn define_merges_with_left_neighbour() {
+    let mut vec: PartialVec<u8> = PartialVec::empty();
+    vec.define(0, vec![1, 2, 3]);
+    vec.define(3, vec![4, 5, 6]);
+
+    assert_eq!(vec.entries.len(), 1);
+    assert_eq!(vec.contiguous_range(0..6), Some(&[1, 2, 3, 4, 5, 6][..]));
+}
+
+/// A write that fills the gap between two existing entries should collapse all three into one.
+#[test]
+fn define_bridges_two_entries() {
+    let mut vec: PartialVec<u8> = PartialVec::empty();
+    vec.define(0, vec![1, 2, 3]);
+    vec.define(5, vec![6, 7, 8]);
+    vec.define(3, vec![4, 5]);
+
+    assert_eq!(vec.entries.len(), 1);
+    assert_eq!(
+        vec.contiguous_range(0..8),
+        Some(&[1, 2, 3, 4, 5, 6, 7, 8][..])
+    );
+}
+
+/// Triggers the `insert_entry` path where an existing entry is grown up to its right neighbour's
+/// start, and the remainder of the new data overlaps that neighbour.
+#[test]
+fn define_extension_meets_right_neighbour() {
+    let mut vec: PartialVec<u8> = PartialVec::empty();
+    vec.define(0, vec![1, 2, 3]);
+    vec.define(10, vec![11]);
+    vec.define(2, vec![3, 4, 5, 6, 7, 8, 9, 10, 11]);
+
+    assert_eq!(vec.entries.len(), 1);
+    assert_eq!(
+        vec.contiguous_range(0..11),
+        Some(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11][..])
+    );
+}
+
+/// A write that starts inside an existing entry and extends past its end should overwrite the
+/// overlapping suffix and grow the entry with the remainder.
+#[test]
+fn define_partially_overwrites_left_neighbour() {
+    let mut vec: PartialVec<u8> = PartialVec::empty();
+    vec.define(0, vec![1, 2, 3]);
+    vec.define(2, vec![30, 40, 50]);
+
+    assert_eq!(vec.entries.len(), 1);
+    assert_eq!(vec.contiguous_range(0..5), Some(&[1, 2, 30, 40, 50][..]));
+}
+
+/// A write that covers an existing entry completely and continues past it should replace that
+/// entry's contents wholesale, then keep going.
+#[test]
+fn define_fully_overwrites_left_neighbour() {
+    let mut vec: PartialVec<u8> = PartialVec::empty();
+    vec.define(0, vec![1, 2, 3]);
+    vec.define(0, vec![10, 20, 30, 40, 50]);
+
+    assert_eq!(vec.entries.len(), 1);
+    assert_eq!(vec.contiguous_range(0..5), Some(&[10, 20, 30, 40, 50][..]));
+}
+
+/// A write that ends inside an existing right-hand entry should overwrite that entry's prefix
+/// and leave its suffix intact, coalescing the two entries into one.
+#[test]
+fn define_partially_overwrites_right_neighbour() {
+    let mut vec: PartialVec<u8> = PartialVec::empty();
+    vec.define(0, vec![1, 2, 3]);
+    vec.define(10, vec![11, 12, 13, 14, 15]);
+    vec.define(2, vec![3, 4, 5, 6, 7, 8, 9, 10, 110, 120]);
+
+    assert_eq!(vec.entries.len(), 1);
+    assert_eq!(
+        vec.contiguous_range(0..15),
+        Some(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 110, 120, 13, 14, 15][..])
+    );
+}
+
+/// A write that fully overlaps a right-hand entry should replace it entirely while merging it
+/// into the growing entry on the left.
+#[test]
+fn define_fully_overwrites_right_neighbour() {
+    let mut vec: PartialVec<u8> = PartialVec::empty();
+    vec.define(0, vec![1, 2, 3]);
+    vec.define(10, vec![11, 12, 13]);
+    vec.define(2, vec![3, 4, 5, 6, 7, 8, 9, 10, 110, 120, 130, 140]);
+
+    assert_eq!(vec.entries.len(), 1);
+    assert_eq!(
+        vec.contiguous_range(0..14),
+        Some(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 110, 120, 130, 140][..])
+    );
+}
+
+/// A single write that spans several existing entries on the right should overwrite each of them
+/// in turn and coalesce the lot into one entry.
+#[test]
+fn define_spans_multiple_right_neighbours() {
+    let mut vec: PartialVec<u8> = PartialVec::empty();
+    vec.define(0, vec![1, 2, 3]);
+    vec.define(10, vec![11, 12, 13]);
+    vec.define(20, vec![21, 22, 23, 24, 25]);
+    vec.define(
+        2,
+        vec![
+            3, 4, 5, 6, 7, 8, 9, 10, 110, 120, 130, 14, 15, 16, 17, 18, 19, 20, 210, 220,
+        ],
+    );
+
+    assert_eq!(vec.entries.len(), 1);
+    assert_eq!(
+        vec.contiguous_range(0..25),
+        Some(
+            &[
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 110, 120, 130, 14, 15, 16, 17, 18, 19, 20, 210, 220,
+                23, 24, 25
+            ][..]
+        )
+    );
 }


### PR DESCRIPTION
Closes RV-993

# What
Allows `PartialVec::contiguous_range` to return slices which cover multiple entries.

# Why
Currently this requires the whole range to live inside a single entry.

# How
`PartialVec::define` coalesces any adjacent entries it touches using two pointers followed by a drain.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
