### PR TITLE
test(dursto): `kv_test` runs PBTs on same inputs and compares traces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2521,7 +2521,6 @@ dependencies = [
  "log",
  "octez-riscv-data",
  "octez-riscv-test-utils",
- "paste",
  "perfect-derive",
  "proptest",
  "rand 0.10.1",

--- a/durable-storage/Cargo.toml
+++ b/durable-storage/Cargo.toml
@@ -32,7 +32,6 @@ workspace = true
 optional = true
 
 [dev-dependencies]
-paste.workspace = true
 proptest.workspace = true
 criterion.workspace = true
 octez-riscv-test-utils.workspace = true

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -479,7 +479,6 @@ mod tests {
     use octez_riscv_data::mode::Verify;
     use proptest::prelude::*;
     use proptest::prop_assert_eq;
-    use proptest::proptest;
     use tezos_smart_rollup_constants::core::MAX_FILE_CHUNK_SIZE;
     use tokio::runtime::Handle;
 
@@ -493,6 +492,7 @@ mod tests {
     use crate::merkle_layer::new_verify_layer;
     use crate::merkle_worker::BackgroundKeyValueStore;
     use crate::merkle_worker::BackgroundPersistentKeyValueStore;
+    use crate::storage::KeyValueStore;
     use crate::storage::TestKeyValueStoreSetup;
     use crate::storage::kv_test;
 
@@ -503,14 +503,15 @@ mod tests {
         Database::try_new(handle, repo).expect("Creating a test database should succeed")
     }
 
-    fn new_verify_database<KV: TestKeyValueStoreSetup>() -> Database<KV, Verify> {
+    fn new_verify_database<KV: KeyValueStore>(repo: &KV::Repo) -> Database<KV, Verify> {
         Database {
             inner: super::VerifyImpl {
-                merkle: new_verify_layer::<KV>(),
+                merkle: new_verify_layer::<KV>(repo),
             },
         }
     }
 
+    #[cfg(feature = "rocksdb")]
     fn new_persistent_database<KV>() -> (
         tokio::runtime::Runtime,
         KV::Keepalive,
@@ -559,59 +560,67 @@ mod tests {
         ));
     }
 
-    kv_test!(test_database_commit_and_checkout, KV: BackgroundPersistentKeyValueStore, {
-        let (runtime, _keepalive, repo, _database) = new_persistent_database::<KV>();
-        let handle = runtime.handle();
-        proptest!(|(
-            entries in prop::collection::vec(
-                (prop::collection::vec(any::<u8>(), 1..=KEY_MAX_SIZE),
-                 prop::collection::vec(any::<u8>(), 0..200)),
-                1..50,
-            ),
-        )| {
-            let mut database = new_database::<KV>(handle, &repo);
-            let expected = insert_entries(&mut database, entries);
+    kv_test!(test_database_commit_and_checkout, KV: BackgroundPersistentKeyValueStore,
+        setup_runtime |handle, repo| = {
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(2)
+                .build()
+                .expect("Creating a Tokio runtime should succeed");
+            let handle = runtime.handle().clone();
+            let (_keepalive, repo) = KV::setup_repo();
+            (runtime, handle, _keepalive, repo)
+        },
+    [
+        entries in prop::collection::vec(
+            (prop::collection::vec(any::<u8>(), 1..=KEY_MAX_SIZE),
+             prop::collection::vec(any::<u8>(), 0..200)),
+            1..50,
+        ),
+    ], {
+        let mut database = new_database::<KV>(handle, repo);
+        let expected = insert_entries(&mut database, entries);
 
-            let expected_hash = database.hash().expect("Hash should be calculated");
-            let commit_id = database.commit(&repo).expect("Commit should succeed");
+        let expected_hash = database.hash().expect("Hash should be calculated");
+        let commit_id = database.commit(repo).expect("Commit should succeed");
 
-            let checked_out = Database::<KV, _>::checkout(handle, &repo, commit_id)
-                .expect("Checkout should succeed");
+        let checked_out = Database::<KV, _>::checkout(handle, repo, commit_id)
+            .expect("Checkout should succeed");
 
-            prop_assert_eq!(checked_out.hash().expect("Hash should be calculated"), expected_hash);
+        prop_assert_eq!(checked_out.hash().expect("Hash should be calculated"), expected_hash);
 
-            for (key, value) in expected {
-                checked_out.assert_database_value(&key, value.as_ref());
-            }
-        });
+        for (key, value) in expected {
+            checked_out.assert_database_value(&key, value.as_ref());
+        }
     });
 
-    kv_test!(test_database_delete, KV: BackgroundKeyValueStore, {
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .build()
-            .expect("Creating a Tokio runtime should succeed");
-        let handle = runtime.handle();
-        let (_keepalive, repo) = KV::setup_repo();
-        proptest!(|(
-            keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..=KEY_MAX_SIZE), 0..100),
-            data in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..200), 0..100)
-        )| {
-            let mut database = new_database::<KV>(handle, &repo);
+    kv_test!(test_database_delete, KV: BackgroundKeyValueStore,
+        setup_runtime |handle, repo| = {
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .build()
+                .expect("Creating a Tokio runtime should succeed");
+            let handle = runtime.handle().clone();
+            let (_keepalive, repo) = KV::setup_repo();
+            (runtime, handle, _keepalive, repo)
+        },
+    [
+        keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..=KEY_MAX_SIZE), 0..100),
+        data in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..200), 0..100),
+    ], {
+        let mut database = new_database::<KV>(handle, repo);
 
-            for (key, data) in keys.iter().zip(data.iter()) {
-                let key = Key::new(key).expect("Size less than KEY_MAX_SIZE");
-                database
-                    .set(key.clone(), Bytes::copy_from_slice(data))
-                    .expect("Writing should succeed");
-                prop_assert!(database.exists(&key).expect("There should be no other `PersistenceLayerError`s"));
+        for (key, data) in keys.iter().zip(data.iter()) {
+            let key = Key::new(key).expect("Size less than KEY_MAX_SIZE");
+            database
+                .set(key.clone(), Bytes::copy_from_slice(data))
+                .expect("Writing should succeed");
+            prop_assert!(database.exists(&key).expect("There should be no other `PersistenceLayerError`s"));
 
-                let before = database.hash().expect("Hash should be calculated");
-                database.delete(key.clone()).expect("Deleting should succeed");
-                let after = database.hash().expect("Hash should be calculated");
-                assert_ne!(before, after);
-                prop_assert!(!database.exists(&key).expect("There should be no other `PersistenceLayerError`s"));
-            }
-        });
+            let before = database.hash().expect("Hash should be calculated");
+            database.delete(key.clone()).expect("Deleting should succeed");
+            let after = database.hash().expect("Hash should be calculated");
+            assert_ne!(before, after);
+            prop_assert!(!database.exists(&key).expect("There should be no other `PersistenceLayerError`s"));
+        }
     });
 
     kv_test!(test_database_delete_nonexistent, KV: BackgroundKeyValueStore, {
@@ -761,72 +770,76 @@ mod tests {
         ));
     });
 
-    kv_test!(test_database_exists, KV: BackgroundKeyValueStore, {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .build()
-            .expect("Creating a Tokio runtime should succeed");
-        let handle = runtime.handle();
-        let (_keepalive, repo) = KV::setup_repo();
-        proptest!(|(
-            keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..KEY_MAX_SIZE), 0..100),
-            data in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..200), 0..100)
-        )| {
-            let mut database = new_database::<KV>(handle, &repo);
+    kv_test!(test_database_exists, KV: BackgroundKeyValueStore,
+        setup_runtime |handle, repo| = {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .build()
+                .expect("Creating a Tokio runtime should succeed");
+            let handle = runtime.handle().clone();
+            let (_keepalive, repo) = KV::setup_repo();
+            (runtime, handle, _keepalive, repo)
+        },
+    [
+        keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..KEY_MAX_SIZE), 0..100),
+        data in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..200), 0..100),
+    ], {
+        let mut database = new_database::<KV>(handle, repo);
 
-            let mut seen = HashSet::new();
+        let mut seen = HashSet::new();
 
-            for (key, data) in keys.iter().zip(data.iter()) {
-                let key = Key::new(key).expect("Size less than KEY_MAX_SIZE");
-                let data: &[u8] = data;
+        for (key, data) in keys.iter().zip(data.iter()) {
+            let key = Key::new(key).expect("Size less than KEY_MAX_SIZE");
+            let data: &[u8] = data;
 
-                prop_assert_ne!(database.exists(&key)
-                        .expect("There should be no other `PersistenceLayerError`s"),
-                    seen.insert(key.clone()));
+            prop_assert_ne!(database.exists(&key)
+                    .expect("There should be no other `PersistenceLayerError`s"),
+                seen.insert(key.clone()));
 
-                database
-                    .set(key.clone(), Bytes::copy_from_slice(data))
-                    .expect("Writing should succeed");
-                prop_assert!(database.exists(&key).expect("There should be no other `PersistenceLayerError`s"));
-            }
-        });
+            database
+                .set(key.clone(), Bytes::copy_from_slice(data))
+                .expect("Writing should succeed");
+            prop_assert!(database.exists(&key).expect("There should be no other `PersistenceLayerError`s"));
+        }
     });
 
-    kv_test!(test_database_hash, KV: BackgroundKeyValueStore, {
-        // Needs a thread for sending and a thread for receiving
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(2)
-            .build()
-            .expect("Creating a Tokio runtime should succeed");
-        let handle = runtime.handle();
-        let (_keepalive, repo) = KV::setup_repo();
-        proptest!(|(
-            keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..=KEY_MAX_SIZE), 0..100),
-            data in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..200), 0..100)
-        )| {
-            let mut database = new_database::<KV>(handle, &repo);
+    kv_test!(test_database_hash, KV: BackgroundKeyValueStore,
+        setup_runtime |handle, repo| = {
+            // Needs a thread for sending and a thread for receiving
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(2)
+                .build()
+                .expect("Creating a Tokio runtime should succeed");
+            let handle = runtime.handle().clone();
+            let (_keepalive, repo) = KV::setup_repo();
+            (runtime, handle, _keepalive, repo)
+        },
+    [
+        keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..=KEY_MAX_SIZE), 0..100),
+        data in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..200), 0..100),
+    ], {
+        let mut database = new_database::<KV>(handle, repo);
 
-            let mut seen = HashSet::new();
+        let mut seen = HashSet::new();
 
-            for (key, data) in keys.iter().zip(data.iter()) {
-                let key = Key::new(key).expect("Size less than KEY_MAX_SIZE");
-                let data: &[u8] = data;
+        for (key, data) in keys.iter().zip(data.iter()) {
+            let key = Key::new(key).expect("Size less than KEY_MAX_SIZE");
+            let data: &[u8] = data;
 
-                let before = database.hash().expect("Hash should be calculated");
+            let before = database.hash().expect("Hash should be calculated");
 
-                database
-                    .set(key.clone(), Bytes::copy_from_slice(data))
-                    .expect("Writing should succeed");
+            database
+                .set(key.clone(), Bytes::copy_from_slice(data))
+                .expect("Writing should succeed");
 
-                let after = database.hash().expect("Hash should be calculated");
+            let after = database.hash().expect("Hash should be calculated");
 
-                let existing_pair = !seen.insert((key, data));
-                // Avoid the edge case of an identical hash from a previously seen identical
-                // key-value pair, where no other keys were written to in between.
-                if !existing_pair {
-                    prop_assert_ne!(before, after);
-                }
+            let existing_pair = !seen.insert((key, data));
+            // Avoid the edge case of an identical hash from a previously seen identical
+            // key-value pair, where no other keys were written to in between.
+            if !existing_pair {
+                prop_assert_ne!(before, after);
             }
-        });
+        }
     });
 
     kv_test!(test_database_hash_revert, KV: BackgroundKeyValueStore, {
@@ -866,124 +879,128 @@ mod tests {
         assert_eq!(before, reverted);
     });
 
-    kv_test!(test_database_read, KV: BackgroundKeyValueStore, {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .build()
-            .expect("Creating a Tokio runtime should succeed");
-        let handle = runtime.handle();
-        let (_keepalive, repo) = KV::setup_repo();
-        proptest!(|(
-            keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..KEY_MAX_SIZE), 0..100),
-            data in prop::collection::vec(prop::collection::vec(any::<u8>(), 3..100), 0..100)
-        )| {
-            let mut database = new_database::<KV>(handle, &repo);
+    kv_test!(test_database_read, KV: BackgroundKeyValueStore,
+        setup_runtime |handle, repo| = {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .build()
+                .expect("Creating a Tokio runtime should succeed");
+            let handle = runtime.handle().clone();
+            let (_keepalive, repo) = KV::setup_repo();
+            (runtime, handle, _keepalive, repo)
+        },
+    [
+        keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..KEY_MAX_SIZE), 0..100),
+        data in prop::collection::vec(prop::collection::vec(any::<u8>(), 3..100), 0..100),
+    ], {
+        let mut database = new_database::<KV>(handle, repo);
 
-            for (key, data) in keys.iter().zip(data.iter()) {
-                let key = Key::new(key).expect("Size less than KEY_MAX_SIZE");
-                let mut read_data: [u8; 100] = [42; 100];
+        for (key, data) in keys.iter().zip(data.iter()) {
+            let key = Key::new(key).expect("Size less than KEY_MAX_SIZE");
+            let mut read_data: [u8; 100] = [42; 100];
 
-                let read_data_before = read_data;
+            let read_data_before = read_data;
 
-                // Set the data
+            // Set the data
+            database
+                .set(key.clone(), Bytes::copy_from_slice(data))
+                .expect("Setting should succeed");
+
+            // The offset is bigger than the value
+            prop_assert!(database.read(&key, data.len() + 1, read_data.as_mut_slice()).is_err());
+            prop_assert_eq!(read_data, read_data_before);
+
+            // Partial value write, where the output parameter is smaller than the data.
+            prop_assert_eq!(
                 database
-                    .set(key.clone(), Bytes::copy_from_slice(data))
-                    .expect("Setting should succeed");
+                    .read(&key, 0, read_data[1..data.len()].as_mut())
+                    .expect(
+                        "Reading a value larger than the output parameter's size should succeed"
+                    ),
+                data.len() - 1
+            );
+            prop_assert_eq!(read_data[0], read_data_before[0]);
+            prop_assert_eq!(&read_data[1..data.len()], &data[..data.len() - 1]);
+            prop_assert_eq!(&read_data[data.len()..], &read_data_before[data.len()..]);
+            let read_data_before = read_data;
 
-                // The offset is bigger than the value
-                prop_assert!(database.read(&key, data.len() + 1, read_data.as_mut_slice()).is_err());
-                prop_assert_eq!(read_data, read_data_before);
+            let read = database
+                .read(&key, data.len(), read_data.as_mut_slice())
+                .expect("A zero-sized write should succeed");
+            prop_assert_eq!(read, 0);
+            prop_assert_eq!(read_data, read_data_before);
 
-                // Partial value write, where the output parameter is smaller than the data.
-                prop_assert_eq!(
-                    database
-                        .read(&key, 0, read_data[1..data.len()].as_mut())
-                        .expect(
-                            "Reading a value larger than the output parameter's size should succeed"
-                        ),
-                    data.len() - 1
-                );
-                prop_assert_eq!(read_data[0], read_data_before[0]);
-                prop_assert_eq!(&read_data[1..data.len()], &data[..data.len() - 1]);
-                prop_assert_eq!(&read_data[data.len()..], &read_data_before[data.len()..]);
-                let read_data_before = read_data;
+            // Whole value write
+            let read = database
+                .read(&key, 0, read_data.as_mut_slice())
+                .expect("Writing the whole value should succeed");
+            prop_assert_eq!(read, data.len());
+            prop_assert_eq!(&read_data[..data.len()], data.as_slice());
+            prop_assert_eq!(&read_data[data.len()..], &read_data_before[data.len()..]);
 
-                let read = database
-                    .read(&key, data.len(), read_data.as_mut_slice())
-                    .expect("A zero-sized write should succeed");
-                prop_assert_eq!(read, 0);
-                prop_assert_eq!(read_data, read_data_before);
+            // Partial value write
+            prop_assert_eq!(&read_data[2..data.len()], &data[2..]);
+            let read = database
+                .read(&key, data.len() - 1, read_data[1..2].as_mut())
+                .expect("A partial write should succeed");
+            prop_assert_eq!(read, 1);
+            prop_assert_eq!(&read_data[1..2], &data[data.len() - 1..]);
+            prop_assert_eq!(&read_data[2..data.len()], &data[2..]);
+            prop_assert_eq!(&read_data[data.len()..], &read_data_before[data.len()..]);
 
-                // Whole value write
-                let read = database
-                    .read(&key, 0, read_data.as_mut_slice())
-                    .expect("Writing the whole value should succeed");
-                prop_assert_eq!(read, data.len());
-                prop_assert_eq!(&read_data[..data.len()], data.as_slice());
-                prop_assert_eq!(&read_data[data.len()..], &read_data_before[data.len()..]);
-
-                // Partial value write
-                prop_assert_eq!(&read_data[2..data.len()], &data[2..]);
-                let read = database
-                    .read(&key, data.len() - 1, read_data[1..2].as_mut())
-                    .expect("A partial write should succeed");
-                prop_assert_eq!(read, 1);
-                prop_assert_eq!(&read_data[1..2], &data[data.len() - 1..]);
-                prop_assert_eq!(&read_data[2..data.len()], &data[2..]);
-                prop_assert_eq!(&read_data[data.len()..], &read_data_before[data.len()..]);
-
-                // Write limited by buffer
-                let mut small_buffer: [u8; 3] = [0, 0 ,0];
-                let read = database
-                    .read(&key, 0, small_buffer.as_mut_slice())
-                    .expect("Writing into a smaller buffer should succeed");
-                prop_assert_eq!(read, small_buffer.len());
-                prop_assert_eq!(&small_buffer, &data[0..3]);
-            }
-        });
+            // Write limited by buffer
+            let mut small_buffer: [u8; 3] = [0, 0 ,0];
+            let read = database
+                .read(&key, 0, small_buffer.as_mut_slice())
+                .expect("Writing into a smaller buffer should succeed");
+            prop_assert_eq!(read, small_buffer.len());
+            prop_assert_eq!(&small_buffer, &data[0..3]);
+        }
     });
 
-    kv_test!(test_database_read_bytes, KV: BackgroundKeyValueStore, {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .build()
-            .expect("Creating a Tokio runtime should succeed");
-        let handle = runtime.handle();
-        let (_keepalive, repo) = KV::setup_repo();
-        proptest!(|(
-            keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..KEY_MAX_SIZE), 0..100),
-            data in prop::collection::vec(prop::collection::vec(any::<u8>(), 3..100), 0..100)
-        )| {
-            let mut database = new_database::<KV>(handle, &repo);
+    kv_test!(test_database_read_bytes, KV: BackgroundKeyValueStore,
+        setup_runtime |handle, repo| = {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .build()
+                .expect("Creating a Tokio runtime should succeed");
+            let handle = runtime.handle().clone();
+            let (_keepalive, repo) = KV::setup_repo();
+            (runtime, handle, _keepalive, repo)
+        },
+    [
+        keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..KEY_MAX_SIZE), 0..100),
+        data in prop::collection::vec(prop::collection::vec(any::<u8>(), 3..100), 0..100),
+    ], {
+        let mut database = new_database::<KV>(handle, repo);
 
-            for (key, data) in keys.iter().zip(data.iter()) {
-                let key = Key::new(key).expect("Size less than KEY_MAX_SIZE");
+        for (key, data) in keys.iter().zip(data.iter()) {
+            let key = Key::new(key).expect("Size less than KEY_MAX_SIZE");
 
-                // Set the data
-                database
-                    .set(key.clone(), Bytes::copy_from_slice(data))
-                    .expect("Setting should succeed");
+            // Set the data
+            database
+                .set(key.clone(), Bytes::copy_from_slice(data))
+                .expect("Setting should succeed");
 
-                // The offset is bigger than the value
-                prop_assert!(database.read_bytes(&key, data.len() + 1, 1).is_err());
+            // The offset is bigger than the value
+            prop_assert!(database.read_bytes(&key, data.len() + 1, 1).is_err());
 
-                // Whole value read
-                let result = database
-                    .read_bytes(&key, 0, data.len())
-                    .expect("Reading from offset 0 should succeed");
-                prop_assert_eq!(result.as_ref(), data.as_slice());
+            // Whole value read
+            let result = database
+                .read_bytes(&key, 0, data.len())
+                .expect("Reading from offset 0 should succeed");
+            prop_assert_eq!(result.as_ref(), data.as_slice());
 
-                // Zero-sized read at end of value
-                let result = database
-                    .read_bytes(&key, 0, 0)
-                    .expect("A zero-sized read should succeed");
-                prop_assert_eq!(result.as_ref(), &[] as &[u8]);
+            // Zero-sized read at end of value
+            let result = database
+                .read_bytes(&key, 0, 0)
+                .expect("A zero-sized read should succeed");
+            prop_assert_eq!(result.as_ref(), &[] as &[u8]);
 
-                // Partial read from last byte
-                let result = database
-                    .read_bytes(&key, data.len() - 1, 1)
-                    .expect("A partial read should succeed");
-                prop_assert_eq!(result.as_ref(), &data[data.len() - 1..]);
-            }
-        });
+            // Partial read from last byte
+            let result = database
+                .read_bytes(&key, data.len() - 1, 1)
+                .expect("A partial read should succeed");
+            prop_assert_eq!(result.as_ref(), &data[data.len() - 1..]);
+        }
     });
 
     kv_test!(test_database_read_bytes_no_key, KV: BackgroundKeyValueStore, {
@@ -1066,67 +1083,71 @@ mod tests {
         assert_eq!(read_data_before, read_data);
     });
 
-    kv_test!(test_database_value_length, KV: BackgroundKeyValueStore, {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .build()
-            .expect("Creating a Tokio runtime should succeed");
-        let handle = runtime.handle();
-        let (_keepalive, repo) = KV::setup_repo();
-        proptest!(|(
-            keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..KEY_MAX_SIZE), 0..100),
-            data in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..100), 0..100)
-        )| {
-            let mut database = new_database::<KV>(handle, &repo);
+    kv_test!(test_database_value_length, KV: BackgroundKeyValueStore,
+        setup_runtime |handle, repo| = {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .build()
+                .expect("Creating a Tokio runtime should succeed");
+            let handle = runtime.handle().clone();
+            let (_keepalive, repo) = KV::setup_repo();
+            (runtime, handle, _keepalive, repo)
+        },
+    [
+        keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..KEY_MAX_SIZE), 0..100),
+        data in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..100), 0..100),
+    ], {
+        let mut database = new_database::<KV>(handle, repo);
 
-            for (key, data) in keys.iter().zip(data.iter()) {
-                let key = Key::new(key).expect("Size less than KEY_MAX_SIZE");
-                let data = Bytes::copy_from_slice(data);
+        for (key, data) in keys.iter().zip(data.iter()) {
+            let key = Key::new(key).expect("Size less than KEY_MAX_SIZE");
+            let data = Bytes::copy_from_slice(data);
 
+            database
+                .set(key.clone(), Bytes::copy_from_slice(&data))
+                .expect("Writing should succeed");
+            prop_assert_eq!(
                 database
-                    .set(key.clone(), Bytes::copy_from_slice(&data))
-                    .expect("Writing should succeed");
-                prop_assert_eq!(
-                    database
-                        .value_length(&key)
-                        .expect("Getting the value length should succeed"),
-                    data.len()
-                );
-            }
-        });
+                    .value_length(&key)
+                    .expect("Getting the value length should succeed"),
+                data.len()
+            );
+        }
     });
 
-    kv_test!(test_database_write, KV: BackgroundKeyValueStore, {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .build()
-            .expect("Creating a Tokio runtime should succeed");
-        let handle = runtime.handle();
-        let (_keepalive, repo) = KV::setup_repo();
-        proptest!(|(
-            keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..KEY_MAX_SIZE), 0..10),
-            offsets in prop::collection::vec(0..10usize, 0..10),
-            initial_data in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..200), 0..10),
-            patch in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..200), 0..10)
-        )| {
-            let mut database = new_database::<KV>(handle, &repo);
+    kv_test!(test_database_write, KV: BackgroundKeyValueStore,
+        setup_runtime |handle, repo| = {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .build()
+                .expect("Creating a Tokio runtime should succeed");
+            let handle = runtime.handle().clone();
+            let (_keepalive, repo) = KV::setup_repo();
+            (runtime, handle, _keepalive, repo)
+        },
+    [
+        keys in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..KEY_MAX_SIZE), 0..10),
+        offsets in prop::collection::vec(0..10usize, 0..10),
+        initial_data in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..200), 0..10),
+        patch in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..200), 0..10),
+    ], {
+        let mut database = new_database::<KV>(handle, repo);
 
-            for (((key, offset), initial_data), patch) in keys.iter().zip(offsets.iter()).zip(initial_data.iter()).zip(patch.iter()) {
-                let key = Key::new(key).expect("Size less than KEY_MAX_SIZE");
+        for (((key, offset), initial_data), patch) in keys.iter().zip(offsets.iter()).zip(initial_data.iter()).zip(patch.iter()) {
+            let key = Key::new(key).expect("Size less than KEY_MAX_SIZE");
 
-                let initial_data = Bytes::copy_from_slice(initial_data);
-                assert!(database.set(key.clone(), initial_data.clone()).is_ok());
+            let initial_data = Bytes::copy_from_slice(initial_data);
+            assert!(database.set(key.clone(), initial_data.clone()).is_ok());
 
-                let patch = Bytes::copy_from_slice(patch);
-                let expected_written = patch.len();
-                let result = database.write(key.clone(), *offset, patch.clone());
-                if *offset > initial_data.len() {
-                    prop_assert!(result.is_err());
-                } else {
-                    prop_assert_eq!(result.unwrap(), expected_written);
-                    let expected_length = std::cmp::max(initial_data.len(), offset + patch.len());
-                    prop_assert_eq!(database.value_length(&key).unwrap(), expected_length);
-                }
+            let patch = Bytes::copy_from_slice(patch);
+            let expected_written = patch.len();
+            let result = database.write(key.clone(), *offset, patch.clone());
+            if *offset > initial_data.len() {
+                prop_assert!(result.is_err());
+            } else {
+                prop_assert_eq!(result.unwrap(), expected_written);
+                let expected_length = std::cmp::max(initial_data.len(), offset + patch.len());
+                prop_assert_eq!(database.value_length(&key).unwrap(), expected_length);
             }
-        });
+        }
     });
 
     kv_test!(test_database_write_new_nonzero_offset, KV: BackgroundKeyValueStore, {
@@ -1342,7 +1363,8 @@ mod tests {
     });
 
     kv_test!(test_verify_database_delete, KV: BackgroundKeyValueStore, {
-        let mut database = new_verify_database::<KV>();
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut database = new_verify_database::<KV>(&repo);
         let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
 
         database
@@ -1375,69 +1397,73 @@ mod tests {
             .expect("Verify mode does not return `OperationError`s");
     });
 
-    kv_test!(test_verify_database_set_and_read, KV: BackgroundKeyValueStore, {
-        proptest!(|(data in prop::collection::vec(any::<u8>(), 0..200))| {
-            let mut database = new_verify_database::<KV>();
-            let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
+    kv_test!(test_verify_database_set_and_read, KV: BackgroundKeyValueStore,
+        setup |repo| = { KV::setup_repo() },
+    [
+        data in prop::collection::vec(any::<u8>(), 0..200),
+    ], {
+        let mut database = new_verify_database::<KV>(repo);
+        let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
 
-            database
-                .set(key.clone(), Bytes::copy_from_slice(&data))
-                .expect("Verify mode does not return `OperationError`s");
+        database
+            .set(key.clone(), Bytes::copy_from_slice(&data))
+            .expect("Verify mode does not return `OperationError`s");
 
-            let result = database
-                .read_bytes(&key, 0, data.len())
-                .expect("Verify mode does not return `OperationError`s");
-            prop_assert_eq!(result.as_ref(), data.as_slice());
-        });
+        let result = database
+            .read_bytes(&key, 0, data.len())
+            .expect("Verify mode does not return `OperationError`s");
+        prop_assert_eq!(result.as_ref(), data.as_slice());
     });
 
-    kv_test!(test_verify_database_value_length, KV: BackgroundKeyValueStore, {
-        proptest!(|(data in prop::collection::vec(any::<u8>(), 0..200))| {
-            let mut database = new_verify_database::<KV>();
-            let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
+    kv_test!(test_verify_database_value_length, KV: BackgroundKeyValueStore,
+        setup |repo| = { KV::setup_repo() },
+    [
+        data in prop::collection::vec(any::<u8>(), 0..200),
+    ], {
+        let mut database = new_verify_database::<KV>(repo);
+        let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
 
+        database
+            .set(key.clone(), Bytes::copy_from_slice(&data))
+            .expect("Verify mode does not return `OperationError`s");
+
+        prop_assert_eq!(
             database
-                .set(key.clone(), Bytes::copy_from_slice(&data))
-                .expect("Verify mode does not return `OperationError`s");
-
-            prop_assert_eq!(
-                database
-                    .value_length(&key)
-                    .expect("Verify mode does not return `OperationError`s"),
-                data.len()
-            );
-        });
+                .value_length(&key)
+                .expect("Verify mode does not return `OperationError`s"),
+            data.len()
+        );
     });
 
-    kv_test!(test_verify_database_write_partial, KV: BackgroundKeyValueStore, {
-        proptest!(|(
-            initial in prop::collection::vec(any::<u8>(), 1..200),
-            patch in prop::collection::vec(any::<u8>(), 0..200),
-            offset_frac in 0_usize..=100,
-        )| {
-            let offset = offset_frac * initial.len() / 100;
-            let patch_len = patch.len().min(initial.len() - offset);
-            let patch = &patch[..patch_len];
+    kv_test!(test_verify_database_write_partial, KV: BackgroundKeyValueStore,
+        setup |repo| = { KV::setup_repo() },
+    [
+        initial in prop::collection::vec(any::<u8>(), 1..200),
+        patch in prop::collection::vec(any::<u8>(), 0..200),
+        offset_frac in 0_usize..=100,
+    ], {
+        let offset = offset_frac * initial.len() / 100;
+        let patch_len = patch.len().min(initial.len() - offset);
+        let patch = &patch[..patch_len];
 
-            let mut database = new_verify_database::<KV>();
-            let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
+        let mut database = new_verify_database::<KV>(repo);
+        let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
 
-            database
-                .set(key.clone(), Bytes::copy_from_slice(&initial))
-                .expect("Verify mode does not return `OperationError`s");
+        database
+            .set(key.clone(), Bytes::copy_from_slice(&initial))
+            .expect("Verify mode does not return `OperationError`s");
 
-            let written = database
-                .write(key.clone(), offset, Bytes::copy_from_slice(patch))
-                .expect("Verify mode does not return `OperationError`s");
-            prop_assert_eq!(written, patch_len);
+        let written = database
+            .write(key.clone(), offset, Bytes::copy_from_slice(patch))
+            .expect("Verify mode does not return `OperationError`s");
+        prop_assert_eq!(written, patch_len);
 
-            let result = database
-                .read_bytes(&key, 0, initial.len())
-                .expect("Verify mode does not return `OperationError`s");
+        let result = database
+            .read_bytes(&key, 0, initial.len())
+            .expect("Verify mode does not return `OperationError`s");
 
-            let mut expected = initial.clone();
-            expected[offset..offset + patch_len].copy_from_slice(patch);
-            prop_assert_eq!(result.as_ref(), expected.as_slice());
-        });
+        let mut expected = initial.clone();
+        expected[offset..offset + patch_len].copy_from_slice(patch);
+        prop_assert_eq!(result.as_ref(), expected.as_slice());
     });
 }

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -58,8 +58,6 @@ use crate::storage::Loadable;
 use crate::storage::PersistentKeyValueStore;
 use crate::storage::Storable;
 use crate::storage::StoreOptions;
-#[cfg(test)]
-use crate::storage::TestKeyValueStoreSetup;
 
 /// A layer for transforming data into a Merkle-ised representation before commitment to a
 /// [`PersistentKeyValueStore`].
@@ -589,10 +587,8 @@ impl<KV> MerkleLayer<KV, Verify> {
 /// Construct a verify-mode [`MerkleLayer`] for an empty initial state. Used in tests that exercise
 /// verify-mode mutation primitives in isolation.
 #[cfg(test)]
-pub(crate) fn new_verify_layer<KV: KeyValueStore + TestKeyValueStoreSetup>()
--> MerkleLayer<KV, Verify> {
-    let (_keepalive, repo) = KV::setup_repo();
-    let normal_ml = new_merkle_layer::<KV>(&repo);
+pub(crate) fn new_verify_layer<KV: KeyValueStore>(repo: &KV::Repo) -> MerkleLayer<KV, Verify> {
+    let normal_ml = new_merkle_layer::<KV>(repo);
     let prove_ml = normal_ml.start_proof();
     let proof = MerkleProof::from_foldable(&prove_ml);
     MerkleLayer::from_proof(proof).expect("empty-tree proof should deserialise")
@@ -621,7 +617,6 @@ mod tests {
     use octez_riscv_data::mode::utils::catch_not_found;
     use proptest::prelude::*;
     use proptest::prop_assert_eq;
-    use proptest::proptest;
 
     use super::MerkleLayer;
     use super::MerkleLayerMode;
@@ -931,58 +926,60 @@ mod tests {
             .expect("the tree should be retrieved successfully.");
     });
 
-    kv_test!(test_mavl_cow_prop, KV, {
-        proptest!(|(keys1 in prop::collection::vec(any::<[u8; 2]>(), 0..500), keys2 in prop::collection::vec(any::<[u8; 2]>(), 0..500))| {
-            let data1 = bytes::Bytes::from("property");
-            let data2 = bytes::Bytes::from("cow");
+    kv_test!(test_mavl_cow_prop, KV,
+        setup |repo| = { KV::setup_repo() },
+    [
+        keys1 in prop::collection::vec(any::<[u8; 2]>(), 0..500),
+        keys2 in prop::collection::vec(any::<[u8; 2]>(), 0..500),
+    ], {
+        let data1 = bytes::Bytes::from("property");
+        let data2 = bytes::Bytes::from("cow");
 
-            let (_keepalive, repo) = KV::setup_repo();
-            let mut ml = new_merkle_layer::<KV>(&repo);
+        let mut ml = new_merkle_layer::<KV>(repo);
 
-            // Set all the keys in the tree
-            for bytes in &keys1 {
-                let key = Key::new(bytes).expect("Sizes less than KEY_MAX_SIZE");
-                ml.set(&key, &data1).expect("setting node should succeed");
-            }
+        // Set all the keys in the tree
+        for bytes in &keys1 {
+            let key = Key::new(bytes).expect("Sizes less than KEY_MAX_SIZE");
+            ml.set(&key, &data1).expect("setting node should succeed");
+        }
 
-            // Create a cheap copy
-            let original_hash = ml.hash();
-            let mut ml2 = ml.try_clone_with(ml.inner.persistence.clone());
+        // Create a cheap copy
+        let original_hash = ml.hash();
+        let mut ml2 = ml.try_clone_with(ml.inner.persistence.clone());
+        prop_assert_eq!(original_hash, ml2.hash());
+
+        // Delete all the keys in the copy
+        for bytes in &keys1 {
+            let key = Key::new(bytes).expect("Sizes less than KEY_MAX_SIZE");
+            ml2.delete(&key).expect("deleting node should succeed.");
+            prop_assert_eq!(ml2.get(&key).expect(""), None);
+        }
+
+        // Set new keys in the copy
+        for bytes in &keys2 {
+            let key = Key::new(bytes).expect("Sizes less than KEY_MAX_SIZE");
+            ml2.set(&key, &data2).expect("setting node should succeed");
+        }
+
+        if keys1.is_empty() && keys2.is_empty() {
             prop_assert_eq!(original_hash, ml2.hash());
+        } else {
+            prop_assert_ne!(original_hash, ml2.hash());
+        }
+        prop_assert_eq!(original_hash, ml.hash());
 
-            // Delete all the keys in the copy
-            for bytes in &keys1 {
-                let key = Key::new(bytes).expect("Sizes less than KEY_MAX_SIZE");
-                ml2.delete(&key).expect("deleting node should succeed.");
-                prop_assert_eq!(ml2.get(&key).expect(""), None);
-            }
+        // Check both trees are still correct
+        for bytes in &keys1 {
+            let key = Key::new(bytes).expect("Sizes less than KEY_MAX_SIZE");
+            prop_assert_eq!(ml.get(&key).expect("The node should be retrieved successfully").expect("The data should exist."), &data1);
+        }
+        for bytes in &keys2 {
+            let key = Key::new(bytes).expect("Sizes less than KEY_MAX_SIZE");
+            prop_assert_eq!(ml2.get(&key).expect("The node should be retrieved successfully").expect("The data should exist."), &data2);
+        }
 
-            // Set new keys in the copy
-            for bytes in &keys2 {
-                let key = Key::new(bytes).expect("Sizes less than KEY_MAX_SIZE");
-                ml2.set(&key, &data2).expect("setting node should succeed");
-            }
-
-            if keys1.is_empty() && keys2.is_empty() {
-                prop_assert_eq!(original_hash, ml2.hash());
-            } else {
-                prop_assert_ne!(original_hash, ml2.hash());
-            }
-            prop_assert_eq!(original_hash, ml.hash());
-
-            // Check both trees are still correct
-            for bytes in &keys1 {
-                let key = Key::new(bytes).expect("Sizes less than KEY_MAX_SIZE");
-                prop_assert_eq!(ml.get(&key).expect("The node should be retrieved successfully").expect("The data should exist."), &data1);
-            }
-            for bytes in &keys2 {
-                let key = Key::new(bytes).expect("Sizes less than KEY_MAX_SIZE");
-                prop_assert_eq!(ml2.get(&key).expect("The node should be retrieved successfully").expect("The data should exist."), &data2);
-            }
-
-            ml.tree().check(&ml.inner.resolver).expect("the tree should be retrieved successfully.");
-            ml2.tree().check(&ml2.inner.resolver).expect("the tree should be retrieved successfully.");
-        });
+        ml.tree().check(&ml.inner.resolver).expect("the tree should be retrieved successfully.");
+        ml2.tree().check(&ml2.inner.resolver).expect("the tree should be retrieved successfully.");
     });
 
     kv_test!(test_mavl_create, KV, {
@@ -1248,29 +1245,30 @@ mod tests {
         }
     });
 
-    kv_test!(test_mavl_create_prop, KV, {
-        proptest!(|(keys in prop::collection::vec(any::<[u8; 2]>(), 0..500))| {
-            let data = bytes::Bytes::from("property");
-            let (_keepalive, repo) = KV::setup_repo();
-            let mut ml = new_merkle_layer::<KV>(&repo);
-            let old_hash = ml.hash();
+    kv_test!(test_mavl_create_prop, KV,
+        setup |repo| = { KV::setup_repo() },
+    [
+        keys in prop::collection::vec(any::<[u8; 2]>(), 0..500),
+    ], {
+        let data = bytes::Bytes::from("property");
+        let mut ml = new_merkle_layer::<KV>(repo);
+        let old_hash = ml.hash();
 
-            for bytes in &keys {
-                let key = Key::new(bytes).expect("Sizes less than KEY_MAX_SIZE");
-                ml.set(&key, &data).expect("setting node should succeed");
-            }
+        for bytes in &keys {
+            let key = Key::new(bytes).expect("Sizes less than KEY_MAX_SIZE");
+            ml.set(&key, &data).expect("setting node should succeed");
+        }
 
-            if !keys.is_empty() {
-                assert_ne!(old_hash, ml.hash());
-            }
+        if !keys.is_empty() {
+            assert_ne!(old_hash, ml.hash());
+        }
 
-            for bytes in &keys {
-                let key = Key::new(bytes).expect("Sizes less than KEY_MAX_SIZE");
-                prop_assert_eq!(ml.get(&key).expect("The node should be retrieved successfully").expect("The data should exist."), &data);
-            }
+        for bytes in &keys {
+            let key = Key::new(bytes).expect("Sizes less than KEY_MAX_SIZE");
+            prop_assert_eq!(ml.get(&key).expect("The node should be retrieved successfully").expect("The data should exist."), &data);
+        }
 
-            ml.tree().check(&ml.inner.resolver).expect("the tree should be retrieved successfully.");
-        });
+        ml.tree().check(&ml.inner.resolver).expect("the tree should be retrieved successfully.");
     });
 
     kv_test!(test_mavl_delete, KV, {
@@ -1296,32 +1294,33 @@ mod tests {
             .expect("the tree should be retrieved successfully.");
     });
 
-    kv_test!(test_mavl_delete_prop, KV, {
-        proptest!(|(keys in prop::collection::vec(any::<[u8; 2]>(), 0..500))| {
-            let data = bytes::Bytes::from("delete_prop");
-            let (_keepalive, repo) = KV::setup_repo();
-            let mut ml = new_merkle_layer::<KV>(&repo);
-            let empty_hash = ml.hash();
+    kv_test!(test_mavl_delete_prop, KV,
+        setup |repo| = { KV::setup_repo() },
+    [
+        keys in prop::collection::vec(any::<[u8; 2]>(), 0..500),
+    ], {
+        let data = bytes::Bytes::from("delete_prop");
+        let mut ml = new_merkle_layer::<KV>(repo);
+        let empty_hash = ml.hash();
 
-            for bytes in &keys {
-                let key = Key::new(bytes).expect("Sizes less than KEY_MAX_SIZE");
-                ml.set(&key, &data).expect("setting node should succeed");
-            }
+        for bytes in &keys {
+            let key = Key::new(bytes).expect("Sizes less than KEY_MAX_SIZE");
+            ml.set(&key, &data).expect("setting node should succeed");
+        }
 
-            if !keys.is_empty() {
-                prop_assert_ne!(empty_hash, ml.hash());
-            }
+        if !keys.is_empty() {
+            prop_assert_ne!(empty_hash, ml.hash());
+        }
 
-            for bytes in &keys {
-                let key = Key::new(bytes).expect("Sizes less than KEY_MAX_SIZE");
-                ml.delete(&key).expect("delete should succeed.");
-                prop_assert_eq!(ml.get(&key).expect("The node should be retrieved successfully."), None);
-            }
+        for bytes in &keys {
+            let key = Key::new(bytes).expect("Sizes less than KEY_MAX_SIZE");
+            ml.delete(&key).expect("delete should succeed.");
+            prop_assert_eq!(ml.get(&key).expect("The node should be retrieved successfully."), None);
+        }
 
-            prop_assert_eq!(empty_hash, ml.hash());
+        prop_assert_eq!(empty_hash, ml.hash());
 
-            ml.tree().check(&ml.inner.resolver).expect("the tree should be retrieved successfully.");
-        });
+        ml.tree().check(&ml.inner.resolver).expect("the tree should be retrieved successfully.");
     });
 
     fn test_mavl_delete_keys<KV: KeyValueStore>(repo: &KV::Repo, keys: &[Key]) {
@@ -1555,42 +1554,43 @@ mod tests {
             .expect("the tree should be retrieved successfully.");
     });
 
-    kv_test!(test_mavl_write_prop, KV, {
-        proptest!(|(keys in prop::collection::vec(any::<[u8; 2]>(), 0..10))| {
-            let data = bytes::Bytes::from(vec![0; 500]);
-            let alternating = bytes::Bytes::from([1, 0]
-                .iter()
-                .cycle()
-                .take(500)
-                .cloned()
-                .collect::<Vec<_>>());
+    kv_test!(test_mavl_write_prop, KV,
+        setup |repo| = { KV::setup_repo() },
+    [
+        keys in prop::collection::vec(any::<[u8; 2]>(), 0..10),
+    ], {
+        let data = bytes::Bytes::from(vec![0; 500]);
+        let alternating = bytes::Bytes::from([1, 0]
+            .iter()
+            .cycle()
+            .take(500)
+            .cloned()
+            .collect::<Vec<_>>());
 
-            let (_keepalive, repo) = KV::setup_repo();
-            let mut ml = new_merkle_layer::<KV>(&repo);
-            let old_hash = ml.hash();
+        let mut ml = new_merkle_layer::<KV>(repo);
+        let old_hash = ml.hash();
 
-            for bytes in &keys {
-                let key = Key::new(bytes).expect("Sizes less than KEY_MAX_SIZE");
-                ml.set(&key, &data).expect("setting node should succeed");
-                for offset in 0..250 {
-                    ml.write(&key, offset * 2, &[1]).expect("write should succeed.");
-                }
+        for bytes in &keys {
+            let key = Key::new(bytes).expect("Sizes less than KEY_MAX_SIZE");
+            ml.set(&key, &data).expect("setting node should succeed");
+            for offset in 0..250 {
+                ml.write(&key, offset * 2, &[1]).expect("write should succeed.");
             }
+        }
 
-            if !keys.is_empty() {
-                assert_ne!(old_hash, ml.hash());
-            }
+        if !keys.is_empty() {
+            assert_ne!(old_hash, ml.hash());
+        }
 
-            for bytes in &keys {
-                let key = Key::new(bytes).expect("Sizes less than KEY_MAX_SIZE");
-                prop_assert_eq!(ml.get(&key)
-                                .expect("The node should be retrieved successfully")
-                                .expect("The data should exist."),
-                                &alternating);
-            }
+        for bytes in &keys {
+            let key = Key::new(bytes).expect("Sizes less than KEY_MAX_SIZE");
+            prop_assert_eq!(ml.get(&key)
+                            .expect("The node should be retrieved successfully")
+                            .expect("The data should exist."),
+                            &alternating);
+        }
 
-            ml.tree().check(&ml.inner.resolver).expect("the tree should be retrieved successfully.");
-        });
+        ml.tree().check(&ml.inner.resolver).expect("the tree should be retrieved successfully.");
     });
 
     #[derive(Debug, Clone)]
@@ -1635,93 +1635,94 @@ mod tests {
             })
     }
 
-    kv_test!(test_merkle_layer_checkout_lazy_from_commit, KV: PersistentKeyValueStore, {
-        proptest!(|(operations in (1usize..100usize).prop_flat_map(generated_operations_strategy))| {
-            use std::collections::BTreeMap;
-            use std::collections::BTreeSet;
+    kv_test!(test_merkle_layer_checkout_lazy_from_commit, KV: PersistentKeyValueStore,
+        setup |repo| = { KV::setup_repo() },
+    [
+        operations in (1usize..100usize).prop_flat_map(generated_operations_strategy),
+    ], {
+        use std::collections::BTreeMap;
+        use std::collections::BTreeSet;
 
-            let (_keepalive, repo) = KV::setup_repo();
-            let persistence: Arc<KV> = KV::new(&repo)
-                .expect("Creating a persistence layer should succeed")
-                .into();
+        let persistence: Arc<KV> = KV::new(repo)
+            .expect("Creating a persistence layer should succeed")
+            .into();
 
-            let mut merkle_layer = MerkleLayer::new(persistence.clone());
-            let mut reference: BTreeMap<Key, Vec<u8>> = BTreeMap::new();
-            let mut touched: BTreeSet<Key> = BTreeSet::new();
+        let mut merkle_layer = MerkleLayer::new(persistence.clone());
+        let mut reference: BTreeMap<Key, Vec<u8>> = BTreeMap::new();
+        let mut touched: BTreeSet<Key> = BTreeSet::new();
 
-            for operation in operations {
-                match operation {
-                    GeneratedOperation::Set(bytes, value) => {
-                        let key = Key::new(&bytes).expect("Size less than KEY_MAX_SIZE");
-                        merkle_layer
-                            .set(&key, &value)
-                            .expect("Set operation should succeed");
-                        reference.insert(key.clone(), value);
-                        touched.insert(key);
-                    }
-                    GeneratedOperation::Write(bytes, value, offset_hint) => {
-                        let key = Key::new(&bytes).expect("Size less than KEY_MAX_SIZE");
-                        let offset = match reference.get(&key) {
-                            Some(existing) if !existing.is_empty() => {
-                                1 + (offset_hint as usize % existing.len())
-                            }
-                            _ => 0,
-                        };
-
-                        merkle_layer
-                            .write(&key, offset, &value)
-                            .expect("Write operation should succeed");
-
-                        let entry = reference.entry(key.clone()).or_default();
-                        let new_len = offset
-                            .checked_add(value.len())
-                            .expect("Generated offset and value length should not overflow");
-                        if entry.len() < new_len {
-                            entry.resize(new_len, 0);
+        for operation in operations {
+            match operation {
+                GeneratedOperation::Set(bytes, value) => {
+                    let key = Key::new(&bytes).expect("Size less than KEY_MAX_SIZE");
+                    merkle_layer
+                        .set(&key, &value)
+                        .expect("Set operation should succeed");
+                    reference.insert(key.clone(), value);
+                    touched.insert(key);
+                }
+                GeneratedOperation::Write(bytes, value, offset_hint) => {
+                    let key = Key::new(&bytes).expect("Size less than KEY_MAX_SIZE");
+                    let offset = match reference.get(&key) {
+                        Some(existing) if !existing.is_empty() => {
+                            1 + (offset_hint as usize % existing.len())
                         }
-                        entry[offset..new_len].copy_from_slice(&value);
-                        touched.insert(key);
+                        _ => 0,
+                    };
+
+                    merkle_layer
+                        .write(&key, offset, &value)
+                        .expect("Write operation should succeed");
+
+                    let entry = reference.entry(key.clone()).or_default();
+                    let new_len = offset
+                        .checked_add(value.len())
+                        .expect("Generated offset and value length should not overflow");
+                    if entry.len() < new_len {
+                        entry.resize(new_len, 0);
                     }
-                    GeneratedOperation::Delete(bytes) => {
-                        let key = Key::new(&bytes).expect("Sizes less than KEY_MAX_SIZE");
-                        merkle_layer
-                            .delete(&key)
-                            .expect("Delete operation should succeed");
-                        reference.remove(&key);
-                        touched.insert(key);
-                    }
+                    entry[offset..new_len].copy_from_slice(&value);
+                    touched.insert(key);
+                }
+                GeneratedOperation::Delete(bytes) => {
+                    let key = Key::new(&bytes).expect("Sizes less than KEY_MAX_SIZE");
+                    merkle_layer
+                        .delete(&key)
+                        .expect("Delete operation should succeed");
+                    reference.remove(&key);
+                    touched.insert(key);
                 }
             }
+        }
 
-            let expected_hash = merkle_layer.hash();
-            let commit_opts = crate::storage::StoreOptions::default().with_deep().with_node_data();
-            let commit_id = merkle_layer.commit(&commit_opts).expect("Commit operation should succeed");
+        let expected_hash = merkle_layer.hash();
+        let commit_opts = crate::storage::StoreOptions::default().with_deep().with_node_data();
+        let commit_id = merkle_layer.commit(&commit_opts).expect("Commit operation should succeed");
 
-            let mut lazy_loaded = MerkleLayer::checkout(persistence, commit_id)
-                .expect("Lazy checkout should succeed");
-            let loaded_hash = lazy_loaded.hash();
+        let mut lazy_loaded = MerkleLayer::checkout(persistence, commit_id)
+            .expect("Lazy checkout should succeed");
+        let loaded_hash = lazy_loaded.hash();
 
-            prop_assert_eq!(loaded_hash, expected_hash);
+        prop_assert_eq!(loaded_hash, expected_hash);
 
-            for key in touched {
-                let expected = reference.get(&key);
-                let loaded = lazy_loaded
-                    .get(&key)
-                    .expect("Lookup in lazy-loaded tree should succeed");
+        for key in touched {
+            let expected = reference.get(&key);
+            let loaded = lazy_loaded
+                .get(&key)
+                .expect("Lookup in lazy-loaded tree should succeed");
 
-                match (expected, loaded) {
-                    (Some(expected), Some(loaded)) => {
-                        let mut loaded_bytes = vec![0; loaded.len()];
-                        let bytes_read = loaded.read(0, &mut loaded_bytes);
-                        prop_assert_eq!(bytes_read, loaded_bytes.len());
-                        prop_assert_eq!(loaded_bytes.as_slice(), expected.as_slice());
-                    }
-                    (None, None) => {}
-                    (Some(_), None) => panic!("Expected an existing key in lazy-loaded tree: {key:?}"),
-                    (None, Some(_)) => panic!("Expected a missing key in lazy-loaded tree: {key:?}"),
+            match (expected, loaded) {
+                (Some(expected), Some(loaded)) => {
+                    let mut loaded_bytes = vec![0; loaded.len()];
+                    let bytes_read = loaded.read(0, &mut loaded_bytes);
+                    prop_assert_eq!(bytes_read, loaded_bytes.len());
+                    prop_assert_eq!(loaded_bytes.as_slice(), expected.as_slice());
                 }
+                (None, None) => {}
+                (Some(_), None) => panic!("Expected an existing key in lazy-loaded tree: {key:?}"),
+                (None, Some(_)) => panic!("Expected a missing key in lazy-loaded tree: {key:?}"),
             }
-        });
+        }
     });
 
     // - Add some data to the Merkle layer.
@@ -1965,7 +1966,8 @@ mod tests {
     kv_test!(test_verify_delete, KV, {
         let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
 
-        let mut ml: MerkleLayer<KV, Verify> = new_verify_layer::<KV>();
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut ml: MerkleLayer<KV, Verify> = new_verify_layer::<KV>(&repo);
         ml.delete(&key)
             .expect("deleting a key that doesn't exist should succeed");
 
@@ -1984,7 +1986,8 @@ mod tests {
             .map(|r| r.expect("Size less than KEY_MAX_SIZE"));
         let data: [&[u8]; 3] = [b"too cold", b"too hot", b"just right"];
 
-        let mut ml: MerkleLayer<KV, Verify> = new_verify_layer::<KV>();
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut ml: MerkleLayer<KV, Verify> = new_verify_layer::<KV>(&repo);
         for (key, datum) in keys.iter().zip(data.iter()) {
             ml.set(key, datum).expect("setting node should succeed");
         }
@@ -2001,12 +2004,12 @@ mod tests {
     kv_test!(test_verify_try_clone_with_cow, KV, {
         let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
 
-        let mut ml: MerkleLayer<KV, Verify> = new_verify_layer::<KV>();
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut ml: MerkleLayer<KV, Verify> = new_verify_layer::<KV>(&repo);
         let cow_data = "🐮<(verify a moo!)";
         ml.set(&key, cow_data.as_bytes())
             .expect("setting node should succeed");
 
-        let (_keepalive, repo) = KV::setup_repo();
         let kv: Arc<KV> = KV::new(&repo)
             .expect("Creating a persistence layer should succeed")
             .into();
@@ -2034,7 +2037,8 @@ mod tests {
     kv_test!(test_verify_write_partial, KV, {
         let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
 
-        let mut ml: MerkleLayer<KV, Verify> = new_verify_layer::<KV>();
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut ml: MerkleLayer<KV, Verify> = new_verify_layer::<KV>(&repo);
         ml.set(&key, b"partial")
             .expect("setting node should succeed");
         ml.write(&key, 4, b"ying").expect("write should succeed");
@@ -2180,127 +2184,134 @@ mod tests {
         );
     });
 
-    kv_test!(prove_verify_round_trips_mixed, KV, {
-        proptest!(|(setup_keys in prop::collection::vec(any::<[u8; 2]>(), 1..30), seed in 0..100usize)| {
-            let keys: Vec<Key> = setup_keys
-                .iter()
-                .map(|b| Key::new(b).expect("key should be valid"))
-                .collect();
+    kv_test!(prove_verify_round_trips_mixed, KV,
+    [
+        setup_keys in prop::collection::vec(any::<[u8; 2]>(), 1..30),
+        seed in 0..100usize,
+    ], {
+        let keys: Vec<Key> = setup_keys
+            .iter()
+            .map(|b| Key::new(b).expect("key should be valid"))
+            .collect();
 
-            let mut operations = Vec::new();
-            // TODO RV-985: Expand to more operations in each test.
-            // This is currently limited to one operation, as this is the minimum requirement,
-            // and proof semantics are not supported for more than one operation yet.
-            let ops_count = 1;
-            for i in 0..ops_count {
-                let key = keys[i % keys.len()].clone();
-                let data = vec![seed as u8; 5];
-                match (i + seed) % 3 {
-                    0 => operations.push(Operation::Set(key, data)),
-                    1 => operations.push(Operation::Delete(key)),
-                    _ => {
-                        // All setup keys have data set to 10 bytes long.
-                        // Data length is 5 bytes, so valid offsets are 0..=5.
-                        let offset = (i + seed) % 5;
-                        operations.push(Operation::Write(key, offset, data));
-                    }
+        let mut operations = Vec::new();
+        // TODO RV-985: Expand to more operations in each test.
+        // This is currently limited to one operation, as this is the minimum requirement,
+        // and proof semantics are not supported for more than one operation yet.
+        let ops_count = 1;
+        for i in 0..ops_count {
+            let key = keys[i % keys.len()].clone();
+            let data = vec![seed as u8; 5];
+            match (i + seed) % 3 {
+                0 => operations.push(Operation::Set(key, data)),
+                1 => operations.push(Operation::Delete(key)),
+                _ => {
+                    // All setup keys have data set to 10 bytes long.
+                    // Data length is 5 bytes, so valid offsets are 0..=5.
+                    let offset = (i + seed) % 5;
+                    operations.push(Operation::Write(key, offset, data));
                 }
             }
+        }
 
-            assert_prove_mode_correct::<KV>(&setup_keys, &operations);
-        });
+        assert_prove_mode_correct::<KV>(&setup_keys, &operations);
     });
 
-    kv_test!(prove_verify_round_trips_writes_only, KV, {
-        // no structural change as every key already exists.
-        proptest!(|(
-            setup_keys in prop::collection::vec(any::<[u8; 2]>(), 1..30),
-            // Setup keys are written with their own 2-byte representation as data, so the only
-            // valid offsets for an in-place / appending write are 0..=2.
-            offsets in prop::collection::vec(0usize..=2, 1..30),
-        )| {
-            let keys: Vec<Key> = setup_keys
-                .iter()
-                .map(|b| Key::new(b).expect("key should be valid"))
-                .collect();
+    // no structural change as every key already exists.
+    kv_test!(prove_verify_round_trips_writes_only, KV,
+    [
+        setup_keys in prop::collection::vec(any::<[u8; 2]>(), 1..30),
+        // Setup keys are written with their own 2-byte representation as data, so the only
+        // valid offsets for an in-place / appending write are 0..=2.
+        offsets in prop::collection::vec(0usize..=2, 1..30),
+    ], {
+        let keys: Vec<Key> = setup_keys
+            .iter()
+            .map(|b| Key::new(b).expect("key should be valid"))
+            .collect();
 
-            let step_ops: Vec<Operation> = keys
-                .iter()
-                .enumerate()
-                .map(|(i, key)| {
-                    let offset = offsets[i % offsets.len()];
-                    Operation::Write(key.clone(), offset, vec![0xAA; 1 + (i % 8)])
-                })
-                .collect();
+        let step_ops: Vec<Operation> = keys
+            .iter()
+            .enumerate()
+            .map(|(i, key)| {
+                let offset = offsets[i % offsets.len()];
+                Operation::Write(key.clone(), offset, vec![0xAA; 1 + (i % 8)])
+            })
+            .collect();
 
-            assert_prove_mode_correct::<KV>(&setup_keys, &step_ops);
-        });
+        assert_prove_mode_correct::<KV>(&setup_keys, &step_ops);
     });
 
-    kv_test!(prove_verify_round_trips_deletes_only, KV, {
-        proptest!(|(setup_keys in prop::collection::vec(any::<[u8; 2]>(), 1..30), delete_indices in prop::collection::vec(any::<usize>(), 1..10))| {
-            let keys: Vec<Key> = setup_keys
-                .iter()
-                .map(|b| Key::new(b).expect("key should be valid"))
-                .collect();
+    kv_test!(prove_verify_round_trips_deletes_only, KV,
+    [
+        setup_keys in prop::collection::vec(any::<[u8; 2]>(), 1..30),
+        delete_indices in prop::collection::vec(any::<usize>(), 1..10),
+    ], {
+        let keys: Vec<Key> = setup_keys
+            .iter()
+            .map(|b| Key::new(b).expect("key should be valid"))
+            .collect();
 
-            let step_ops: Vec<Operation> = delete_indices
-                .iter()
-                .map(|&i| Operation::Delete(keys[i % keys.len()].clone()))
-                .collect();
+        let step_ops: Vec<Operation> = delete_indices
+            .iter()
+            .map(|&i| Operation::Delete(keys[i % keys.len()].clone()))
+            .collect();
 
-            assert_prove_mode_correct::<KV>(&setup_keys, &step_ops);
-        });
+        assert_prove_mode_correct::<KV>(&setup_keys, &step_ops);
     });
 
-    kv_test!(prove_verify_round_trips_insertions, KV, {
-        // prove_verify_insertions: sets on new keys (insertions + rotations)
-        proptest!(|(setup_keys in prop::collection::vec(any::<[u8; 2]>(), 1..20), new_keys in prop::collection::vec(any::<[u8; 2]>(), 1..10))| {
-            let step_ops: Vec<Operation> = new_keys
-                .iter()
-                // ensure we don't accidentally mix insertions with overwritting old keys
-                // - the proof system doesn't currently support this
-                // TODO (RV-985): remove this line
-                .filter(|bytes| !setup_keys.contains(bytes))
-                .enumerate()
-                .map(|(i, bytes)| {
-                    let key = Key::new(bytes).expect("key should be valid");
-                    Operation::Set(key, vec![0xBB; 1 + (i % 8)])
-                })
-                .collect();
-
-            assert_prove_mode_correct::<KV>(&setup_keys, &step_ops);
-        });
-    });
-
-    kv_test!(prove_verify_round_trip_reads_only, KV, {
-        proptest!(|(setup_keys in prop::collection::vec(any::<[u8; 2]>(), 1..30), read_indices in prop::collection::vec(any::<usize>(), 1..15))| {
-            let (_keepalive, repo) = KV::setup_repo();
-            let mut normal_ml = new_merkle_layer::<KV>(&repo);
-
-            for bytes in &setup_keys {
+    // prove_verify_insertions: sets on new keys (insertions + rotations)
+    kv_test!(prove_verify_round_trips_insertions, KV,
+    [
+        setup_keys in prop::collection::vec(any::<[u8; 2]>(), 1..20),
+        new_keys in prop::collection::vec(any::<[u8; 2]>(), 1..10),
+    ], {
+        let step_ops: Vec<Operation> = new_keys
+            .iter()
+            // ensure we don't accidentally mix insertions with overwritting old keys
+            // - the proof system doesn't currently support this
+            // TODO (RV-985): remove this line
+            .filter(|bytes| !setup_keys.contains(bytes))
+            .enumerate()
+            .map(|(i, bytes)| {
                 let key = Key::new(bytes).expect("key should be valid");
-                normal_ml.set(&key, bytes).expect("set should succeed");
-            }
+                Operation::Set(key, vec![0xBB; 1 + (i % 8)])
+            })
+            .collect();
 
-            let normal_hash = normal_ml.hash();
-            let prove_ml = normal_ml.start_proof();
+        assert_prove_mode_correct::<KV>(&setup_keys, &step_ops);
+    });
 
-            for &i in &read_indices {
-                let key = Key::new(&setup_keys[i % setup_keys.len()]).expect("key should be valid");
-                let _ = prove_ml.get(&key).expect("get should succeed");
-            }
+    kv_test!(prove_verify_round_trip_reads_only, KV,
+    [
+        setup_keys in prop::collection::vec(any::<[u8; 2]>(), 1..30),
+        read_indices in prop::collection::vec(any::<usize>(), 1..15),
+    ], {
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut normal_ml = new_merkle_layer::<KV>(&repo);
 
-            prop_assert_eq!(
-                normal_hash,
-                prove_ml.hash(),
-            );
+        for bytes in &setup_keys {
+            let key = Key::new(bytes).expect("key should be valid");
+            normal_ml.set(&key, bytes).expect("set should succeed");
+        }
 
-            let proof = MerkleProof::from_foldable(&prove_ml);
-            prop_assert_eq!(
-                normal_hash,
-                proof.root_hash(),
-            );
-        });
+        let normal_hash = normal_ml.hash();
+        let prove_ml = normal_ml.start_proof();
+
+        for &i in &read_indices {
+            let key = Key::new(&setup_keys[i % setup_keys.len()]).expect("key should be valid");
+            let _ = prove_ml.get(&key).expect("get should succeed");
+        }
+
+        prop_assert_eq!(
+            normal_hash,
+            prove_ml.hash(),
+        );
+
+        let proof = MerkleProof::from_foldable(&prove_ml);
+        prop_assert_eq!(
+            normal_hash,
+            proof.root_hash(),
+        );
     });
 }

--- a/durable-storage/src/merkle_worker.rs
+++ b/durable-storage/src/merkle_worker.rs
@@ -312,6 +312,7 @@ mod tests {
     use crate::key::Key;
     use crate::merkle_layer::MerkleLayer;
     use crate::merkle_worker::MerkleWorker;
+    use crate::storage::KeyValueStore;
     use crate::storage::kv_test;
 
     fn key_strategy() -> impl Strategy<Value = Key> {
@@ -451,31 +452,33 @@ mod tests {
         }
     }
 
-    kv_test!(commands, KV: super::BackgroundPersistentKeyValueStore, {
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(2)
-            .build()
-            .expect("Creating a Tokio runtime should succeed");
-        let handle = runtime.handle();
+    kv_test!(commands, KV: super::BackgroundPersistentKeyValueStore,
+        setup_runtime |handle, repo| = {
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(2)
+                .build()
+                .expect("Creating a Tokio runtime should succeed");
+            let handle = runtime.handle().clone();
+            let (_keepalive, repo) = KV::setup_repo();
+            (runtime, handle, _keepalive, repo)
+        },
+    [
+        commands in proptest::collection::vec(TestCommand::strategy(), 1..100),
+    ], {
+        let persistence_layer = KV::new(repo).expect("Creating a persistence layer should succeed");
+        let persistence_layer = Arc::new(persistence_layer);
+        let mut merkle_layer = MerkleLayer::new(persistence_layer);
 
-        let (_keepalive, repo) = KV::setup_repo();
+        let persistence_worker = KV::new(repo).expect("Creating a persistence layer should succeed");
+        let persistence_worker = Arc::new(persistence_worker);
+        let mut merkle_worker = MerkleWorker::new(handle, persistence_worker);
 
-        proptest::proptest!(|(commands in proptest::collection::vec(TestCommand::strategy(), 1..100))| {
-            let persistence_layer = KV::new(&repo).expect("Creating a persistence layer should succeed");
-            let persistence_layer = Arc::new(persistence_layer);
-            let mut merkle_layer = MerkleLayer::new(persistence_layer);
+        for command in commands {
+            command.run::<KV>(handle, repo, &mut merkle_worker, &mut merkle_layer);
+        }
 
-            let persistence_worker = KV::new(&repo).expect("Creating a persistence layer should succeed");
-            let persistence_worker = Arc::new(persistence_worker);
-            let mut merkle_worker = MerkleWorker::new(handle, persistence_worker);
-
-            for command in commands {
-                command.run::<KV>(handle, &repo, &mut merkle_worker, &mut merkle_layer);
-            }
-
-            let layer_hash = merkle_layer.hash();
-            let worker_hash = merkle_worker.hash().unwrap();
-            prop_assert_eq!(layer_hash, worker_hash);
-        });
+        let layer_hash = merkle_layer.hash();
+        let worker_hash = merkle_worker.hash().unwrap();
+        prop_assert_eq!(layer_hash, worker_hash);
     });
 }

--- a/durable-storage/src/registry.rs
+++ b/durable-storage/src/registry.rs
@@ -408,6 +408,7 @@ pub(super) mod tests {
     use crate::merkle_worker::BackgroundKeyValueStore;
     use crate::merkle_worker::BackgroundPersistentKeyValueStore;
     use crate::repo::RegistryRepo;
+    use crate::storage::TestKeyValueStoreSetup;
     use crate::storage::kv_test;
 
     pub(super) fn setup_registry<KV: BackgroundKeyValueStore>(

--- a/durable-storage/src/storage.rs
+++ b/durable-storage/src/storage.rs
@@ -149,34 +149,183 @@ cfg_if::cfg_if! {
             }
         }
 
-        /// Macro that runs a test against every available KV backend.
+        /// Macro which runs a test against every available KV backend and compares traces.
         ///
-        /// Without the `rocksdb` feature this expands to a single `#[test]` using the in-memory store.
-        /// With the `rocksdb` feature it expands to 2 tests, one using the in-memory store and one
-        /// using the persistence layer.
+        /// It can be used in 3 ways, one for unit tests, one for property-based tests with no
+        /// setup before the proptest loop, and one for property-based tests with setup:
+        ///
+        /// 1. `kv_test!(name, KV: Bound, { body })`:
+        ///    Expands to a single `#[test]` whose body runs once per available backend.
+        ///    When the `rocksdb` flag is off the test only runs with the in-memory backend.
+        ///    When it is on, the test runs twice, once with the persistence layer and once
+        ///    with the in-memory backend.
+        ///
+        /// 2. `kv_test!(name, KV: Bound, [args in strategies], { body })`:
+        ///    Expands to a single `#[test]` running one `proptest!` over the given strategies.
+        ///    Each iteration runs the body once per available backend with the same
+        ///    proptest-generated inputs.
+        ///
+        /// 3. `kv_test!(name, KV: Bound, <setup>, [args in strategies], { body })`:
+        ///    Same as 2, with `<setup>` which runs once per backend before the proptest loop.
+        ///    It must be one of:
+        ///    - `setup |repo| = { ... }` for tests that only need a repo. The block
+        ///      must return `(KV::Keepalive, KV::Repo)`. Inside the test body only
+        ///      `repo: &KV::Repo` is exposed.
+        ///    - `setup_runtime |handle, repo| = { ... }` for tests that need a Tokio
+        ///      runtime. The block must return `(Runtime, Handle, KV::Keepalive, KV::Repo)`.
+        ///      Inside the test body, `handle: &Handle` and `repo: &KV::Repo` are exposed.
+        ///
+        /// Note: For PBTs, in order to run the test body twice, the generated inputs are cloned.
+        /// For this to be valid, cloning must create a deep copy. This means that proptests over
+        /// pointers should not be run with this macro.
+        ///
+        /// In both cases, the "return" value of the body is taken to be a trace. The traces
+        /// produced by the 2 runs / iterations are then compared.
         macro_rules! kv_test {
-            ($(#[$attr:meta])* $fun_name:ident, $ty_name:ident $(: $ty_bound:path)?, $body:block) => {
-                paste::paste! {
-                    $(#[$attr])*
-                    #[test]
-                    fn [<$fun_name _in_memory>]() {
-                        fn inner<$ty_name: $crate::storage::TestKeyValueStoreSetup $(+ $ty_bound)?>()
-                        where
-                            <$ty_name as $crate::storage::KeyValueStore>::Repo: $crate::repo::RegistryRepo,
-                        $body
-                        inner::<$crate::storage::in_memory::InMemoryKeyValueStore>();
+            // Property-based test variant with no setup.
+            // Forwards to the shared `@prop_test` arm with an empty setup.
+            ($(#[$attr:meta])* $fun_name:ident, $ty_name:ident $(: $ty_bound:path)?,
+             [$($arg:ident in $strat:expr),* $(,)?],
+             $body:block) => {
+                $crate::storage::kv_test!(@prop_test
+                    $(#[$attr])* $fun_name, $ty_name $(: $ty_bound)?,
+                    ret_ty = (),
+                    setup_values = _unused,
+                    setup = {},
+                    args = [$($arg in $strat),*],
+                    body = $body
+                );
+            };
+
+            // Property-based test variant with `setup`.
+            // Forwards to the shared `@prop_test` arm with the setup tuple shape.
+            ($(#[$attr:meta])* $fun_name:ident, $ty_name:ident $(: $ty_bound:path)?,
+             setup |$repo:ident| = $setup:block,
+             [$($arg:ident in $strat:expr),* $(,)?],
+             $body:block) => {
+                $crate::storage::kv_test!(@prop_test
+                    $(#[$attr])* $fun_name, $ty_name $(: $ty_bound)?,
+                    ret_ty = (
+                        <$ty_name as $crate::storage::TestKeyValueStoreSetup>::Keepalive,
+                        <$ty_name as $crate::storage::KeyValueStore>::Repo,
+                    ),
+                    setup_values = (_keepalive, $repo),
+                    setup = $setup,
+                    args = [$($arg in $strat),*],
+                    body = $body
+                );
+            };
+
+            // Property-based test variant with `setup_runtime`.
+            // Forwards to the shared `@prop_test` arm with the setup tuple shape.
+            ($(#[$attr:meta])* $fun_name:ident, $ty_name:ident $(: $ty_bound:path)?,
+             setup_runtime |$handle:ident, $repo:ident| = $setup:block,
+             [$($arg:ident in $strat:expr),* $(,)?],
+             $body:block) => {
+                $crate::storage::kv_test!(@prop_test
+                    $(#[$attr])* $fun_name, $ty_name $(: $ty_bound)?,
+                    ret_ty = (
+                        ::tokio::runtime::Runtime,
+                        ::tokio::runtime::Handle,
+                        <$ty_name as $crate::storage::TestKeyValueStoreSetup>::Keepalive,
+                        <$ty_name as $crate::storage::KeyValueStore>::Repo,
+                    ),
+                    setup_values = (_runtime, $handle, _keepalive, $repo),
+                    setup = $setup,
+                    args = [$($arg in $strat),*],
+                    body = $body
+                );
+            };
+
+            // Internal arm for property-based tests
+            (@prop_test
+             $(#[$attr:meta])* $fun_name:ident, $ty_name:ident $(: $ty_bound:path)?,
+             ret_ty = $ret_ty:ty,
+             setup_values = $setup_values:tt,
+             setup = $setup:block,
+             args = [$($arg:ident in $strat:expr),* $(,)?],
+             body = $body:block) => {
+                $(#[$attr])*
+                #[test]
+                fn $fun_name() {
+                    fn _kv_test_setup<
+                        $ty_name: $crate::storage::TestKeyValueStoreSetup
+                                $(+ $ty_bound)?,
+                    >() -> $ret_ty
+                    where
+                        <$ty_name as $crate::storage::KeyValueStore>::Repo:
+                            $crate::repo::RegistryRepo,
+                    {
+                        $setup
                     }
 
                     #[cfg(feature = "rocksdb")]
-                    $(#[$attr])*
-                    #[test]
-                    fn [<$fun_name _rocksdb>]() {
-                        fn inner<$ty_name: $crate::storage::TestKeyValueStoreSetup $(+ $ty_bound)?>()
-                        where
-                            <$ty_name as $crate::storage::KeyValueStore>::Repo: $crate::repo::RegistryRepo,
+                    let rocksdb_setup =
+                        _kv_test_setup::<$crate::persistence_layer::PersistenceLayer>();
+
+                    let in_memory_setup =
+                        _kv_test_setup::<$crate::storage::in_memory::InMemoryKeyValueStore>();
+
+                    ::proptest::proptest!(|($($arg in $strat),*)| {
+                        #[cfg(feature = "rocksdb")]
+                        let rocksdb_trace = {
+                            type $ty_name = $crate::persistence_layer::PersistenceLayer;
+                            let $setup_values = &rocksdb_setup;
+                            eprintln!("Running test with persistence layer");
+                            $(let $arg = ::std::clone::Clone::clone(&$arg);)*
+                            $body
+                        };
+
+                        let _in_memory_trace = {
+                            type $ty_name = $crate::storage::in_memory::InMemoryKeyValueStore;
+                            let $setup_values = &in_memory_setup;
+                            eprintln!("Running test with in-memory backend");
+                            $body
+                        };
+
+                        #[cfg(feature = "rocksdb")]
+                        ::proptest::prop_assert_eq!(
+                            rocksdb_trace, _in_memory_trace,
+                            "trace mismatch"
+                        );
+                    });
+                }
+            };
+
+            // Unit test variant
+            ($(#[$attr:meta])* $fun_name:ident, $ty_name:ident $(: $ty_bound:path)?, $body:block) => {
+                $(#[$attr])*
+                #[test]
+                fn $fun_name() {
+                    fn _bound_check<
+                        $ty_name: $crate::storage::TestKeyValueStoreSetup
+                                $(+ $ty_bound)?,
+                    >()
+                    where
+                        <$ty_name as $crate::storage::KeyValueStore>::Repo:
+                            $crate::repo::RegistryRepo,
+                    {}
+
+                    #[cfg(feature = "rocksdb")]
+                    let rocksdb_trace = {
+                        type $ty_name = $crate::persistence_layer::PersistenceLayer;
+                        _bound_check::<$ty_name>();
+                        eprintln!("Running test with persistence layer");
                         $body
-                        inner::<$crate::persistence_layer::PersistenceLayer>();
-                    }
+                    };
+
+                    let _in_memory_trace = {
+                        type $ty_name = $crate::storage::in_memory::InMemoryKeyValueStore;
+                        _bound_check::<$ty_name>();
+                        eprintln!("Running test with in-memory backend");
+                        $body
+                    };
+
+                    #[cfg(feature = "rocksdb")]
+                    assert_eq!(
+                        rocksdb_trace, _in_memory_trace,
+                        "trace mismatch"
+                    );
                 }
             };
         }


### PR DESCRIPTION
Part of RV-979.

# What

Expands the `kv_test!` macro in preparation for comparing traces across test runs:

- A new variant is added for property-based tests which lifts input generation at the macro level.
- Another variant is also added for property-based tests which sets up the test before running the proptest rloop.
- The existing variant, now only used for unit tests, produces a single test function which runs using both backends instead of one test function per backend.
- Both variants compare traces produced by each test runs. These are currently just unit.

Producing meaningful traces will be added in future PRs:
- #1036 

# Why

We want to be able to compare execution traces between tests which run over multiple configurations in order to assess semantic consistency.

# How

The `kv_test!` macro is significantly reworked, mostly because using a defined `inner` function for the test body is no longer possible. On one hand, for the proptest variant, we want to run test bodies with varying number and types of arguments to account for the proptest inputs. On the other, both variants will need to support getting a return value from running a test. I originally wanted to pin this to something like `-> impl Debug + PartialEq` but that doesn't work, so I resorted to keeping the bounds check as a separate function and not constraining the return type at all in the macro. This allows all the existing tests which return unit to work with no further modifications and, in the future, for tests in each module to return different types of traces.

Apart from the expanded macro, proptest-based tests are rewritten to use the new macro variant.

# Manually Testing

```
make all
```

The diff for the second commit is inflated by the formatting changes in PBTs. I suggest reviewing using `git diff -w` or similar.

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
