### PR TITLE
Fix `Tree::upsert` semantics

### DIFF
--- a/durable-storage/src/avl/tree.rs
+++ b/durable-storage/src/avl/tree.rs
@@ -265,17 +265,13 @@ impl<NodeId> Tree<NodeId> {
     {
         let node = self.root_mut();
         let Some(node) = node else {
-            // We can't create a new `Node` with a non-zero offset.
+            // The key does not exist and a new `Node` will be created unless the call to `data` fails.
             //
-            // This shouldn't happen: it's prevented by the `Database` API.
-            assert_eq!(offset, 0);
-
             // TODO: RV-895: Dynamic creation of the `Bytes<M>` state component may cause
             // problems with proof generation
             let mut new_data = Bytes::<M>::default();
             data(&mut new_data)?;
 
-            // The key does not exist and a new `Node` shall be created.
             let new_node: Node<TreeId, M> = Node::new(key.clone(), new_data);
             let new_id = NodeId::from(new_node);
             self.0 = Some(new_id);

--- a/durable-storage/src/avl/tree.rs
+++ b/durable-storage/src/avl/tree.rs
@@ -1039,4 +1039,50 @@ mod tests {
 
         golden.write_all(&serialised).unwrap();
     }
+
+    #[test]
+    fn test_write_non_existent_key_non_zero_offset() {
+        let mut tree: Tree<ArcNodeId> = Default::default();
+        let mut resolver = ArcResolver;
+
+        let new = Key::new(&[0]).expect("Size less than KEY_MAX_SIZE");
+        let result = tree.write(&new, 1, b"offset too large", &mut resolver);
+        assert!(matches!(
+            result,
+            Err(Error::InvalidArgument(InvalidArgumentError::OffsetTooLarge))
+        ));
+        assert!(
+            tree.root().is_none(),
+            "A failed write must not insert a node into an empty tree."
+        );
+
+        let existing = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
+        tree.set(&existing, b"zero offset", &mut resolver)
+            .expect("Setting an existing key should succeed.");
+        let new = Key::new(&[2]).expect("Size less than KEY_MAX_SIZE");
+        let result = tree.write(&new, 1, b"nonzero offset", &mut resolver);
+        assert!(matches!(
+            result,
+            Err(Error::InvalidArgument(InvalidArgumentError::OffsetTooLarge))
+        ));
+
+        let value = tree
+            .get(&existing, &resolver)
+            .expect("Resolver failure not expected.")
+            .expect("Pre-existing key should still be present.");
+        let mut buf = [0u8; 11];
+        value.read(0, &mut buf);
+        assert_eq!(&buf, b"zero offset");
+        assert!(matches!(tree.get(&new, &resolver), Ok(None)));
+
+        tree.write(&existing, 1, b"o", &mut resolver)
+            .expect("Writing to an existing key with a non-zero offset should succeed.");
+        let value = tree
+            .get(&existing, &resolver)
+            .expect("Resolver failure not expected.")
+            .expect("Pre-existing key should still be present.");
+        let mut buf = [0u8; 11];
+        value.read(0, &mut buf);
+        assert_eq!(&buf, b"zoro offset");
+    }
 }


### PR DESCRIPTION
Blocks RV-965

# What
In the `Database` we want `write`s with non-zero offsets to return `OffsetTooLarge`.

When implementing `Prove` (see #1035) we implement a `Database` without a persistence layer, where all operations go first to the Merkle layer.

This causes an existing issue to surface: the `OffsetTooLarge` error being returned implicitly depended on the persistence layer operation being called first.

# Why
Needed for `Prove` implementation.

# How
Removes the assertion and adds a test.

Removing the assertion is OK as the `write` closure handles this itself.

# Manually Testing

```
make all
```
Drop the first commit and run `cargo test test_write_non_existent_key_non_zero_offset` to see the failure

# Regressions
A new test has been added.

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
