### PR TITLE
fix(dursto): Fix Prove and Verify Implementations of the Merkle Layer.

### DIFF
--- a/data/src/hash.rs
+++ b/data/src/hash.rs
@@ -8,6 +8,7 @@
 use std::borrow::Borrow;
 use std::collections::VecDeque;
 use std::ops::Deref;
+use std::sync::Arc;
 
 use bincode::Decode;
 use bincode::Encode;
@@ -277,7 +278,9 @@ impl PartialHash {
         proof: Option<MerkleProof>,
         foldable: &impl Foldable<PartialHashFold>,
     ) -> PartialHash {
-        foldable.fold(PartialHashFold { proof })
+        foldable.fold(PartialHashFold {
+            proof: proof.map(Arc::new),
+        })
     }
 }
 
@@ -293,8 +296,12 @@ impl Foldable<PartialHashFold> for PartialHash {
 
 /// [`Fold`] implementation for computing the [`PartialHash`] of a state
 pub struct PartialHashFold {
-    /// Original proof which is the source of previous hashes
-    proof: Option<MerkleProof>,
+    /// Original proof which is the source of previous hashes.
+    ///
+    /// Stored as `Arc` so that callers (notably the verify-mode AVL fold) can attach a node-local
+    /// override cheaply: the override site only bumps the refcount instead of automatically
+    /// deep-cloning the proof.
+    proof: Option<Arc<MerkleProof>>,
 }
 
 impl PartialHashFold {
@@ -314,6 +321,15 @@ impl PartialHashFold {
         }
     }
 
+    /// Replace the reference proof outright.
+    ///
+    /// Use when a sub-structure carries its own captured proof that should override whatever the
+    /// parent fold passed down. Unlike [`PartialHashFold::map_reference_proof`], this does not
+    /// require the existing proof to be `Some`.
+    pub fn with_proof(self, proof: Option<Arc<MerkleProof>>) -> PartialHashFold {
+        PartialHashFold { proof }
+    }
+
     /// Modify the reference proof that `PartialHashFold` uses when traversing the described
     /// foldable structure.
     ///
@@ -325,7 +341,10 @@ impl PartialHashFold {
         proj: impl FnOnce(MerkleProof) -> Option<MerkleProof>,
     ) -> PartialHashFold {
         PartialHashFold {
-            proof: self.proof.and_then(proj),
+            proof: self
+                .proof
+                .and_then(|arc| proj(Arc::unwrap_or_clone(arc)))
+                .map(Arc::new),
         }
     }
 }
@@ -343,6 +362,10 @@ impl Fold for PartialHashFold {
                 child_hashes: VecDeque::new(),
             };
         };
+
+        // Unwrap the `Arc` cheaply when it has a single owner; clone the inner proof when shared
+        // (e.g. when the same captured proof is reused after multiple Arc clones at fold time).
+        let tree = Arc::unwrap_or_clone(tree);
 
         match tree {
             Tree::Node(node) => PartialHashNodeFold {
@@ -385,7 +408,9 @@ impl NodeFold for PartialHashNodeFold {
         let hash = match self.children.pop_front() {
             Some(tree) => {
                 let prev_hash = tree.root_hash();
-                let hash = child.fold(PartialHashFold { proof: Some(tree) });
+                let hash = child.fold(PartialHashFold {
+                    proof: Some(Arc::new(tree)),
+                });
 
                 // If the child is absent but we have the previous hash, we can use it here.
                 match hash {

--- a/data/src/merkle_proof.rs
+++ b/data/src/merkle_proof.rs
@@ -20,6 +20,7 @@ use crate::foldable::seq_tree::tree_depth;
 use crate::hash::Hash;
 use crate::hash::PartialHash;
 use crate::hash::PartialHashFold;
+use crate::merkle_proof::proof_tree::MerkleProof;
 
 /// Possible outcomes when parsing a node or a leaf from a Merkle proof
 /// where the leaf is assumed to have type `T`.
@@ -153,6 +154,21 @@ pub trait Deserialiser {
 
     /// It is expected for the proof to be a node. Obtain the deserialiser for the branch case.
     fn into_node(self) -> Result<Self::DeserialiserNode, Self::Error>;
+
+    /// Capture an owned snapshot of the proof at the current position, if available.
+    ///
+    /// Deserialisers backed by an in-memory proof tree (e.g. [`crate::merkle_proof::proof_tree`])
+    /// can clone their internal `MerkleProof`. Stream deserialisers cannot reconstruct the proof
+    /// without re-parsing, so they return `None` (the default).
+    ///
+    /// Used by verify-mode types (notably the AVL `VerifyNodeId` / `VerifyTreeId`) that need to
+    /// retain their original sub-proof so they can fold against it later, even after the working
+    /// tree has been structurally rearranged.
+    ///
+    /// TODO RV-994: Investigate avoiding the extra allocation required for this.
+    fn capture_owned_proof(&self) -> Option<MerkleProof> {
+        None
+    }
 }
 
 /// The trait used for deserialising a proof's node.

--- a/data/src/merkle_proof/proof_tree.rs
+++ b/data/src/merkle_proof/proof_tree.rs
@@ -515,6 +515,13 @@ impl<'t> Deserialiser for ProofTree<'t> {
     fn into_node(self) -> Result<Self::DeserialiserNode, Self::Error> {
         Ok(self.as_node()?.map_present(Vec::into_iter))
     }
+
+    fn capture_owned_proof(&self) -> Option<MerkleProof> {
+        match self {
+            ProofPart::Absent => None,
+            ProofPart::Present(proof) => Some((*proof).clone()),
+        }
+    }
 }
 
 /// Similar to [`ProofTree`], but owns the underlying [`MerkleProof`]

--- a/durable-storage/src/avl/node.rs
+++ b/durable-storage/src/avl/node.rs
@@ -25,13 +25,12 @@ use octez_riscv_data::merkle_proof::DeserialiserNode;
 use octez_riscv_data::merkle_proof::FromProof;
 use octez_riscv_data::mode::Mode;
 use octez_riscv_data::mode::Normal;
-use octez_riscv_data::mode::Prove;
 use octez_riscv_data::serialisation::deserialise;
 use octez_riscv_data::serialisation::serialise;
 use perfect_derive::perfect_derive;
 
 use super::resolver::LazyTreeId;
-use super::resolver::ProveTreeId;
+use super::resolver::ProveNode;
 use super::resolver::TreeResolver;
 use super::tree::Tree;
 use crate::avl::resolver::AvlResolver;
@@ -76,8 +75,8 @@ pub struct Node<TreeId, M: Mode> {
 }
 
 impl Node<LazyTreeId, Normal> {
-    /// Converts the [`Node`] to [`Prove`] mode.
-    pub fn into_proof(self) -> Node<ProveTreeId, Prove<'static>> {
+    /// Converts the [`Node`] to prove mode.
+    pub fn into_proof(self) -> ProveNode {
         Node {
             meta: self.meta.into_proof(),
             data: self.data.into_proof(),
@@ -92,6 +91,11 @@ impl<TreeId, M: Mode> Node<TreeId, M> {
     /// Mark the hash of this node as dirty.
     fn invalidate_hash(&mut self) {
         self.hash = OnceLock::new();
+    }
+
+    /// Direct access to the left child identifier.
+    pub(crate) fn left_id(&self) -> &TreeId {
+        &self.left
     }
 
     /// A mutable reference to the left branch.
@@ -111,6 +115,11 @@ impl<TreeId, M: Mode> Node<TreeId, M> {
         resolver: &impl TreeResolver<NodeId, TreeId>,
     ) -> Result<&Tree<NodeId>, OperationalError> {
         resolver.resolve(&self.left)
+    }
+
+    /// Direct access to the right child identifier.
+    pub(crate) fn right_id(&self) -> &TreeId {
+        &self.right
     }
 
     /// A mutable reference to the right branch.

--- a/durable-storage/src/avl/node.rs
+++ b/durable-storage/src/avl/node.rs
@@ -134,20 +134,21 @@ impl<TreeId, M: Mode> Node<TreeId, M> {
 }
 
 impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
-    /// The data stored in a [`Node`] within the subtree of this [`Node`] with a given [`Key`] .
+    /// Find the id of the [`Node`] within the subtree of this [`Node`] with a given [`Key`].
     pub(super) fn get<'a, NodeId>(
         mut node: &'a NodeId,
         key: &Key,
         resolver: &impl AvlResolver<NodeId, TreeId, M>,
-    ) -> Result<Option<&'a Bytes<M>>, OperationalError>
+    ) -> Result<Option<&'a NodeId>, OperationalError>
     where
         NodeId: 'a,
         TreeId: 'a,
+        M: 'a,
     {
         loop {
             let resolved_node = resolver.resolve(node)?;
             match resolved_node.key().cmp(key) {
-                Ordering::Equal => return Ok(Some(&resolved_node.data)),
+                Ordering::Equal => return Ok(Some(node)),
                 Ordering::Greater => {
                     let Some(left) = resolved_node.left_ref(resolver)?.root() else {
                         return Ok(None);

--- a/durable-storage/src/avl/resolver.rs
+++ b/durable-storage/src/avl/resolver.rs
@@ -48,6 +48,7 @@ use octez_riscv_data::merkle_proof::DeserialiserNode;
 use octez_riscv_data::merkle_proof::FromProof;
 use octez_riscv_data::merkle_proof::Partial;
 use octez_riscv_data::merkle_proof::SuspendedResult;
+use octez_riscv_data::merkle_proof::proof_tree::MerkleProof;
 use octez_riscv_data::merkle_proof::proof_tree::MerkleProofFold;
 use octez_riscv_data::mode::Mode;
 use octez_riscv_data::mode::Normal;
@@ -757,22 +758,40 @@ impl<R: Resolver<LazyTreeId, Tree<LazyNodeId>>> Resolver<ProveTreeId, Tree<Prove
 ///
 /// Absent nodes are not a valid variant as they indicate a bad proof: any node accessed during
 /// validation should be present or blinded from being accessed in the proof.
+///
+/// `Present` carries the [`MerkleProof`] sub-tree the node was originally deserialised from. The
+/// [`Foldable<PartialHashFold>`] implementation overrides the inherited proof with that captured
+/// sub-proof, so the node folds against the proof of *its initial-tree position* even after AVL
+/// rebalancing has moved it elsewhere in the working tree. Without this, structural drift between
+/// the proof and the working tree causes wrong `prev_hash` substitutions or [`PartialHash::InvalidProof`].
 #[derive(Clone, Debug)]
 pub enum VerifyNodeId {
-    Present(Arc<Node<VerifyTreeId, Verify>>),
+    Present {
+        node: Arc<Node<VerifyTreeId, Verify>>,
+        original_proof: Option<Arc<MerkleProof>>,
+    },
     Blinded(Hash),
 }
 
 impl From<Node<VerifyTreeId, Verify>> for VerifyNodeId {
     fn from(node: Node<VerifyTreeId, Verify>) -> Self {
-        VerifyNodeId::Present(Arc::new(node))
+        VerifyNodeId::Present {
+            node: Arc::new(node),
+            original_proof: None,
+        }
     }
 }
 
 impl Foldable<PartialHashFold> for VerifyNodeId {
     fn fold(&self, builder: PartialHashFold) -> PartialHash {
         match self {
-            VerifyNodeId::Present(inner) => inner.as_ref().fold(builder),
+            VerifyNodeId::Present {
+                node,
+                original_proof,
+            } => {
+                let builder = builder.with_proof(original_proof.clone());
+                node.as_ref().fold(builder)
+            }
             VerifyNodeId::Blinded(hash) => builder.present(*hash),
         }
     }
@@ -780,12 +799,17 @@ impl Foldable<PartialHashFold> for VerifyNodeId {
 
 impl FromProof for VerifyNodeId {
     fn from_proof<Proof: Deserialiser>(proof: Proof) -> SuspendedResult<Proof, Self> {
+        // Capture the sub-proof BEFORE consuming `proof`; `into_node` moves it.
+        let original_proof = proof.capture_owned_proof().map(Arc::new);
         let ctx = proof.into_node()?;
         match ctx.presence() {
             Partial::Blinded(hash) => ctx.done(VerifyNodeId::Blinded(hash)),
             Partial::Present(()) => {
                 let (ctx, node) = Node::from_branches(ctx)?;
-                ctx.done(VerifyNodeId::Present(Arc::new(node)))
+                ctx.done(VerifyNodeId::Present {
+                    node: Arc::new(node),
+                    original_proof,
+                })
             }
             // SAFETY: called only in `Verify` mode
             Partial::Absent => unsafe { not_found() },
@@ -794,9 +818,12 @@ impl FromProof for VerifyNodeId {
 }
 
 /// Identifier for a tree resolved in [`Verify`] mode.
+///
+/// `Present` carries the [`MerkleProof`] sub-tree this tree slot was deserialised from; see
+/// [`VerifyNodeId`] for the rationale.
 #[derive(Clone, Debug)]
 pub enum VerifyTreeId {
-    Present(Tree<VerifyNodeId>),
+    Present { tree: Tree<VerifyNodeId> },
     Blinded(Hash),
     Absent,
 }
@@ -804,7 +831,7 @@ pub enum VerifyTreeId {
 impl Foldable<PartialHashFold> for VerifyTreeId {
     fn fold(&self, builder: PartialHashFold) -> PartialHash {
         match self {
-            VerifyTreeId::Present(inner) => inner.fold(builder),
+            VerifyTreeId::Present { tree } => tree.fold(builder),
             VerifyTreeId::Blinded(hash) => builder.present(*hash),
             VerifyTreeId::Absent => builder.previous(),
         }
@@ -818,7 +845,7 @@ impl FromProof for VerifyTreeId {
         let tree_id = match partial {
             Partial::Absent => VerifyTreeId::Absent,
             Partial::Blinded(hash) => VerifyTreeId::Blinded(hash),
-            Partial::Present(tree) => VerifyTreeId::Present(tree),
+            Partial::Present(tree) => VerifyTreeId::Present { tree },
         };
         ctx.done(tree_id)
     }
@@ -828,7 +855,9 @@ impl FromProof for VerifyTreeId {
 // `Tree::replace_with_successor`, may cause issues with round-trip verification.
 impl Default for VerifyTreeId {
     fn default() -> Self {
-        Self::Present(Tree::default())
+        Self::Present {
+            tree: Tree::default(),
+        }
     }
 }
 
@@ -842,7 +871,7 @@ impl Resolver<VerifyNodeId, Node<VerifyTreeId, Verify>> for VerifyResolver {
         id: &'a VerifyNodeId,
     ) -> Result<&'a Node<VerifyTreeId, Verify>, OperationalError> {
         match id {
-            VerifyNodeId::Present(inner) => Ok(inner),
+            VerifyNodeId::Present { node, .. } => Ok(node),
             // SAFETY: called only in `Verify` mode
             VerifyNodeId::Blinded(_) => unsafe { not_found() },
         }
@@ -853,7 +882,7 @@ impl Resolver<VerifyNodeId, Node<VerifyTreeId, Verify>> for VerifyResolver {
         id: &'a mut VerifyNodeId,
     ) -> Result<&'a mut Node<VerifyTreeId, Verify>, OperationalError> {
         match id {
-            VerifyNodeId::Present(inner) => Ok(Arc::make_mut(inner)),
+            VerifyNodeId::Present { node, .. } => Ok(Arc::make_mut(node)),
             // SAFETY: called only in `Verify` mode
             VerifyNodeId::Blinded(_) => unsafe { not_found() },
         }
@@ -866,7 +895,7 @@ impl Resolver<VerifyTreeId, Tree<VerifyNodeId>> for VerifyResolver {
         id: &'a VerifyTreeId,
     ) -> Result<&'a Tree<VerifyNodeId>, OperationalError> {
         match id {
-            VerifyTreeId::Present(inner) => Ok(inner),
+            VerifyTreeId::Present { tree, .. } => Ok(tree),
             // SAFETY: called only in `Verify` mode
             VerifyTreeId::Blinded(_) | VerifyTreeId::Absent => unsafe { not_found() },
         }
@@ -877,7 +906,7 @@ impl Resolver<VerifyTreeId, Tree<VerifyNodeId>> for VerifyResolver {
         id: &'a mut VerifyTreeId,
     ) -> Result<&'a mut Tree<VerifyNodeId>, OperationalError> {
         match id {
-            VerifyTreeId::Present(inner) => Ok(inner),
+            VerifyTreeId::Present { tree, .. } => Ok(tree),
             // SAFETY: called only in `Verify` mode
             VerifyTreeId::Blinded(_) | VerifyTreeId::Absent => unsafe { not_found() },
         }
@@ -1550,7 +1579,10 @@ mod tests {
     fn test_verify_resolver_resolve_mut_node() {
         let key = Key::new(&[2]).expect("key should be valid");
         let node: Node<VerifyTreeId, Verify> = Node::new(key.clone(), Bytes::<Verify>::new(0));
-        let mut id = VerifyNodeId::Present(Arc::new(node));
+        let mut id = VerifyNodeId::Present {
+            node: Arc::new(node),
+            original_proof: None,
+        };
 
         let mut resolver = VerifyResolver;
 
@@ -1583,9 +1615,12 @@ mod tests {
     fn test_verify_resolver_resolves_tree() {
         let key = Key::new(&[1]).expect("key should be valid");
         let node: Node<VerifyTreeId, Verify> = Node::new(key, Bytes::<Verify>::new(0));
-        let node_id = VerifyNodeId::Present(Arc::new(node));
+        let node_id = VerifyNodeId::Present {
+            node: Arc::new(node),
+            original_proof: None,
+        };
         let tree: Tree<VerifyNodeId> = Some(node_id).into();
-        let id = VerifyTreeId::Present(tree);
+        let id = VerifyTreeId::Present { tree };
 
         let resolver = VerifyResolver;
         let resolved = resolver

--- a/durable-storage/src/avl/resolver.rs
+++ b/durable-storage/src/avl/resolver.rs
@@ -49,7 +49,6 @@ use octez_riscv_data::merkle_proof::FromProof;
 use octez_riscv_data::merkle_proof::Partial;
 use octez_riscv_data::merkle_proof::SuspendedResult;
 use octez_riscv_data::merkle_proof::proof_tree::MerkleProof;
-use octez_riscv_data::merkle_proof::proof_tree::MerkleProofFold;
 use octez_riscv_data::mode::Mode;
 use octez_riscv_data::mode::Normal;
 use octez_riscv_data::mode::Prove;
@@ -85,6 +84,9 @@ trait_set! {
     /// Specialised [`Resolver`] for MAVL nodes and trees
     pub trait AvlResolver<NodeId, TreeId, M: Mode> = NodeResolver<NodeId, TreeId, M> + TreeResolver<NodeId, TreeId>;
 }
+
+/// Node value materialised in [`Prove`] mode.
+pub(crate) type ProveNode = Node<ProveTreeId, Prove<'static>>;
 
 /// Identifier for a node that is always present.
 #[derive(Debug, Clone, derive_more::From)]
@@ -322,6 +324,12 @@ impl From<Hash> for LazyTreeId {
     }
 }
 
+impl From<Tree<LazyNodeId>> for LazyTreeId {
+    fn from(value: Tree<LazyNodeId>) -> Self {
+        Self(LazyId::new(value))
+    }
+}
+
 impl Default for LazyTreeId {
     fn default() -> Self {
         Self(LazyId {
@@ -451,6 +459,40 @@ impl<KV: KeyValueStore> Resolver<LazyTreeId, Tree<LazyNodeId>> for LazyResolver<
     }
 }
 
+/// Resolver that only accesses already-cached prove-mode values.
+///
+/// Returns [`OperationalError::ResolverInvariantViolated`] if a node or tree has not been
+/// resolved yet, since callers are expected to only traverse pre-resolved subtrees.
+pub(crate) struct CachedOnlyResolver;
+
+impl Resolver<ProveNodeId, ProveNode> for CachedOnlyResolver {
+    fn resolve<'a>(&self, id: &'a ProveNodeId) -> Result<&'a ProveNode, OperationalError> {
+        id.cached_node()
+            .ok_or(OperationalError::ResolverInvariantViolated)
+    }
+
+    fn resolve_mut<'a>(
+        &mut self,
+        _id: &'a mut ProveNodeId,
+    ) -> Result<&'a mut ProveNode, OperationalError> {
+        unreachable!("CachedOnlyResolver does not support mutable resolution")
+    }
+}
+
+impl Resolver<ProveTreeId, Tree<ProveNodeId>> for CachedOnlyResolver {
+    fn resolve<'a>(&self, id: &'a ProveTreeId) -> Result<&'a Tree<ProveNodeId>, OperationalError> {
+        id.inner()
+            .ok_or(OperationalError::ResolverInvariantViolated)
+    }
+
+    fn resolve_mut<'a>(
+        &mut self,
+        _id: &'a mut ProveTreeId,
+    ) -> Result<&'a mut Tree<ProveNodeId>, OperationalError> {
+        unreachable!("CachedOnlyResolver does not support mutable resolution")
+    }
+}
+
 /// Identifier for a node resolved in [`Prove`] mode.
 ///
 /// This wrapper keeps the original [`LazyNodeId`] to allow delegating hash computation and
@@ -458,7 +500,7 @@ impl<KV: KeyValueStore> Resolver<LazyTreeId, Tree<LazyNodeId>> for LazyResolver<
 /// node in `inner` so repeated accesses do not rebuild it.
 #[derive(Clone, Debug)]
 pub struct ProveNodeId {
-    inner: OnceLock<Rc<Node<ProveTreeId, Prove<'static>>>>,
+    inner: OnceLock<Rc<ProveNode>>,
     node: LazyNodeId,
     deleted_nodes: Rc<RefCell<BTreeMap<Hash, DeletedNodeFields>>>,
 }
@@ -485,8 +527,8 @@ impl Drop for ProveNodeId {
 // TODO RV-895: This method is implemented to satisfy trait-bounds in `tree::upsert`.
 // The current implementation around proofs for created nodes during proof-generation
 // needs to be fixed.
-impl From<Node<ProveTreeId, Prove<'static>>> for ProveNodeId {
-    fn from(node: Node<ProveTreeId, Prove<'static>>) -> Self {
+impl From<ProveNode> for ProveNodeId {
+    fn from(node: ProveNode) -> Self {
         ProveNodeId {
             inner: OnceLock::from(Rc::new(node)),
             node: LazyNodeId::from(Hash::hash_bytes(&[])),
@@ -500,8 +542,7 @@ impl ProveNodeId {
     ///
     /// Used by the `MerkleLayer`-level fold to extract per-field read flags from a node that
     /// was resolved during the proof step.
-    #[expect(dead_code, reason = "used by MerkleLayer fold in follow-up commit")]
-    pub(crate) fn cached_node(&self) -> Option<&Node<ProveTreeId, Prove<'static>>> {
+    pub(crate) fn cached_node(&self) -> Option<&ProveNode> {
         self.inner.get().map(|rc| rc.as_ref())
     }
 }
@@ -511,15 +552,6 @@ impl Foldable<HashFold> for ProveNodeId {
         match self.inner.get() {
             Some(inner) => *inner.hash(),
             None => self.node.fold(builder),
-        }
-    }
-}
-
-impl Foldable<MerkleProofFold> for ProveNodeId {
-    fn fold(&self, builder: MerkleProofFold) -> <MerkleProofFold as Fold>::Folded {
-        match self.inner.get() {
-            Some(inner) => inner.as_ref().fold(builder),
-            None => builder.into_blind(Hash::from_foldable(&self.node)),
         }
     }
 }
@@ -556,18 +588,8 @@ impl Foldable<HashFold> for ProveTreeId {
 }
 
 impl ProveTreeId {
-    #[expect(dead_code, reason = "used by CachedOnlyResolver in follow-up commit")]
     pub(crate) fn inner(&self) -> Option<&Tree<ProveNodeId>> {
         self.inner.get()
-    }
-}
-
-impl Foldable<MerkleProofFold> for ProveTreeId {
-    fn fold(&self, builder: MerkleProofFold) -> <MerkleProofFold as Fold>::Folded {
-        match self.inner.get() {
-            Some(inner) => inner.fold(builder),
-            None => builder.into_blind(Hash::from_foldable(&self.tree)),
-        }
     }
 }
 
@@ -576,7 +598,6 @@ impl Foldable<MerkleProofFold> for ProveTreeId {
 /// Only `meta` and `data` carry the per-field read flags consumed by the
 /// `MerkleLayer`-level fold; subtree IDs and the hash cache are unnecessary.
 #[derive(Debug)]
-#[expect(dead_code, reason = "used by MerkleLayer fold in follow-up commit")]
 pub(crate) struct DeletedNodeFields {
     pub(crate) meta: Atom<Meta, Prove<'static>>,
     pub(crate) data: Bytes<Prove<'static>>,
@@ -613,29 +634,39 @@ pub(crate) struct ProveResolver<R> {
 
 impl<R> ProveResolver<R> {
     /// Start the prove resolution process.
-    pub(crate) fn start(inner: R) -> Self {
+    pub(crate) fn start(inner: R, root_tree_hash: Option<Hash>) -> Self {
+        let mut accessed_items = AccessedItems::default();
+        if let Some(root_hash) = root_tree_hash {
+            accessed_items.trees.insert(root_hash);
+        }
+
         Self {
             inner,
-            accessed_items: RefCell::default(),
+            accessed_items: RefCell::new(accessed_items),
             deleted_nodes: Rc::new(RefCell::new(BTreeMap::new())),
         }
     }
 
+    /// The wrapped resolver used for [`LazyNodeId`] / [`LazyTreeId`] resolution.
+    ///
+    /// The fold uses this directly to walk the initial tree, bypassing the access-tracking
+    /// methods.
+    pub(crate) fn inner(&self) -> &R {
+        &self.inner
+    }
+
     /// Whether a node with the given hash was accessed during the proof step.
-    #[expect(dead_code, reason = "used by MerkleLayer fold in follow-up commit")]
     pub(crate) fn was_node_accessed(&self, hash: &Hash) -> bool {
         self.accessed_items.borrow().nodes.contains(hash)
     }
 
     /// Whether a tree with the given hash was accessed during the proof step.
-    #[expect(dead_code, reason = "used by MerkleLayer fold in follow-up commit")]
     pub(crate) fn was_tree_accessed(&self, hash: &Hash) -> bool {
         self.accessed_items.borrow().trees.contains(hash)
     }
 
     /// Prove-mode projections of nodes unlinked from the working tree during the step, keyed by
     /// their initial-tree hash.
-    #[expect(dead_code, reason = "used by MerkleLayer fold in follow-up commit")]
     pub(crate) fn deleted_nodes(&self) -> impl Deref<Target = BTreeMap<Hash, DeletedNodeFields>> {
         self.deleted_nodes.borrow()
     }
@@ -672,18 +703,15 @@ impl<R> ProveResolver<R> {
 }
 
 impl<R: Resolver<LazyNodeId, Node<LazyTreeId, Normal>> + Resolver<LazyTreeId, Tree<LazyNodeId>>>
-    Resolver<ProveNodeId, Node<ProveTreeId, Prove<'static>>> for ProveResolver<R>
+    Resolver<ProveNodeId, ProveNode> for ProveResolver<R>
 {
-    fn resolve<'b>(
-        &self,
-        id: &'b ProveNodeId,
-    ) -> Result<&'b Node<ProveTreeId, Prove<'static>>, OperationalError> {
+    fn resolve<'b>(&self, id: &'b ProveNodeId) -> Result<&'b ProveNode, OperationalError> {
         if let Some(inner) = id.inner.get() {
             return Ok(inner);
         }
 
         let resolved = self.resolve_and_track_node(&id.node)?;
-        let result_node: Node<ProveTreeId, Prove<'static>> = resolved.clone().into_proof();
+        let result_node: ProveNode = resolved.clone().into_proof();
         id.inner
             .set(Rc::new(result_node))
             .map_err(|_| OperationalError::ResolverInvariantViolated)?;
@@ -694,7 +722,7 @@ impl<R: Resolver<LazyNodeId, Node<LazyTreeId, Normal>> + Resolver<LazyTreeId, Tr
     fn resolve_mut<'b>(
         &mut self,
         id: &'b mut ProveNodeId,
-    ) -> Result<&'b mut Node<ProveTreeId, Prove<'static>>, OperationalError> {
+    ) -> Result<&'b mut ProveNode, OperationalError> {
         {
             // SAFETY: Rust doesn't understand that the reference on `id.inner` is dropped on return.
             let inner_mut = unsafe { &mut *(&mut id.inner as *mut OnceLock<_>) };
@@ -704,7 +732,7 @@ impl<R: Resolver<LazyNodeId, Node<LazyTreeId, Normal>> + Resolver<LazyTreeId, Tr
         }
 
         let resolved = self.resolve_and_track_node(&id.node)?;
-        let result_node: Node<ProveTreeId, Prove<'static>> = resolved.clone().into_proof();
+        let result_node: ProveNode = resolved.clone().into_proof();
         id.inner
             .set(Rc::new(result_node))
             .map_err(|_| OperationalError::ResolverInvariantViolated)?;
@@ -1365,7 +1393,7 @@ mod tests {
         let lazy_tree: Tree<LazyNodeId> = Some(LazyNodeId::from(root_hash)).into();
         let lazy_resolver = LazyResolver::new(persistence_layer);
 
-        let prove_resolver = ProveResolver::start(lazy_resolver);
+        let prove_resolver = ProveResolver::start(lazy_resolver, None);
         let lazy_node_id = lazy_tree.root().expect("tree should have a root");
 
         let prove_id = lazy_node_id.clone().into_proof(&prove_resolver);
@@ -1384,7 +1412,7 @@ mod tests {
 
         let expected_hash = Hash::from_foldable(lazy_root);
 
-        let prove_resolver = ProveResolver::start(lazy_resolver);
+        let prove_resolver = ProveResolver::start(lazy_resolver, None);
         let prove_id = lazy_root.clone().into_proof(&prove_resolver);
 
         // Hash before resolve (delegates to lazy path).
@@ -1412,7 +1440,7 @@ mod tests {
         let lazy_tree: Tree<LazyNodeId> = Some(LazyNodeId::from(root_hash)).into();
         let lazy_resolver = LazyResolver::new(persistence_layer);
 
-        let prove_resolver = ProveResolver::start(lazy_resolver);
+        let prove_resolver = ProveResolver::start(lazy_resolver, None);
         let prove_root_id = lazy_tree
             .root()
             .expect("tree should have a root")
@@ -1449,7 +1477,7 @@ mod tests {
         let lazy_tree: Tree<LazyNodeId> = Some(LazyNodeId::from(root_hash)).into();
         let lazy_resolver = LazyResolver::new(persistence_layer.clone());
 
-        let prove_resolver = ProveResolver::start(lazy_resolver);
+        let prove_resolver = ProveResolver::start(lazy_resolver, None);
         let prove_id = lazy_tree
             .root()
             .expect("tree should have a root")
@@ -1477,7 +1505,7 @@ mod tests {
         let lazy_tree: Tree<LazyNodeId> = Some(LazyNodeId::from(root_hash)).into();
         let lazy_resolver = LazyResolver::new(persistence_layer);
 
-        let mut prove_resolver = ProveResolver::start(lazy_resolver);
+        let mut prove_resolver = ProveResolver::start(lazy_resolver, None);
         let mut prove_id = lazy_tree
             .root()
             .expect("tree should have a root")
@@ -1514,7 +1542,7 @@ mod tests {
         let lazy_left_node_hash = Hash::from_foldable(lazy_left_id);
 
         // Now get the same hash via the prove resolver path.
-        let prove_resolver = ProveResolver::start(lazy_resolver);
+        let prove_resolver = ProveResolver::start(lazy_resolver, None);
         let prove_root_id = lazy_root.clone().into_proof(&prove_resolver);
         let prove_node = prove_resolver
             .resolve(&prove_root_id)
@@ -1544,7 +1572,7 @@ mod tests {
         let empty_lazy_tree: LazyTreeId = LazyTreeId::default();
         let prove_tree_id = empty_lazy_tree.clone().into_proof();
 
-        let prove_resolver = ProveResolver::start(lazy_resolver);
+        let prove_resolver = ProveResolver::start(lazy_resolver, None);
         let tree = prove_resolver
             .resolve(&prove_tree_id)
             .expect("resolving empty prove tree should succeed");

--- a/durable-storage/src/avl/tree.rs
+++ b/durable-storage/src/avl/tree.rs
@@ -398,6 +398,14 @@ impl Foldable<MerkleProofFold> for Tree<ProveNodeId> {
 
 impl Foldable<PartialHashFold> for Tree<VerifyNodeId> {
     fn fold(&self, builder: PartialHashFold) -> PartialHash {
+        // SAFETY: Extra care is required in folding for `Verify` in the MAVL tree, due to
+        // consequences from restructuring due to AVL balancing. This fold correctness relies
+        // on:
+        // (a) the `bool_leaf` always folding to `PartialHash::Present(...)` so its `prev_hash` is
+        // never substituted from the popped proof child.
+        // (b) the inner `VerifyNodeId` overrides the proof with its own captured sub-proof, before
+        // delegating to `Node::fold`. Otherwise, using `previous` could result in incorrect
+        // substitution.
         let mut node = builder.into_node_fold();
 
         let present = self.0.is_some();

--- a/durable-storage/src/avl/tree.rs
+++ b/durable-storage/src/avl/tree.rs
@@ -156,12 +156,12 @@ impl<NodeId> Tree<NodeId> {
     }
 
     #[inline]
-    /// The data stored in a [`Node`] in the [`Tree`] with a given [`Key`].
-    pub(crate) fn get<'a, TreeId: 'a, M: BytesMode + AtomMode>(
+    /// Find the id of the [`Node`] in the [`Tree`] with a given [`Key`].
+    pub(crate) fn get<'a, TreeId: 'a, M: BytesMode + AtomMode + 'a>(
         &'a self,
         key: &Key,
         resolver: &impl AvlResolver<NodeId, TreeId, M>,
-    ) -> Result<Option<&'a Bytes<M>>, OperationalError> {
+    ) -> Result<Option<&'a NodeId>, OperationalError> {
         let Some(node) = self.root() else {
             return Ok(None);
         };
@@ -983,7 +983,10 @@ mod tests {
             for operation in operations {
                 match operation {
                     Operation::Get(key) => {
-                        let tree_value = tree.get(&key, &resolver)?;
+                        let tree_value = match tree.get(&key, &resolver)? {
+                            Some(node_id) => Some(resolver.resolve(node_id)?.data()),
+                            None => None,
+                        };
 
                         // The values in the Options are comparable, but the Options themselves are
                         // not. So we need to awkwardly match on both Options to compare them.
@@ -1081,10 +1084,14 @@ mod tests {
             Err(Error::InvalidArgument(InvalidArgumentError::OffsetTooLarge))
         ));
 
-        let value = tree
+        let node_id = tree
             .get(&existing, &resolver)
             .expect("Resolver failure not expected.")
             .expect("Pre-existing key should still be present.");
+        let value = resolver
+            .resolve(node_id)
+            .expect("Resolver failure not expected.")
+            .data();
         let mut buf = [0u8; 11];
         value.read(0, &mut buf);
         assert_eq!(&buf, b"zero offset");
@@ -1092,10 +1099,14 @@ mod tests {
 
         tree.write(&existing, 1, b"o", &mut resolver)
             .expect("Writing to an existing key with a non-zero offset should succeed.");
-        let value = tree
+        let node_id = tree
             .get(&existing, &resolver)
             .expect("Resolver failure not expected.")
             .expect("Pre-existing key should still be present.");
+        let value = resolver
+            .resolve(node_id)
+            .expect("Resolver failure not expected.")
+            .data();
         let mut buf = [0u8; 11];
         value.read(0, &mut buf);
         assert_eq!(&buf, b"zoro offset");

--- a/durable-storage/src/avl/tree.rs
+++ b/durable-storage/src/avl/tree.rs
@@ -24,8 +24,6 @@ use octez_riscv_data::merkle_proof::Deserialiser;
 use octez_riscv_data::merkle_proof::DeserialiserNode;
 use octez_riscv_data::merkle_proof::FromProof;
 use octez_riscv_data::merkle_proof::Partial;
-use octez_riscv_data::merkle_proof::proof_tree::MerkleProofFold;
-use octez_riscv_data::merkle_proof::proof_tree::MinimumPresence;
 use octez_riscv_data::mode::utils::not_found;
 use octez_riscv_data::serialisation::deserialise;
 use octez_riscv_data::serialisation::serialise;
@@ -230,7 +228,7 @@ impl<NodeId> Tree<NodeId> {
 
     #[inline]
     /// A reference to the root [`Node`].
-    pub(super) fn root(&self) -> Option<&NodeId> {
+    pub(crate) fn root(&self) -> Option<&NodeId> {
         self.0.as_ref()
     }
 
@@ -380,23 +378,6 @@ impl<NodeId: Foldable<HashFold>> Foldable<HashFold> for Tree<NodeId> {
 
         let present = self.0.is_some();
         node.add(&Hash::hash_encodable(present).expect("Hashing a bool should never fail"));
-
-        if let Some(inner) = self.0.as_ref() {
-            node.add(inner);
-        }
-
-        node.done()
-    }
-}
-
-impl Foldable<MerkleProofFold> for Tree<ProveNodeId> {
-    fn fold(&self, builder: MerkleProofFold) -> <MerkleProofFold as Fold>::Folded {
-        let mut node = builder.into_node_fold();
-
-        let present = self.0.is_some();
-        let bool_data = serialise(present).expect("Serialising a bool should never fail");
-        let bool_leaf = MerkleProofFold::new_leaf(MinimumPresence::Present, bool_data);
-        node.add(&bool_leaf);
 
         if let Some(inner) = self.0.as_ref() {
             node.add(inner);

--- a/durable-storage/src/avl/tree.rs
+++ b/durable-storage/src/avl/tree.rs
@@ -47,6 +47,11 @@ use crate::storage::Loadable;
 use crate::storage::Storable;
 use crate::storage::StoreOptions;
 
+/// Hash of the empty AVL tree (`Tree::<NodeId>(None)`).
+/// The empty-tree hash is independent of the `NodeId` type parameter.
+static EMPTY_TREE_HASH: LazyLock<Hash> =
+    LazyLock::new(|| Hash::from_foldable(&Tree::<LazyNodeId>::default()));
+
 /// A key-value store tree with left and right nodes that supports traversal and value retrieval.
 #[perfect_derive(Clone, Default, Debug)]
 #[derive(derive_more::From)]
@@ -68,6 +73,11 @@ impl<NodeId: FromProof> Tree<NodeId> {
     ) -> Result<(D, Partial<Self>), <D::Parent as Deserialiser>::Error> {
         match ctx.presence() {
             Partial::Absent => Ok((ctx, Partial::Absent)),
+            // TODO: RV-895: The proof should include the empty tree rather
+            // than blinding it.
+            Partial::Blinded(hash) if hash == *EMPTY_TREE_HASH => {
+                Ok((ctx, Partial::Present(Tree::default())))
+            }
             Partial::Blinded(hash) => Ok((ctx, Partial::Blinded(hash))),
             Partial::Present(()) => {
                 let (ctx, present) = ctx.next_branch_with(|proof| proof.into_leaf::<bool>())?;
@@ -451,12 +461,9 @@ impl<NodeId: Storable> Storable for Tree<NodeId> {
 
 impl<NodeId: Loadable> Loadable for Tree<NodeId> {
     fn load(id: Hash, store: &impl KeyValueStore) -> Result<Self, OperationalError> {
-        static EMPTY_HASH: LazyLock<Hash> =
-            LazyLock::new(|| Hash::from_foldable(&Tree::<LazyNodeId>(None)));
-
         // Empty trees are not stored. We can short-circuit here, if we detect the requested hash
         // corresponds to the hash of the empty tree.
-        if id == *EMPTY_HASH {
+        if id == *EMPTY_TREE_HASH {
             return Ok(Self(None));
         }
 

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -485,13 +485,12 @@ mod tests {
 
     use super::Database;
     use super::DatabaseMode;
-    use crate::avl::tree::Tree;
     use crate::database::MAX_VALUE_SIZE;
     use crate::errors::Error;
     use crate::errors::InvalidArgumentError;
     use crate::key::KEY_MAX_SIZE;
     use crate::key::Key;
-    use crate::merkle_layer::MerkleLayer;
+    use crate::merkle_layer::new_verify_layer;
     use crate::merkle_worker::BackgroundKeyValueStore;
     use crate::merkle_worker::BackgroundPersistentKeyValueStore;
     use crate::storage::TestKeyValueStoreSetup;
@@ -507,7 +506,7 @@ mod tests {
     fn new_verify_database<KV>() -> Database<KV, Verify> {
         Database {
             inner: super::VerifyImpl {
-                merkle: MerkleLayer::from_verify_tree(Tree::default()),
+                merkle: new_verify_layer(),
             },
         }
     }

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -503,10 +503,10 @@ mod tests {
         Database::try_new(handle, repo).expect("Creating a test database should succeed")
     }
 
-    fn new_verify_database<KV>() -> Database<KV, Verify> {
+    fn new_verify_database<KV: TestKeyValueStoreSetup>() -> Database<KV, Verify> {
         Database {
             inner: super::VerifyImpl {
-                merkle: new_verify_layer(),
+                merkle: new_verify_layer::<KV>(),
             },
         }
     }

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -22,6 +22,8 @@ use std::sync::Arc;
 
 use octez_riscv_data::components::bytes::Bytes;
 use octez_riscv_data::hash::Hash;
+use octez_riscv_data::hash::PartialHash;
+use octez_riscv_data::merkle_proof::proof_tree::MerkleProof;
 use octez_riscv_data::mode::Modal;
 use octez_riscv_data::mode::Mode;
 use octez_riscv_data::mode::Normal;
@@ -35,6 +37,7 @@ use crate::avl::resolver::ProveNodeId;
 use crate::avl::resolver::ProveResolver;
 use crate::avl::resolver::VerifyNodeId;
 use crate::avl::resolver::VerifyResolver;
+use crate::avl::resolver::VerifyTreeId;
 use crate::avl::tree::Tree;
 use crate::commit::CommitId;
 use crate::errors::Error;
@@ -250,12 +253,22 @@ impl MerkleLayerMode for Verify {
             inner: VerifyImpl {
                 tree: this.inner.tree.clone(),
                 resolver: VerifyResolver,
+                original_proof: this.inner.original_proof.clone(),
             },
         }
     }
 
-    fn hash<KV>(_this: &MerkleLayer<KV, Self>) -> Hash {
-        unimplemented!("Blocked by RV-961")
+    fn hash<KV>(this: &MerkleLayer<KV, Self>) -> Hash {
+        // The wrapping `original_proof: None` is intentional: it lets each per-node sub-proof
+        // captured on `VerifyNodeId::Present` drive its own subtree fold (via
+        // `PartialHashFold::with_proof`), while the top-level `Some(proof)` we pass in is the
+        // fallback consumed by the root `into_node_fold` call.
+        let tree_id = VerifyTreeId::Present {
+            tree: this.inner.tree.clone(),
+        };
+        PartialHash::from_foldable(Some((*this.inner.original_proof).clone()), &tree_id)
+            .to_hash()
+            .expect("verify-mode hash should resolve to Present")
     }
 
     fn delete<KV: KeyValueStore>(
@@ -391,6 +404,9 @@ struct ProveImpl<KV> {
 struct VerifyImpl {
     tree: Tree<VerifyNodeId>,
     resolver: VerifyResolver,
+    /// Original proof the verify-mode tree was deserialised from. Required by [`MerkleLayer::hash`]
+    /// to resolve `prev_hash` substitutions in [`PartialHashFold::previous`] for blinded subtrees.
+    original_proof: Arc<MerkleProof>,
 }
 
 impl<KV> MerkleLayer<KV, Verify> {
@@ -400,13 +416,21 @@ impl<KV> MerkleLayer<KV, Verify> {
     }
 }
 
+/// Construct a verify-mode [`MerkleLayer`] for an empty initial state. Used in tests that exercise
+/// verify-mode mutation primitives in isolation.
+#[cfg(test)]
+pub(crate) fn new_verify_layer<KV>() -> MerkleLayer<KV, Verify> {
+    let proof = MerkleProof::from_foldable(&Tree::<ProveNodeId>::default());
+    MerkleLayer::from_proof(proof).expect("The proof should be deserialisable")
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
 
     use octez_riscv_data::components::bytes::Bytes;
-    use octez_riscv_data::hash::PartialHash;
     use octez_riscv_data::merkle_proof::FromProof;
+    use octez_riscv_data::merkle_proof::ProofError;
     use octez_riscv_data::merkle_proof::proof_tree::MerkleProof;
     use octez_riscv_data::merkle_proof::proof_tree::ProofTree;
     use octez_riscv_data::mode::Normal;
@@ -419,13 +443,13 @@ mod tests {
 
     use super::MerkleLayer;
     use super::ProveImpl;
+    use super::new_verify_layer;
     use crate::avl::node::Node;
     use crate::avl::resolver::ArcTreeId;
     use crate::avl::resolver::LazyNodeId;
     use crate::avl::resolver::LazyResolver;
     use crate::avl::resolver::LazyTreeId;
     use crate::avl::resolver::ProveResolver;
-    use crate::avl::resolver::VerifyNodeId;
     use crate::avl::resolver::VerifyResolver;
     use crate::avl::resolver::VerifyTreeId;
     use crate::avl::tree::Tree;
@@ -459,14 +483,28 @@ mod tests {
     }
 
     impl<KV> MerkleLayer<KV, Verify> {
-        /// Construct a Verify-mode MerkleLayer from a deserialised tree.
-        pub(crate) fn from_verify_tree(tree: Tree<VerifyNodeId>) -> Self {
-            MerkleLayer {
+        /// Construct a Verify-mode [`MerkleLayer`] by deserialising a [`MerkleProof`].
+        ///
+        /// The proof is retained so [`MerkleLayer::hash`] can resolve `prev_hash` substitutions for
+        /// blinded subtrees that fold to [`PartialHash::Previous`].
+        pub fn from_proof(proof: MerkleProof) -> Result<Self, ProofError> {
+            let proof = Arc::new(proof);
+            let tree_id = VerifyTreeId::from_proof(ProofTree::Present(&proof))?.into_result();
+            let VerifyTreeId::Present { tree, .. } = tree_id else {
+                // The top-level fold for a Normal-mode `Tree<LazyNodeId>` always emits a node fold,
+                // so a well-formed proof's root deserialises as `Present`. `Blinded`/`Absent` here
+                // would mean the entire state has been hidden — an unusable verify layer.
+                return Err(ProofError::Custom(
+                    "malformed proof - deserialising MAVL tree without being present.".into(),
+                ));
+            };
+            Ok(MerkleLayer {
                 inner: VerifyImpl {
                     tree,
                     resolver: VerifyResolver,
+                    original_proof: proof,
                 },
-            }
+            })
         }
     }
 
@@ -1581,17 +1619,10 @@ mod tests {
         assert_eq!(node, b"prove to verify");
 
         // Verify mode
+
         let proof = MerkleProof::from_foldable(&prove_ml.inner.tree);
-        let verify_tree_id = VerifyTreeId::from_proof(ProofTree::Present(&proof))
-            .expect("The proof should be deserialisable")
-            .into_result();
-
-        let tree = match verify_tree_id {
-            VerifyTreeId::Present(tree) => tree,
-            _ => panic!("Should be present"),
-        };
-
-        let verify_ml: MerkleLayer<KV, Verify> = MerkleLayer::from_verify_tree(tree);
+        let verify_ml: MerkleLayer<KV, Verify> =
+            MerkleLayer::from_proof(proof).expect("The proof should be deserialisable");
 
         let node = verify_ml
             .get(&keys[1])
@@ -1603,7 +1634,7 @@ mod tests {
     kv_test!(test_verify_delete, KV, {
         let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
 
-        let mut ml: MerkleLayer<KV, Verify> = MerkleLayer::from_verify_tree(Tree::default());
+        let mut ml: MerkleLayer<KV, Verify> = new_verify_layer::<KV>();
         ml.delete(&key)
             .expect("deleting a key that doesn't exist should succeed");
 
@@ -1622,7 +1653,7 @@ mod tests {
             .map(|r| r.expect("Size less than KEY_MAX_SIZE"));
         let data: [&[u8]; 3] = [b"too cold", b"too hot", b"just right"];
 
-        let mut ml: MerkleLayer<KV, Verify> = MerkleLayer::from_verify_tree(Tree::default());
+        let mut ml: MerkleLayer<KV, Verify> = new_verify_layer::<KV>();
         for (key, datum) in keys.iter().zip(data.iter()) {
             ml.set(key, datum).expect("setting node should succeed");
         }
@@ -1639,7 +1670,7 @@ mod tests {
     kv_test!(test_verify_try_clone_with_cow, KV, {
         let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
 
-        let mut ml: MerkleLayer<KV, Verify> = MerkleLayer::from_verify_tree(Tree::default());
+        let mut ml: MerkleLayer<KV, Verify> = new_verify_layer::<KV>();
         let cow_data = "🐮<(verify a moo!)";
         ml.set(&key, cow_data.as_bytes())
             .expect("setting node should succeed");
@@ -1672,7 +1703,7 @@ mod tests {
     kv_test!(test_verify_write_partial, KV, {
         let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
 
-        let mut ml: MerkleLayer<KV, Verify> = MerkleLayer::from_verify_tree(Tree::default());
+        let mut ml: MerkleLayer<KV, Verify> = new_verify_layer::<KV>();
         ml.set(&key, b"partial")
             .expect("setting node should succeed");
         ml.write(&key, 4, b"ying").expect("write should succeed");
@@ -1765,15 +1796,8 @@ mod tests {
         let merkle_proof = MerkleProof::from_foldable(&prove_ml.inner.tree);
 
         // ---- Verify: deserialize proof, replay identical ops ----
-        let verify_tree_id = VerifyTreeId::from_proof(ProofTree::Present(&merkle_proof))
-            .expect("proof deserialization should succeed")
-            .into_result();
-
-        let VerifyTreeId::Present(verify_tree) = verify_tree_id else {
-            panic!("expected Present tree from proof");
-        };
-
-        let mut verify_ml: MerkleLayer<KV, Verify> = MerkleLayer::from_verify_tree(verify_tree);
+        let mut verify_ml: MerkleLayer<KV, Verify> =
+            MerkleLayer::from_proof(merkle_proof).expect("proof deserialization should succeed");
 
         let final_hash = catch_not_found(move || {
             let data = verify_ml
@@ -1786,10 +1810,7 @@ mod tests {
                 .write(&keys[1], 0, b"BETA")
                 .expect("write should succeed");
 
-            let verify_tree_id = VerifyTreeId::Present(verify_ml.inner.tree);
-            PartialHash::from_foldable(Some(merkle_proof), &verify_tree_id)
-                .to_hash()
-                .expect("verify hash should be computable")
+            verify_ml.hash()
         })
         .expect("verify operations should not trigger not_found");
 

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -21,18 +21,27 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use octez_riscv_data::components::bytes::Bytes;
+use octez_riscv_data::foldable::Fold;
+use octez_riscv_data::foldable::Foldable;
+use octez_riscv_data::foldable::NodeFold;
 use octez_riscv_data::hash::Hash;
+use octez_riscv_data::hash::HashFold;
 use octez_riscv_data::hash::PartialHash;
 use octez_riscv_data::merkle_proof::proof_tree::MerkleProof;
+use octez_riscv_data::merkle_proof::proof_tree::MerkleProofFold;
+use octez_riscv_data::merkle_proof::proof_tree::MinimumPresence;
 use octez_riscv_data::mode::Modal;
 use octez_riscv_data::mode::Mode;
 use octez_riscv_data::mode::Normal;
 use octez_riscv_data::mode::Prove;
 use octez_riscv_data::mode::Verify;
+use octez_riscv_data::serialisation::serialise;
 use perfect_derive::perfect_derive;
 
+use crate::avl::resolver::CachedOnlyResolver;
 use crate::avl::resolver::LazyNodeId;
 use crate::avl::resolver::LazyResolver;
+use crate::avl::resolver::LazyTreeId;
 use crate::avl::resolver::ProveNodeId;
 use crate::avl::resolver::ProveResolver;
 use crate::avl::resolver::Resolver;
@@ -49,6 +58,8 @@ use crate::storage::Loadable;
 use crate::storage::PersistentKeyValueStore;
 use crate::storage::Storable;
 use crate::storage::StoreOptions;
+#[cfg(test)]
+use crate::storage::TestKeyValueStoreSetup;
 
 /// A layer for transforming data into a Merkle-ised representation before commitment to a
 /// [`PersistentKeyValueStore`].
@@ -203,23 +214,28 @@ impl MerkleLayerMode for Prove<'static> {
         this: &MerkleLayer<KV, Self>,
         persistence: Arc<KV>,
     ) -> MerkleLayer<KV, Self> {
+        // TODO RV-985: This requires work for supporting under multi-step proofs.
+        let resolver = ProveResolver::start(LazyResolver::new(persistence), None);
         MerkleLayer {
             inner: ProveImpl {
-                tree: this.inner.tree.clone(),
-                resolver: ProveResolver::start(LazyResolver::new(persistence)),
+                initial_tree: this.inner.initial_tree.clone(),
+                working_tree: this.inner.working_tree.clone(),
+                resolver,
             },
         }
     }
 
     fn hash<KV>(this: &MerkleLayer<KV, Self>) -> Hash {
-        this.inner.tree.hash()
+        this.inner.working_tree.hash()
     }
 
     fn delete<KV: KeyValueStore>(
         this: &mut MerkleLayer<KV, Self>,
         key: &Key,
     ) -> Result<(), OperationalError> {
-        this.inner.tree.delete(key, &mut this.inner.resolver)?;
+        this.inner
+            .working_tree
+            .delete(key, &mut this.inner.resolver)?;
         Ok(())
     }
 
@@ -228,7 +244,9 @@ impl MerkleLayerMode for Prove<'static> {
         key: &Key,
         data: &[u8],
     ) -> Result<(), OperationalError> {
-        this.inner.tree.set(key, data, &mut this.inner.resolver)?;
+        this.inner
+            .working_tree
+            .set(key, data, &mut this.inner.resolver)?;
         Ok(())
     }
 
@@ -239,7 +257,7 @@ impl MerkleLayerMode for Prove<'static> {
         data: &[u8],
     ) -> Result<(), Error> {
         this.inner
-            .tree
+            .working_tree
             .write(key, offset, data, &mut this.inner.resolver)?;
         Ok(())
     }
@@ -396,18 +414,166 @@ impl<KV> NormalImpl<KV> {
 }
 
 #[derive(Debug)]
-struct ProveImpl<KV> {
-    tree: Tree<ProveNodeId>,
-    resolver: ProveResolver<LazyResolver<KV>>,
-}
-
-#[derive(Debug)]
 struct VerifyImpl {
     tree: Tree<VerifyNodeId>,
     resolver: VerifyResolver,
     /// Original proof the verify-mode tree was deserialised from. Required by [`MerkleLayer::hash`]
     /// to resolve `prev_hash` substitutions in [`PartialHashFold::previous`] for blinded subtrees.
     original_proof: Arc<MerkleProof>,
+}
+
+/// Prove-mode backing state for a [`MerkleLayer`].
+///
+/// - `initial_tree`: an immutable snapshot of the Normal-mode tree, captured at `start_proof`
+///   time. This is what the [`MerkleProofFold`] implementation on [`MerkleLayer`] walks.
+/// - `working_tree`: a Prove-mode projection that the step mutates. Its root hash is the
+///   final-state hash and its per-node read flags are the source of truth for
+///   deciding which fields of an initial node were actually read.
+/// - `resolver`: a [`ProveResolver`] wrapping a [`LazyResolver`]. Its access set tells the fold
+///   which initial-tree nodes can be blinded.
+///
+/// [`MerkleProofFold`]: octez_riscv_data::merkle_proof::proof_tree::MerkleProofFold
+#[derive(Debug)]
+struct ProveImpl<KV> {
+    initial_tree: LazyTreeId,
+    working_tree: Tree<ProveNodeId>,
+    resolver: ProveResolver<LazyResolver<KV>>,
+}
+
+impl<KV: KeyValueStore> Foldable<HashFold> for MerkleLayer<KV, Prove<'_>> {
+    fn fold(&self, _builder: HashFold) -> <HashFold as Fold>::Folded {
+        self.inner.working_tree.hash()
+    }
+}
+
+impl<KV: KeyValueStore> Foldable<MerkleProofFold> for MerkleLayer<KV, Prove<'_>> {
+    fn fold(&self, builder: MerkleProofFold) -> <MerkleProofFold as Fold>::Folded {
+        let wrapper = InitialTreeFold {
+            tree_id: &self.inner.initial_tree,
+            prove_impl: &self.inner,
+        };
+        wrapper.fold(builder)
+    }
+}
+
+/// Wrapper that folds an initial-tree [`Tree<LazyNodeId>`] into a [`MerkleProofFold`].
+struct InitialTreeFold<'a, KV> {
+    tree_id: &'a LazyTreeId,
+    prove_impl: &'a ProveImpl<KV>,
+}
+
+impl<KV: KeyValueStore> Foldable<MerkleProofFold> for InitialTreeFold<'_, KV> {
+    fn fold(&self, builder: MerkleProofFold) -> <MerkleProofFold as Fold>::Folded {
+        let tree_hash = Hash::from_foldable(self.tree_id);
+
+        if !self.prove_impl.resolver.was_tree_accessed(&tree_hash) {
+            // TODO: RV-968 - replace `into_blind` with a non-`CompressibleMerkleProof`-constructing
+            // API once it is available.
+            return builder.into_blind(tree_hash);
+        }
+
+        // If accessed, we can resolve the tree, which should exist in the resolver's cache.
+        let tree = self
+            .prove_impl
+            .resolver
+            .inner()
+            .resolve(self.tree_id)
+            .expect("Accessed tree should be cached in LazyResolver");
+
+        let mut node_fold = builder.into_node_fold();
+
+        // Bool leaf: true if the initial tree is occupied.
+        let present = tree.root().is_some();
+        let bool_data = serialise(present).expect("Serialising a bool should not fail");
+        let bool_leaf = MerkleProofFold::new_leaf(MinimumPresence::Present, bool_data);
+        node_fold.add(&bool_leaf);
+
+        if let Some(lazy_node_id) = tree.root() {
+            let child = InitialNodeFold {
+                node_id: lazy_node_id,
+                prove_impl: self.prove_impl,
+            };
+            node_fold.add(&child);
+        }
+
+        node_fold.done()
+    }
+}
+
+/// Wrapper that folds an initial-node [`LazyNodeId`] into a [`MerkleProofFold`].
+///
+/// If the node was not accessed during the step, it is blinded.  Otherwise, per-field presence
+/// (meta, data) is taken from the prove-mode `Node`'s read flags, and the children are folded
+/// recursively off the `initial_tree`'s structure (not the working tree's).
+struct InitialNodeFold<'a, KV> {
+    node_id: &'a LazyNodeId,
+    prove_impl: &'a ProveImpl<KV>,
+}
+
+impl<KV: KeyValueStore> Foldable<MerkleProofFold> for InitialNodeFold<'_, KV> {
+    fn fold(&self, builder: MerkleProofFold) -> <MerkleProofFold as Fold>::Folded {
+        let hash = Hash::from_foldable(self.node_id);
+
+        if !self.prove_impl.resolver.was_node_accessed(&hash) {
+            // TODO: RV-968 - replace `into_blind` with a non-`CompressibleMerkleProof`-constructing
+            // API once it is available.
+            return builder.into_blind(hash);
+        }
+
+        // Resolve the initial node to get its key and children.
+        let initial_node = self
+            .prove_impl
+            .resolver
+            .inner()
+            .resolve(self.node_id)
+            .expect("Accessed node should be cached in LazyResolver");
+
+        // Find the prove-mode projection carrying the read flags.
+        //
+        // 1. Check `deleted_nodes` first (covers delete and delete-reinsert-same-key).
+        //    For delete-then-reinsert-same-key: the deleted node's flags are correct because
+        //    this fold walks the *initial* tree — the initial node was read/deleted during the
+        //    step, so its flags reflect that access. The newly inserted node at the same key
+        //    is a different node in the working tree and is irrelevant to the initial fold.
+        // 2. Otherwise search the working tree by key.
+        let deleted_map = self.prove_impl.resolver.deleted_nodes();
+        let (meta, data) = if let Some(deleted_node) = deleted_map.get(&hash) {
+            (&deleted_node.meta, &deleted_node.data)
+        } else {
+            let key = initial_node.key();
+            let cached_only_resolver = CachedOnlyResolver;
+            let cached_id = self
+                .prove_impl
+                .working_tree
+                .get(key, &cached_only_resolver)
+                .expect("Working-tree lookup should not fail for an accessed node")
+                .expect("Accessed node should still be present in the working tree");
+            let cached = cached_only_resolver
+                .resolve(cached_id)
+                .expect("Working-tree lookup should not fail for an accessed node.");
+            (cached.meta(), cached.data())
+        };
+
+        // Fold meta + data from the prove-mode node (they carry per-field read flags).
+        let mut node_fold = builder.into_node_fold();
+        node_fold.add(meta);
+        node_fold.add(data);
+
+        // Fold left + right from the initial tree's children.
+        let left = InitialTreeFold {
+            tree_id: initial_node.left_id(),
+            prove_impl: self.prove_impl,
+        };
+        node_fold.add(&left);
+
+        let right = InitialTreeFold {
+            tree_id: initial_node.right_id(),
+            prove_impl: self.prove_impl,
+        };
+        node_fold.add(&right);
+
+        node_fold.done()
+    }
 }
 
 impl<KV> MerkleLayer<KV, Verify> {
@@ -427,9 +593,21 @@ impl<KV> MerkleLayer<KV, Verify> {
 /// Construct a verify-mode [`MerkleLayer`] for an empty initial state. Used in tests that exercise
 /// verify-mode mutation primitives in isolation.
 #[cfg(test)]
-pub(crate) fn new_verify_layer<KV>() -> MerkleLayer<KV, Verify> {
-    let proof = MerkleProof::from_foldable(&Tree::<ProveNodeId>::default());
-    MerkleLayer::from_proof(proof).expect("The proof should be deserialisable")
+pub(crate) fn new_verify_layer<KV: KeyValueStore + TestKeyValueStoreSetup>()
+-> MerkleLayer<KV, Verify> {
+    let (_keepalive, repo) = KV::setup_repo();
+    let normal_ml = new_merkle_layer::<KV>(&repo);
+    let prove_ml = normal_ml.start_proof();
+    let proof = MerkleProof::from_foldable(&prove_ml);
+    MerkleLayer::from_proof(proof).expect("empty-tree proof should deserialise")
+}
+
+#[cfg(test)]
+fn new_merkle_layer<KV: KeyValueStore>(repo: &KV::Repo) -> MerkleLayer<KV, Normal> {
+    let persistence_layer = KV::new(repo)
+        .expect("Creating a persistence layer should succeed")
+        .into();
+    MerkleLayer::new(persistence_layer)
 }
 
 #[cfg(test)]
@@ -451,6 +629,7 @@ mod tests {
 
     use super::MerkleLayer;
     use super::ProveImpl;
+    use super::new_merkle_layer;
     use super::new_verify_layer;
     use crate::avl::node::Node;
     use crate::avl::resolver::ArcTreeId;
@@ -490,11 +669,38 @@ mod tests {
                 None => Ok(None),
             }
         }
+
+        /// Snapshot the current tree and enter prove mode.
+        ///
+        /// The returned layer holds two trees: an immutable `initial_tree` (a cheap `Clone` of the
+        /// Normal-mode tree) and a `working_tree` derived from it via [`Tree::into_proof`]. Mutations
+        /// during the proof step run against the working tree; the initial tree drives the
+        /// [`MerkleProofFold`] that generates the proof.
+        ///
+        /// [`MerkleProofFold`]: octez_riscv_data::merkle_proof::proof_tree::MerkleProofFold
+        pub fn start_proof(&self) -> MerkleLayer<KV, Prove<'static>> {
+            let initial_tree = self.inner.tree.clone();
+            let root_tree_hash = initial_tree.hash();
+            let resolver = ProveResolver::start(
+                LazyResolver::new(self.inner.persistence.clone()),
+                Some(root_tree_hash),
+            );
+            let working_tree = initial_tree.clone().into_proof(&resolver);
+            let initial_tree_id = LazyTreeId::from(initial_tree);
+
+            MerkleLayer {
+                inner: ProveImpl {
+                    initial_tree: initial_tree_id,
+                    working_tree,
+                    resolver,
+                },
+            }
+        }
     }
 
     impl<KV: KeyValueStore> MerkleLayer<KV, Prove<'static>> {
         fn get(&self, key: &Key) -> Result<Option<&Bytes<Prove<'static>>>, OperationalError> {
-            let node = self.inner.tree.get(key, &self.inner.resolver)?;
+            let node = self.inner.working_tree.get(key, &self.inner.resolver)?;
             match node {
                 Some(node_id) => {
                     let resolved_node = self.inner.resolver.resolve(node_id)?;
@@ -529,13 +735,6 @@ mod tests {
                 },
             })
         }
-    }
-
-    fn new_merkle_layer<KV: KeyValueStore>(repo: &KV::Repo) -> MerkleLayer<KV, Normal> {
-        let persistence_layer = KV::new(repo)
-            .expect("Creating a persistence layer should succeed")
-            .into();
-        MerkleLayer::new(persistence_layer)
     }
 
     kv_test!(test_mavl_cow, KV, {
@@ -1489,10 +1688,12 @@ mod tests {
         let persistence: Arc<KV> = KV::new(&repo)
             .expect("Creating a persistence layer should succeed")
             .into();
+        let resolver = ProveResolver::start(LazyResolver::new(persistence), None);
         let mut ml: MerkleLayer<KV, Prove<'static>> = MerkleLayer {
             inner: ProveImpl {
-                tree: Tree::default(),
-                resolver: ProveResolver::start(LazyResolver::new(persistence)),
+                initial_tree: LazyTreeId::default(),
+                working_tree: Tree::default(),
+                resolver,
             },
         };
         ml.delete(&key)
@@ -1517,10 +1718,12 @@ mod tests {
         let persistence: Arc<KV> = KV::new(&repo)
             .expect("Creating a persistence layer should succeed")
             .into();
+        let resolver = ProveResolver::start(LazyResolver::new(persistence), None);
         let mut ml: MerkleLayer<KV, Prove<'static>> = MerkleLayer {
             inner: ProveImpl {
-                tree: Tree::default(),
-                resolver: ProveResolver::start(LazyResolver::new(persistence)),
+                initial_tree: LazyTreeId::default(),
+                working_tree: Tree::default(),
+                resolver,
             },
         };
         for (key, datum) in keys.iter().zip(data.iter()) {
@@ -1543,10 +1746,12 @@ mod tests {
         let persistence: Arc<KV> = KV::new(&repo)
             .expect("Creating a persistence layer should succeed")
             .into();
+        let resolver = ProveResolver::start(LazyResolver::new(persistence), None);
         let mut ml: MerkleLayer<KV, Prove<'static>> = MerkleLayer {
             inner: ProveImpl {
-                tree: Tree::default(),
-                resolver: ProveResolver::start(LazyResolver::new(persistence)),
+                initial_tree: LazyTreeId::default(),
+                working_tree: Tree::default(),
+                resolver,
             },
         };
         let cow_data = "🐮<(prove a moo!)";
@@ -1585,10 +1790,12 @@ mod tests {
         let persistence: Arc<KV> = KV::new(&repo)
             .expect("Creating a persistence layer should succeed")
             .into();
+        let resolver = ProveResolver::start(LazyResolver::new(persistence), None);
         let mut ml: MerkleLayer<KV, Prove<'static>> = MerkleLayer {
             inner: ProveImpl {
-                tree: Tree::default(),
-                resolver: ProveResolver::start(LazyResolver::new(persistence)),
+                initial_tree: LazyTreeId::default(),
+                working_tree: Tree::default(),
+                resolver,
             },
         };
         ml.set(&key, b"partial")
@@ -1623,16 +1830,7 @@ mod tests {
             .expect("setting node should succeed");
 
         // `Prove` mode
-        let resolver = LazyResolver::new(normal_ml.inner.persistence.clone());
-        let resolver = ProveResolver::start(resolver);
-        let prove_tree = normal_ml.inner.tree.into_proof(&resolver);
-
-        let prove_ml: MerkleLayer<KV, Prove<'static>> = MerkleLayer {
-            inner: ProveImpl {
-                tree: prove_tree,
-                resolver,
-            },
-        };
+        let prove_ml = normal_ml.start_proof();
 
         // Read to mark it as present in the proof
         let node = prove_ml
@@ -1642,8 +1840,7 @@ mod tests {
         assert_eq!(node, b"prove to verify");
 
         // Verify mode
-
-        let proof = MerkleProof::from_foldable(&prove_ml.inner.tree);
+        let proof = MerkleProof::from_foldable(&prove_ml);
         let verify_ml: MerkleLayer<KV, Verify> =
             MerkleLayer::from_proof(proof).expect("The proof should be deserialisable");
 
@@ -1757,16 +1954,7 @@ mod tests {
 
         let normal_hash = normal_ml.hash();
 
-        let resolver = LazyResolver::new(normal_ml.inner.persistence.clone());
-        let resolver = ProveResolver::start(resolver);
-        let prove_tree = normal_ml.inner.tree.into_proof(&resolver);
-
-        let prove_ml: MerkleLayer<KV, Prove<'static>> = MerkleLayer {
-            inner: ProveImpl {
-                tree: prove_tree,
-                resolver,
-            },
-        };
+        let prove_ml = normal_ml.start_proof();
 
         assert_eq!(normal_hash, prove_ml.hash());
     });
@@ -1790,17 +1978,8 @@ mod tests {
 
         let initial_hash = normal_ml.hash();
 
-        // ---- Prove: read key then overwrite it ----
-        let resolver = LazyResolver::new(normal_ml.inner.persistence.clone());
-        let resolver = ProveResolver::start(resolver);
-        let prove_tree = normal_ml.inner.tree.into_proof(&resolver);
-
-        let mut prove_ml: MerkleLayer<KV, Prove<'static>> = MerkleLayer {
-            inner: ProveImpl {
-                tree: prove_tree,
-                resolver,
-            },
-        };
+        // ---- Prove: start proof, read key2, write key2 ----
+        let mut prove_ml = normal_ml.start_proof();
 
         let data = prove_ml
             .get(&keys[1])
@@ -1816,7 +1995,7 @@ mod tests {
         assert_ne!(initial_hash, expected_hash, "write should change the hash");
 
         // ---- Generate proof ----
-        let merkle_proof = MerkleProof::from_foldable(&prove_ml.inner.tree);
+        let merkle_proof = MerkleProof::from_foldable(&prove_ml);
 
         // ---- Verify: deserialize proof, replay identical ops ----
         let mut verify_ml: MerkleLayer<KV, Verify> =

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -278,10 +278,6 @@ impl MerkleLayerMode for Verify {
     }
 
     fn hash<KV>(this: &MerkleLayer<KV, Self>) -> Hash {
-        // The wrapping `original_proof: None` is intentional: it lets each per-node sub-proof
-        // captured on `VerifyNodeId::Present` drive its own subtree fold (via
-        // `PartialHashFold::with_proof`), while the top-level `Some(proof)` we pass in is the
-        // fallback consumed by the root `into_node_fold` call.
         let tree_id = VerifyTreeId::Present {
             tree: this.inner.tree.clone(),
         };
@@ -628,6 +624,7 @@ mod tests {
     use proptest::proptest;
 
     use super::MerkleLayer;
+    use super::MerkleLayerMode;
     use super::ProveImpl;
     use super::new_merkle_layer;
     use super::new_verify_layer;
@@ -646,6 +643,7 @@ mod tests {
     use crate::merkle_layer::VerifyImpl;
     use crate::storage::KeyValueStore;
     use crate::storage::PersistentKeyValueStore;
+    use crate::storage::TestKeyValueStoreSetup;
     use crate::storage::kv_test;
 
     impl<KV: KeyValueStore> MerkleLayer<KV, Normal> {
@@ -735,6 +733,119 @@ mod tests {
                 },
             })
         }
+    }
+
+    /// Operations executed during a prove step and replayed during verification.
+    #[derive(Debug, Clone)]
+    enum Operation {
+        /// Set (insert or overwrite) a key.
+        Set(Key, Vec<u8>),
+        /// Delete a key (may be absent — that is a no-op on both sides).
+        Delete(Key),
+        /// In-place write at the given offset.
+        /// Only applied to keys that are known to exist.
+        /// The offset must be `<= existing_data_len` for the write to succeed.
+        Write(Key, usize, Vec<u8>),
+    }
+
+    fn apply_operation<KV: KeyValueStore, M: MerkleLayerMode>(
+        ml: &mut MerkleLayer<KV, M>,
+        op: &Operation,
+    ) {
+        match op {
+            Operation::Set(key, data) => {
+                ml.set(key, data).expect("set should succeed");
+            }
+            Operation::Delete(key) => {
+                ml.delete(key).expect("delete should succeed");
+            }
+            Operation::Write(key, offset, data) => {
+                ml.write(key, *offset, data).expect("write should succeed");
+            } // TODO RV-895: add `get` to step op
+        }
+    }
+
+    /// Core assertion: prove-mode proof and hash are consistent with Normal mode and the proof
+    /// can be replayed under Verify mode to reach the same final hash.
+    ///
+    /// Checks three properties:
+    /// 1. The proof's initial root hash matches the initial Normal-mode hash (proof encodes initial
+    ///    state correctly).
+    /// 2. The prove-mode final hash matches Normal-mode after an identical operation (prove-mode
+    ///    mutations are faithful).
+    /// 3. Replaying the same operation against the Verify-mode tree decoded from the proof
+    ///    produces the same final hash as prove mode (the proof carries enough information for
+    ///    full verification).
+    fn assert_prove_mode_correct<KV: KeyValueStore + TestKeyValueStoreSetup>(
+        setup_keys: &[[u8; 2]],
+        operations: &[Operation],
+    ) {
+        // ---- Normal: build initial tree ----
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut normal_ml = new_merkle_layer::<KV>(&repo);
+
+        for bytes in setup_keys {
+            let key = Key::new(bytes).expect("key should be valid");
+            let data = [bytes[0]; 10];
+            normal_ml.set(&key, &data).expect("set should succeed");
+        }
+
+        let initial_hash = normal_ml.hash();
+
+        // ---- Prove: start proof and execute operations ----
+        let mut prove_ml = normal_ml.start_proof();
+        for op in operations {
+            apply_operation(&mut prove_ml, op);
+        }
+        let prove_final_hash = prove_ml.hash();
+
+        // ---- Generate proof ----
+        let merkle_proof = MerkleProof::from_foldable(&prove_ml);
+
+        // Property 1: proof's root hash == initial Normal-mode hash.
+        assert_eq!(
+            initial_hash,
+            merkle_proof.root_hash(),
+            "proof root hash must match initial Normal-mode hash"
+        );
+
+        // ---- Normal: replay same operations for reference hash ----
+        for op in operations {
+            apply_operation(&mut normal_ml, op);
+        }
+        let normal_final_hash = normal_ml.hash();
+
+        // Property 2: prove-mode final hash == Normal-mode final hash.
+        assert_eq!(
+            normal_final_hash, prove_final_hash,
+            "prove-mode final hash must match Normal-mode final hash"
+        );
+
+        // ---- Verify: deserialise the proof and replay the same operations ----
+        let mut verify_ml: MerkleLayer<KV, Verify> = MerkleLayer::from_proof(merkle_proof.clone())
+            .expect("proof deserialisation should succeed");
+
+        // Property 3a: verify-mode initial hash matches.
+        let verify_initial_hash = verify_ml.hash();
+        assert_eq!(
+            initial_hash, verify_initial_hash,
+            "verify-mode initial hash must match Normal-mode initial hash"
+        );
+
+        let operations_for_verify = operations.to_vec();
+        let verify_final_hash = catch_not_found(move || {
+            for op in &operations_for_verify {
+                apply_operation(&mut verify_ml, op);
+            }
+            verify_ml.hash()
+        })
+        .expect("verify replay should not trigger not_found — proof must cover all accesses");
+
+        // Property 3b: verify-mode final hash matches.
+        assert_eq!(
+            prove_final_hash, verify_final_hash,
+            "verify-mode replay must reach the same final hash as prove mode"
+        );
     }
 
     kv_test!(test_mavl_cow, KV, {
@@ -1959,6 +2070,53 @@ mod tests {
         assert_eq!(normal_hash, prove_ml.hash());
     });
 
+    kv_test!(test_read_only_proof_hash_matches_hash_fold, KV, {
+        let keys = [Key::new(&[0]), Key::new(&[1]), Key::new(&[2])]
+            .map(|r| r.expect("Size less than KEY_MAX_SIZE"));
+
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut normal_ml = new_merkle_layer::<KV>(&repo);
+        normal_ml
+            .set(&keys[0], b"alpha")
+            .expect("set should succeed");
+        normal_ml
+            .set(&keys[1], b"beta")
+            .expect("set should succeed");
+        normal_ml
+            .set(&keys[2], b"gamma")
+            .expect("set should succeed");
+
+        let normal_hash = normal_ml.hash();
+
+        let prove_ml = normal_ml.start_proof();
+
+        // Read-only: access keys without any mutation.
+        let got = prove_ml
+            .get(&keys[0])
+            .expect("get should succeed")
+            .expect("key should exist");
+        assert_eq!(got, b"alpha");
+
+        let got = prove_ml
+            .get(&keys[2])
+            .expect("get should succeed")
+            .expect("key should exist");
+        assert_eq!(got, b"gamma");
+
+        assert_eq!(
+            normal_hash,
+            prove_ml.hash(),
+            "read-only prove step must not change the hash"
+        );
+
+        let proof = MerkleProof::from_foldable(&prove_ml);
+        assert_eq!(
+            normal_hash,
+            proof.root_hash(),
+            "read-only proof root hash must match the original HashFold"
+        );
+    });
+
     kv_test!(test_prove_verify_round_trip_write, KV, {
         let keys = [Key::new(&[1]), Key::new(&[2]), Key::new(&[3])]
             .map(|r| r.expect("key should be valid"));
@@ -2020,5 +2178,125 @@ mod tests {
             expected_hash, final_hash,
             "prove and verify hashes should match after identical get + write operations"
         );
+    });
+
+    kv_test!(prove_verify_round_trips_mixed, KV, {
+        proptest!(|(setup_keys in prop::collection::vec(any::<[u8; 2]>(), 1..30), seed in 0..100usize)| {
+            let keys: Vec<Key> = setup_keys
+                .iter()
+                .map(|b| Key::new(b).expect("key should be valid"))
+                .collect();
+
+            let mut operations = Vec::new();
+            // TODO RV-985: Expand to more operations in each test.
+            // This is currently limited to one operation, as this is the minimum requirement,
+            // and proof semantics are not supported for more than one operation yet.
+            let ops_count = 1;
+            for i in 0..ops_count {
+                let key = keys[i % keys.len()].clone();
+                let data = vec![seed as u8; 5];
+                match (i + seed) % 3 {
+                    0 => operations.push(Operation::Set(key, data)),
+                    1 => operations.push(Operation::Delete(key)),
+                    _ => {
+                        // All setup keys have data set to 10 bytes long.
+                        // Data length is 5 bytes, so valid offsets are 0..=5.
+                        let offset = (i + seed) % 5;
+                        operations.push(Operation::Write(key, offset, data));
+                    }
+                }
+            }
+
+            assert_prove_mode_correct::<KV>(&setup_keys, &operations);
+        });
+    });
+
+    kv_test!(prove_verify_round_trips_writes_only, KV, {
+        // no structural change as every key already exists.
+        proptest!(|(
+            setup_keys in prop::collection::vec(any::<[u8; 2]>(), 1..30),
+            // Setup keys are written with their own 2-byte representation as data, so the only
+            // valid offsets for an in-place / appending write are 0..=2.
+            offsets in prop::collection::vec(0usize..=2, 1..30),
+        )| {
+            let keys: Vec<Key> = setup_keys
+                .iter()
+                .map(|b| Key::new(b).expect("key should be valid"))
+                .collect();
+
+            let step_ops: Vec<Operation> = keys
+                .iter()
+                .enumerate()
+                .map(|(i, key)| {
+                    let offset = offsets[i % offsets.len()];
+                    Operation::Write(key.clone(), offset, vec![0xAA; 1 + (i % 8)])
+                })
+                .collect();
+
+            assert_prove_mode_correct::<KV>(&setup_keys, &step_ops);
+        });
+    });
+
+    kv_test!(prove_verify_round_trips_deletes_only, KV, {
+        proptest!(|(setup_keys in prop::collection::vec(any::<[u8; 2]>(), 1..30), delete_indices in prop::collection::vec(any::<usize>(), 1..10))| {
+            let keys: Vec<Key> = setup_keys
+                .iter()
+                .map(|b| Key::new(b).expect("key should be valid"))
+                .collect();
+
+            let step_ops: Vec<Operation> = delete_indices
+                .iter()
+                .map(|&i| Operation::Delete(keys[i % keys.len()].clone()))
+                .collect();
+
+            assert_prove_mode_correct::<KV>(&setup_keys, &step_ops);
+        });
+    });
+
+    kv_test!(prove_verify_round_trips_insertions, KV, {
+        // prove_verify_insertions: sets on new keys (insertions + rotations)
+        proptest!(|(setup_keys in prop::collection::vec(any::<[u8; 2]>(), 1..20), new_keys in prop::collection::vec(any::<[u8; 2]>(), 1..10))| {
+            let step_ops: Vec<Operation> = new_keys
+                .iter()
+                .enumerate()
+                .map(|(i, bytes)| {
+                    let key = Key::new(bytes).expect("key should be valid");
+                    Operation::Set(key, vec![0xBB; 1 + (i % 8)])
+                })
+                .collect();
+
+            assert_prove_mode_correct::<KV>(&setup_keys, &step_ops);
+        });
+    });
+
+    kv_test!(prove_verify_round_trip_reads_only, KV, {
+        proptest!(|(setup_keys in prop::collection::vec(any::<[u8; 2]>(), 1..30), read_indices in prop::collection::vec(any::<usize>(), 1..15))| {
+            let (_keepalive, repo) = KV::setup_repo();
+            let mut normal_ml = new_merkle_layer::<KV>(&repo);
+
+            for bytes in &setup_keys {
+                let key = Key::new(bytes).expect("key should be valid");
+                normal_ml.set(&key, bytes).expect("set should succeed");
+            }
+
+            let normal_hash = normal_ml.hash();
+            let prove_ml = normal_ml.start_proof();
+
+            for &i in &read_indices {
+                let key = Key::new(&setup_keys[i % setup_keys.len()]).expect("key should be valid");
+                let _ = prove_ml.get(&key).expect("get should succeed");
+            }
+
+            prop_assert_eq!(
+                normal_hash,
+                prove_ml.hash(),
+            );
+
+            let proof = MerkleProof::from_foldable(&prove_ml);
+            prop_assert_eq!(
+                normal_hash,
+                proof.root_hash(),
+            );
+        });
     });
 }

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -35,6 +35,7 @@ use crate::avl::resolver::LazyNodeId;
 use crate::avl::resolver::LazyResolver;
 use crate::avl::resolver::ProveNodeId;
 use crate::avl::resolver::ProveResolver;
+use crate::avl::resolver::Resolver;
 use crate::avl::resolver::VerifyNodeId;
 use crate::avl::resolver::VerifyResolver;
 use crate::avl::resolver::VerifyTreeId;
@@ -412,7 +413,14 @@ struct VerifyImpl {
 impl<KV> MerkleLayer<KV, Verify> {
     /// Returns an immutable reference to the data stored for a given [Key].
     pub(crate) fn get(&self, key: &Key) -> Result<Option<&Bytes<Verify>>, OperationalError> {
-        self.inner.tree.get(key, &self.inner.resolver)
+        let node = self.inner.tree.get(key, &self.inner.resolver)?;
+        match node {
+            Some(node_id) => {
+                let resolved_node = self.inner.resolver.resolve(node_id)?;
+                Ok(Some(resolved_node.data()))
+            }
+            None => Ok(None),
+        }
     }
 }
 
@@ -450,6 +458,7 @@ mod tests {
     use crate::avl::resolver::LazyResolver;
     use crate::avl::resolver::LazyTreeId;
     use crate::avl::resolver::ProveResolver;
+    use crate::avl::resolver::Resolver;
     use crate::avl::resolver::VerifyResolver;
     use crate::avl::resolver::VerifyTreeId;
     use crate::avl::tree::Tree;
@@ -472,13 +481,27 @@ mod tests {
 
         /// Returns an immutable reference to the data stored for a given [Key].
         pub fn get(&mut self, key: &Key) -> Result<Option<&Bytes<Normal>>, OperationalError> {
-            self.inner.tree.get(key, &self.inner.resolver)
+            let node = self.inner.tree.get(key, &self.inner.resolver)?;
+            match node {
+                Some(node_id) => {
+                    let resolved_node = self.inner.resolver.resolve(node_id)?;
+                    Ok(Some(resolved_node.data()))
+                }
+                None => Ok(None),
+            }
         }
     }
 
     impl<KV: KeyValueStore> MerkleLayer<KV, Prove<'static>> {
         fn get(&self, key: &Key) -> Result<Option<&Bytes<Prove<'static>>>, OperationalError> {
-            self.inner.tree.get(key, &self.inner.resolver)
+            let node = self.inner.tree.get(key, &self.inner.resolver)?;
+            match node {
+                Some(node_id) => {
+                    let resolved_node = self.inner.resolver.resolve(node_id)?;
+                    Ok(Some(resolved_node.data()))
+                }
+                None => Ok(None),
+            }
         }
     }
 


### PR DESCRIPTION
Closes RV-957.
Closes RV-961.

  # What

  Fix the `Prove` and `Verify` implementations of `MerkleLayer` so that proof generation
  and verification round-trip correctly across AVL-rebalancing operations
  (`set` on existing/new keys, `delete`, `write`).

  # Why

  The previous prove-mode fold walked the *working* tree, so any AVL rotation triggered
  by the step rearranged the structure relative to the proof and produced root hashes
  that no longer matched the Normal-mode hash. On the verify side, sub-proofs decoded
  into `VerifyNodeId` / `VerifyTreeId` were folded against the inherited parent proof
  rather than the sub-proof they originated from — this caused incorrect `prev_hash`
  substitutions or `PartialHash::InvalidProof` once nodes had been moved by rebalancing.

  # How

  Two structural fixes plus tests:

  1. **Verify side**: each `VerifyNodeId::Present` / `VerifyTreeId::Present` now carries
     the `MerkleProof` sub-tree it was deserialised from, captured up-front via the
     new `Deserialiser::capture_owned_proof()` hook. Their `Foldable<PartialHashFold>`
     impls override the inherited proof with this captured sub-proof before delegating,
     so each node folds against its initial-tree position even after rebalancing.
  2. **Prove side**: `start_proof()` snapshots the Normal-mode tree as an immutable
     `initial_tree`. The `MerkleProofFold` impl on `MerkleLayer<KV, Prove<'_>>` walks
     that snapshot — not the mutating working tree — using `was_node_accessed`/
     `was_tree_accessed` to decide what to blind, and pulling per-field read flags from
     the prove-mode `working_tree` / `deleted_nodes` map.

  # Per-commit breakdown

  1. Plumbing:
     - `PartialHashFold.proof` becomes `Option<Arc<MerkleProof>>` so callers can attach
       a node-local override without deep-cloning.
     - Adds `PartialHashFold::with_proof()` (replace outright, unlike
       `map_reference_proof` which requires `Some`).
     - Adds `Deserialiser::capture_owned_proof()` (default `None`; overridden by
       `ProofTree` to clone the in-memory sub-proof). Stream deserialisers can't
       reconstruct without re-parsing, so the default is correct.

  2. Use the new override:
     - `VerifyNodeId::Present` / `VerifyTreeId::Present` become struct variants
       carrying `original_proof: Option<Arc<MerkleProof>>`, captured before
       `into_node()` consumes the deserialiser.
     - Their `Foldable<PartialHashFold>` impls call `builder.with_proof(...)` before
       delegating to the inner `Node` / `Tree`, so the fold sees each node's
       own sub-proof rather than the parent's view.
     - Resolver impls and tests updated for the new struct layout.

  3. Walk the initial tree, not the mutating one:
     - Removes the broken `Foldable<MerkleProofFold>` impls on `Tree<ProveNodeId>` and
       `ProveNodeId`.
     - Adds `Foldable<MerkleProofFold>` for `MerkleLayer<KV, Prove<'_>>`, implemented
       via two wrappers (`InitialTreeFold` / `InitialNodeFold`) that recurse through the
       initial `LazyTreeId` snapshot, blinding any node/tree the resolver did not
       touch and pulling read-flag-bearing `meta` / `data` from either the working tree
       (via `Tree::get_resolved` + the new `CachedOnlyResolver`) or `deleted_nodes` for
       keys removed during the step.
     - `MerkleLayer<Normal>::start_proof()` is the new entry point: it clones the
       Normal tree, derives the prove-mode `working_tree` from it, and seeds the
       `ProveResolver` with the root hash so the root tree is always considered
       accessed (`ProveResolver::start` now takes `root_tree_hash`).
     - `ProveImpl` is now `{ initial_tree, working_tree, resolver }`. Existing
       prove-mode write-paths and tests adapted to the rename.
     - Removes `#[expect(dead_code, …)]` on `cached_node`, `inner`, `was_*_accessed`,
       `deleted_nodes`, `DeletedNodeFields` now that the fold consumes them.

  4. PBTs:
     - `assert_prove_mode_correct` asserts (1) `proof.root_hash() == initial Normal
       hash`, (2) prove-final == Normal-final after replaying the same op, (3)
       verify-mode replay over the deserialised proof reaches the same final hash.
     - Five proptest cases: random single-op (set/delete/write), writes-only,
       deletes-only, new-key insertions, and read-only.
     - Single-op cases note the current `ops_count = 1` limitation
       (multi-step proofs not yet supported).

# Manually Testing

```
make all
```

# Regressions

<!--
    Explain changes to regression test captures. If there are no changes to these, delete this
    section.
-->

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
