### PR TITLE
feat(durable): include data hash in StoredNode

### DIFF
--- a/durable-storage/src/avl/node.rs
+++ b/durable-storage/src/avl/node.rs
@@ -56,6 +56,7 @@ pub(crate) struct Meta {
 #[derive(Encode, Decode)]
 struct StoredNode {
     meta: Meta,
+    data: Hash,
     left: Hash,
     right: Hash,
 }
@@ -835,6 +836,7 @@ impl<TreeId: Storable> Storable for Node<TreeId, Normal> {
         // should be written to the KV store separately.
         let repr = StoredNode {
             meta: self.meta.deref().clone(),
+            data: Hash::from_foldable(&self.data),
             left: Hash::from_foldable(&self.left),
             right: Hash::from_foldable(&self.right),
         };
@@ -861,7 +863,12 @@ impl<TreeId: Storable> Storable for Node<TreeId, Normal> {
 
 impl<TreeId: Loadable> Loadable for Node<TreeId, Normal> {
     fn load(id: Hash, store: &impl KeyValueStore) -> Result<Self, OperationalError> {
-        let StoredNode { meta, left, right } = {
+        let StoredNode {
+            meta,
+            left,
+            right,
+            data: _,
+        } = {
             let bytes =
                 store
                     .blob_get(id)


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

- Part of RV-955

# What

Store the hash of bytes in the `StoredNode`

# Why

In order to handle the delete after checkout bug (where resolving the node fails in the avl tree, because the value is already deleted from the KV store), we will move loading into a new `Data` component. This will, if loading fails, just keep the hash. Any attempt to access the bytes will fail with the `CommitIdMissing` error in this case - but will allow either `HashFold` to occur (the hash is known), or for the node to be deleted. 

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
