### PR TITLE
refactor(durable): pass data as generic DataId in avl tree

### DIFF
--- a/durable-storage/src/avl/node.rs
+++ b/durable-storage/src/avl/node.rs
@@ -61,9 +61,9 @@ struct StoredNode {
 
 /// A node that supports rebalancing and Merklisation.
 #[perfect_derive(Clone, Default, Debug)]
-pub struct Node<TreeId, M: Mode> {
+pub struct Node<TreeId, DataId, M: Mode> {
     meta: Atom<Meta, M>,
-    data: Bytes<M>,
+    data: DataId,
     left: TreeId,
     right: TreeId,
 
@@ -74,7 +74,7 @@ pub struct Node<TreeId, M: Mode> {
     hash: OnceLock<Hash>,
 }
 
-impl Node<LazyTreeId, Normal> {
+impl Node<LazyTreeId, Bytes<Normal>, Normal> {
     /// Converts the [`Node`] to prove mode.
     pub fn into_proof(self) -> ProveNode {
         Node {
@@ -87,7 +87,7 @@ impl Node<LazyTreeId, Normal> {
     }
 }
 
-impl<TreeId, M: Mode> Node<TreeId, M> {
+impl<TreeId, DataId, M: Mode> Node<TreeId, DataId, M> {
     /// Mark the hash of this node as dirty.
     fn invalidate_hash(&mut self) {
         self.hash = OnceLock::new();
@@ -142,15 +142,16 @@ impl<TreeId, M: Mode> Node<TreeId, M> {
     }
 }
 
-impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
+impl<TreeId, DataId, M: AtomMode> Node<TreeId, DataId, M> {
     /// Find the id of the [`Node`] within the subtree of this [`Node`] with a given [`Key`].
     pub(super) fn get<'a, NodeId>(
         mut node: &'a NodeId,
         key: &Key,
-        resolver: &impl AvlResolver<NodeId, TreeId, M>,
+        resolver: &impl AvlResolver<NodeId, DataId, TreeId, M>,
     ) -> Result<Option<&'a NodeId>, OperationalError>
     where
         NodeId: 'a,
+        DataId: 'a,
         TreeId: 'a,
         M: 'a,
     {
@@ -175,7 +176,7 @@ impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
     }
 
     /// Create a new leaf [`Node`] from the given key and data.
-    pub(crate) fn new(key: Key, data: impl Into<Bytes<M>>) -> Self
+    pub(crate) fn new(key: Key, data: impl Into<DataId>) -> Self
     where
         TreeId: Default,
     {
@@ -197,11 +198,11 @@ impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
     ) -> Result<(D, Self), <D::Parent as Deserialiser>::Error>
     where
         Atom<Meta, M>: FromProof,
-        Bytes<M>: FromProof,
+        DataId: FromProof,
         TreeId: FromProof,
     {
         let (ctx, meta) = ctx.next_branch::<Atom<Meta, M>>()?;
-        let (ctx, data) = ctx.next_branch::<Bytes<M>>()?;
+        let (ctx, data) = ctx.next_branch::<DataId>()?;
         let (ctx, left) = ctx.next_branch::<TreeId>()?;
         let (ctx, right) = ctx.next_branch::<TreeId>()?;
 
@@ -223,7 +224,7 @@ impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
     pub(crate) fn hash(&self) -> &Hash
     where
         Atom<Meta, M>: Foldable<HashFold>,
-        Bytes<M>: Foldable<HashFold>,
+        DataId: Foldable<HashFold>,
         TreeId: Foldable<HashFold>,
     {
         self.hash.get_or_init(|| Hash::from_foldable(self))
@@ -255,7 +256,7 @@ impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
 
     /// Retrieve the value associated with this node.
     #[inline]
-    pub(crate) fn data(&self) -> &Bytes<M> {
+    pub(crate) fn data(&self) -> &DataId {
         &self.data
     }
 
@@ -266,7 +267,7 @@ impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
     /// it is an invalid AVL tree.
     pub(super) fn rebalance<NodeId: Clone>(
         node: &mut NodeId,
-        resolver: &mut impl AvlResolver<NodeId, TreeId, M>,
+        resolver: &mut impl AvlResolver<NodeId, DataId, TreeId, M>,
     ) -> Result<(), OperationalError> {
         let resolved_node = resolver.resolve(node)?;
         let balance_factor = resolved_node.balance_factor();
@@ -312,7 +313,7 @@ impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
     ///  - `true` if the [`Tree`] has shrunk in size.
     pub(super) fn replace_with_successor<NodeId>(
         node: &mut NodeId,
-        resolver: &mut impl AvlResolver<NodeId, TreeId, M>,
+        resolver: &mut impl AvlResolver<NodeId, DataId, TreeId, M>,
     ) -> Result<(NodeId, bool), OperationalError>
     where
         NodeId: Clone,
@@ -377,7 +378,7 @@ impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
     ///  - True if this [`Node`]'s subtree has shrunk in size.
     pub(super) fn take_min<NodeId>(
         node: &mut NodeId,
-        resolver: &mut impl AvlResolver<NodeId, TreeId, M>,
+        resolver: &mut impl AvlResolver<NodeId, DataId, TreeId, M>,
     ) -> Result<(Tree<NodeId>, Tree<NodeId>, bool), OperationalError>
     where
         NodeId: Clone,
@@ -415,11 +416,13 @@ impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
         key: &Key,
         offset: usize,
         data: impl FnOnce(&mut Bytes<M>) -> Result<(), Error>,
-        resolver: &mut impl AvlResolver<NodeId, TreeId, M>,
+        resolver: &mut impl AvlResolver<NodeId, DataId, TreeId, M>,
     ) -> Result<bool, Error>
     where
         TreeId: Default,
-        NodeId: Clone + From<Node<TreeId, M>>,
+        DataId: From<Bytes<M>>,
+        NodeId: Clone + From<Node<TreeId, DataId, M>>,
+        M: BytesMode,
     {
         // SAFETY: The default recursion limit in Rust is 128
         // see: <https://doc.rust-lang.org/reference/attributes/limits.html#r-attributes.limits.recursion_limit.syntax>
@@ -441,7 +444,8 @@ impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
         match self.meta.key.cmp(key) {
             // The key already exists and should be updated.
             Ordering::Equal => {
-                data(&mut self.data)?;
+                let bytes = resolver.resolve_mut_bytes(&mut self.data, &self.meta.key)?;
+                data(bytes)?;
                 self.invalidate_hash();
                 Ok(false)
             }
@@ -483,7 +487,7 @@ impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
     /// or 0.
     fn rotate_left<NodeId>(
         node: &mut NodeId,
-        resolver: &mut impl AvlResolver<NodeId, TreeId, M>,
+        resolver: &mut impl AvlResolver<NodeId, DataId, TreeId, M>,
     ) -> Result<(), OperationalError>
     where
         NodeId: Clone,
@@ -556,7 +560,7 @@ impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
     /// Assumes this [`Node`]'s balance factor is -2 and the left [Node]'s balance factor is +1.
     fn rotate_left_right<NodeId>(
         node: &mut NodeId,
-        resolver: &mut impl AvlResolver<NodeId, TreeId, M>,
+        resolver: &mut impl AvlResolver<NodeId, DataId, TreeId, M>,
     ) -> Result<(), OperationalError>
     where
         NodeId: Clone,
@@ -625,7 +629,7 @@ impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
     /// or 0.
     fn rotate_right<NodeId>(
         node: &mut NodeId,
-        resolver: &mut impl AvlResolver<NodeId, TreeId, M>,
+        resolver: &mut impl AvlResolver<NodeId, DataId, TreeId, M>,
     ) -> Result<(), OperationalError>
     where
         NodeId: Clone,
@@ -698,7 +702,7 @@ impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
     /// Assumes this [`Node`]'s balance factor is +2 and the left [Node]'s balance factor is -1.
     fn rotate_right_left<NodeId>(
         node: &mut NodeId,
-        resolver: &mut impl AvlResolver<NodeId, TreeId, M>,
+        resolver: &mut impl AvlResolver<NodeId, DataId, TreeId, M>,
     ) -> Result<(), OperationalError>
     where
         NodeId: Clone,
@@ -751,16 +755,16 @@ impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
 }
 
 #[cfg(test)]
-impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
+impl<TreeId, DataId, M: AtomMode> Node<TreeId, DataId, M> {
     /// Returns true if the balance factors stored in the [`Node`]'s subtree are correct.
     pub(super) fn has_correct_balance_factors<NodeId>(
         &self,
-        resolver: &impl AvlResolver<NodeId, TreeId, M>,
+        resolver: &impl AvlResolver<NodeId, DataId, TreeId, M>,
     ) -> Result<bool, OperationalError>
     where
         NodeId: std::fmt::Debug,
         TreeId: std::fmt::Debug,
-        Bytes<M>: std::fmt::Debug,
+        DataId: std::fmt::Debug,
         Atom<Meta, M>: std::fmt::Debug,
     {
         let left_height = self.left_ref(resolver)?.height(resolver)?;
@@ -788,7 +792,7 @@ impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
     /// Returns the height of this [`Node`]'s subtree.
     pub(super) fn height<NodeId>(
         &self,
-        resolver: &impl AvlResolver<NodeId, TreeId, M>,
+        resolver: &impl AvlResolver<NodeId, DataId, TreeId, M>,
     ) -> Result<u32, OperationalError> {
         let left_height = self.left_ref(resolver)?.height(resolver)?;
         let right_height = self.right_ref(resolver)?.height(resolver)?;
@@ -798,7 +802,7 @@ impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
     /// Returns true if this [`Node`]'s subtree is balanced.
     pub(super) fn is_balanced<NodeId>(
         &self,
-        resolver: &impl AvlResolver<NodeId, TreeId, M>,
+        resolver: &impl AvlResolver<NodeId, DataId, TreeId, M>,
     ) -> Result<bool, OperationalError> {
         let balance_factor = self.balance_factor();
         if balance_factor.abs() > 1 {
@@ -817,7 +821,7 @@ impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
         &self,
         min: &Key,
         max: &Key,
-        resolver: &impl AvlResolver<NodeId, TreeId, M>,
+        resolver: &impl AvlResolver<NodeId, DataId, TreeId, M>,
     ) -> Result<bool, OperationalError> {
         if self.key() < min || self.key() > max {
             return Ok(false);
@@ -835,7 +839,7 @@ impl<TreeId, M: BytesMode + AtomMode> Node<TreeId, M> {
     }
 }
 
-impl<TreeId: Storable> Storable for Node<TreeId, Normal> {
+impl<TreeId: Storable> Storable for Node<TreeId, Bytes<Normal>, Normal> {
     fn store(
         &self,
         store: &impl KeyValueStore,
@@ -869,7 +873,7 @@ impl<TreeId: Storable> Storable for Node<TreeId, Normal> {
     }
 }
 
-impl<TreeId: Loadable> Loadable for Node<TreeId, Normal> {
+impl<TreeId: Loadable> Loadable for Node<TreeId, Bytes<Normal>, Normal> {
     fn load(id: Hash, store: &impl KeyValueStore) -> Result<Self, OperationalError> {
         let StoredNode { meta, left, right } = {
             let bytes =
@@ -909,12 +913,12 @@ impl<TreeId: Loadable> Loadable for Node<TreeId, Normal> {
     }
 }
 
-impl<F, TreeId, M> Foldable<F> for Node<TreeId, M>
+impl<F, TreeId, DataId, M> Foldable<F> for Node<TreeId, DataId, M>
 where
     F: Fold,
     M: Mode,
     Atom<Meta, M>: Foldable<F>,
-    Bytes<M>: Foldable<F>,
+    DataId: Foldable<F>,
     TreeId: Foldable<F>,
 {
     fn fold(&self, builder: F) -> <F as Fold>::Folded {

--- a/durable-storage/src/avl/resolver.rs
+++ b/durable-storage/src/avl/resolver.rs
@@ -60,6 +60,7 @@ use super::node::Node;
 use super::tree::Tree;
 use crate::avl::node::Meta;
 use crate::errors::OperationalError;
+use crate::key::Key;
 use crate::storage::KeyValueStore;
 use crate::storage::Loadable;
 use crate::storage::Storable;
@@ -74,24 +75,40 @@ pub trait Resolver<Id, Value> {
     fn resolve_mut<'a>(&mut self, id: &'a mut Id) -> Result<&'a mut Value, OperationalError>;
 }
 
+/// Trait for resolving data identifiers to bytes.
+///
+/// This requires additional data beyond just the id itself - as
+/// the data of nodes are stored separately.
+pub trait DataResolver<Id, M: Mode> {
+    /// Resolve a data identifier to bytes, using the key.
+    fn resolve_bytes<'a>(&self, id: &'a Id, key: &Key) -> Result<&'a Bytes<M>, OperationalError>;
+
+    /// Resolve a data identifier to mutable bytes, using the key.
+    fn resolve_mut_bytes<'a>(
+        &self,
+        id: &'a mut Id,
+        key: &Key,
+    ) -> Result<&'a mut Bytes<M>, OperationalError>;
+}
+
 trait_set! {
     /// Specialised [`Resolver`] for MAVL nodes
-    pub trait NodeResolver<NodeId, TreeId, M: Mode> = Resolver<NodeId, Node<TreeId, M>>;
+    pub trait NodeResolver<NodeId, DataId, TreeId, M: Mode> = Resolver<NodeId, Node<TreeId, DataId, M>> + DataResolver<DataId, M>;
 
     /// Specialised [`Resolver`] for MAVL trees
     pub trait TreeResolver<NodeId, TreeId> = Resolver<TreeId, Tree<NodeId>>;
 
     /// Specialised [`Resolver`] for MAVL nodes and trees
-    pub trait AvlResolver<NodeId, TreeId, M: Mode> = NodeResolver<NodeId, TreeId, M> + TreeResolver<NodeId, TreeId>;
+    pub trait AvlResolver<NodeId, DataId, TreeId, M: Mode> = NodeResolver<NodeId, DataId, TreeId, M> + TreeResolver<NodeId, TreeId>;
 }
 
 /// Node value materialised in [`Prove`] mode.
-pub(crate) type ProveNode = Node<ProveTreeId, Prove<'static>>;
+pub(crate) type ProveNode = Node<ProveTreeId, Bytes<Prove<'static>>, Prove<'static>>;
 
 /// Identifier for a node that is always present.
 #[derive(Debug, Clone, derive_more::From)]
-#[from(Node<ArcTreeId, Normal>)]
-pub struct ArcNodeId(Arc<Node<ArcTreeId, Normal>>);
+#[from(Node<ArcTreeId, Bytes<Normal>, Normal>)]
+pub struct ArcNodeId(Arc<Node<ArcTreeId, Bytes<Normal>, Normal>>);
 
 impl Foldable<HashFold> for ArcNodeId {
     fn fold(&self, _builder: HashFold) -> <HashFold as Fold>::Folded {
@@ -148,18 +165,18 @@ impl Loadable for ArcTreeId {
 #[derive(Clone, Debug)]
 pub struct ArcResolver;
 
-impl Resolver<ArcNodeId, Node<ArcTreeId, Normal>> for ArcResolver {
+impl Resolver<ArcNodeId, Node<ArcTreeId, Bytes<Normal>, Normal>> for ArcResolver {
     fn resolve<'a>(
         &self,
         id: &'a ArcNodeId,
-    ) -> Result<&'a Node<ArcTreeId, Normal>, OperationalError> {
+    ) -> Result<&'a Node<ArcTreeId, Bytes<Normal>, Normal>, OperationalError> {
         Ok(id.0.as_ref())
     }
 
     fn resolve_mut<'a>(
         &mut self,
         id: &'a mut ArcNodeId,
-    ) -> Result<&'a mut Node<ArcTreeId, Normal>, OperationalError> {
+    ) -> Result<&'a mut Node<ArcTreeId, Bytes<Normal>, Normal>, OperationalError> {
         Ok(Arc::make_mut(&mut id.0))
     }
 }
@@ -174,6 +191,24 @@ impl Resolver<ArcTreeId, Tree<ArcNodeId>> for ArcResolver {
         id: &'a mut ArcTreeId,
     ) -> Result<&'a mut Tree<ArcNodeId>, OperationalError> {
         Ok(&mut id.0)
+    }
+}
+
+impl DataResolver<Bytes<Normal>, Normal> for ArcResolver {
+    fn resolve_bytes<'a>(
+        &self,
+        id: &'a Bytes<Normal>,
+        _key: &Key,
+    ) -> Result<&'a Bytes<Normal>, OperationalError> {
+        Ok(id)
+    }
+
+    fn resolve_mut_bytes<'a>(
+        &self,
+        id: &'a mut Bytes<Normal>,
+        _key: &Key,
+    ) -> Result<&'a mut Bytes<Normal>, OperationalError> {
+        Ok(id)
     }
 }
 
@@ -235,7 +270,7 @@ impl<Value> From<Hash> for LazyId<Value> {
 
 /// Identifier for an AVL node.
 #[derive(Debug, Clone)]
-pub struct LazyNodeId(LazyId<Arc<Node<LazyTreeId, Normal>>>);
+pub struct LazyNodeId(LazyId<Arc<Node<LazyTreeId, Bytes<Normal>, Normal>>>);
 
 impl LazyNodeId {
     /// Wrap this lazy node identifier in a prove-mode identifier.
@@ -252,8 +287,8 @@ impl LazyNodeId {
     }
 }
 
-impl From<Node<LazyTreeId, Normal>> for LazyNodeId {
-    fn from(value: Node<LazyTreeId, Normal>) -> Self {
+impl From<Node<LazyTreeId, Bytes<Normal>, Normal>> for LazyNodeId {
+    fn from(value: Node<LazyTreeId, Bytes<Normal>, Normal>) -> Self {
         let value = Arc::new(value);
         Self(LazyId::new(value))
     }
@@ -394,11 +429,13 @@ impl<KV> LazyResolver<KV> {
     }
 }
 
-impl<KV: KeyValueStore> Resolver<LazyNodeId, Node<LazyTreeId, Normal>> for LazyResolver<KV> {
+impl<KV: KeyValueStore> Resolver<LazyNodeId, Node<LazyTreeId, Bytes<Normal>, Normal>>
+    for LazyResolver<KV>
+{
     fn resolve<'a>(
         &self,
         id: &'a LazyNodeId,
-    ) -> Result<&'a Node<LazyTreeId, Normal>, OperationalError> {
+    ) -> Result<&'a Node<LazyTreeId, Bytes<Normal>, Normal>, OperationalError> {
         if let Some(value) = id.0.inner.get() {
             return Ok(value);
         }
@@ -411,7 +448,7 @@ impl<KV: KeyValueStore> Resolver<LazyNodeId, Node<LazyTreeId, Normal>> for LazyR
     fn resolve_mut<'a>(
         &mut self,
         id: &'a mut LazyNodeId,
-    ) -> Result<&'a mut Node<LazyTreeId, Normal>, OperationalError> {
+    ) -> Result<&'a mut Node<LazyTreeId, Bytes<Normal>, Normal>, OperationalError> {
         if let Some(value) = id.0.inner.get_mut() {
             let temp = value as *mut Arc<_>;
             // This unsafe workaround is required because the rust borrow-checker
@@ -459,6 +496,24 @@ impl<KV: KeyValueStore> Resolver<LazyTreeId, Tree<LazyNodeId>> for LazyResolver<
     }
 }
 
+impl<KV> DataResolver<Bytes<Normal>, Normal> for LazyResolver<KV> {
+    fn resolve_bytes<'a>(
+        &self,
+        id: &'a Bytes<Normal>,
+        _key: &Key,
+    ) -> Result<&'a Bytes<Normal>, OperationalError> {
+        Ok(id)
+    }
+
+    fn resolve_mut_bytes<'a>(
+        &self,
+        id: &'a mut Bytes<Normal>,
+        _key: &Key,
+    ) -> Result<&'a mut Bytes<Normal>, OperationalError> {
+        Ok(id)
+    }
+}
+
 /// Resolver that only accesses already-cached prove-mode values.
 ///
 /// Returns [`OperationalError::ResolverInvariantViolated`] if a node or tree has not been
@@ -490,6 +545,24 @@ impl Resolver<ProveTreeId, Tree<ProveNodeId>> for CachedOnlyResolver {
         _id: &'a mut ProveTreeId,
     ) -> Result<&'a mut Tree<ProveNodeId>, OperationalError> {
         unreachable!("CachedOnlyResolver does not support mutable resolution")
+    }
+}
+
+impl<'inner> DataResolver<Bytes<Prove<'inner>>, Prove<'inner>> for CachedOnlyResolver {
+    fn resolve_bytes<'a>(
+        &self,
+        id: &'a Bytes<Prove<'inner>>,
+        _key: &Key,
+    ) -> Result<&'a Bytes<Prove<'inner>>, OperationalError> {
+        Ok(id)
+    }
+
+    fn resolve_mut_bytes<'a>(
+        &self,
+        id: &'a mut Bytes<Prove<'inner>>,
+        _key: &Key,
+    ) -> Result<&'a mut Bytes<Prove<'inner>>, OperationalError> {
+        Ok(id)
     }
 }
 
@@ -675,9 +748,9 @@ impl<R> ProveResolver<R> {
     fn resolve_and_track_node<'a>(
         &self,
         id: &'a LazyNodeId,
-    ) -> Result<&'a Node<LazyTreeId, Normal>, OperationalError>
+    ) -> Result<&'a Node<LazyTreeId, Bytes<Normal>, Normal>, OperationalError>
     where
-        R: Resolver<LazyNodeId, Node<LazyTreeId, Normal>>,
+        R: Resolver<LazyNodeId, Node<LazyTreeId, Bytes<Normal>, Normal>>,
     {
         self.accessed_items
             .borrow_mut()
@@ -702,8 +775,10 @@ impl<R> ProveResolver<R> {
     }
 }
 
-impl<R: Resolver<LazyNodeId, Node<LazyTreeId, Normal>> + Resolver<LazyTreeId, Tree<LazyNodeId>>>
-    Resolver<ProveNodeId, ProveNode> for ProveResolver<R>
+impl<R> Resolver<ProveNodeId, ProveNode> for ProveResolver<R>
+where
+    R: Resolver<LazyNodeId, Node<LazyTreeId, Bytes<Normal>, Normal>>
+        + Resolver<LazyTreeId, Tree<LazyNodeId>>,
 {
     fn resolve<'b>(&self, id: &'b ProveNodeId) -> Result<&'b ProveNode, OperationalError> {
         if let Some(inner) = id.inner.get() {
@@ -743,8 +818,9 @@ impl<R: Resolver<LazyNodeId, Node<LazyTreeId, Normal>> + Resolver<LazyTreeId, Tr
     }
 }
 
-impl<R: Resolver<LazyTreeId, Tree<LazyNodeId>>> Resolver<ProveTreeId, Tree<ProveNodeId>>
-    for ProveResolver<R>
+impl<R> Resolver<ProveTreeId, Tree<ProveNodeId>> for ProveResolver<R>
+where
+    R: Resolver<LazyTreeId, Tree<LazyNodeId>>,
 {
     fn resolve<'b>(&self, id: &'b ProveTreeId) -> Result<&'b Tree<ProveNodeId>, OperationalError> {
         if let Some(inner) = id.inner.get() {
@@ -782,6 +858,24 @@ impl<R: Resolver<LazyTreeId, Tree<LazyNodeId>>> Resolver<ProveTreeId, Tree<Prove
     }
 }
 
+impl<'inner, R> DataResolver<Bytes<Prove<'inner>>, Prove<'inner>> for ProveResolver<R> {
+    fn resolve_bytes<'a>(
+        &self,
+        id: &'a Bytes<Prove<'inner>>,
+        _key: &Key,
+    ) -> Result<&'a Bytes<Prove<'inner>>, OperationalError> {
+        Ok(id)
+    }
+
+    fn resolve_mut_bytes<'a>(
+        &self,
+        id: &'a mut Bytes<Prove<'inner>>,
+        _key: &Key,
+    ) -> Result<&'a mut Bytes<Prove<'inner>>, OperationalError> {
+        Ok(id)
+    }
+}
+
 /// Identifier for a node resolved in [`Verify`] mode.
 ///
 /// Absent nodes are not a valid variant as they indicate a bad proof: any node accessed during
@@ -795,14 +889,14 @@ impl<R: Resolver<LazyTreeId, Tree<LazyNodeId>>> Resolver<ProveTreeId, Tree<Prove
 #[derive(Clone, Debug)]
 pub enum VerifyNodeId {
     Present {
-        node: Arc<Node<VerifyTreeId, Verify>>,
+        node: Arc<Node<VerifyTreeId, Bytes<Verify>, Verify>>,
         original_proof: Option<Arc<MerkleProof>>,
     },
     Blinded(Hash),
 }
 
-impl From<Node<VerifyTreeId, Verify>> for VerifyNodeId {
-    fn from(node: Node<VerifyTreeId, Verify>) -> Self {
+impl From<Node<VerifyTreeId, Bytes<Verify>, Verify>> for VerifyNodeId {
+    fn from(node: Node<VerifyTreeId, Bytes<Verify>, Verify>) -> Self {
         VerifyNodeId::Present {
             node: Arc::new(node),
             original_proof: None,
@@ -893,11 +987,11 @@ impl Default for VerifyTreeId {
 #[derive(Debug)]
 pub struct VerifyResolver;
 
-impl Resolver<VerifyNodeId, Node<VerifyTreeId, Verify>> for VerifyResolver {
+impl Resolver<VerifyNodeId, Node<VerifyTreeId, Bytes<Verify>, Verify>> for VerifyResolver {
     fn resolve<'a>(
         &self,
         id: &'a VerifyNodeId,
-    ) -> Result<&'a Node<VerifyTreeId, Verify>, OperationalError> {
+    ) -> Result<&'a Node<VerifyTreeId, Bytes<Verify>, Verify>, OperationalError> {
         match id {
             VerifyNodeId::Present { node, .. } => Ok(node),
             // SAFETY: called only in `Verify` mode
@@ -908,7 +1002,7 @@ impl Resolver<VerifyNodeId, Node<VerifyTreeId, Verify>> for VerifyResolver {
     fn resolve_mut<'a>(
         &mut self,
         id: &'a mut VerifyNodeId,
-    ) -> Result<&'a mut Node<VerifyTreeId, Verify>, OperationalError> {
+    ) -> Result<&'a mut Node<VerifyTreeId, Bytes<Verify>, Verify>, OperationalError> {
         match id {
             VerifyNodeId::Present { node, .. } => Ok(Arc::make_mut(node)),
             // SAFETY: called only in `Verify` mode
@@ -938,6 +1032,24 @@ impl Resolver<VerifyTreeId, Tree<VerifyNodeId>> for VerifyResolver {
             // SAFETY: called only in `Verify` mode
             VerifyTreeId::Blinded(_) | VerifyTreeId::Absent => unsafe { not_found() },
         }
+    }
+}
+
+impl DataResolver<Bytes<Verify>, Verify> for VerifyResolver {
+    fn resolve_bytes<'a>(
+        &self,
+        id: &'a Bytes<Verify>,
+        _key: &Key,
+    ) -> Result<&'a Bytes<Verify>, OperationalError> {
+        Ok(id)
+    }
+
+    fn resolve_mut_bytes<'a>(
+        &self,
+        id: &'a mut Bytes<Verify>,
+        _key: &Key,
+    ) -> Result<&'a mut Bytes<Verify>, OperationalError> {
+        Ok(id)
     }
 }
 
@@ -1057,7 +1169,7 @@ mod tests {
         NodeId: Storable,
         TreeId: Storable,
         KV: KeyValueStore,
-        Res: AvlResolver<NodeId, TreeId, Normal>,
+        Res: AvlResolver<NodeId, Bytes<Normal>, TreeId, Normal>,
     {
         let store_options = StoreOptions::default().with_shallow().with_node_data();
 
@@ -1606,7 +1718,8 @@ mod tests {
     #[test]
     fn test_verify_resolver_resolve_mut_node() {
         let key = Key::new(&[2]).expect("key should be valid");
-        let node: Node<VerifyTreeId, Verify> = Node::new(key.clone(), Bytes::<Verify>::new(0));
+        let node: Node<VerifyTreeId, Bytes<Verify>, Verify> =
+            Node::new(key.clone(), Bytes::<Verify>::new(0));
         let mut id = VerifyNodeId::Present {
             node: Arc::new(node),
             original_proof: None,
@@ -1642,7 +1755,8 @@ mod tests {
     #[test]
     fn test_verify_resolver_resolves_tree() {
         let key = Key::new(&[1]).expect("key should be valid");
-        let node: Node<VerifyTreeId, Verify> = Node::new(key, Bytes::<Verify>::new(0));
+        let node: Node<VerifyTreeId, Bytes<Verify>, Verify> =
+            Node::new(key, Bytes::<Verify>::new(0));
         let node_id = VerifyNodeId::Present {
             node: Arc::new(node),
             original_proof: None,

--- a/durable-storage/src/avl/tree.rs
+++ b/durable-storage/src/avl/tree.rs
@@ -97,10 +97,10 @@ impl<NodeId> Tree<NodeId> {
     /// Delete the [`Node`] in the [`Tree`] with a given key.
     ///
     /// Returns true if the [`Tree`] has shrunk in size.
-    pub fn delete<TreeId, M: BytesMode + AtomMode>(
+    pub fn delete<TreeId, DataId, M: AtomMode>(
         &mut self,
         key: &Key,
-        resolver: &mut impl AvlResolver<NodeId, TreeId, M>,
+        resolver: &mut impl AvlResolver<NodeId, DataId, TreeId, M>,
     ) -> Result<bool, OperationalError>
     where
         NodeId: Clone,
@@ -155,10 +155,10 @@ impl<NodeId> Tree<NodeId> {
 
     #[inline]
     /// Find the id of the [`Node`] in the [`Tree`] with a given [`Key`].
-    pub(crate) fn get<'a, TreeId: 'a, M: BytesMode + AtomMode + 'a>(
+    pub(crate) fn get<'a, TreeId: 'a, DataId: 'a, M: AtomMode + 'a>(
         &'a self,
         key: &Key,
-        resolver: &impl AvlResolver<NodeId, TreeId, M>,
+        resolver: &impl AvlResolver<NodeId, DataId, TreeId, M>,
     ) -> Result<Option<&'a NodeId>, OperationalError> {
         let Some(node) = self.root() else {
             return Ok(None);
@@ -170,14 +170,15 @@ impl<NodeId> Tree<NodeId> {
     /// Set the value of the [`Node`] with a given key.
     ///
     /// Returns true if the [`Tree`] has grown in size.
-    pub fn set<TreeId, M: BytesMode + AtomMode>(
+    pub fn set<TreeId, DataId, M: BytesMode + AtomMode>(
         &mut self,
         key: &Key,
         data: &[u8],
-        resolver: &mut impl AvlResolver<NodeId, TreeId, M>,
+        resolver: &mut impl AvlResolver<NodeId, DataId, TreeId, M>,
     ) -> Result<bool, OperationalError>
     where
-        NodeId: Clone + From<Node<TreeId, M>>,
+        NodeId: Clone + From<Node<TreeId, DataId, M>>,
+        DataId: From<Bytes<M>>,
         TreeId: Default,
     {
         let result = self.upsert(
@@ -213,9 +214,9 @@ impl<NodeId> Tree<NodeId> {
 
     #[inline]
     /// The difference in heights between any child branches in the [`Tree`].
-    pub(super) fn balance_factor<TreeId, M: BytesMode + AtomMode>(
+    pub(super) fn balance_factor<TreeId, DataId, M: AtomMode>(
         &self,
-        resolver: &impl NodeResolver<NodeId, TreeId, M>,
+        resolver: &impl NodeResolver<NodeId, DataId, TreeId, M>,
     ) -> Result<i64, OperationalError> {
         let Some(node) = self.root() else {
             return Ok(0);
@@ -245,9 +246,9 @@ impl<NodeId> Tree<NodeId> {
     ///  - The occupied [`Tree`] with the minimum [`Key`].
     ///  - The minimum [`Tree`]'s right child, if it hasn't been moved to its new position.
     ///  - True if the [`Tree`] has shrunk in size.
-    pub(super) fn take_min<TreeId, M: BytesMode + AtomMode>(
+    pub(super) fn take_min<TreeId, DataId, M: AtomMode>(
         &mut self,
-        resolver: &mut impl AvlResolver<NodeId, TreeId, M>,
+        resolver: &mut impl AvlResolver<NodeId, DataId, TreeId, M>,
     ) -> Result<(Tree<NodeId>, Tree<NodeId>, bool), OperationalError>
     where
         NodeId: Clone,
@@ -273,15 +274,16 @@ impl<NodeId> Tree<NodeId> {
     /// `data` defines what data is upserted.
     ///
     /// Returns true if the [`Tree`] has grown in size.
-    pub(crate) fn upsert<TreeId, M: BytesMode + AtomMode>(
+    pub(crate) fn upsert<TreeId, DataId, M: BytesMode + AtomMode>(
         &mut self,
         key: &Key,
         offset: usize,
         data: impl FnOnce(&mut Bytes<M>) -> Result<(), Error>,
-        resolver: &mut impl AvlResolver<NodeId, TreeId, M>,
+        resolver: &mut impl AvlResolver<NodeId, DataId, TreeId, M>,
     ) -> Result<bool, Error>
     where
-        NodeId: Clone + From<Node<TreeId, M>>,
+        NodeId: Clone + From<Node<TreeId, DataId, M>>,
+        DataId: From<Bytes<M>>,
         TreeId: Default,
     {
         let node = self.root_mut();
@@ -293,7 +295,7 @@ impl<NodeId> Tree<NodeId> {
             let mut new_data = Bytes::<M>::default();
             data(&mut new_data)?;
 
-            let new_node: Node<TreeId, M> = Node::new(key.clone(), new_data);
+            let new_node: Node<TreeId, DataId, M> = Node::new(key.clone(), new_data);
             let new_id = NodeId::from(new_node);
             self.0 = Some(new_id);
 
@@ -314,15 +316,16 @@ impl<NodeId> Tree<NodeId> {
     /// given offset, overwriting existing data if the node already exists.
     ///
     /// Returns true if the [`Tree`] has grown in size.
-    pub(crate) fn write<TreeId, M: BytesMode + AtomMode>(
+    pub(crate) fn write<TreeId, DataId, M: BytesMode + AtomMode>(
         &mut self,
         key: &Key,
         offset: usize,
         data: &[u8],
-        resolver: &mut impl AvlResolver<NodeId, TreeId, M>,
+        resolver: &mut impl AvlResolver<NodeId, DataId, TreeId, M>,
     ) -> Result<bool, Error>
     where
-        NodeId: Clone + From<Node<TreeId, M>>,
+        NodeId: Clone + From<Node<TreeId, DataId, M>>,
+        DataId: From<Bytes<M>>,
         TreeId: Default,
     {
         self.upsert(
@@ -351,9 +354,9 @@ impl<NodeId> Tree<NodeId> {
     ///
     /// The [`Tree`] must already have balance factor in the range of -2..=2, else it is an invalid
     /// AVL tree.
-    fn rebalance<TreeId, M: BytesMode + AtomMode>(
+    fn rebalance<TreeId, DataId, M: AtomMode>(
         &mut self,
-        resolver: &mut impl AvlResolver<NodeId, TreeId, M>,
+        resolver: &mut impl AvlResolver<NodeId, DataId, TreeId, M>,
     ) -> Result<(), OperationalError>
     where
         NodeId: Clone,
@@ -469,6 +472,7 @@ impl<NodeId: Loadable> Loadable for Tree<NodeId> {
 mod tests {
     use std::collections::BTreeMap;
     use std::io::prelude::*;
+    use std::marker::PhantomData;
 
     use goldenfile::Mint;
     use octez_riscv_data::components::atom::Atom;
@@ -481,20 +485,21 @@ mod tests {
     use crate::avl::resolver::ArcNodeId;
     use crate::avl::resolver::ArcResolver;
     use crate::avl::resolver::ArcTreeId;
+    use crate::avl::resolver::DataResolver;
     use crate::avl::resolver::Resolver;
     use crate::key::KEY_MAX_SIZE;
     use crate::key::Key;
 
     impl<NodeId> Tree<NodeId> {
         /// Asserts that the [`Tree`] is a valid AVL tree
-        pub(crate) fn check<TreeId, M: BytesMode + AtomMode>(
+        pub(crate) fn check<TreeId, DataId, M: AtomMode>(
             &self,
-            resolver: &impl AvlResolver<NodeId, TreeId, M>,
+            resolver: &impl AvlResolver<NodeId, DataId, TreeId, M>,
         ) -> Result<(), OperationalError>
         where
             NodeId: std::fmt::Debug,
             TreeId: std::fmt::Debug,
-            Bytes<M>: std::fmt::Debug,
+            DataId: std::fmt::Debug,
             Atom<Meta, M>: std::fmt::Debug,
         {
             let inorder = self.is_inorder(resolver)?;
@@ -513,9 +518,9 @@ mod tests {
         }
 
         /// Returns true if the [`Tree`] is in-order.
-        pub(crate) fn is_inorder<TreeId, M: BytesMode + AtomMode>(
+        pub(crate) fn is_inorder<TreeId, DataId, M: AtomMode>(
             &self,
-            resolver: &impl AvlResolver<NodeId, TreeId, M>,
+            resolver: &impl AvlResolver<NodeId, DataId, TreeId, M>,
         ) -> Result<bool, OperationalError> {
             self.is_inorder_inner(
                 &Key::new(&[u8::MIN]).expect("Size less than KEY_MAX_SIZE"),
@@ -525,14 +530,14 @@ mod tests {
         }
 
         /// Returns true if the balance factors stored in any [`Node`]'s subtree are correct.
-        pub(crate) fn has_correct_balance_factors<TreeId, M: BytesMode + AtomMode>(
+        pub(crate) fn has_correct_balance_factors<TreeId, DataId, M: AtomMode>(
             &self,
-            resolver: &impl AvlResolver<NodeId, TreeId, M>,
+            resolver: &impl AvlResolver<NodeId, DataId, TreeId, M>,
         ) -> Result<bool, OperationalError>
         where
             NodeId: std::fmt::Debug,
             TreeId: std::fmt::Debug,
-            Bytes<M>: std::fmt::Debug,
+            DataId: std::fmt::Debug,
             Atom<Meta, M>: std::fmt::Debug,
         {
             match self.root() {
@@ -544,9 +549,9 @@ mod tests {
         }
 
         /// Returns the height of the [`Tree`].
-        pub(crate) fn height<TreeId, M: BytesMode + AtomMode>(
+        pub(crate) fn height<TreeId, DataId, M: AtomMode>(
             &self,
-            resolver: &impl AvlResolver<NodeId, TreeId, M>,
+            resolver: &impl AvlResolver<NodeId, DataId, TreeId, M>,
         ) -> Result<u32, OperationalError> {
             match self.root() {
                 None => Ok(0),
@@ -555,9 +560,9 @@ mod tests {
         }
 
         /// Returns true if the [`Tree`] is balanced.
-        pub(crate) fn is_balanced<TreeId, M: BytesMode + AtomMode>(
+        pub(crate) fn is_balanced<TreeId, DataId, M: AtomMode>(
             &self,
-            resolver: &impl AvlResolver<NodeId, TreeId, M>,
+            resolver: &impl AvlResolver<NodeId, DataId, TreeId, M>,
         ) -> Result<bool, OperationalError> {
             match self.root() {
                 None => Ok(true),
@@ -568,11 +573,11 @@ mod tests {
         }
 
         /// Returns true if the [`Tree`] is in-order and all values lie between the `min` and `max`.
-        pub(crate) fn is_inorder_inner<TreeId, M: BytesMode + AtomMode>(
+        pub(crate) fn is_inorder_inner<TreeId, DataId, M: AtomMode>(
             &self,
             min: &Key,
             max: &Key,
-            resolver: &impl AvlResolver<NodeId, TreeId, M>,
+            resolver: &impl AvlResolver<NodeId, DataId, TreeId, M>,
         ) -> Result<bool, OperationalError> {
             match self.root() {
                 None => Ok(true),
@@ -594,12 +599,13 @@ mod tests {
             'tree,
             'res,
             TreeId,
+            DataId,
             M: octez_riscv_data::mode::Mode,
-            Res: AvlResolver<NodeId, TreeId, M>,
+            Res: AvlResolver<NodeId, DataId, TreeId, M>,
         >(
             &'tree self,
             resolver: &'res Res,
-        ) -> TreeIterator<'tree, 'res, NodeId, TreeId, M, Res> {
+        ) -> TreeIterator<'tree, 'res, NodeId, DataId, TreeId, M, Res> {
             TreeIterator {
                 stack: vec![],
                 current: self,
@@ -616,21 +622,26 @@ mod tests {
     /// in-order traversal without recursion.
     ///
     /// Resolution failures are surfaced as iterator items of type `Err`.
-    pub(crate) struct TreeIterator<'tree, 'res, NodeId, TreeId, M, Resolver> {
+    pub(crate) struct TreeIterator<'tree, 'res, NodeId, DataId, TreeId, M, Resolver> {
         stack: Vec<&'tree NodeId>,
         current: &'tree Tree<NodeId>,
         resolver: &'res Resolver,
-        _marker: std::marker::PhantomData<fn() -> (TreeId, M)>,
+        #[expect(
+            clippy::type_complexity,
+            reason = "Moving into type would hide underlying use"
+        )]
+        _marker: PhantomData<fn() -> (TreeId, DataId, M)>,
     }
 
     impl<
         'tree,
         'res,
         NodeId,
+        DataId: 'tree,
         TreeId: 'tree,
         M: octez_riscv_data::mode::Mode + 'tree,
-        Resolver: AvlResolver<NodeId, TreeId, M>,
-    > TreeIterator<'tree, 'res, NodeId, TreeId, M, Resolver>
+        Resolver: AvlResolver<NodeId, DataId, TreeId, M>,
+    > TreeIterator<'tree, 'res, NodeId, DataId, TreeId, M, Resolver>
     {
         /// Helper to descend to the leftmost node in the current subtree, pushing nodes onto the stack.
         fn advance_to_leftmost_in_subtree(
@@ -655,7 +666,7 @@ mod tests {
         /// Helper to pop the next node from the stack and prepare to traverse its right subtree.
         fn pop_and_prepare_right_subtree(
             &mut self,
-        ) -> Result<Option<&'tree Node<TreeId, M>>, OperationalError> {
+        ) -> Result<Option<&'tree Node<TreeId, DataId, M>>, OperationalError> {
             let node_id = match self.stack.pop() {
                 Some(id) => id,
                 None => return Ok(None),
@@ -671,12 +682,13 @@ mod tests {
         'tree,
         'res,
         NodeId,
+        DataId: 'tree,
         TreeId: 'tree,
         M: octez_riscv_data::mode::Mode + 'tree,
-        Resolver: AvlResolver<NodeId, TreeId, M>,
-    > Iterator for TreeIterator<'tree, 'res, NodeId, TreeId, M, Resolver>
+        Resolver: AvlResolver<NodeId, DataId, TreeId, M>,
+    > Iterator for TreeIterator<'tree, 'res, NodeId, DataId, TreeId, M, Resolver>
     {
-        type Item = Result<&'tree Node<TreeId, M>, OperationalError>;
+        type Item = Result<&'tree Node<TreeId, DataId, M>, OperationalError>;
 
         fn next(&mut self) -> Option<Self::Item> {
             if let Some(root_id) = self.current.root() {
@@ -782,11 +794,11 @@ mod tests {
         }
     }
 
-    impl Resolver<ArcNodeId, Node<ArcTreeId, Normal>> for FailOnKeyResolver {
+    impl Resolver<ArcNodeId, Node<ArcTreeId, Bytes<Normal>, Normal>> for FailOnKeyResolver {
         fn resolve<'a>(
             &self,
             id: &'a ArcNodeId,
-        ) -> Result<&'a Node<ArcTreeId, Normal>, OperationalError> {
+        ) -> Result<&'a Node<ArcTreeId, Bytes<Normal>, Normal>, OperationalError> {
             let node = ArcResolver.resolve(id)?;
 
             if node.key() == &self.target_failure_key {
@@ -799,7 +811,7 @@ mod tests {
         fn resolve_mut<'a>(
             &mut self,
             id: &'a mut ArcNodeId,
-        ) -> Result<&'a mut Node<ArcTreeId, Normal>, OperationalError> {
+        ) -> Result<&'a mut Node<ArcTreeId, Bytes<Normal>, Normal>, OperationalError> {
             let node = ArcResolver.resolve_mut(id)?;
 
             if node.key() == &self.target_failure_key {
@@ -820,6 +832,26 @@ mod tests {
             id: &'a mut ArcTreeId,
         ) -> Result<&'a mut Tree<ArcNodeId>, OperationalError> {
             ArcResolver.resolve_mut(id)
+        }
+    }
+
+    impl DataResolver<Bytes<Normal>, Normal> for FailOnKeyResolver {
+        fn resolve_bytes<'a>(
+            &self,
+            id: &'a Bytes<Normal>,
+            _key: &Key,
+        ) -> Result<&'a Bytes<Normal>, OperationalError> {
+            // resolution would fail on the node by the key first
+            Ok(id)
+        }
+
+        fn resolve_mut_bytes<'a>(
+            &self,
+            id: &'a mut Bytes<Normal>,
+            _key: &Key,
+        ) -> Result<&'a mut Bytes<Normal>, OperationalError> {
+            // resolution would fail on the node by the key first
+            Ok(id)
         }
     }
 

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -875,13 +875,14 @@ mod tests {
         assert_ne!(original_hash, ml2.hash());
         assert_eq!(original_hash, ml.hash());
 
-        let old_node1: Node<LazyTreeId, Normal> =
+        let old_node1: Node<LazyTreeId, Bytes<Normal>, Normal> =
             Node::new(keys[0].clone(), bytes::Bytes::copy_from_slice(&data[0]));
-        let new_node1: Node<LazyTreeId, Normal> = Node::new(keys[0].clone(), cow_data.as_bytes());
+        let new_node1: Node<LazyTreeId, Bytes<Normal>, Normal> =
+            Node::new(keys[0].clone(), cow_data.as_bytes());
 
-        let node2: Node<LazyTreeId, Normal> =
+        let node2: Node<LazyTreeId, Bytes<Normal>, Normal> =
             Node::new(keys[1].clone(), bytes::Bytes::copy_from_slice(&data[1]));
-        let node3: Node<LazyTreeId, Normal> =
+        let node3: Node<LazyTreeId, Bytes<Normal>, Normal> =
             Node::new(keys[2].clone(), bytes::Bytes::copy_from_slice(&data[2]));
 
         assert_eq!(
@@ -994,7 +995,7 @@ mod tests {
         ml.set(&key, &data).expect("setting node should succeed");
         assert_ne!(empty_hash, ml.hash());
 
-        let node: Node<LazyTreeId, Normal> = Node::new(key.clone(), data);
+        let node: Node<LazyTreeId, Bytes<Normal>, Normal> = Node::new(key.clone(), data);
         let get_node = ml
             .get(&key)
             .expect("The node should be retrieved successfully")
@@ -1015,7 +1016,7 @@ mod tests {
         ml.set(&key, &data).expect("setting node should succeed");
         let old_hash = ml.hash();
 
-        let node: Node<LazyTreeId, Normal> = Node::new(key.clone(), data);
+        let node: Node<LazyTreeId, Bytes<Normal>, Normal> = Node::new(key.clone(), data);
         let get_node = ml
             .get(&key)
             .expect("The node should be retrieved successfully")
@@ -1031,7 +1032,7 @@ mod tests {
                 .expect("The tree should be retrieved successfully."),
             "AVL isn't in order: {ml:?}"
         );
-        let node: Node<LazyTreeId, Normal> = Node::new(key.clone(), data2);
+        let node: Node<LazyTreeId, Bytes<Normal>, Normal> = Node::new(key.clone(), data2);
         let get_node = ml
             .get(&key)
             .expect("The node should be retrieved successfully")
@@ -1501,7 +1502,7 @@ mod tests {
         let old_hash = ml.hash();
         ml.write(&key, 0, &data).expect("write should succeed.");
 
-        let node: Node<ArcTreeId, Normal> = Node::new(key.clone(), data);
+        let node: Node<ArcTreeId, Bytes<Normal>, Normal> = Node::new(key.clone(), data);
         let get_node = ml
             .get(&key)
             .expect("The node should be retrieved successfully")
@@ -1524,7 +1525,7 @@ mod tests {
         let old_hash = ml.hash();
 
         let data_len = data.len();
-        let node: Node<LazyTreeId, Normal> = Node::new(key.clone(), data);
+        let node: Node<LazyTreeId, Bytes<Normal>, Normal> = Node::new(key.clone(), data);
         let get_node = ml
             .get(&key)
             .expect("The node should be retrieved successfully")
@@ -1541,7 +1542,7 @@ mod tests {
                 .expect("The tree should be retrieved successfully."),
             "AVL isn't in order: {ml:?}"
         );
-        let node: Node<LazyTreeId, Normal> =
+        let node: Node<LazyTreeId, Bytes<Normal>, Normal> =
             Node::new(key.clone(), bytes::Bytes::from("a good value"));
         let get_node = ml
             .get(&key)
@@ -1769,7 +1770,7 @@ mod tests {
             .expect("The commit operation should not fail");
 
         for node in merkle_layer.inner.tree.iter(&merkle_layer.inner.resolver) {
-            let node: &Node<LazyTreeId, Normal> =
+            let node: &Node<LazyTreeId, Bytes<Normal>, Normal> =
                 node.expect("The node should be retrieved successfully");
 
             node.store(
@@ -1778,7 +1779,7 @@ mod tests {
             )
             .expect("Storing node should succeed");
 
-            let loaded_node: Node<LazyTreeId, Normal> =
+            let loaded_node: Node<LazyTreeId, Bytes<Normal>, Normal> =
                 Node::load(*node.hash(), merkle_layer.inner.persistence.as_ref())
                     .expect("Loading node should succeed");
 


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

- Part of [RV-955](https://linear.app/tezos/issue/RV-955)Part of [RV-955](https://linear.app/tezos/issue/RV-955)

# What

Refactor the avl `Node` to be generic over the `DataId`. When needing access to the underlying `Bytes`, it must be resolved.

# Why

This is a first step towards lazy resolution of Bytes. This will allow `delete` to function when the node's data has already been deleted from the KV store (as `delete` will no longer load/resolve the data).

This _should_ also make the database more performant when it's been recently checked out - as intermediate values won't be loaded from the database even when the nodes are resolved (turning two roundtrips to the DB to one)

# How

For now, resolution does nothing: the bytes are still eagerly loaded. Subsequent MR will introduce `LazyBytes`, and use it alongside the `LazyResolver`.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
