### PR TITLE
test(durable): do not mix insertion/updates in multi-step proof tests

### DIFF
--- a/durable-storage/proptest-regressions/merkle_layer.txt
+++ b/durable-storage/proptest-regressions/merkle_layer.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 6f3816de0c63e15b8d291d0dab0e77f3a6e6cc72bee54754a26a670e0ffd7acf # shrinks to setup_keys = [[174, 0], [173, 202], [0, 0], [0, 1], [0, 2]], new_keys = [[0, 3], [173, 202]]

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -2258,6 +2258,10 @@ mod tests {
         proptest!(|(setup_keys in prop::collection::vec(any::<[u8; 2]>(), 1..20), new_keys in prop::collection::vec(any::<[u8; 2]>(), 1..10))| {
             let step_ops: Vec<Operation> = new_keys
                 .iter()
+                // ensure we don't accidentally mix insertions with overwritting old keys
+                // - the proof system doesn't currently support this
+                // TODO (RV-985): remove this line
+                .filter(|bytes| !setup_keys.contains(bytes))
                 .enumerate()
                 .map(|(i, bytes)| {
                     let key = Key::new(bytes).expect("key should be valid");


### PR DESCRIPTION
- Related to RV-961

<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

# What

Prevent accidentally including 'update' operations in the multi-step 'insertion only' prove-verify roundtrip test

# Why

Mixing the operation kinds is not currently supported in multi-step mode

# How

Filter out 'new keys' that are part of the setup keys. Just use a simple linear scan as we're checking very few keys overall.

# Manually Testing

```
make all
```


# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
