### PR TITLE
fix(durable): deletion immediately after checkout crashes merkle worker

### DIFF
--- a/durable-storage/src/avl/node.rs
+++ b/durable-storage/src/avl/node.rs
@@ -55,6 +55,7 @@ pub(crate) struct Meta {
 #[derive(Encode, Decode)]
 struct StoredNode {
     meta: Meta,
+    data: Hash,
     left: Hash,
     right: Hash,
 }
@@ -849,6 +850,7 @@ impl<TreeId: Storable> Storable for Node<TreeId, Bytes<Normal>, Normal> {
         // should be written to the KV store separately.
         let repr = StoredNode {
             meta: self.meta.deref().clone(),
+            data: Hash::from_foldable(&self.data),
             left: Hash::from_foldable(&self.left),
             right: Hash::from_foldable(&self.right),
         };
@@ -875,7 +877,12 @@ impl<TreeId: Storable> Storable for Node<TreeId, Bytes<Normal>, Normal> {
 
 impl<TreeId: Loadable> Loadable for Node<TreeId, Bytes<Normal>, Normal> {
     fn load(id: Hash, store: &impl KeyValueStore) -> Result<Self, OperationalError> {
-        let StoredNode { meta, left, right } = {
+        let StoredNode {
+            meta,
+            left,
+            right,
+            data: _,
+        } = {
             let bytes =
                 store
                     .blob_get(id)

--- a/durable-storage/src/avl/node.rs
+++ b/durable-storage/src/avl/node.rs
@@ -29,12 +29,14 @@ use octez_riscv_data::serialisation::deserialise;
 use octez_riscv_data::serialisation::serialise;
 use perfect_derive::perfect_derive;
 
+use super::resolver::LazyDataId;
 use super::resolver::LazyTreeId;
 use super::resolver::ProveNode;
 use super::resolver::TreeResolver;
 use super::tree::Tree;
 use crate::avl::resolver::AvlResolver;
 use crate::errors::Error;
+use crate::errors::InvalidArgumentError;
 use crate::errors::OperationalError;
 use crate::key::Key;
 use crate::storage::KeyValueStore;
@@ -75,7 +77,7 @@ pub struct Node<TreeId, DataId, M: Mode> {
     hash: OnceLock<Hash>,
 }
 
-impl Node<LazyTreeId, Bytes<Normal>, Normal> {
+impl Node<LazyTreeId, LazyDataId, Normal> {
     /// Converts the [`Node`] to prove mode.
     pub fn into_proof(self) -> ProveNode {
         Node {
@@ -85,6 +87,15 @@ impl Node<LazyTreeId, Bytes<Normal>, Normal> {
             right: self.right.into_proof(),
             hash: self.hash.clone(),
         }
+    }
+
+    /// Resolve the data field on a lazy node.
+    #[cfg(test)]
+    pub(crate) fn resolve_data(
+        &self,
+        resolver: &impl AvlResolver<super::resolver::LazyNodeId, LazyDataId, LazyTreeId, Normal>,
+    ) -> Result<&Bytes<Normal>, OperationalError> {
+        resolver.resolve_bytes(&self.data, &self.meta.key)
     }
 }
 
@@ -840,7 +851,10 @@ impl<TreeId, DataId, M: AtomMode> Node<TreeId, DataId, M> {
     }
 }
 
-impl<TreeId: Storable> Storable for Node<TreeId, Bytes<Normal>, Normal> {
+impl<TreeId: Storable, DataId> Storable for Node<TreeId, DataId, Normal>
+where
+    DataId: Foldable<HashFold> + Borrow<[u8]>,
+{
     fn store(
         &self,
         store: &impl KeyValueStore,
@@ -875,13 +889,13 @@ impl<TreeId: Storable> Storable for Node<TreeId, Bytes<Normal>, Normal> {
     }
 }
 
-impl<TreeId: Loadable> Loadable for Node<TreeId, Bytes<Normal>, Normal> {
+impl<TreeId: Loadable, DataId: DataLoadable> Loadable for Node<TreeId, DataId, Normal> {
     fn load(id: Hash, store: &impl KeyValueStore) -> Result<Self, OperationalError> {
         let StoredNode {
             meta,
             left,
             right,
-            data: _,
+            data,
         } = {
             let bytes =
                 store
@@ -897,15 +911,7 @@ impl<TreeId: Loadable> Loadable for Node<TreeId, Bytes<Normal>, Normal> {
 
         // The stored representation does not include the `data` field, so we need to load it
         // separately from the KV store.
-        let data = {
-            let bytes = store.get(meta.key.as_ref()).map_err(|error| {
-                OperationalError::CommitValueMissing {
-                    key: meta.key.clone(),
-                    source: Box::new(error),
-                }
-            })?;
-            Bytes::from(bytes.as_ref())
-        };
+        let data = DataId::load(data, &meta.key, store)?;
 
         let left = TreeId::load(left, store)?;
         let right = TreeId::load(right, store)?;
@@ -935,5 +941,56 @@ where
         node.add(&self.left);
         node.add(&self.right);
         node.done()
+    }
+}
+
+/// Helper trait for node data that can be reconstructed
+/// from a [`KeyValueStore`] by content hash and key.
+trait DataLoadable: Sized {
+    /// Load data identified by `id` and `key` from `store`.
+    fn load(id: Hash, key: &Key, store: &impl KeyValueStore) -> Result<Self, OperationalError>;
+}
+
+impl DataLoadable for Bytes<Normal> {
+    fn load(_id: Hash, key: &Key, store: &impl KeyValueStore) -> Result<Self, OperationalError> {
+        let data = {
+            let bytes =
+                store
+                    .get(key.as_ref())
+                    .map_err(|error| OperationalError::CommitValueMissing {
+                        key: key.clone(),
+                        source: Box::new(error),
+                    })?;
+            Bytes::from(bytes.as_ref())
+        };
+
+        Ok(data)
+    }
+}
+
+impl DataLoadable for LazyDataId {
+    fn load(id: Hash, key: &Key, store: &impl KeyValueStore) -> Result<Self, OperationalError> {
+        // TODO (RV-998): go all in on laziness
+        let data = match store.get(key.as_ref()) {
+            Ok(bytes) => {
+                let bytes = Bytes::from(bytes.as_ref());
+                LazyDataId::from(bytes)
+            }
+            // On deletion, the persistence layer has already deleted the value from the
+            // KV-store. Therefore, loading fails with `KeyNotFound`. To ensure deletion
+            // still succeeds, we wrap the value. This is okay as the node will be deleted
+            // immediately.
+            //
+            // Attempting to do anything with the data (except hashing) will fail.
+            Err(Error::InvalidArgument(InvalidArgumentError::KeyNotFound)) => LazyDataId::from(id),
+            Err(error) => {
+                return Err(OperationalError::CommitValueMissing {
+                    key: key.clone(),
+                    source: Box::new(error),
+                });
+            }
+        };
+
+        Ok(data)
     }
 }

--- a/durable-storage/src/avl/resolver.rs
+++ b/durable-storage/src/avl/resolver.rs
@@ -27,6 +27,7 @@
 //! [`Tree`]: crate::avl::tree::Tree
 //! [`Node`]: crate::avl::node::Node
 
+use std::borrow::Borrow;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
@@ -54,6 +55,7 @@ use octez_riscv_data::mode::Normal;
 use octez_riscv_data::mode::Prove;
 use octez_riscv_data::mode::Verify;
 use octez_riscv_data::mode::utils::not_found;
+use perfect_derive::perfect_derive;
 use trait_set::trait_set;
 
 use super::node::Node;
@@ -270,7 +272,7 @@ impl<Value> From<Hash> for LazyId<Value> {
 
 /// Identifier for an AVL node.
 #[derive(Debug, Clone)]
-pub struct LazyNodeId(LazyId<Arc<Node<LazyTreeId, Bytes<Normal>, Normal>>>);
+pub struct LazyNodeId(LazyId<Arc<Node<LazyTreeId, LazyDataId, Normal>>>);
 
 impl LazyNodeId {
     /// Wrap this lazy node identifier in a prove-mode identifier.
@@ -287,8 +289,8 @@ impl LazyNodeId {
     }
 }
 
-impl From<Node<LazyTreeId, Bytes<Normal>, Normal>> for LazyNodeId {
-    fn from(value: Node<LazyTreeId, Bytes<Normal>, Normal>) -> Self {
+impl From<Node<LazyTreeId, LazyDataId, Normal>> for LazyNodeId {
+    fn from(value: Node<LazyTreeId, LazyDataId, Normal>) -> Self {
         let value = Arc::new(value);
         Self(LazyId::new(value))
     }
@@ -332,6 +334,132 @@ impl Storable for LazyNodeId {
 impl Loadable for LazyNodeId {
     fn load(id: Hash, _store: &impl KeyValueStore) -> Result<Self, OperationalError> {
         Ok(Self::from(id))
+    }
+}
+
+/// Identifier for the bytes of an AVL node.
+#[perfect_derive(Debug, Clone)]
+pub struct LazyDataId(LazyId<Bytes<Normal>>);
+
+impl LazyDataId {
+    /// Converts the [`LazyDataId`] to prove mode.
+    pub(crate) fn into_proof(mut self) -> Bytes<Prove<'static>> {
+        self.0
+            .inner
+            .take()
+            .expect("All nodes with unresolved data are deleted immediately.")
+            .into_proof()
+    }
+
+    /// Attempt to load the bytes value from the database, returning
+    /// a reference to the bytes.
+    pub(crate) fn try_get(
+        &self,
+        key: &Key,
+        store: &impl KeyValueStore,
+    ) -> Result<&Bytes<Normal>, OperationalError> {
+        if let Some(bytes) = self.0.inner.get() {
+            return Ok(bytes);
+        }
+
+        self.try_load_inner(key, store)?;
+        let bytes = self.0.inner.get().expect("Try load succeeded");
+
+        Ok(bytes)
+    }
+
+    /// Attempt to load the bytes value from the database, returning
+    /// a mutable reference to the bytes.
+    fn try_get_mut(
+        &mut self,
+        key: &Key,
+        store: &impl KeyValueStore,
+    ) -> Result<&mut Bytes<Normal>, OperationalError> {
+        // evict the cached-hash, if any - the value will be mutated
+        self.0.hash = None;
+
+        if let Some(bytes) = self.0.inner.get_mut() {
+            let temp = bytes as *mut Bytes<Normal>;
+            // This unsafe workaround is required because the rust borrow-checker
+            // is unable to identify the `bytes` mutable reference being dropped straight
+            // away if the condition is false.
+            //
+            // SAFETY: This is a value `&mut Bytes<Normal>` reference with no other
+            // references to the same Bytes being used after this return.
+            return Ok(unsafe { &mut *temp });
+        }
+
+        self.try_load_inner(key, store)?;
+        let bytes = self.0.inner.get_mut().expect("Try load succeeded");
+
+        Ok(bytes)
+    }
+
+    /// Attempt to load the value from a key-value store.
+    ///
+    /// The stored representation of nodes does not include the `data` field,
+    /// so we need to load it separately from the KV store.
+    ///
+    /// If this succeeds, the inner lazy-id is guaranteed to be
+    /// initialised.
+    fn try_load_inner(
+        &self,
+        key: &Key,
+        store: &impl KeyValueStore,
+    ) -> Result<(), OperationalError> {
+        let bytes = store
+            .get(key)
+            .map_err(|error| OperationalError::CommitValueMissing {
+                key: key.clone(),
+                source: Box::new(error),
+            })?;
+        let bytes = Bytes::from(bytes.as_ref());
+
+        // TODO (RV-987): ensure eventual consistency
+        // It's possible it's been initialised by another thread,
+        // but this should not affect overall semantics (see RV-987)
+        let _ = self.0.inner.set(bytes);
+
+        Ok(())
+    }
+}
+
+impl From<Bytes<Normal>> for LazyDataId {
+    fn from(value: Bytes<Normal>) -> Self {
+        Self(LazyId::new(value))
+    }
+}
+
+impl From<Hash> for LazyDataId {
+    fn from(value: Hash) -> Self {
+        Self(LazyId::from(value))
+    }
+}
+
+impl Borrow<[u8]> for LazyDataId {
+    fn borrow(&self) -> &[u8] {
+        let Some(bytes) = self.0.inner.get() else {
+            unreachable!(
+                "All LazyDataId instances are currently populated, except for nodes under deletion"
+            );
+        };
+
+        bytes.borrow()
+    }
+}
+
+impl Foldable<HashFold> for LazyDataId {
+    fn fold(&self, _builder: HashFold) -> <HashFold as Fold>::Folded {
+        if let Some(hash) = self.0.hash() {
+            return *hash;
+        }
+
+        let bytes = self
+            .0
+            .inner
+            .get()
+            .expect("ID should be present when the hash is absent");
+        Hash::from_foldable(bytes)
     }
 }
 
@@ -429,13 +557,13 @@ impl<KV> LazyResolver<KV> {
     }
 }
 
-impl<KV: KeyValueStore> Resolver<LazyNodeId, Node<LazyTreeId, Bytes<Normal>, Normal>>
+impl<KV: KeyValueStore> Resolver<LazyNodeId, Node<LazyTreeId, LazyDataId, Normal>>
     for LazyResolver<KV>
 {
     fn resolve<'a>(
         &self,
         id: &'a LazyNodeId,
-    ) -> Result<&'a Node<LazyTreeId, Bytes<Normal>, Normal>, OperationalError> {
+    ) -> Result<&'a Node<LazyTreeId, LazyDataId, Normal>, OperationalError> {
         if let Some(value) = id.0.inner.get() {
             return Ok(value);
         }
@@ -448,7 +576,7 @@ impl<KV: KeyValueStore> Resolver<LazyNodeId, Node<LazyTreeId, Bytes<Normal>, Nor
     fn resolve_mut<'a>(
         &mut self,
         id: &'a mut LazyNodeId,
-    ) -> Result<&'a mut Node<LazyTreeId, Bytes<Normal>, Normal>, OperationalError> {
+    ) -> Result<&'a mut Node<LazyTreeId, LazyDataId, Normal>, OperationalError> {
         if let Some(value) = id.0.inner.get_mut() {
             let temp = value as *mut Arc<_>;
             // This unsafe workaround is required because the rust borrow-checker
@@ -496,21 +624,21 @@ impl<KV: KeyValueStore> Resolver<LazyTreeId, Tree<LazyNodeId>> for LazyResolver<
     }
 }
 
-impl<KV> DataResolver<Bytes<Normal>, Normal> for LazyResolver<KV> {
+impl<KV: KeyValueStore> DataResolver<LazyDataId, Normal> for LazyResolver<KV> {
     fn resolve_bytes<'a>(
         &self,
-        id: &'a Bytes<Normal>,
-        _key: &Key,
+        id: &'a LazyDataId,
+        key: &Key,
     ) -> Result<&'a Bytes<Normal>, OperationalError> {
-        Ok(id)
+        id.try_get(key, &*self.persistence_layer)
     }
 
     fn resolve_mut_bytes<'a>(
         &self,
-        id: &'a mut Bytes<Normal>,
-        _key: &Key,
+        id: &'a mut LazyDataId,
+        key: &Key,
     ) -> Result<&'a mut Bytes<Normal>, OperationalError> {
-        Ok(id)
+        id.try_get_mut(key, &*self.persistence_layer)
     }
 }
 
@@ -741,16 +869,16 @@ impl<R> ProveResolver<R> {
     /// Prove-mode projections of nodes unlinked from the working tree during the step, keyed by
     /// their initial-tree hash.
     pub(crate) fn deleted_nodes(&self) -> impl Deref<Target = BTreeMap<Hash, DeletedNodeFields>> {
-        self.deleted_nodes.borrow()
+        self.deleted_nodes.deref().borrow()
     }
 
     /// Track node access and resolve the underlying lazy node in one step.
     fn resolve_and_track_node<'a>(
         &self,
         id: &'a LazyNodeId,
-    ) -> Result<&'a Node<LazyTreeId, Bytes<Normal>, Normal>, OperationalError>
+    ) -> Result<&'a Node<LazyTreeId, LazyDataId, Normal>, OperationalError>
     where
-        R: Resolver<LazyNodeId, Node<LazyTreeId, Bytes<Normal>, Normal>>,
+        R: Resolver<LazyNodeId, Node<LazyTreeId, LazyDataId, Normal>>,
     {
         self.accessed_items
             .borrow_mut()
@@ -777,7 +905,7 @@ impl<R> ProveResolver<R> {
 
 impl<R> Resolver<ProveNodeId, ProveNode> for ProveResolver<R>
 where
-    R: Resolver<LazyNodeId, Node<LazyTreeId, Bytes<Normal>, Normal>>
+    R: Resolver<LazyNodeId, Node<LazyTreeId, LazyDataId, Normal>>
         + Resolver<LazyTreeId, Tree<LazyNodeId>>,
 {
     fn resolve<'b>(&self, id: &'b ProveNodeId) -> Result<&'b ProveNode, OperationalError> {
@@ -1055,13 +1183,16 @@ impl DataResolver<Bytes<Verify>, Verify> for VerifyResolver {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Borrow;
     use std::sync::Arc;
     use std::sync::OnceLock;
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering;
 
     use octez_riscv_data::components::bytes::Bytes;
+    use octez_riscv_data::foldable::Foldable;
     use octez_riscv_data::hash::Hash;
+    use octez_riscv_data::hash::HashFold;
     use octez_riscv_data::mode::Normal;
     use octez_riscv_data::mode::Verify;
     use octez_riscv_data::mode::utils::NotFound;
@@ -1161,15 +1292,16 @@ mod tests {
         }
     }
 
-    fn persist_tree<NodeId, TreeId, Res, KV>(
+    fn persist_tree<NodeId, DataId, TreeId, Res, KV>(
         tree: &Tree<NodeId>,
         resolver: &Res,
         persistence_layer: &KV,
     ) where
         NodeId: Storable,
         TreeId: Storable,
+        DataId: Foldable<HashFold> + Borrow<[u8]>,
         KV: KeyValueStore,
-        Res: AvlResolver<NodeId, Bytes<Normal>, TreeId, Normal>,
+        Res: AvlResolver<NodeId, DataId, TreeId, Normal>,
     {
         let store_options = StoreOptions::default().with_shallow().with_node_data();
 
@@ -1392,9 +1524,12 @@ mod tests {
         let node = lazy_resolver
             .resolve(root_id)
             .expect("resolving mutated node should succeed");
+        let node_data = node
+            .resolve_data(&lazy_resolver)
+            .expect("resolving node's data should succeed");
 
-        let mut data = vec![0; node.data().len()];
-        node.data().read(0, &mut data);
+        let mut data = vec![0; node_data.len()];
+        node_data.read(0, &mut data);
         assert_eq!(data.as_slice(), b"root-mutated");
 
         let persisted_tree_hash = lazy_tree.hash();
@@ -1421,8 +1556,12 @@ mod tests {
             .expect("resolving persisted mutated root node should succeed");
         assert_eq!(persistence_layer.blob_get_calls(), 3);
 
-        let mut reloaded_data = vec![0; reloaded_node.data().len()];
-        reloaded_node.data().read(0, &mut reloaded_data);
+        let reloaded_node_data = reloaded_node
+            .resolve_data(&lazy_resolver)
+            .expect("resolving peristed mutated root node data should succeed");
+
+        let mut reloaded_data = vec![0; reloaded_node_data.len()];
+        reloaded_node_data.read(0, &mut reloaded_data);
         assert_eq!(reloaded_data.as_slice(), b"root-mutated");
     }
 

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -727,6 +727,35 @@ mod tests {
         assert_eq!(before, after);
     });
 
+    kv_test!(#[ignore] test_database_delete_after_checkout, KV: BackgroundPersistentKeyValueStore, {
+        // Arrange
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .build()
+            .expect("Creating a Tokio runtime should succeed");
+        let handle = runtime.handle();
+        let (_keepalive, repo) = KV::setup_repo();
+
+        let mut db = new_database::<KV>(handle, &repo);
+        let key = Key::new(&[]).expect("Size less than KEY_MAX_SIZE");
+
+        let initial_hash = db.hash().expect("Hashing should succeed");
+
+        db.set(key.clone(), Bytes::new()).expect("Writing should succeed");
+
+        let commit = db.commit(&repo).expect("Commit should succeed");
+
+        // Act
+        let mut db = Database::<KV, _>::checkout(handle, &repo, commit).expect("Checkout should succeed");
+
+        db.delete(key).expect("Delete should succeed");
+
+        // Assert
+        // - we emit another operation to actually observe any crash.
+        let final_hash = db.hash().expect("Hashing should succeed");
+        assert_eq!(initial_hash, final_hash, "Empty DB should always hash to the same value");
+    });
+
     kv_test!(test_database_checkout_commit_creates_new_snapshot, KV: BackgroundPersistentKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(2)

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -727,7 +727,8 @@ mod tests {
         assert_eq!(before, after);
     });
 
-    kv_test!(#[ignore] test_database_delete_after_checkout, KV: BackgroundPersistentKeyValueStore, {
+    // Test to verify the fix for RV-955 (deletion after checkout failed).
+    kv_test!(test_database_delete_after_checkout, KV: BackgroundPersistentKeyValueStore, {
         // Arrange
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(2)

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -642,6 +642,7 @@ mod tests {
     use super::new_verify_layer;
     use crate::avl::node::Node;
     use crate::avl::resolver::ArcTreeId;
+    use crate::avl::resolver::LazyDataId;
     use crate::avl::resolver::LazyNodeId;
     use crate::avl::resolver::LazyResolver;
     use crate::avl::resolver::LazyTreeId;
@@ -675,7 +676,8 @@ mod tests {
             match node {
                 Some(node_id) => {
                     let resolved_node = self.inner.resolver.resolve(node_id)?;
-                    Ok(Some(resolved_node.data()))
+                    let data = resolved_node.resolve_data(&self.inner.resolver)?;
+                    Ok(Some(data))
                 }
                 None => Ok(None),
             }
@@ -1796,7 +1798,7 @@ mod tests {
             .expect("The commit operation should not fail");
 
         for node in merkle_layer.inner.tree.iter(&merkle_layer.inner.resolver) {
-            let node: &Node<LazyTreeId, Bytes<Normal>, Normal> =
+            let node: &Node<LazyTreeId, LazyDataId, Normal> =
                 node.expect("The node should be retrieved successfully");
 
             node.store(
@@ -1812,7 +1814,9 @@ mod tests {
             assert_eq!(node.hash(), loaded_node.hash());
             assert_eq!(node.balance_factor(), loaded_node.balance_factor());
             assert_eq!(node.key(), loaded_node.key());
-            assert_eq!(node.data(), loaded_node.data());
+
+            let node_data = node.resolve_data(&merkle_layer.inner.resolver).expect("Loading data should succeed");
+            assert_eq!(node_data, loaded_node.data());
         }
 
         let root_hash = merkle_layer.hash();


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

- closes RV-955
- closes RV-956

# What

Fix a crash in the merkle worker, that would occur when deleting a value immediately after a checkout.

# Why

Operations in the database happen first in the persistence layer, before being sent to the merkle layer. This is to ensure that we only send succeeding operations to the merkle layer.

The database should be able to handle deletes.

# How

The issue occurred for delete, however, where first the value would be deleted out the persistence layer, and only then would the deletion be sent to the merkle layer. Since the relevant node had not yet been resolved, however, the merkle layer would attempt to load the data from the persistence layer, which was now missing!

Instead, we switch to use a `LazyDataId` wrapper over the bytes. For now, we still attempt to eagerly resolve the data, but if it fails for `NotFound` we don't crash the worker. Instead, we crash the worker on any subsequent attempt to read the bytes. 

Since, for now, we are addressing the main case of not found for a node that will be immediately deleted, this is okay.  There is still the race condition captured by [RV-987](https://linear.app/tezos/issue/RV-987/race-condition-in-database-between-merklelayer-and-persistencelayer) - which will address further cases where this can occur. 

This will lead us to making `LazyDataId` fully lazy (only resolving when absolutely needed) - but it does add further complexity around `impl Storeable for Node`, and `into_proof` etc. 

This MR represents a good-enough stopping point to address an immediate bug, without adding too much more complexity - which can then be reviewed on its own subsequently.

# Manually Testing

```
make all
```
checkout the first commit, and run the following to see the new deletion test does in fact fail before the fix is applied:
```
cargo nextest run -p octez-riscv-durable-storage --run-ignored only
```


# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
