### PR TITLE
test: add shared prefix for all TestableTmpdir instances

### DIFF
--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -86,9 +86,13 @@ pub struct TestableTmpdir {
 }
 
 impl TestableTmpdir {
+    /// Prefix for all instances of [`TestableTmpdir`].
+    const PREFIX: &str = "rvtest-";
+
     /// Create a new temporary directory for testing
     pub fn new() -> Self {
-        let tempdir = TempDir::new().expect("Should be able to create temp dir");
+        let tempdir =
+            TempDir::with_prefix(Self::PREFIX).expect("Should be able to create temp dir");
 
         Self { tempdir }
     }


### PR DESCRIPTION


# What

add shared prefix for all TestableTmpDir instances.

# Why

This allows much easier cleanup of databases from `TMPDIR` after a test-run failure.
e.g. `/tmp/rvtest-XXX`.


# Manually Testing

```
make all
```
break a test (e.g. `panic!` in `database.rs`), then run it. The tmp dir will be placed as described.


# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
