### PR TITLE
test(data): benchmark that searches for biggest proof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2497,6 +2497,7 @@ dependencies = [
  "bytes",
  "derive_more",
  "hex",
+ "humansize",
  "memmap2",
  "perfect-derive",
  "proptest",

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -30,3 +30,9 @@ optional = true
 [dev-dependencies]
 proptest.workspace = true
 rand.workspace = true
+humansize.workspace = true
+
+[[bench]]
+name = "proof"
+harness = false
+required-features = ["unstable-test-utils"]

--- a/data/benches/proof.rs
+++ b/data/benches/proof.rs
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2026 TriliTech <contact@trili.tech>
+//
+// SPDX-License-Identifier: MIT
+
+use humansize::BINARY;
+use humansize::format_size;
+use octez_riscv_data::components::bytes::Bytes;
+use octez_riscv_data::components::bytes::test_utils::BytesMutOp;
+use octez_riscv_data::merkle_proof::proof_tree::MerkleProof;
+use octez_riscv_data::mode::Normal;
+use octez_riscv_data::mode::Provable;
+use octez_riscv_data::serialisation::serialise;
+use proptest::prelude::Strategy;
+use proptest::strategy::ValueTree;
+use proptest::test_runner::TestRunner;
+
+/// 64 MiB: the maximum size of a `Bytes` component in the durable storage
+const LENGTH: usize = 1024 * 1024 * 64;
+
+/// Given a `strategy` to generate instances of type `A` and an `eval` function to evaluate those
+/// according to some metric. We always make at least one attempt, followed by some number of
+/// `repeats`, to find the worst case, returning the example with the worst outcome we found.
+///
+/// Another function `setup` is provided to create some background state once instead of on every
+/// repeat, in case this provides a performance benefit.
+fn find_worst<A, State, Metric: Ord>(
+    strategy: impl Strategy<Value = A>,
+    setup: impl Fn() -> State,
+    eval: impl Fn(&State, &A) -> Metric,
+    repeats: usize,
+) -> (A, Metric) {
+    let mut runner = TestRunner::default();
+
+    let state = setup();
+
+    let mut gen_a = || {
+        strategy
+            .new_tree(&mut runner)
+            .expect("can use `strategy` to generate values")
+            .current()
+    };
+    let mut max_a = gen_a();
+    let mut max_eval = eval(&state, &max_a);
+    for _ in 0..repeats {
+        let a = gen_a();
+        let ev = eval(&state, &a);
+
+        if ev > max_eval {
+            max_a = a;
+            max_eval = ev;
+        }
+    }
+
+    (max_a, max_eval)
+}
+
+/// Initialise a `Bytes<Normal>` component for generating proofs over.
+fn init_state() -> Bytes<Normal> {
+    let v = [1u8, 2, 3, 4, 5]
+        .iter()
+        .copied()
+        .cycle()
+        .take(LENGTH)
+        .collect::<Vec<_>>();
+    Bytes::from(&v[..])
+}
+
+/// Produce the proof for a given bytes component and operation.
+fn produce_proof(state: &Bytes<Normal>, op: &BytesMutOp) -> Vec<u8> {
+    let mut bytes_prove = state.start_proof();
+    let _result = op.run(&mut bytes_prove);
+
+    let proof_tree = MerkleProof::from_foldable(&bytes_prove);
+    serialise(proof_tree).expect("can serialise proof")
+}
+
+/// An evaluation function that measures the length of the proof for a given `op`.
+fn proof_size(state: &Bytes<Normal>, op: &BytesMutOp) -> usize {
+    produce_proof(state, op).len()
+}
+
+fn main() {
+    let (worst_op, eval) = find_worst(BytesMutOp::any(LENGTH), init_state, proof_size, 1000);
+    println!("Biggest: {worst_op:?}, {}", format_size(eval, BINARY),);
+}

--- a/data/src/components/bytes/test_utils.rs
+++ b/data/src/components/bytes/test_utils.rs
@@ -15,7 +15,6 @@ use proptest::prop_oneof;
 
 use crate::components::bytes::Bytes;
 use crate::components::bytes::BytesMode;
-use crate::components::bytes::PAGE_SIZE;
 
 /// Operations to be issued against an immutable Bytes state component
 #[derive(Debug, Clone)]
@@ -26,9 +25,9 @@ pub enum BytesOp {
 
 impl BytesOp {
     /// Strategy for generating operations to be issued against the Bytes state component
-    pub fn any() -> impl Strategy<Value = Self> + Clone {
+    pub fn any(length: usize) -> impl Strategy<Value = Self> + Clone {
         prop_oneof![
-            (0usize..8192, 0usize..50).prop_map(|(offset, size)| Self::Read { offset, size }),
+            (0..length, 0usize..50).prop_map(|(offset, size)| Self::Read { offset, size }),
             Just(Self::Len),
         ]
     }
@@ -57,13 +56,12 @@ pub enum BytesMutOp {
 
 impl BytesMutOp {
     /// Strategy for generating operations to be issued against the Bytes state component
-    pub fn any() -> impl Strategy<Value = Self> + Clone {
-        let upper_bound = 64 * PAGE_SIZE;
+    pub fn any(length: usize) -> impl Strategy<Value = Self> + Clone {
         prop_oneof![
-            (0usize..upper_bound, vec(any::<u8>(), 0..50))
+            (0..length, vec(any::<u8>(), 0..50))
                 .prop_map(|(offset, data)| Self::Write { offset, data }),
-            (0usize..upper_bound).prop_map(|new_size| Self::Resize { new_size }),
-            BytesOp::any().prop_map(|op| Self::Immutable { op }),
+            (0..length).prop_map(|new_size| Self::Resize { new_size }),
+            BytesOp::any(length).prop_map(|op| Self::Immutable { op }),
         ]
     }
 

--- a/data/src/components/bytes/tests.rs
+++ b/data/src/components/bytes/tests.rs
@@ -10,6 +10,7 @@ use proptest::prop_assert_eq;
 use proptest::proptest;
 
 use crate::components::bytes::Bytes;
+use crate::components::bytes::PAGE_SIZE;
 use crate::components::bytes::test_utils::BytesMutOp;
 use crate::foldable::Foldable;
 use crate::foldable::Unfoldable;
@@ -389,7 +390,7 @@ mode_test!(append_adds_to_end, F, {
 // Bytes behaves the same across different modes
 #[test]
 fn bytes_are_same_across_modes() {
-    proptest!(|(ops in vec(BytesMutOp::any(), 1..20))| {
+    proptest!(|(ops in vec(BytesMutOp::any(64 * PAGE_SIZE), 1..20))| {
         let mut bytes_normal = Bytes::<Normal>::default();
         let results_normal = ops.iter().map(|op| op.run(&mut bytes_normal)).collect::<Vec<_>>();
         let hash_normal = Hash::from_foldable(&bytes_normal);
@@ -417,7 +418,7 @@ fn bytes_are_same_across_modes() {
 
 #[test]
 fn proof_round_trip() {
-    proptest!(|(ops in vec(BytesMutOp::any(), 1..20))| {
+    proptest!(|(ops in vec(BytesMutOp::any(64 * PAGE_SIZE), 1..20))| {
         let mut bytes_normal = Bytes::<Normal>::default();
 
         for op in ops {

--- a/data/src/components/vector/tests.rs
+++ b/data/src/components/vector/tests.rs
@@ -20,6 +20,7 @@ use crate::components::atom::tests::AtomMutOp;
 use crate::components::atom::tests::AtomOp;
 use crate::components::bytes::Bytes;
 use crate::components::bytes::BytesMode;
+use crate::components::bytes::PAGE_SIZE;
 use crate::components::bytes::test_utils::BytesMutOp;
 use crate::components::bytes::test_utils::BytesOp;
 use crate::components::vector::VectorMode;
@@ -189,7 +190,12 @@ where
 
 /// Strategy for generating test cases for the vector implementation using [`Bytes`] operations
 fn vector_bytes_case() -> impl Strategy<Value = VectorCase<Vec<u8>, BytesOp, BytesMutOp>> {
-    vector_case(vec(any::<u8>(), 0..32), BytesOp::any(), BytesMutOp::any())
+    let length = 64 * PAGE_SIZE;
+    vector_case(
+        vec(any::<u8>(), 0..32),
+        BytesOp::any(length),
+        BytesMutOp::any(length),
+    )
 }
 
 /// Strategy for generating test cases for the vector implementation using [`Atom`] operations


### PR DESCRIPTION
Closes RV-989.

# What

Add a benchmark that generates random valid proofs on a bytes component (of 64MiB) and prints the largest proof it finds.

# Why

This benchmark itself isn't really very useful, for proof size we'll mostly calculate the maximum we expect analytically and use a proptest instead to check no proofs are bigger.

This PR introduces the functions that we can use to search for maximally bad proofs on other metrics, such as verification time or memory allocations. Follow-up PRs will add those benchmarks too. We really just use `proof_size` as a simple example of an evaluation function.

# How

There are two commits. The first is a very mechanistic move of some code from a test module into a new `test_utils` module so that it can be accessed from the benchmark code. The second commit is where all the new stuff is.

# Manually Testing

To run the benchmark:

```
cargo bench --bench proof
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
