### PR TITLE
Add `kv_test!`-based equivalent for registry integration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2522,6 +2522,7 @@ dependencies = [
  "hex",
  "log",
  "octez-riscv-data",
+ "octez-riscv-durable-storage",
  "octez-riscv-test-utils",
  "perfect-derive",
  "proptest",

--- a/durable-storage/Cargo.toml
+++ b/durable-storage/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [features]
 default = ["rocksdb"]
+unstable-test-utils = ["dep:proptest"]
 
 [dependencies]
 bincode.workspace = true
@@ -31,9 +32,14 @@ trait-set.workspace = true
 workspace = true
 optional = true
 
+[dependencies.proptest]
+workspace = true
+optional = true
+
 [dev-dependencies]
 proptest.workspace = true
 criterion.workspace = true
+octez-riscv-durable-storage = { path = ".", features = ["unstable-test-utils"] }
 octez-riscv-test-utils.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/durable-storage/src/lib.rs
+++ b/durable-storage/src/lib.rs
@@ -39,3 +39,4 @@ pub mod persistence_layer;
 pub mod registry;
 pub mod repo;
 pub mod storage;
+pub mod test_helpers;

--- a/durable-storage/src/registry.rs
+++ b/durable-storage/src/registry.rs
@@ -1440,6 +1440,19 @@ pub(super) mod tests {
 
         assert!(registry.resize_tick(5).is_err());
     });
+
+    kv_test!(test_durable_storage_end_to_end, KV: BackgroundPersistentKeyValueStore,
+    [
+        generated in crate::test_helpers::operations_strategy(1usize..100)
+    ],
+    {
+        // Every test iteration expects an empty repo, so not setting it in a `setup` block
+        let (_keepalive, repo) = KV::setup_repo();
+
+        let (keys, values, ops) = generated;
+        let operations = crate::test_helpers::make_operations(keys, values, ops);
+        crate::test_helpers::run_operations::<KV>(repo, operations)
+    });
 }
 
 #[cfg(feature = "rocksdb")]

--- a/durable-storage/src/storage/in_memory.rs
+++ b/durable-storage/src/storage/in_memory.rs
@@ -21,10 +21,10 @@ use crate::errors::OperationalError;
 /// Will never write to disk.
 #[derive(Debug, Default, Clone)]
 pub struct InMemoryRepo {
-    #[cfg(test)]
+    #[cfg(any(test, feature = "unstable-test-utils"))]
     commits: std::sync::Arc<RwLock<HashMap<crate::commit::CommitId, InMemorySnapshot>>>,
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "unstable-test-utils"))]
     registry_commits: std::sync::Arc<RwLock<HashMap<crate::commit::CommitId, Vec<u8>>>>,
 }
 
@@ -196,14 +196,14 @@ impl KeyValueStore for InMemoryKeyValueStore {
 }
 
 /// Test-only snapshot repository for [`InMemoryRepo`]
-#[cfg(test)]
+#[cfg(any(test, feature = "unstable-test-utils"))]
 #[derive(Debug)]
 struct InMemorySnapshot {
     blobs: HashMap<Bytes, Bytes>,
     values: HashMap<Bytes, BytesMut>,
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "unstable-test-utils"))]
 impl super::PersistentKeyValueStore for InMemoryKeyValueStore {
     fn commit_to_path(&self, _path: &std::path::Path) -> Result<(), OperationalError> {
         unimplemented!("In-memory store cannot commit to disk")
@@ -254,7 +254,7 @@ impl super::PersistentKeyValueStore for InMemoryKeyValueStore {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "unstable-test-utils"))]
 impl crate::repo::RegistryRepo for InMemoryRepo {
     fn read_registry_commit(
         &self,

--- a/durable-storage/src/test_helpers.rs
+++ b/durable-storage/src/test_helpers.rs
@@ -3,6 +3,8 @@
 //
 // SPDX-License-Identifier: MIT
 
+#![cfg(any(test, feature = "unstable-test-utils"))]
+
 //! Shared utilities for end to end durable storage property-based tests
 //!
 //! Used by the integration test in `tests/integration_test.rs` and

--- a/durable-storage/src/test_helpers.rs
+++ b/durable-storage/src/test_helpers.rs
@@ -1,0 +1,497 @@
+// SPDX-FileCopyrightText: 2026 Trilitech <contact@trili.tech>
+// SPDX-FileCopyrightText: 2026 Nomadic Labs <contact@nomadic-labs.com>
+//
+// SPDX-License-Identifier: MIT
+
+//! Shared utilities for end to end durable storage property-based tests
+//!
+//! Used by the integration test in `tests/integration_test.rs` and
+//! its in-crate `kv_test!` mirror in `registry.rs`.
+
+use std::collections::HashMap;
+
+use bytes::Bytes;
+use octez_riscv_data::hash::Hash;
+use octez_riscv_data::mode::Normal;
+use proptest::prelude::*;
+use proptest::sample::Index;
+use tezos_smart_rollup_constants::core::MAX_FILE_CHUNK_SIZE;
+
+use crate::commit::CommitId;
+use crate::key::KEY_MAX_SIZE;
+use crate::key::Key;
+use crate::merkle_worker::BackgroundPersistentKeyValueStore;
+use crate::registry::Registry;
+use crate::repo::RegistryRepo;
+
+#[derive(Debug, Clone)]
+pub enum Operation {
+    // Database operations
+    Set(Key, Bytes),
+    Write(Key, usize, Bytes),
+    Read(Key, usize, usize),
+    Delete(Key),
+    Exists(Key),
+    ValueLength(Key),
+    Hash,
+    Commit,
+    Checkout,
+
+    // Registry operations
+    GrowRegistry,
+    ShrinkRegistry,
+    CopyDatabase,
+    MoveDatabase,
+    ClearDatabase,
+}
+
+pub const VALUE_MAX_SIZE: usize = 10_000;
+
+#[derive(Debug, Clone)]
+pub enum OperationView {
+    // Database operations
+    Set(Index, Index),
+    Write(Index, usize, Index),
+    Read(Index, usize, usize),
+    Delete(Index),
+    Exists(Index),
+    ValueLength(Index),
+    Hash,
+    Commit,
+    Checkout,
+
+    // Registry operations
+    GrowRegistry,
+    ShrinkRegistry,
+    CopyDatabase,
+    MoveDatabase,
+    ClearDatabase,
+}
+
+pub fn make_operations(
+    keys: Vec<Key>,
+    values: Vec<Bytes>,
+    ops: Vec<OperationView>,
+) -> Vec<Operation> {
+    ops.into_iter()
+        .map(|op| match op {
+            OperationView::Set(k_idx, v_idx) => Operation::Set(
+                keys[k_idx.index(keys.len())].clone(),
+                values[v_idx.index(values.len())].clone(),
+            ),
+            OperationView::Write(k_idx, offset, v_idx) => Operation::Write(
+                keys[k_idx.index(keys.len())].clone(),
+                offset,
+                values[v_idx.index(values.len())].clone(),
+            ),
+            OperationView::Read(k_idx, offset, len) => {
+                Operation::Read(keys[k_idx.index(keys.len())].clone(), offset, len)
+            }
+            OperationView::Delete(idx) => Operation::Delete(keys[idx.index(keys.len())].clone()),
+            OperationView::Exists(idx) => Operation::Exists(keys[idx.index(keys.len())].clone()),
+            OperationView::ValueLength(idx) => {
+                Operation::ValueLength(keys[idx.index(keys.len())].clone())
+            }
+            OperationView::Hash => Operation::Hash,
+            OperationView::Commit => Operation::Commit,
+            OperationView::Checkout => Operation::Checkout,
+            OperationView::GrowRegistry => Operation::GrowRegistry,
+            OperationView::ShrinkRegistry => Operation::ShrinkRegistry,
+            OperationView::CopyDatabase => Operation::CopyDatabase,
+            OperationView::MoveDatabase => Operation::MoveDatabase,
+            OperationView::ClearDatabase => Operation::ClearDatabase,
+        })
+        .collect()
+}
+
+fn key_strategy() -> impl Strategy<Value = Key> {
+    proptest::collection::vec(any::<u8>(), 1usize..=KEY_MAX_SIZE)
+        .prop_map(|bytes| Key::new(&bytes).expect("The size is less than KEY_MAX_SIZE"))
+}
+
+fn value_strategy() -> impl Strategy<Value = Bytes> {
+    proptest::collection::vec(any::<u8>(), 1usize..=VALUE_MAX_SIZE).prop_map(Bytes::from)
+}
+
+pub fn operations_strategy(
+    length: impl Strategy<Value = usize>,
+) -> impl Strategy<Value = (Vec<Key>, Vec<Bytes>, Vec<OperationView>)> {
+    length.prop_flat_map(|length| {
+        let count = length.div_ceil(10);
+        let set = (any::<Index>(), any::<Index>()).prop_map(|(k, v)| OperationView::Set(k, v));
+
+        let read = (
+            any::<Index>(),
+            prop_oneof![
+                2 => Just(0),
+                1 => 1..=VALUE_MAX_SIZE,
+            ],
+            0..=VALUE_MAX_SIZE,
+        )
+            .prop_map(|(k, off, len)| OperationView::Read(k, off, len));
+
+        // Writes biased towards valid offsets
+        let write_valid = (
+            any::<Index>(),
+            prop_oneof![
+                2 => Just(0),
+                1 => 1..=VALUE_MAX_SIZE,
+            ],
+            any::<Index>(),
+        )
+            .prop_map(|(k, off, v)| OperationView::Write(k, off, v));
+
+        // Writes biased towards out-of-bounds offsets
+        let write_invalid = (any::<Index>(), VALUE_MAX_SIZE..=usize::MAX, any::<Index>())
+            .prop_map(|(k, off, v)| OperationView::Write(k, off, v));
+
+        (
+            proptest::collection::vec(key_strategy(), count),
+            proptest::collection::vec(value_strategy(), count),
+            // The chosen frequencies emulate real workloads
+            proptest::collection::vec(
+                prop_oneof![
+                    // Database operations
+                    20 => set,
+                    20 => read,
+                    3 => write_valid,
+                    2 => write_invalid,
+
+                    10 => any::<Index>().prop_map(OperationView::Delete),
+                    10 => any::<Index>().prop_map(OperationView::Exists),
+                    5 => any::<Index>().prop_map(OperationView::ValueLength),
+                    10 => Just(OperationView::Hash),
+                    3 => Just(OperationView::Commit),
+                    3 => Just(OperationView::Checkout),
+
+                    // Registry operations
+                    3 => Just(OperationView::GrowRegistry),
+                    2 => Just(OperationView::ShrinkRegistry),
+                    2 => Just(OperationView::CopyDatabase),
+                    1 => Just(OperationView::MoveDatabase),
+                    2 => Just(OperationView::ClearDatabase),
+                ],
+                length,
+            ),
+        )
+    })
+}
+
+#[derive(Clone, Debug, Default)]
+struct GoldenData {
+    seen: HashMap<Key, Bytes>,
+    last: Option<(Hash, HashMap<Key, Bytes>)>,
+    ambiguous_hash: bool,
+}
+
+fn grow_registry<KV>(registry: &mut Registry<KV, Normal>, golden: &mut Vec<GoldenData>)
+where
+    KV: BackgroundPersistentKeyValueStore,
+    KV::Repo: RegistryRepo,
+{
+    let new = registry.len();
+
+    registry
+        .resize_tick(new.saturating_add(1))
+        .expect("Resizing the registry should succeed");
+
+    if let Some(previous) = new.checked_sub(1) {
+        registry
+            .copy_database(previous, new)
+            .expect("Copying the database should succeed");
+    }
+
+    if golden.is_empty() {
+        golden.resize(1, Default::default());
+    } else {
+        golden.push(golden[golden.len() - 1].clone());
+    }
+}
+
+/// Get the index of the current database, growing the registry until it has a valid index.
+fn get_index<KV>(registry: &mut Registry<KV, Normal>, golden: &mut Vec<GoldenData>) -> usize
+where
+    KV: BackgroundPersistentKeyValueStore,
+    KV::Repo: RegistryRepo,
+{
+    if let Some(index) = registry.len().checked_sub(1) {
+        index
+    } else {
+        grow_registry(registry, golden);
+        get_index(registry, golden)
+    }
+}
+
+fn update_value(value: &mut Bytes, offset: usize, bytes: Bytes) {
+    let mut new_value: Vec<u8> = value.clone().into();
+    let overwrite_len = std::cmp::min(bytes.len(), new_value.len().saturating_sub(offset));
+    if overwrite_len > 0 {
+        new_value[offset..offset + overwrite_len].copy_from_slice(&bytes[..overwrite_len]);
+    }
+    if bytes.len() > overwrite_len {
+        new_value.extend_from_slice(&bytes[overwrite_len..]);
+    }
+    *value = Bytes::copy_from_slice(&new_value);
+}
+
+pub fn run_operations<KV>(repo: KV::Repo, operations: Vec<Operation>)
+where
+    KV: BackgroundPersistentKeyValueStore,
+    KV::Repo: RegistryRepo,
+{
+    let checkout_repo = repo.clone();
+    let mut checkout_candidates: HashMap<Hash, bool> = HashMap::new();
+
+    let mut registry: Registry<KV, Normal> =
+        Registry::new(repo).expect("Creating the registry should succeed");
+
+    let mut golden: Vec<GoldenData> = vec![];
+
+    for operation in operations {
+        match operation {
+            // Database operations
+            Operation::Set(key, bytes) => {
+                let index = get_index(&mut registry, &mut golden);
+
+                let data = Bytes::copy_from_slice(&bytes);
+
+                let result = registry
+                    .database_mut(index)
+                    .expect("The index is in bounds")
+                    .set(key.clone(), data);
+
+                if bytes.len() <= MAX_FILE_CHUNK_SIZE {
+                    assert!(
+                        result.is_ok(),
+                        "Set should have succeeded but failed: {:?}",
+                        result.err()
+                    );
+
+                    golden[index].seen.insert(key, bytes.clone());
+                } else {
+                    assert!(result.is_err(), "Set should have failed but succeeded");
+                }
+            }
+            Operation::Write(key, offset, bytes) => {
+                let data = Bytes::copy_from_slice(&bytes);
+                let index = get_index(&mut registry, &mut golden);
+
+                let result = registry
+                    .database_mut(index)
+                    .expect("The index is in bounds")
+                    .write(key.clone(), offset, data);
+
+                let should_succeed = if let Some(map_value) = golden[index].seen.get_mut(&key) {
+                    if offset > map_value.len()
+                        || offset.checked_add(bytes.len()).is_none()
+                        || bytes.len() > MAX_FILE_CHUNK_SIZE
+                    {
+                        false
+                    } else {
+                        update_value(map_value, offset, bytes);
+                        true
+                    }
+                } else if offset > 0 || bytes.len() > MAX_FILE_CHUNK_SIZE {
+                    false
+                } else {
+                    golden[index].seen.insert(key, bytes);
+                    true
+                };
+
+                if should_succeed {
+                    assert!(
+                        result.is_ok(),
+                        "Write should have succeeded but failed: {:?}",
+                        result.err()
+                    );
+                } else {
+                    assert!(result.is_err(), "Write should have failed but succeeded");
+                }
+            }
+            Operation::Read(key, offset, len) => {
+                let index = get_index(&mut registry, &mut golden);
+                let mut database_value = vec![0; len];
+
+                let mut cursor = 0;
+                let mut result = registry
+                    .database(index)
+                    .expect("The index is in bounds")
+                    .read(&key, offset + cursor, &mut database_value[cursor..]);
+
+                while let Ok(read) = result {
+                    if read == 0 {
+                        break;
+                    }
+                    cursor += read;
+                    result = registry
+                        .database(index)
+                        .expect("The index is in bounds")
+                        .read(&key, offset + cursor, &mut database_value[cursor..])
+                }
+
+                if let Some(map_value) = golden[index].seen.get(&key) {
+                    if offset > map_value.len() || len > MAX_FILE_CHUNK_SIZE {
+                        assert!(result.is_err());
+                    } else {
+                        let expected_len = std::cmp::min(len, map_value.len() - offset);
+                        assert!(cursor >= expected_len);
+                        assert_eq!(
+                            &database_value[..expected_len],
+                            &map_value[offset..offset + expected_len]
+                        );
+                    }
+                } else {
+                    assert!(result.is_err());
+                }
+            }
+            Operation::Delete(key) => {
+                let index = get_index(&mut registry, &mut golden);
+
+                // The hash of the `Database` can differ even if the key-value pairs stored are
+                // the same, because deletion and reinsertion can cause the shape of the AVL
+                // tree to change.
+                let deleted = golden[index].seen.remove(&key).is_some();
+                if deleted {
+                    golden[index].ambiguous_hash = true;
+                }
+
+                registry
+                    .database_mut(index)
+                    .expect("The index is in bounds")
+                    .delete(key)
+                    .expect("Deleting should succeed");
+            }
+            Operation::Exists(key) => {
+                let index = get_index(&mut registry, &mut golden);
+
+                let in_database = registry
+                    .database(index)
+                    .expect("The index is in bounds")
+                    .exists(&key)
+                    .expect("Writing should succeed");
+                let in_map = golden[index].seen.contains_key(&key);
+
+                assert_eq!(in_database, in_map);
+            }
+            Operation::ValueLength(key) => {
+                let index = get_index(&mut registry, &mut golden);
+
+                let database_length = registry
+                    .database(index)
+                    .expect("The index is in bounds")
+                    .value_length(&key);
+
+                let map_value = golden[index].seen.get(&key);
+
+                match (database_length, map_value) {
+                    (Ok(database_length), Some(map_value)) => {
+                        assert_eq!(database_length, map_value.len())
+                    }
+                    (Err(_), None) => (),
+                    _ => panic!("The value exists in one map but not the other"),
+                }
+            }
+            Operation::Hash => {
+                let index = get_index(&mut registry, &mut golden);
+
+                let new_digest = registry
+                    .database(index)
+                    .expect("The index is in bounds")
+                    .hash()
+                    .expect("Hash should succeed");
+
+                if let (Some((old_digest, old_map)), false) =
+                    (&golden[index].last, &golden[index].ambiguous_hash)
+                {
+                    assert_eq!(new_digest == *old_digest, golden[index].seen == *old_map);
+                }
+
+                golden[index].last = Some((new_digest, golden[index].seen.clone()));
+
+                checkout_candidates
+                    .entry(Hash::from_foldable(&registry))
+                    .or_insert(false);
+            }
+            Operation::Commit => {
+                let commit_id = registry.commit().expect("Committing should succeed");
+                checkout_candidates.insert(*commit_id.as_hash(), true);
+            }
+            Operation::Checkout => {
+                if !checkout_candidates.is_empty() {
+                    let index = rand::random_range(0..checkout_candidates.len());
+                    let (&commit_hash, &committed) = checkout_candidates
+                        .iter()
+                        .nth(index)
+                        .expect("Index is within bounds");
+                    let checkout_result = Registry::<KV, Normal>::checkout(
+                        checkout_repo.clone(),
+                        CommitId::from(commit_hash),
+                    );
+
+                    assert_eq!(
+                        checkout_result.is_ok(),
+                        committed,
+                        "Checkout result did not match whether the commit id was committed"
+                    );
+                }
+            }
+
+            // Registry operations
+            Operation::GrowRegistry => grow_registry(&mut registry, &mut golden),
+            Operation::ShrinkRegistry => {
+                // Make sure there's a database to drop
+                if registry.is_empty() {
+                    grow_registry(&mut registry, &mut golden);
+                };
+
+                let new_size = registry.len().saturating_sub(1);
+                registry
+                    .resize_tick(new_size)
+                    .expect("Resizing the registry should succeed");
+
+                golden.truncate(new_size);
+            }
+            Operation::ClearDatabase => {
+                let index = get_index(&mut registry, &mut golden);
+
+                registry
+                    .clear_database(index)
+                    .expect("Clearing the database should be successful");
+
+                golden[index].seen.clear();
+                golden[index].ambiguous_hash = false;
+                golden[index].last = None;
+            }
+            Operation::CopyDatabase => {
+                let (src, dst) = {
+                    while registry.len() < 2 {
+                        grow_registry(&mut registry, &mut golden);
+                    }
+                    (registry.len() - 2, registry.len() - 1)
+                };
+
+                registry
+                    .copy_database(src, dst)
+                    .expect("Copying the database should be successful");
+
+                golden[dst] = golden[src].clone();
+            }
+            Operation::MoveDatabase => {
+                let (src, dst) = {
+                    while registry.len() < 2 {
+                        grow_registry(&mut registry, &mut golden);
+                    }
+                    (registry.len() - 2, registry.len() - 1)
+                };
+
+                registry
+                    .move_database(src, dst)
+                    .expect("Moving the database should be successful");
+
+                let empty = Default::default();
+                let new_dst = std::mem::replace(&mut golden[src], empty);
+                golden[dst] = new_dst;
+            }
+        }
+    }
+}

--- a/durable-storage/tests/integration_test.rs
+++ b/durable-storage/tests/integration_test.rs
@@ -1,52 +1,39 @@
 #![cfg(test)]
 
-use std::collections::HashMap;
-
 use bytes::Bytes;
-use octez_riscv_data::hash::Hash;
-use octez_riscv_data::mode::Normal;
-use octez_riscv_durable_storage::key::KEY_MAX_SIZE;
 use octez_riscv_durable_storage::key::Key;
-use octez_riscv_durable_storage::registry::Registry;
-use proptest::prelude::*;
+use octez_riscv_durable_storage::test_helpers::Operation;
+use octez_riscv_durable_storage::test_helpers::make_operations;
+use octez_riscv_durable_storage::test_helpers::operations_strategy;
+use octez_riscv_durable_storage::test_helpers::run_operations;
 use proptest::proptest;
-use proptest::sample::Index;
-use tezos_smart_rollup_constants::core::MAX_FILE_CHUNK_SIZE;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "rocksdb")] {
         use octez_riscv_durable_storage::persistence_layer::PersistenceLayer;
+        use octez_riscv_durable_storage::repo::DirectoryManager;
+        use octez_riscv_test_utils::TestableTmpdir;
         type TestKv = PersistenceLayer;
 
         const PROPTEST_CASES: u32 = 128;
 
+        fn setup_repo() -> (TestableTmpdir, DirectoryManager) {
+            let tmpdir = TestableTmpdir::new();
+            let base_dir = tmpdir.path().join("registry");
+            let repo = DirectoryManager::new(&base_dir).expect("Failed to create manager");
+            (tmpdir, repo)
+        }
     } else {
         use octez_riscv_durable_storage::storage::in_memory::InMemoryKeyValueStore;
+        use octez_riscv_durable_storage::storage::in_memory::InMemoryRepo;
         type TestKv = InMemoryKeyValueStore;
 
         const PROPTEST_CASES: u32 = 256;
+
+        fn setup_repo() -> ((), InMemoryRepo) {
+            ((), InMemoryRepo::default())
+        }
     }
-}
-
-#[derive(Debug, Clone)]
-enum Operation {
-    // Database operations
-    Set(Key, Bytes),
-    Write(Key, usize, Bytes),
-    Read(Key, usize, usize),
-    Delete(Key),
-    Exists(Key),
-    ValueLength(Key),
-    Hash,
-    Commit,
-    Checkout,
-
-    // Registry operations
-    GrowRegistry,
-    ShrinkRegistry,
-    CopyDatabase,
-    MoveDatabase,
-    ClearDatabase,
 }
 
 #[test]
@@ -69,472 +56,16 @@ fn test_durable_storage_manual() {
         Operation::ShrinkRegistry,
     ];
 
-    test_durable_storage_inner(operations)
-}
-
-const VALUE_MAX_SIZE: usize = 10_000;
-
-#[derive(Debug, Clone)]
-enum OperationView {
-    // Database operations
-    Set(Index, Index),
-    Write(Index, usize, Index),
-    Read(Index, usize, usize),
-    Delete(Index),
-    Exists(Index),
-    ValueLength(Index),
-    Hash,
-    Commit,
-    Checkout,
-
-    // Registry operations
-    GrowRegistry,
-    ShrinkRegistry,
-    CopyDatabase,
-    MoveDatabase,
-    ClearDatabase,
+    let (_keepalive, repo) = setup_repo();
+    run_operations::<TestKv>(repo, operations);
 }
 
 proptest! {
     #![proptest_config(proptest::test_runner::Config::with_cases(PROPTEST_CASES))]
     #[test]
     fn test_durable_storage_prop((keys, values, ops) in operations_strategy(1usize..100)) {
-        // Auto formatting doesn't work within the proptest macro, so this passes off to a
-        // standalone function.
-        test_durable_storage(keys, values, ops)
-    }
-}
-
-fn test_durable_storage(keys: Vec<Key>, values: Vec<Bytes>, ops: Vec<OperationView>) {
-    // `OperationView` uses an index to choose keys and values from a generated set so that
-    // proptest's shrinking algorithm can find a minimal-failing test with fewer iterations.
-    let operations = ops
-        .into_iter()
-        .map(|op| match op {
-            OperationView::Set(k_idx, v_idx) => Operation::Set(
-                keys[k_idx.index(keys.len())].clone(),
-                values[v_idx.index(values.len())].clone(),
-            ),
-            OperationView::Write(k_idx, offset, v_idx) => Operation::Write(
-                keys[k_idx.index(keys.len())].clone(),
-                offset,
-                values[v_idx.index(values.len())].clone(),
-            ),
-            OperationView::Read(k_idx, offset, len) => {
-                Operation::Read(keys[k_idx.index(keys.len())].clone(), offset, len)
-            }
-            OperationView::Delete(idx) => Operation::Delete(keys[idx.index(keys.len())].clone()),
-            OperationView::Exists(idx) => Operation::Exists(keys[idx.index(keys.len())].clone()),
-            OperationView::ValueLength(idx) => {
-                Operation::ValueLength(keys[idx.index(keys.len())].clone())
-            }
-            OperationView::Hash => Operation::Hash,
-            OperationView::Commit => Operation::Commit,
-            OperationView::Checkout => Operation::Checkout,
-            OperationView::GrowRegistry => Operation::GrowRegistry,
-            OperationView::ShrinkRegistry => Operation::ShrinkRegistry,
-            OperationView::CopyDatabase => Operation::CopyDatabase,
-            OperationView::MoveDatabase => Operation::MoveDatabase,
-            OperationView::ClearDatabase => Operation::ClearDatabase,
-        })
-        .collect();
-    test_durable_storage_inner(operations)
-}
-
-fn key_strategy() -> impl Strategy<Value = Key> {
-    proptest::collection::vec(any::<u8>(), 1usize..=KEY_MAX_SIZE)
-        .prop_map(|bytes| Key::new(&bytes).expect("The size is less than KEY_MAX_SIZE"))
-}
-
-fn value_strategy() -> impl Strategy<Value = Bytes> {
-    proptest::collection::vec(any::<u8>(), 1usize..=VALUE_MAX_SIZE).prop_map(Bytes::from)
-}
-
-fn operations_strategy(
-    length: impl Strategy<Value = usize>,
-) -> impl Strategy<Value = (Vec<Key>, Vec<Bytes>, Vec<OperationView>)> {
-    length.prop_flat_map(|length| {
-        let count = length.div_ceil(10);
-        let set = (any::<Index>(), any::<Index>()).prop_map(|(k, v)| OperationView::Set(k, v));
-
-        let read = (
-            any::<Index>(),
-            prop_oneof![
-                2 => Just(0),
-                1 => 1..=VALUE_MAX_SIZE,
-            ],
-            0..=VALUE_MAX_SIZE,
-        )
-            .prop_map(|(k, off, len)| OperationView::Read(k, off, len));
-
-        // Writes biased towards valid offsets
-        let write_valid = (
-            any::<Index>(),
-            prop_oneof![
-                2 => Just(0),
-                1 => 1..=VALUE_MAX_SIZE,
-            ],
-            any::<Index>(),
-        )
-            .prop_map(|(k, off, v)| OperationView::Write(k, off, v));
-
-        // Writes biased towards out-of-bounds offsets
-        let write_invalid = (any::<Index>(), VALUE_MAX_SIZE..=usize::MAX, any::<Index>())
-            .prop_map(|(k, off, v)| OperationView::Write(k, off, v));
-
-        (
-            proptest::collection::vec(key_strategy(), count),
-            proptest::collection::vec(value_strategy(), count),
-            // The chosen frequencies emulate real workloads
-            proptest::collection::vec(
-                prop_oneof![
-                    // Database operations
-                    20 => set,
-                    20 => read,
-                    3 => write_valid,
-                    2 => write_invalid,
-
-                    10 => any::<Index>().prop_map(OperationView::Delete),
-                    10 => any::<Index>().prop_map(OperationView::Exists),
-                    5 => any::<Index>().prop_map(OperationView::ValueLength),
-                    10 => Just(OperationView::Hash),
-                    3 => Just(OperationView::Commit),
-                    3 => Just(OperationView::Checkout),
-
-                    // Registry operations
-                    3 => Just(OperationView::GrowRegistry),
-                    2 => Just(OperationView::ShrinkRegistry),
-                    2 => Just(OperationView::CopyDatabase),
-                    1 => Just(OperationView::MoveDatabase),
-                    2 => Just(OperationView::ClearDatabase),
-                ],
-                length,
-            ),
-        )
-    })
-}
-
-#[derive(Clone, Debug, Default)]
-struct GoldenData {
-    seen: HashMap<Key, Bytes>,
-    last: Option<(Hash, HashMap<Key, Bytes>)>,
-    ambiguous_hash: bool,
-}
-
-fn grow_registry(registry: &mut Registry<TestKv, Normal>, golden: &mut Vec<GoldenData>) {
-    let new = registry.len();
-
-    registry
-        .resize_tick(new.saturating_add(1))
-        .expect("Resizing the registry should succeed");
-
-    if let Some(previous) = new.checked_sub(1) {
-        registry.copy_database(previous, new).unwrap();
-    }
-
-    if golden.is_empty() {
-        golden.resize(1, Default::default());
-    } else {
-        golden.push(golden[golden.len() - 1].clone());
-    }
-}
-
-// Get the index of the current database, or grow the registry until it has a valid index
-fn get_index(registry: &mut Registry<TestKv, Normal>, golden: &mut Vec<GoldenData>) -> usize {
-    if let Some(index) = registry.len().checked_sub(1) {
-        index
-    } else {
-        grow_registry(registry, golden);
-        get_index(registry, golden)
-    }
-}
-
-fn update_value(value: &mut Bytes, offset: usize, bytes: Bytes) {
-    let mut new_value: Vec<u8> = value.clone().into();
-    let overwrite_len = std::cmp::min(bytes.len(), new_value.len().saturating_sub(offset));
-    if overwrite_len > 0 {
-        new_value[offset..offset + overwrite_len].copy_from_slice(&bytes[..overwrite_len]);
-    }
-    if bytes.len() > overwrite_len {
-        new_value.extend_from_slice(&bytes[overwrite_len..]);
-    }
-    *value = Bytes::copy_from_slice(&new_value);
-}
-
-fn test_durable_storage_inner(operations: Vec<Operation>) {
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "rocksdb")] {
-            use octez_riscv_durable_storage::commit::CommitId;
-            use octez_riscv_durable_storage::repo::DirectoryManager;
-            use octez_riscv_test_utils::TestableTmpdir;
-            use rand::random_range;
-
-            let tmpdir = TestableTmpdir::new();
-            let base_dir = tmpdir.path().join("registry");
-            let repo = DirectoryManager::new(&base_dir).expect("Failed to create manager");
-            let checkout_repo = repo.clone();
-            let mut checkout_candidates: HashMap<Hash, bool> = HashMap::new();
-        } else {
-            use octez_riscv_durable_storage::storage::in_memory::InMemoryRepo;
-            let repo = InMemoryRepo::default();
-        }
-    }
-
-    let mut registry: Registry<TestKv, Normal> =
-        Registry::new(repo).expect("Creating the registry should succeed");
-
-    let mut golden: Vec<GoldenData> = vec![];
-
-    for operation in operations {
-        match operation {
-            // Database operations
-            Operation::Set(key, bytes) => {
-                let index = get_index(&mut registry, &mut golden);
-
-                let data = Bytes::copy_from_slice(&bytes);
-
-                let result = registry
-                    .database_mut(index)
-                    .expect("The index is in bounds")
-                    .set(key.clone(), data);
-
-                if bytes.len() <= MAX_FILE_CHUNK_SIZE {
-                    assert!(
-                        result.is_ok(),
-                        "Set should have succeeded but failed: {:?}",
-                        result.err()
-                    );
-
-                    golden[index].seen.insert(key, bytes.clone());
-                } else {
-                    assert!(result.is_err(), "Set should have failed but succeeded");
-                }
-            }
-            Operation::Write(key, offset, bytes) => {
-                let data = Bytes::copy_from_slice(&bytes);
-                let index = get_index(&mut registry, &mut golden);
-
-                let result = registry
-                    .database_mut(index)
-                    .expect("The index is in bounds")
-                    .write(key.clone(), offset, data);
-
-                let should_succeed = if let Some(map_value) = golden[index].seen.get_mut(&key) {
-                    if offset > map_value.len()
-                        || offset.checked_add(bytes.len()).is_none()
-                        || bytes.len() > MAX_FILE_CHUNK_SIZE
-                    {
-                        false
-                    } else {
-                        update_value(map_value, offset, bytes);
-                        true
-                    }
-                } else if offset > 0 || bytes.len() > MAX_FILE_CHUNK_SIZE {
-                    false
-                } else {
-                    golden[index].seen.insert(key, bytes);
-                    true
-                };
-
-                if should_succeed {
-                    assert!(
-                        result.is_ok(),
-                        "Write should have succeeded but failed: {:?}",
-                        result.err()
-                    );
-                } else {
-                    assert!(result.is_err(), "Write should have failed but succeeded");
-                }
-            }
-            Operation::Read(key, offset, len) => {
-                let index = get_index(&mut registry, &mut golden);
-                let mut database_value = vec![0; len];
-
-                let mut cursor = 0;
-                let mut result = registry
-                    .database(index)
-                    .expect("The index is in bounds")
-                    .read(&key, offset + cursor, &mut database_value[cursor..]);
-
-                while let Ok(read) = result {
-                    if read == 0 {
-                        break;
-                    }
-                    cursor += read;
-                    result = registry
-                        .database(index)
-                        .expect("The index is in bounds")
-                        .read(&key, offset + cursor, &mut database_value[cursor..])
-                }
-
-                if let Some(map_value) = golden[index].seen.get(&key) {
-                    if offset > map_value.len() || len > MAX_FILE_CHUNK_SIZE {
-                        assert!(result.is_err());
-                    } else {
-                        let expected_len = std::cmp::min(len, map_value.len() - offset);
-                        assert!(cursor >= expected_len);
-                        assert_eq!(
-                            &database_value[..expected_len],
-                            &map_value[offset..offset + expected_len]
-                        );
-                    }
-                } else {
-                    assert!(result.is_err());
-                }
-            }
-            Operation::Delete(key) => {
-                let index = get_index(&mut registry, &mut golden);
-
-                // The hash of the `Database` can differ even if the key-value pairs stored are
-                // the same, because deletion and reinsertion can cause the shape of the AVL
-                // tree to change.
-                let deleted = golden[index].seen.remove(&key).is_some();
-                if deleted {
-                    golden[index].ambiguous_hash = true;
-                }
-
-                registry
-                    .database_mut(index)
-                    .expect("The index is in bounds")
-                    .delete(key)
-                    .expect("Deleting should succeed");
-            }
-            Operation::Exists(key) => {
-                let index = get_index(&mut registry, &mut golden);
-
-                let in_database = registry
-                    .database(index)
-                    .expect("The index is in bounds")
-                    .exists(&key)
-                    .expect("Writing should succeed");
-                let in_map = golden[index].seen.contains_key(&key);
-
-                assert_eq!(in_database, in_map);
-            }
-            Operation::ValueLength(key) => {
-                let index = get_index(&mut registry, &mut golden);
-
-                let database_length = registry
-                    .database(index)
-                    .expect("The index is in bounds")
-                    .value_length(&key);
-
-                let map_value = golden[index].seen.get(&key);
-
-                match (database_length, map_value) {
-                    (Ok(database_length), Some(map_value)) => {
-                        assert_eq!(database_length, map_value.len())
-                    }
-                    (Err(_), None) => (),
-                    _ => panic!("The value exists in one map but not the other"),
-                }
-            }
-            Operation::Hash => {
-                let index = get_index(&mut registry, &mut golden);
-
-                let new_digest = registry
-                    .database(index)
-                    .expect("The index is in bounds")
-                    .hash()
-                    .expect("Hash should succeed");
-
-                if let (Some((old_digest, old_map)), false) =
-                    (&golden[index].last, &golden[index].ambiguous_hash)
-                {
-                    assert_eq!(new_digest == *old_digest, golden[index].seen == *old_map);
-                }
-
-                golden[index].last = Some((new_digest, golden[index].seen.clone()));
-
-                #[cfg(feature = "rocksdb")]
-                checkout_candidates
-                    .entry(Hash::from_foldable(&registry))
-                    .or_insert(false);
-            }
-            Operation::Commit => {
-                #[cfg(feature = "rocksdb")]
-                {
-                    let commit_id = registry.commit().expect("Committing should succeed");
-                    checkout_candidates.insert(*commit_id.as_hash(), true);
-                }
-            }
-            Operation::Checkout => {
-                #[cfg(feature = "rocksdb")]
-                {
-                    if !checkout_candidates.is_empty() {
-                        let index = random_range(0..checkout_candidates.len());
-                        let (&commit_hash, &committed) =
-                            checkout_candidates.iter().nth(index).unwrap();
-                        let checkout_result = Registry::<TestKv, Normal>::checkout(
-                            checkout_repo.clone(),
-                            CommitId::from(commit_hash),
-                        );
-
-                        assert_eq!(
-                            checkout_result.is_ok(),
-                            committed,
-                            "Checkout result did not match whether the commit id was committed"
-                        );
-                    }
-                }
-            }
-
-            // Registry operations
-            Operation::GrowRegistry => grow_registry(&mut registry, &mut golden),
-            Operation::ShrinkRegistry => {
-                // Make sure there's a database to drop
-                if registry.is_empty() {
-                    grow_registry(&mut registry, &mut golden);
-                };
-
-                let new_size = registry.len().saturating_sub(1);
-                registry
-                    .resize_tick(new_size)
-                    .expect("Resizing the registry should succeed");
-
-                golden.truncate(new_size);
-            }
-            Operation::ClearDatabase => {
-                let index = get_index(&mut registry, &mut golden);
-
-                registry
-                    .clear_database(index)
-                    .expect("Clearing the database should be successful");
-
-                golden[index].seen.clear();
-                golden[index].ambiguous_hash = false;
-                golden[index].last = None;
-            }
-            Operation::CopyDatabase => {
-                let (src, dst) = {
-                    while registry.len() < 2 {
-                        grow_registry(&mut registry, &mut golden);
-                    }
-                    (registry.len() - 2, registry.len() - 1)
-                };
-
-                registry
-                    .copy_database(src, dst)
-                    .expect("Copying the database should be successful");
-
-                golden[dst] = golden[src].clone();
-            }
-            Operation::MoveDatabase => {
-                let (src, dst) = {
-                    while registry.len() < 2 {
-                        grow_registry(&mut registry, &mut golden);
-                    }
-                    (registry.len() - 2, registry.len() - 1)
-                };
-
-                registry
-                    .move_database(src, dst)
-                    .expect("Moving the database should be successful");
-
-                let empty = Default::default();
-                let new_dst = std::mem::replace(&mut golden[src], empty);
-                golden[dst] = new_dst;
-            }
-        }
+        let (_keepalive, repo) = setup_repo();
+        let operations = make_operations(keys, values, ops);
+        run_operations::<TestKv>(repo, operations);
     }
 }


### PR DESCRIPTION
Closes RV-977.

# What

Adds `test_durable_storage_end_to_end` as a `kv_test!` for the registry which replicates the durable storage integration test.

# Why

To have a property-based test which generates `Registry` operations and runs across different configurations. Next, execution will produce traces which will be compared for consistency.

# How

Most of the helpers and strategies defined in `integration_test.rs` are moved to a new source module `test_helpers.rs`. This module is enabled in test and with a new `test-utils` feature flag (`#[cfg(test)]` is not enough since they need to be exposed in the crate API in order for the integration test to use it).

In addition to just moving:
- `test_durable_storage_inner` is renamed to `run_operations` and can now run with both RocksDB and in-memory backends
- the core of `test_durable_storage` (the `Vec<OperationView>` to `Vec<OperationView>` mapping) is taken out and renamed to `make_operations`

I opted to keep the integration test as is rather than replace with the `kv_test` because the integration test exercises the public API directly, whereas the new `kv_test!` will in the future go through a test-only `Registry` layer for recording traces.

Some of the moved declarations are now public but behind a test-only feature flag and largely self-explanatory so I didn't add any extra documentation.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [ ] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
