### PR TITLE
Modal `Registry`

### DIFF
--- a/durable-storage/src/avl/resolver.rs
+++ b/durable-storage/src/avl/resolver.rs
@@ -1112,7 +1112,7 @@ impl Default for VerifyTreeId {
 }
 
 /// Adapter that projects in-memory AVL identifiers into verify-mode values.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct VerifyResolver;
 
 impl Resolver<VerifyNodeId, Node<VerifyTreeId, Bytes<Verify>, Verify>> for VerifyResolver {

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -570,7 +570,7 @@ impl<KV: BackgroundKeyValueStore, M: DatabaseMode> Database<KV, M> {
 mod traced_database;
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::collections::HashSet;
     use std::sync::Arc;
 
@@ -641,6 +641,27 @@ mod tests {
         let database = new_database::<KV>(handle, &repo);
 
         (runtime, keepalive, repo, database)
+    }
+
+    /// Wrap an existing Prove-mode [`MerkleLayer`] into a [`Database`].
+    pub(crate) fn from_prove_layer<KV: KeyValueStore>(
+        merkle: MerkleLayer<KV, Prove<'static>>,
+    ) -> Database<KV, Prove<'static>> {
+        Database {
+            inner: super::ProveImpl { merkle },
+        }
+    }
+
+    /// Generate a Merkle proof from `database` and produce a Verify-mode database that replays
+    /// the same data via that proof.
+    pub(crate) fn to_verify<KV: KeyValueStore>(
+        database: &Database<KV, Prove<'static>>,
+    ) -> Database<KV, Verify> {
+        Database {
+            inner: super::VerifyImpl {
+                merkle: database.inner.merkle.to_verify(),
+            },
+        }
     }
 
     kv_test!(test_database_commit_and_checkout, KV: BackgroundPersistentKeyValueStore,
@@ -2038,7 +2059,7 @@ mod tests {
 
         // Generate the proof and produce a Verify-mode database from it.
         let (prove_inner, prove_trace) = prove_db.into_parts();
-        let verify_ml: MerkleLayer<KV, Verify> = prove_inner.inner.merkle.into_verify();
+        let verify_ml: MerkleLayer<KV, Verify> = prove_inner.inner.merkle.to_verify();
         let verify_db: Database<KV, Verify> = Database {
             inner: super::VerifyImpl { merkle: verify_ml },
         };

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -24,6 +24,7 @@ use octez_riscv_data::mode::Mode;
 use octez_riscv_data::mode::Normal;
 use octez_riscv_data::mode::Prove;
 use octez_riscv_data::mode::Verify;
+use perfect_derive::perfect_derive;
 use tezos_smart_rollup_constants::core::MAX_FILE_CHUNK_SIZE;
 use tokio::runtime::Handle;
 
@@ -52,6 +53,7 @@ pub const MAX_VALUE_SIZE: usize =
 ///
 /// This structure unifies the key-value store and Merkle layer to allow for persistent storage
 /// alongside a representation which can provide a root hash.
+#[perfect_derive(Clone)]
 #[repr(transparent)]
 pub struct Database<KV, M: Mode> {
     inner: M::Select<DatabaseTemplate<KV>>,
@@ -370,7 +372,19 @@ struct NormalImpl<KV> {
     merkle: MerkleWorker<KV>,
 }
 
+impl<KV> Database<KV, Verify> {
+    /// An empty verify-mode database.
+    pub(crate) fn empty() -> Self {
+        Database {
+            inner: VerifyImpl {
+                merkle: <MerkleLayer<KV, Verify>>::empty(),
+            },
+        }
+    }
+}
+
 /// Verify-mode implementation for the [`Database`].
+#[perfect_derive(Clone)]
 struct VerifyImpl<KV> {
     merkle: MerkleLayer<KV, Verify>,
 }

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -372,6 +372,32 @@ struct NormalImpl<KV> {
     merkle: MerkleWorker<KV>,
 }
 
+impl<KV> Database<KV, Prove<'static>> {
+    /// An empty prove-mode database backed by the given persistence layer.
+    pub(crate) fn empty(persistence: Arc<KV>) -> Self
+    where
+        KV: KeyValueStore,
+    {
+        Database {
+            inner: ProveImpl {
+                merkle: <MerkleLayer<KV, Prove<'static>>>::empty(persistence),
+            },
+        }
+    }
+
+    /// Clone the database, attaching the new clone to a fresh persistence layer.
+    pub(crate) fn clone_with(&self, persistence: Arc<KV>) -> Self
+    where
+        KV: KeyValueStore,
+    {
+        Database {
+            inner: ProveImpl {
+                merkle: self.inner.merkle.clone_with(persistence),
+            },
+        }
+    }
+}
+
 impl<KV> Database<KV, Verify> {
     /// An empty verify-mode database.
     pub(crate) fn empty() -> Self {

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -758,8 +758,8 @@ mod tests {
 
         /// Generate a Merkle proof from the current Prove-mode layer and produce a Verify-mode
         /// layer that replays the same data via that proof.
-        pub(crate) fn into_verify(self) -> MerkleLayer<KV, Verify> {
-            let proof = MerkleProof::from_foldable(&self);
+        pub(crate) fn to_verify(&self) -> MerkleLayer<KV, Verify> {
+            let proof = MerkleProof::from_foldable(self);
             MerkleLayer::from_proof(proof).expect("proof deserialization should succeed")
         }
     }

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -96,6 +96,22 @@ impl<KV> MerkleLayer<KV, Normal> {
     }
 }
 
+impl<KV> MerkleLayer<KV, Prove<'static>> {
+    /// An empty prove-mode Merkle layer backed by the given persistence layer.
+    pub(crate) fn empty(persistence: Arc<KV>) -> Self
+    where
+        KV: KeyValueStore,
+    {
+        MerkleLayer {
+            inner: ProveImpl {
+                initial_tree: LazyTreeId::default(),
+                working_tree: Tree::default(),
+                resolver: ProveResolver::start(LazyResolver::new(persistence), None),
+            },
+        }
+    }
+}
+
 impl<KV> MerkleLayer<KV, Verify> {
     /// An empty verify-mode Merkle layer.
     ///

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -61,7 +61,7 @@ use crate::storage::StoreOptions;
 
 /// A layer for transforming data into a Merkle-ised representation before commitment to a
 /// [`PersistentKeyValueStore`].
-#[perfect_derive(Debug)]
+#[perfect_derive(Clone, Debug)]
 pub struct MerkleLayer<KV, M: Mode> {
     inner: M::Select<MerkleLayerTemplate<KV>>,
 }
@@ -93,6 +93,23 @@ impl<KV> MerkleLayer<KV, Normal> {
         KV: PersistentKeyValueStore,
     {
         self.inner.commit(options)
+    }
+}
+
+impl<KV> MerkleLayer<KV, Verify> {
+    /// An empty verify-mode Merkle layer.
+    ///
+    /// `original_proof` is a stub blind leaf — an empty tree folds to a single `Present` hash
+    /// with no `previous` substitutions, so [`MerkleLayer::hash`] never reads it while the tree
+    /// stays empty or is fully populated by mutations performed within this layer.
+    pub(crate) fn empty() -> Self {
+        MerkleLayer {
+            inner: VerifyImpl {
+                tree: Tree::default(),
+                resolver: VerifyResolver,
+                original_proof: Arc::new(MerkleProof::leaf_blind(Hash::hash_bytes(&[]))),
+            },
+        }
     }
 }
 
@@ -407,7 +424,7 @@ impl<KV> NormalImpl<KV> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct VerifyImpl {
     tree: Tree<VerifyNodeId>,
     resolver: VerifyResolver,

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -13,7 +13,7 @@
 //!
 //! `M` is an implementation of the PVM's operational [`Mode`].
 //!
-//! [`MerkleLayer::try_clone_with`] enables forking snapshots. Clones share the underlying tree
+//! [`MerkleLayer::clone_with`] enables forking snapshots. Clones share the underlying tree
 //! cheaply via an `Arc` and diverge upon mutation, using copy-on-write (CoW) semantics.
 
 use std::convert::Infallible;
@@ -131,11 +131,11 @@ impl<KV> MerkleLayer<KV, Verify> {
 
 impl<KV, M: MerkleLayerMode> MerkleLayer<KV, M> {
     /// Clone the Merkle layer. The new layer will commit to the provided persistence layer.
-    pub fn try_clone_with(&self, persistence: Arc<KV>) -> Self
+    pub fn clone_with(&self, persistence: Arc<KV>) -> Self
     where
         KV: KeyValueStore,
     {
-        M::try_clone_with(self, persistence)
+        M::clone_with(self, persistence)
     }
 
     /// Returns the root hash, potentially re-hashing uncached nodes.
@@ -170,8 +170,8 @@ impl<KV, M: MerkleLayerMode> MerkleLayer<KV, M> {
 
 /// Modes that implements this trait support Merkle layer operations
 pub trait MerkleLayerMode: Mode {
-    /// See [`MerkleLayer::try_clone_with`]
-    fn try_clone_with<KV: KeyValueStore>(
+    /// See [`MerkleLayer::clone_with`]
+    fn clone_with<KV: KeyValueStore>(
         this: &MerkleLayer<KV, Self>,
         persistence: Arc<KV>,
     ) -> MerkleLayer<KV, Self>;
@@ -202,12 +202,12 @@ pub trait MerkleLayerMode: Mode {
 }
 
 impl MerkleLayerMode for Normal {
-    fn try_clone_with<KV: KeyValueStore>(
+    fn clone_with<KV: KeyValueStore>(
         this: &MerkleLayer<KV, Self>,
         persistence: Arc<KV>,
     ) -> MerkleLayer<KV, Self> {
         MerkleLayer {
-            inner: this.inner.try_clone_with(persistence),
+            inner: this.inner.clone_with(persistence),
         }
     }
 
@@ -241,7 +241,7 @@ impl MerkleLayerMode for Normal {
 }
 
 impl MerkleLayerMode for Prove<'static> {
-    fn try_clone_with<KV: KeyValueStore>(
+    fn clone_with<KV: KeyValueStore>(
         this: &MerkleLayer<KV, Self>,
         persistence: Arc<KV>,
     ) -> MerkleLayer<KV, Self> {
@@ -295,7 +295,7 @@ impl MerkleLayerMode for Prove<'static> {
 }
 
 impl MerkleLayerMode for Verify {
-    fn try_clone_with<KV: KeyValueStore>(
+    fn clone_with<KV: KeyValueStore>(
         this: &MerkleLayer<KV, Self>,
         _persistence: Arc<KV>,
     ) -> MerkleLayer<KV, Self> {
@@ -375,7 +375,7 @@ impl<KV> NormalImpl<KV> {
     }
 
     /// Clone the Merkle layer. The new layer will commit to the provided persistence layer.
-    fn try_clone_with(&self, persistence: Arc<KV>) -> Self {
+    fn clone_with(&self, persistence: Arc<KV>) -> Self {
         Self {
             tree: self.tree.clone(),
             persistence: persistence.clone(),
@@ -920,7 +920,7 @@ mod tests {
                 .expect("the tree should be retrieved successfully.");
         }
 
-        let mut ml2 = ml.try_clone_with(ml.inner.persistence.clone());
+        let mut ml2 = ml.clone_with(ml.inner.persistence.clone());
         let original_hash = ml.hash();
         assert_eq!(original_hash, ml2.hash());
 
@@ -1006,7 +1006,7 @@ mod tests {
 
         // Create a cheap copy
         let original_hash = ml.hash();
-        let mut ml2 = ml.try_clone_with(ml.inner.persistence.clone());
+        let mut ml2 = ml.clone_with(ml.inner.persistence.clone());
         prop_assert_eq!(original_hash, ml2.hash());
 
         // Delete all the keys in the copy
@@ -1914,7 +1914,7 @@ mod tests {
         }
     });
 
-    kv_test!(test_prove_try_clone_with_cow, KV, {
+    kv_test!(test_prove_clone_with_cow, KV, {
         let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
 
         let (_keepalive, repo) = KV::setup_repo();
@@ -1938,7 +1938,7 @@ mod tests {
             .expect("Creating a persistence layer should succeed")
             .into();
 
-        let mut ml2 = ml.try_clone_with(kv);
+        let mut ml2 = ml.clone_with(kv);
         let cow_data2 = "🐮<(mooify a moo!)";
         ml2.set(&key, cow_data2.as_bytes())
             .expect("setting node should succeed");
@@ -2064,7 +2064,7 @@ mod tests {
         }
     });
 
-    kv_test!(test_verify_try_clone_with_cow, KV, {
+    kv_test!(test_verify_clone_with_cow, KV, {
         let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
 
         let (_keepalive, repo) = KV::setup_repo();
@@ -2077,7 +2077,7 @@ mod tests {
             .expect("Creating a persistence layer should succeed")
             .into();
 
-        let mut ml2 = ml.try_clone_with(kv);
+        let mut ml2 = ml.clone_with(kv);
         let cow_data2 = "🐮<(mooify a moo!)";
         ml2.set(&key, cow_data2.as_bytes())
             .expect("setting node should succeed");

--- a/durable-storage/src/merkle_worker.rs
+++ b/durable-storage/src/merkle_worker.rs
@@ -165,7 +165,7 @@ impl<KV> Command<KV> {
         ))
     }
 
-    /// Construct a command that performs a [`MerkleLayer::try_clone_with`].
+    /// Construct a command that performs a [`MerkleLayer::clone_with`].
     fn new_clone_with(
         store: Arc<KV>,
     ) -> (
@@ -184,7 +184,7 @@ impl<KV> Command<KV> {
                     "Inconsistent layer on clone: {consistency:?}"
                 );
 
-                let result = layer.try_clone_with(store);
+                let result = layer.clone_with(store);
                 let _ = sender.send(result);
             },
         ));
@@ -300,7 +300,7 @@ impl<KV> MerkleWorker<KV> {
         MerkleWorker { sender }
     }
 
-    /// See [`MerkleLayer::try_clone_with`].
+    /// See [`MerkleLayer::clone_with`].
     pub(crate) fn clone_with(
         &self,
         handle: &Handle,
@@ -497,7 +497,7 @@ mod tests {
                     let persistence_layer =
                         KV::new(repo).expect("Creating a persistence layer should succeed");
                     let persistence_layer = Arc::new(persistence_layer);
-                    *layer = layer.try_clone_with(persistence_layer);
+                    *layer = layer.clone_with(persistence_layer);
 
                     let persistence_worker =
                         KV::new(repo).expect("Creating a persistence layer should succeed");

--- a/durable-storage/src/registry.rs
+++ b/durable-storage/src/registry.rs
@@ -443,6 +443,7 @@ struct VerifyImpl<KV: KeyValueStore>(PhantomData<KV>);
 #[cfg(test)]
 pub(super) mod tests {
     use std::marker::PhantomData;
+    use std::sync::Arc;
 
     use bytes::Bytes;
     use octez_riscv_data::components::vector::VectorMode;
@@ -458,13 +459,17 @@ pub(super) mod tests {
     use super::RegistryManifest;
     use super::VerifyImpl;
     use crate::commit::CommitId;
+    use crate::database::tests::from_prove_layer;
+    use crate::database::tests::to_verify;
     use crate::errors::Error;
     use crate::errors::InvalidArgumentError;
     use crate::errors::OperationalError;
     use crate::key::Key;
+    use crate::merkle_layer::MerkleLayer;
     use crate::merkle_worker::BackgroundKeyValueStore;
     use crate::merkle_worker::BackgroundPersistentKeyValueStore;
     use crate::repo::RegistryRepo;
+    use crate::storage::KeyValueStore;
     use crate::storage::TestKeyValueStoreSetup;
     use crate::storage::kv_test;
 
@@ -1117,6 +1122,123 @@ pub(super) mod tests {
         assert_eq!(registry.len(), 1);
 
         assert!(registry.resize_tick(5).is_err());
+    });
+
+    // Reading through a `Registry<Prove>` populated from snapshots of Normal-mode source
+    // data records a proof; replaying the same reads through the resulting
+    // `Registry<Verify>` must yield the same values.
+    kv_test!(test_verify_replays_prove_reads, KV: BackgroundKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+
+        let key_a = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
+        let key_b = Key::new(&[2]).expect("Size less than KEY_MAX_SIZE");
+
+        let mut normal_a = MerkleLayer::<KV, Normal>::new(Arc::new(
+            KV::new(&repo).expect("Persistence creation should succeed"),
+        ));
+
+        normal_a
+            .set(&key_a, b"foo")
+            .expect("Setting in Normal mode should succeed");
+
+        let mut normal_b = MerkleLayer::<KV, Normal>::new(Arc::new(
+            KV::new(&repo).expect("Persistence creation should succeed"),
+        ));
+
+        normal_b
+            .set(&key_b, b"bar")
+            .expect("Setting in Normal mode should succeed");
+
+        let expected_hashes = [normal_a.hash(), normal_b.hash()];
+
+        let prove_databases = vec![
+            from_prove_layer::<KV>(normal_a.start_proof()),
+            from_prove_layer::<KV>(normal_b.start_proof()),
+        ];
+
+        let prove_registry = Registry::<KV, Prove<'static>> {
+            inner: ProveImpl { repo },
+            databases: <Prove<'static> as VectorMode>::new(prove_databases),
+        };
+
+        let prove_hashes_before = (0..prove_registry.len())
+            .map(|i| {
+                prove_registry
+                    .database(i)
+                    .expect("Database should exist.")
+                    .hash()
+                    .expect("Hashing should succeed.")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(prove_hashes_before.as_slice(), expected_hashes);
+
+        prove_registry
+            .database(0)
+            .expect("Database should exist.")
+            .assert_database_value(&key_a, b"foo");
+        prove_registry
+            .database(1)
+            .expect("Database should exist.")
+            .assert_database_value(&key_b, b"bar");
+
+        let prove_hashes_after = (0..prove_registry.len())
+            .map(|i| {
+                prove_registry
+                    .database(i)
+                    .expect("Database should exist.")
+                    .hash()
+                    .expect("Hashing should succeed.")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            prove_hashes_after, prove_hashes_before,
+            "Reads must not affect Prove-mode hashes."
+        );
+
+        let verify_databases = (0..prove_registry.len())
+            .map(|i| to_verify::<KV>(prove_registry.database(i).expect("Database should exist.")))
+            .collect();
+
+        let verify_registry = Registry::<KV, Verify> {
+            inner: VerifyImpl(PhantomData),
+            databases: <Verify as VectorMode>::new(verify_databases),
+        };
+
+        let verify_hashes_before = (0..verify_registry.len())
+            .map(|i| {
+                verify_registry
+                    .database(i)
+                    .expect("Database should exist.")
+                    .hash()
+                    .expect("Hashing should succeed.")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(verify_hashes_before.as_slice(), expected_hashes);
+
+        // The same reads through the Verify-mode registry should yield the same values.
+        verify_registry
+            .database(0)
+            .expect("Database should exist.")
+            .assert_database_value(&key_a, b"foo");
+
+        verify_registry
+            .database(1)
+            .expect("Database should exist.")
+            .assert_database_value(&key_b, b"bar");
+
+        let verify_hashes_after = (0..verify_registry.len())
+            .map(|i| {
+                verify_registry
+                    .database(i)
+                    .expect("Database should exist.")
+                    .hash()
+                    .expect("Hashing should succeed.")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            verify_hashes_after, verify_hashes_before,
+            "Reads must not affect Verify-mode hashes."
+        );
     });
 
     kv_test!(test_verify_clear_database, KV: BackgroundKeyValueStore, {

--- a/durable-storage/src/registry.rs
+++ b/durable-storage/src/registry.rs
@@ -23,6 +23,7 @@ use octez_riscv_data::hash::Hash;
 use octez_riscv_data::mode::Modal;
 use octez_riscv_data::mode::Mode;
 use octez_riscv_data::mode::Normal;
+use octez_riscv_data::mode::Verify;
 use octez_riscv_data::serialisation::deserialise;
 use octez_riscv_data::serialisation::serialise;
 use tokio::runtime::Runtime;
@@ -309,7 +310,7 @@ impl<KV: KeyValueStore> Modal for RegistryTemplate<KV> {
 
     type Prove<'normal> = Infallible;
 
-    type Verify = Infallible;
+    type Verify = VerifyImpl<KV>;
 }
 
 /// Modes that implement this support operations on [`Registry`]
@@ -346,6 +347,25 @@ impl RegistryMode for Normal {
         database: &Database<KV, Self>,
     ) -> Result<Database<KV, Self>, OperationalError> {
         database.try_clone_with(inner.runtime.handle(), &inner.repo)
+    }
+}
+
+#[expect(
+    private_interfaces,
+    reason = "This method should not be used outside of this module"
+)]
+impl RegistryMode for Verify {
+    fn try_new_database<KV: BackgroundKeyValueStore>(
+        _inner: &Self::Select<RegistryTemplate<KV>>,
+    ) -> Result<Database<KV, Self>, OperationalError> {
+        Ok(<Database<KV, Verify>>::empty())
+    }
+
+    fn try_clone_database<KV: BackgroundKeyValueStore>(
+        _inner: &Self::Select<RegistryTemplate<KV>>,
+        database: &Database<KV, Self>,
+    ) -> Result<Database<KV, Self>, OperationalError> {
+        Ok(database.clone())
     }
 }
 
@@ -390,16 +410,24 @@ struct NormalImpl<KV: KeyValueStore> {
     runtime: Arc<Runtime>,
 }
 
+/// Registry implementation for the [`Verify`] mode.
+struct VerifyImpl<KV: KeyValueStore>(PhantomData<KV>);
+
 #[cfg(test)]
 pub(super) mod tests {
+    use std::marker::PhantomData;
+
     use bytes::Bytes;
+    use octez_riscv_data::components::vector::VectorMode;
     use octez_riscv_data::hash::Hash;
     use octez_riscv_data::mode::Normal;
+    use octez_riscv_data::mode::Verify;
     use octez_riscv_data::serialisation::deserialise;
     use octez_riscv_data::serialisation::serialise;
 
     use super::Registry;
     use super::RegistryManifest;
+    use super::VerifyImpl;
     use crate::commit::CommitId;
     use crate::errors::Error;
     use crate::errors::InvalidArgumentError;
@@ -429,6 +457,24 @@ pub(super) mod tests {
             .resize_tick(2)
             .expect("Growing the registry should succeed.");
 
+        registry
+    }
+
+    fn setup_verify_registry<KV: BackgroundKeyValueStore>() -> Registry<KV, Verify> {
+        Registry {
+            inner: VerifyImpl(PhantomData),
+            databases: <Verify as VectorMode>::new(Vec::new()),
+        }
+    }
+
+    fn setup_verify_size_2_registry<KV: BackgroundKeyValueStore>() -> Registry<KV, Verify> {
+        let mut registry = setup_verify_registry::<KV>();
+        registry
+            .resize_tick(1)
+            .expect("Growing the registry should succeed.");
+        registry
+            .resize_tick(2)
+            .expect("Growing the registry should succeed.");
         registry
     }
 
@@ -835,6 +881,184 @@ pub(super) mod tests {
             Registry::<KV, Normal>::checkout(repo, fake_commit),
             Err(Error::Operational(OperationalError::RegistryCommitMismatch))
         ));
+    });
+
+    kv_test!(test_verify_clear_database, KV: BackgroundKeyValueStore, {
+        let mut registry = setup_verify_size_2_registry::<KV>();
+
+        let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
+        registry
+            .database_mut(0)
+            .expect("Database should exist.")
+            .set(key.clone(), Bytes::from_static(b"value"))
+            .expect("Setting a value should succeed");
+
+        registry
+            .clear_database(0)
+            .expect("Clearing should succeed");
+
+        assert!(
+            !registry
+                .database(0)
+                .expect("Database should exist.")
+                .exists(&key)
+                .expect("Existence check should succeed"),
+            "Database should be empty after clear."
+        );
+    });
+
+    kv_test!(test_verify_copy_database, KV: BackgroundKeyValueStore, {
+        let mut registry = setup_verify_size_2_registry::<KV>();
+
+        let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
+        registry
+            .database_mut(0)
+            .expect("Database should exist.")
+            .set(key.clone(), Bytes::from_static(b"src"))
+            .expect("Setting a value should succeed");
+        registry
+            .database_mut(1)
+            .expect("Database should exist.")
+            .set(key.clone(), Bytes::from_static(b"dst"))
+            .expect("Setting a value should succeed");
+
+        registry
+            .copy_database(0, 1)
+            .expect("Copying should succeed");
+
+        registry
+            .database(1)
+            .expect("Database should exist.")
+            .assert_database_value(&key, b"src");
+    });
+
+    kv_test!(test_verify_database_clone_independence, KV: BackgroundKeyValueStore, {
+        // Cloning via copy should produce an independent database — mutations to the source
+        // after the copy must not propagate to the destination.
+        let mut registry = setup_verify_size_2_registry::<KV>();
+
+        let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
+        registry
+            .database_mut(0)
+            .expect("Database should exist.")
+            .set(key.clone(), Bytes::from_static(b"original"))
+            .expect("Setting a value should succeed");
+
+        registry
+            .copy_database(0, 1)
+            .expect("Copying should succeed");
+
+        registry
+            .database_mut(0)
+            .expect("Database should exist.")
+            .set(key.clone(), Bytes::from_static(b"mutated"))
+            .expect("Setting a value should succeed");
+
+        registry
+            .database(0)
+            .expect("Database should exist.")
+            .assert_database_value(&key, b"mutated");
+        registry
+            .database(1)
+            .expect("Database should exist.")
+            .assert_database_value(&key, b"original");
+    });
+
+    kv_test!(test_verify_database_ops, KV: BackgroundKeyValueStore, {
+        // Exercise read/write/delete on a verify-mode database obtained from the registry.
+        let mut registry = setup_verify_size_2_registry::<KV>();
+
+        let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
+        let database = registry.database_mut(0).expect("Database should exist.");
+        database
+            .set(key.clone(), Bytes::from_static(b"alpha"))
+            .expect("Setting a value should succeed");
+        database.assert_database_value(&key, b"alpha");
+
+        database
+            .delete(key.clone())
+            .expect("Deleting a value should succeed");
+        assert!(
+            !database
+                .exists(&key)
+                .expect("Existence check should succeed")
+        );
+    });
+
+    kv_test!(test_verify_invalid_index, KV: BackgroundKeyValueStore, {
+        let mut registry = setup_verify_size_2_registry::<KV>();
+
+        assert!(matches!(
+            registry.copy_database(0, 2),
+            Err(Error::InvalidArgument(
+                InvalidArgumentError::DatabaseIndexOutOfBounds
+            ))
+        ));
+        assert!(matches!(
+            registry.move_database(2, 0),
+            Err(Error::InvalidArgument(
+                InvalidArgumentError::DatabaseIndexOutOfBounds
+            ))
+        ));
+        assert!(matches!(
+            registry.clear_database(2),
+            Err(Error::InvalidArgument(
+                InvalidArgumentError::DatabaseIndexOutOfBounds
+            ))
+        ));
+    });
+
+    kv_test!(test_verify_move_database, KV: BackgroundKeyValueStore, {
+        let mut registry = setup_verify_size_2_registry::<KV>();
+
+        let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
+        registry
+            .database_mut(0)
+            .expect("Database should exist.")
+            .set(key.clone(), Bytes::from_static(b"value"))
+            .expect("Setting a value should succeed");
+
+        registry
+            .move_database(0, 1)
+            .expect("Moving should succeed");
+
+        assert!(
+            !registry
+                .database(0)
+                .expect("Database should exist.")
+                .exists(&key)
+                .expect("Existence check should succeed"),
+            "Source should be empty after move."
+        );
+        registry
+            .database(1)
+            .expect("Database should exist.")
+            .assert_database_value(&key, b"value");
+    });
+
+    kv_test!(test_verify_new, KV: BackgroundKeyValueStore, {
+        let registry = setup_verify_registry::<KV>();
+        assert!(registry.is_empty());
+    });
+
+    kv_test!(test_verify_resize, KV: BackgroundKeyValueStore, {
+        let mut registry = setup_verify_registry::<KV>();
+
+        while registry.len() < 4 {
+            registry
+                .resize_tick(registry.len() + 1)
+                .expect("Growing the registry should succeed.");
+        }
+        assert_eq!(registry.len(), 4);
+
+        while registry.len() > 1 {
+            registry
+                .resize_tick(registry.len() - 1)
+                .expect("Shrinking the registry should succeed.");
+        }
+        assert_eq!(registry.len(), 1);
+
+        assert!(registry.resize_tick(5).is_err());
     });
 }
 

--- a/durable-storage/src/registry.rs
+++ b/durable-storage/src/registry.rs
@@ -23,6 +23,7 @@ use octez_riscv_data::hash::Hash;
 use octez_riscv_data::mode::Modal;
 use octez_riscv_data::mode::Mode;
 use octez_riscv_data::mode::Normal;
+use octez_riscv_data::mode::Prove;
 use octez_riscv_data::mode::Verify;
 use octez_riscv_data::serialisation::deserialise;
 use octez_riscv_data::serialisation::serialise;
@@ -308,7 +309,7 @@ struct RegistryTemplate<KV: KeyValueStore>(PhantomData<KV>, Infallible);
 impl<KV: KeyValueStore> Modal for RegistryTemplate<KV> {
     type Normal = NormalImpl<KV>;
 
-    type Prove<'normal> = Infallible;
+    type Prove<'normal> = ProveImpl<KV>;
 
     type Verify = VerifyImpl<KV>;
 }
@@ -347,6 +348,27 @@ impl RegistryMode for Normal {
         database: &Database<KV, Self>,
     ) -> Result<Database<KV, Self>, OperationalError> {
         database.try_clone_with(inner.runtime.handle(), &inner.repo)
+    }
+}
+
+#[expect(
+    private_interfaces,
+    reason = "This method should not be used outside of this module"
+)]
+impl RegistryMode for Prove<'static> {
+    fn try_new_database<KV: BackgroundKeyValueStore>(
+        inner: &Self::Select<RegistryTemplate<KV>>,
+    ) -> Result<Database<KV, Self>, OperationalError> {
+        let persistence = Arc::new(KV::new(&inner.repo)?);
+        Ok(<Database<KV, Prove<'static>>>::empty(persistence))
+    }
+
+    fn try_clone_database<KV: BackgroundKeyValueStore>(
+        inner: &Self::Select<RegistryTemplate<KV>>,
+        database: &Database<KV, Self>,
+    ) -> Result<Database<KV, Self>, OperationalError> {
+        let persistence = Arc::new(KV::new(&inner.repo)?);
+        Ok(database.clone_with(persistence))
     }
 }
 
@@ -410,6 +432,11 @@ struct NormalImpl<KV: KeyValueStore> {
     runtime: Arc<Runtime>,
 }
 
+/// Registry implementation for the [`Prove`] mode.
+struct ProveImpl<KV: KeyValueStore> {
+    repo: KV::Repo,
+}
+
 /// Registry implementation for the [`Verify`] mode.
 struct VerifyImpl<KV: KeyValueStore>(PhantomData<KV>);
 
@@ -421,10 +448,12 @@ pub(super) mod tests {
     use octez_riscv_data::components::vector::VectorMode;
     use octez_riscv_data::hash::Hash;
     use octez_riscv_data::mode::Normal;
+    use octez_riscv_data::mode::Prove;
     use octez_riscv_data::mode::Verify;
     use octez_riscv_data::serialisation::deserialise;
     use octez_riscv_data::serialisation::serialise;
 
+    use super::ProveImpl;
     use super::Registry;
     use super::RegistryManifest;
     use super::VerifyImpl;
@@ -457,6 +486,28 @@ pub(super) mod tests {
             .resize_tick(2)
             .expect("Growing the registry should succeed.");
 
+        registry
+    }
+
+    fn setup_prove_registry<KV: BackgroundKeyValueStore>(
+        repo: KV::Repo,
+    ) -> Registry<KV, Prove<'static>> {
+        Registry {
+            inner: ProveImpl { repo },
+            databases: <Prove<'static> as VectorMode>::new(Vec::new()),
+        }
+    }
+
+    fn setup_prove_size_2_registry<KV: BackgroundKeyValueStore>(
+        repo: KV::Repo,
+    ) -> Registry<KV, Prove<'static>> {
+        let mut registry = setup_prove_registry::<KV>(repo);
+        registry
+            .resize_tick(1)
+            .expect("Growing the registry should succeed.");
+        registry
+            .resize_tick(2)
+            .expect("Growing the registry should succeed.");
         registry
     }
 
@@ -881,6 +932,191 @@ pub(super) mod tests {
             Registry::<KV, Normal>::checkout(repo, fake_commit),
             Err(Error::Operational(OperationalError::RegistryCommitMismatch))
         ));
+    });
+
+    kv_test!(test_prove_clear_database, KV: BackgroundKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut registry = setup_prove_size_2_registry::<KV>(repo);
+
+        let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
+        registry
+            .database_mut(0)
+            .expect("Database should exist.")
+            .set(key.clone(), Bytes::from_static(b"value"))
+            .expect("Setting a value should succeed");
+
+        registry
+            .clear_database(0)
+            .expect("Clearing should succeed");
+
+        assert!(
+            !registry
+                .database(0)
+                .expect("Database should exist.")
+                .exists(&key)
+                .expect("Existence check should succeed"),
+            "Database should be empty after clear."
+        );
+    });
+
+    kv_test!(test_prove_copy_database, KV: BackgroundKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut registry = setup_prove_size_2_registry::<KV>(repo);
+
+        let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
+        registry
+            .database_mut(0)
+            .expect("Database should exist.")
+            .set(key.clone(), Bytes::from_static(b"src"))
+            .expect("Setting a value should succeed");
+        registry
+            .database_mut(1)
+            .expect("Database should exist.")
+            .set(key.clone(), Bytes::from_static(b"dst"))
+            .expect("Setting a value should succeed");
+
+        registry
+            .copy_database(0, 1)
+            .expect("Copying should succeed");
+
+        registry
+            .database(1)
+            .expect("Database should exist.")
+            .assert_database_value(&key, b"src");
+    });
+
+    kv_test!(test_prove_database_clone_independence, KV: BackgroundKeyValueStore, {
+        // Cloning via copy should produce an independent database — mutations to the source
+        // after the copy must not propagate to the destination.
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut registry = setup_prove_size_2_registry::<KV>(repo);
+
+        let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
+        registry
+            .database_mut(0)
+            .expect("Database should exist.")
+            .set(key.clone(), Bytes::from_static(b"original"))
+            .expect("Setting a value should succeed");
+
+        registry
+            .copy_database(0, 1)
+            .expect("Copying should succeed");
+
+        registry
+            .database_mut(0)
+            .expect("Database should exist.")
+            .set(key.clone(), Bytes::from_static(b"mutated"))
+            .expect("Setting a value should succeed");
+
+        registry
+            .database(0)
+            .expect("Database should exist.")
+            .assert_database_value(&key, b"mutated");
+        registry
+            .database(1)
+            .expect("Database should exist.")
+            .assert_database_value(&key, b"original");
+    });
+
+    kv_test!(test_prove_database_ops, KV: BackgroundKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut registry = setup_prove_size_2_registry::<KV>(repo);
+
+        let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
+        let database = registry.database_mut(0).expect("Database should exist.");
+        database
+            .set(key.clone(), Bytes::from_static(b"alpha"))
+            .expect("Setting a value should succeed");
+        database.assert_database_value(&key, b"alpha");
+
+        database
+            .delete(key.clone())
+            .expect("Deleting a value should succeed");
+        assert!(
+            !database
+                .exists(&key)
+                .expect("Existence check should succeed")
+        );
+    });
+
+    kv_test!(test_prove_invalid_index, KV: BackgroundKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut registry = setup_prove_size_2_registry::<KV>(repo);
+
+        assert!(matches!(
+            registry.copy_database(0, 2),
+            Err(Error::InvalidArgument(
+                InvalidArgumentError::DatabaseIndexOutOfBounds
+            ))
+        ));
+        assert!(matches!(
+            registry.move_database(2, 0),
+            Err(Error::InvalidArgument(
+                InvalidArgumentError::DatabaseIndexOutOfBounds
+            ))
+        ));
+        assert!(matches!(
+            registry.clear_database(2),
+            Err(Error::InvalidArgument(
+                InvalidArgumentError::DatabaseIndexOutOfBounds
+            ))
+        ));
+    });
+
+    kv_test!(test_prove_move_database, KV: BackgroundKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut registry = setup_prove_size_2_registry::<KV>(repo);
+
+        let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
+        registry
+            .database_mut(0)
+            .expect("Database should exist.")
+            .set(key.clone(), Bytes::from_static(b"value"))
+            .expect("Setting a value should succeed");
+
+        registry
+            .move_database(0, 1)
+            .expect("Moving should succeed");
+
+        assert!(
+            !registry
+                .database(0)
+                .expect("Database should exist.")
+                .exists(&key)
+                .expect("Existence check should succeed"),
+            "Source should be empty after move."
+        );
+        registry
+            .database(1)
+            .expect("Database should exist.")
+            .assert_database_value(&key, b"value");
+    });
+
+    kv_test!(test_prove_new, KV: BackgroundKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+        let registry = setup_prove_registry::<KV>(repo);
+        assert!(registry.is_empty());
+    });
+
+    kv_test!(test_prove_resize, KV: BackgroundKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut registry = setup_prove_registry::<KV>(repo);
+
+        while registry.len() < 4 {
+            registry
+                .resize_tick(registry.len() + 1)
+                .expect("Growing the registry should succeed.");
+        }
+        assert_eq!(registry.len(), 4);
+
+        while registry.len() > 1 {
+            registry
+                .resize_tick(registry.len() - 1)
+                .expect("Shrinking the registry should succeed.");
+        }
+        assert_eq!(registry.len(), 1);
+
+        assert!(registry.resize_tick(5).is_err());
     });
 
     kv_test!(test_verify_clear_database, KV: BackgroundKeyValueStore, {


### PR DESCRIPTION
Closes RV-966
Closes RV-967

# What
Implements `Verify` and `Prove` for the Registry

# Why
This finishes the basic milestone of implementing modality for durable storage

# How
 - Seals  `RegistryMode`
 - Implements `RegistryMode` for each mode

# Manually Testing

```
make all
```

# Regressions

<!--
    Explain changes to regression test captures. If there are no changes to these, delete this
    section.
-->

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
