### PR TITLE
fix(durable): gracefully handle race-condition in background merkle worker

### DIFF
--- a/durable-storage/benches/erc20_core/mod.rs
+++ b/durable-storage/benches/erc20_core/mod.rs
@@ -263,16 +263,21 @@ pub fn bench_run(mut state: BenchmarkState<'_>) {
                 black_box(state.database.hash().expect("Hash should be calculated"));
             }
             Operation::Read { key, size } => {
-                state.read_buffer.truncate(0);
-                match database_read(&mut state.database, key, size, &mut state.read_buffer) {
-                    Ok(_) | Err(Error::InvalidArgument(InvalidArgumentError::KeyNotFound)) => {}
+                match database_read(
+                    &mut state.database,
+                    key,
+                    size,
+                    &mut state.read_buffer[..size],
+                ) {
+                    Ok(read) => {
+                        assert_eq!(
+                            read, size,
+                            "Failed to read exactly {size} bytes from storage"
+                        );
+                    }
+                    Err(Error::InvalidArgument(InvalidArgumentError::KeyNotFound)) => {}
                     Err(e) => panic!("The read should succeed: {e:?}"),
                 }
-                assert_eq!(
-                    state.read_buffer.len(),
-                    size,
-                    "Failed to read exactly {size} bytes from storage"
-                );
             }
             Operation::ValueLength { key } => match state.database.value_length(&key) {
                 Ok(_) | Err(Error::InvalidArgument(InvalidArgumentError::KeyNotFound)) => {}
@@ -298,9 +303,11 @@ fn database_read(
     key: Key,
     size: usize,
     buffer: &mut [u8],
-) -> Result<(), Error> {
+) -> Result<usize, Error> {
     let mut offset = 0;
     let mut remaining = size;
+
+    assert!(remaining <= buffer.len(), "{remaining} <= {}", buffer.len());
 
     while remaining > 0 {
         let chunk = remaining.min(MAX_FILE_CHUNK_SIZE);
@@ -310,7 +317,7 @@ fn database_read(
         remaining -= chunk;
     }
 
-    Ok(())
+    Ok(offset)
 }
 
 /// Write an entire value (possibly larger than [`MAX_FILE_CHUNK_SIZE`]) to the given database.

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -817,7 +817,7 @@ mod tests {
     //
     // This can occur when a subsequent `set` results in a value that is shorter than the
     // offset the write is trying to write to
-    kv_test!(#[ignore] test_write_set_race_condition, KV: BackgroundPersistentKeyValueStore, {
+    kv_test!(test_write_set_race_condition, KV: BackgroundPersistentKeyValueStore, {
         // Arrange
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(2)

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -727,6 +727,140 @@ mod tests {
         assert_eq!(before, after);
     });
 
+    /// Operation to perform immediately before the delete
+    enum RaceConditionOp {
+        Set,
+        Write,
+    }
+
+    fn test_op_then_delete_race_condition<KV>(op: RaceConditionOp)
+    where
+        KV: TestKeyValueStoreSetup + BackgroundPersistentKeyValueStore,
+    {
+        // Arrange
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .build()
+            .expect("Creating a Tokio runtime should succeed");
+        let handle = runtime.handle();
+        let (_keepalive, repo) = KV::setup_repo();
+
+        let mut db = new_database::<KV>(handle, &repo);
+
+        let key = Key::new(&[]).expect("Size less than KEY_MAX_SIZE");
+        let initial_hash = db.hash().expect("Hashing should succeed");
+
+        db.set(key.clone(), Bytes::new())
+            .expect("Writing should succeed");
+        let commit = db.commit(&repo).expect("Commit should succeed");
+
+        // Act
+        let db =
+            Database::<KV, _>::checkout(handle, &repo, commit).expect("Checkout should succeed");
+        let super::NormalImpl { merkle, persistent } = db.inner;
+
+        let new_value = vec![1, 2, 3];
+
+        // simulate race condition: emit persistence layer operations first
+        match op {
+            RaceConditionOp::Set => {
+                persistent
+                    .set(key.as_ref(), &new_value)
+                    .expect("set should succeed");
+            }
+            RaceConditionOp::Write => {
+                persistent
+                    .write(key.as_ref(), 0, &new_value)
+                    .expect("write should succeed");
+            }
+        }
+
+        persistent
+            .delete(key.as_ref())
+            .expect("Delete should succeed");
+
+        // replay on merkle worker - the full operation order should succeed
+        match op {
+            RaceConditionOp::Set => {
+                merkle
+                    .set(key.clone(), Bytes::from(new_value))
+                    .expect("worker should not have crashed");
+            }
+            RaceConditionOp::Write => {
+                merkle
+                    .write(key.clone(), 0, Bytes::from(new_value))
+                    .expect("worker should not have crashed");
+            }
+        }
+        merkle.delete(key).expect("worker should not have crashed");
+
+        // Assert
+        // - hash to ensure consistency
+        let final_hash = merkle.hash().expect("worker should not have crashed");
+        assert_eq!(
+            initial_hash, final_hash,
+            "Empty DB should always hash to the same value"
+        );
+    }
+
+    // Test to exercise fix for RV-987: race condition for set-then-delete failure
+    kv_test!(#[ignore] test_set_delete_race_condition, KV: BackgroundPersistentKeyValueStore, {
+        test_op_then_delete_race_condition::<KV>(RaceConditionOp::Set);
+    });
+
+    // Test to exercise fix for RV-987: race condition for write-then-delete failure
+    kv_test!(#[ignore] test_write_delete_race_condition, KV: BackgroundPersistentKeyValueStore, {
+        test_op_then_delete_race_condition::<KV>(RaceConditionOp::Write);
+    });
+
+    // Test to exercise fix for RV-987: race condition for write-then-set failure
+    //
+    // This can occur when a subsequent `set` results in a value that is shorter than the
+    // offset the write is trying to write to
+    kv_test!(#[ignore] test_write_set_race_condition, KV: BackgroundPersistentKeyValueStore, {
+        // Arrange
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .build()
+            .expect("Creating a Tokio runtime should succeed");
+        let handle = runtime.handle();
+        let (_keepalive, repo) = KV::setup_repo();
+
+        let mut db = new_database::<KV>(handle, &repo);
+
+        let key = Key::new(&[]).expect("Size less than KEY_MAX_SIZE");
+        let original_value = Bytes::new();
+
+        db.set(key.clone(), original_value.clone()).expect("Writing should succeed");
+
+        let initial_hash = db.hash().expect("Hashing should succeed");
+
+        // set to a non-zero length value, needing so we can shorten the value later
+        db.set(key.clone(), Bytes::from(vec![1, 2, 3])).expect("Setting should succeed");
+        let commit = db.commit(&repo).expect("Commit should succeed");
+
+        // Act
+        let db = Database::<KV, _>::checkout(handle, &repo, commit).expect("Checkout should succeed");
+        let super::NormalImpl { merkle, persistent } = db.inner;
+
+        let new_value = vec![5, 6, 7];
+        let offset = 2;
+
+        // simulate race condition: emit persistence layer operations first
+        persistent.write(key.as_ref(), offset, &new_value).expect("write should succeed");
+        // shorten the value - the write on the merkle layer will later fail due to OffsetTooLarge
+        persistent.set(key.as_ref(), []).expect("Set should succeed");
+
+        // replay on merkle worker - the full operation order should succeed
+        merkle.write(key.clone(), offset, Bytes::from(new_value)).expect("worker should not have crashed");
+        merkle.set(key, Bytes::new()).expect("worker should not have crashed");
+
+        // Assert
+        // - hash to ensure consistency
+        let final_hash = merkle.hash().expect("worker should not have crashed");
+        assert_eq!(initial_hash, final_hash, "DB with single identical Key-Value should always hash to the same value");
+    });
+
     // Test to verify the fix for RV-955 (deletion after checkout failed).
     kv_test!(test_database_delete_after_checkout, KV: BackgroundPersistentKeyValueStore, {
         // Arrange

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -804,12 +804,12 @@ mod tests {
     }
 
     // Test to exercise fix for RV-987: race condition for set-then-delete failure
-    kv_test!(#[ignore] test_set_delete_race_condition, KV: BackgroundPersistentKeyValueStore, {
+    kv_test!(test_set_delete_race_condition, KV: BackgroundPersistentKeyValueStore, {
         test_op_then_delete_race_condition::<KV>(RaceConditionOp::Set);
     });
 
     // Test to exercise fix for RV-987: race condition for write-then-delete failure
-    kv_test!(#[ignore] test_write_delete_race_condition, KV: BackgroundPersistentKeyValueStore, {
+    kv_test!(test_write_delete_race_condition, KV: BackgroundPersistentKeyValueStore, {
         test_op_then_delete_race_condition::<KV>(RaceConditionOp::Write);
     });
 

--- a/durable-storage/src/merkle_worker.rs
+++ b/durable-storage/src/merkle_worker.rs
@@ -21,6 +21,7 @@ use trait_set::trait_set;
 
 use crate::commit::CommitId;
 use crate::errors::Error;
+use crate::errors::InvalidArgumentError;
 use crate::errors::OperationalError;
 use crate::key::Key;
 use crate::merkle_layer::MerkleLayer;
@@ -62,6 +63,15 @@ type DynCommand<KV> = dyn FnOnce(&mut MerkleLayer<KV, Normal>) + Send;
 /// consistency of the Merkle layer - and there is no need to crash the worker when such errors
 /// occur.
 ///
+/// ## Out-of-order set
+///
+/// Writes can also fail in a similar way when a subsequent `set` operation reduces the length
+/// of the value stored - and the offset of the write is larger than the new value's length.
+///
+/// Once again, this is not as concerning as it might appear. The write may indeed fail, but the
+/// subsequent set will be handled by the Merkle layer, fully overwriting any value that would have
+/// been written anyway.
+///
 /// ## Eventual consistency
 ///
 /// We do not wish to enforce 'full-synchronisation' on every operation - as this would lose the
@@ -92,6 +102,7 @@ impl<KV> Command<KV> {
                     key: missing_key,
                     source: _,
                 })) if key == missing_key => (),
+                Err(Error::InvalidArgument(InvalidArgumentError::OffsetTooLarge)) => (),
                 result => result.expect("Writing to the Merkle layer should succeed."),
             },
         ))

--- a/durable-storage/src/merkle_worker.rs
+++ b/durable-storage/src/merkle_worker.rs
@@ -40,6 +40,39 @@ trait_set! {
 type DynCommand<KV> = dyn FnOnce(&mut MerkleLayer<KV, Normal>) + Send;
 
 /// Commands that will be sent to the background worker thread to manipulate the Merkle layer
+///
+/// # Race Conditions
+///
+/// As these are handled in a background thread, there are potential race conditions between the
+/// background worker, and the persistence layer. The `MerkleLayer` resolves values lazily from the
+/// `KeyValueStore` - and as a result can attempt to perform operations over unexpected, or
+/// incorrectly shaped, values.
+///
+/// ## Out-of-order delete
+///
+/// One such race condition is that a delete operation may already have been performed in the
+/// `KeyValueStore`, prior to a _previous_ write/set on that value being handled in the Merkle
+/// layer. This can happen when, on the first `set/write`, the value needs to be resolved (loaded).
+/// This takes time to happen - and is fully possible (if many intermediate nodes need to be resolved
+/// first), that a subsequent delete operation has already been handled by the persistence layer.
+///
+/// This results in the write/set failing with [`OperationalError::CommitValueMissing`]. This is
+/// less concerning than it first appears, however, as we know the Merkle layer will subsequently
+/// handle the delete that caused the issue! Therefore, the delete does in fact restore the
+/// consistency of the Merkle layer - and there is no need to crash the worker when such errors
+/// occur.
+///
+/// ## Eventual consistency
+///
+/// We do not wish to enforce 'full-synchronisation' on every operation - as this would lose the
+/// performance gained by allowing the Merkle layer to 'catch-up' in the background thread.
+///
+/// The Merkle layer _will_, however, be fully-consistent at every point that matters: ie on
+/// `Hash` and `Commit`. This is because synchronisation is forced on these operations - and so
+/// if we encountered the above race conditions, the operation that caused (and resolves) them
+/// _must_ occur before the synchronisation points. If it occurs after, then the race condition
+/// cannot have happened to begin with: as all the prior operations will be fully handled first,
+/// before any problemetatic operations can occur.
 struct Command<KV>(Box<DynCommand<KV>>);
 
 impl<KV> Command<KV> {
@@ -53,11 +86,15 @@ impl<KV> Command<KV> {
     where
         KV: KeyValueStore,
     {
-        Self(Box::new(move |layer: &mut MerkleLayer<KV, Normal>| {
-            layer
-                .write(&key, offset, &value)
-                .expect("Writing to the Merkle layer should succeed.");
-        }))
+        Self(Box::new(
+            move |layer: &mut MerkleLayer<KV, Normal>| match layer.write(&key, offset, &value) {
+                Err(Error::Operational(OperationalError::CommitValueMissing {
+                    key: missing_key,
+                    source: _,
+                })) if key == missing_key => (),
+                result => result.expect("Writing to the Merkle layer should succeed."),
+            },
+        ))
     }
 
     /// Construct a command that performs a [`MerkleLayer::set`].
@@ -65,11 +102,15 @@ impl<KV> Command<KV> {
     where
         KV: KeyValueStore,
     {
-        Self(Box::new(move |layer: &mut MerkleLayer<KV, Normal>| {
-            layer
-                .set(&key, &value)
-                .expect("Setting on the Merkle layer should succeed.");
-        }))
+        Self(Box::new(
+            move |layer: &mut MerkleLayer<KV, Normal>| match layer.set(&key, &value) {
+                Err(OperationalError::CommitValueMissing {
+                    key: missing_key,
+                    source: _,
+                }) if key == missing_key => (),
+                result => result.expect("Setting on the Merkle layer should succeed."),
+            },
+        ))
     }
 
     /// Construct a command that performs a [`MerkleLayer::delete`].

--- a/durable-storage/src/merkle_worker.rs
+++ b/durable-storage/src/merkle_worker.rs
@@ -9,6 +9,7 @@
 //! background thread. It allows non-blocking `set`, `write` and `delete` operations while still
 //! providing synchronous access to `hash` and `commit` operations.
 
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -38,7 +39,7 @@ trait_set! {
 }
 
 /// Alias for the inner workings of the [`Command`] struct to make Clippy happy
-type DynCommand<KV> = dyn FnOnce(&mut MerkleLayer<KV, Normal>) + Send;
+type DynCommand<KV> = dyn FnOnce(&mut MerkleLayer<KV, Normal>, &mut BTreeSet<Key>) + Send;
 
 /// Commands that will be sent to the background worker thread to manipulate the Merkle layer
 ///
@@ -82,13 +83,17 @@ type DynCommand<KV> = dyn FnOnce(&mut MerkleLayer<KV, Normal>) + Send;
 /// if we encountered the above race conditions, the operation that caused (and resolves) them
 /// _must_ occur before the synchronisation points. If it occurs after, then the race condition
 /// cannot have happened to begin with: as all the prior operations will be fully handled first,
-/// before any problemetatic operations can occur.
+/// before any problematic operations can occur.
+///
+/// To ensure this condition is upheld, the Merkle worker tracks potentially inconsistent keys,
+/// removing them once operations restoring consistency are handled. We ensure that no inconsistent
+/// keys exist, when at synchronisation points.
 struct Command<KV>(Box<DynCommand<KV>>);
 
 impl<KV> Command<KV> {
     /// Apply this command to the Merkle layer.
-    fn apply(self, layer: &mut MerkleLayer<KV, Normal>) {
-        self.0(layer);
+    fn apply(self, layer: &mut MerkleLayer<KV, Normal>, consistency: &mut BTreeSet<Key>) {
+        self.0(layer, consistency);
     }
 
     /// Construct a command that performs a [`MerkleLayer::write`].
@@ -97,13 +102,24 @@ impl<KV> Command<KV> {
         KV: KeyValueStore,
     {
         Self(Box::new(
-            move |layer: &mut MerkleLayer<KV, Normal>| match layer.write(&key, offset, &value) {
+            move |layer: &mut MerkleLayer<KV, Normal>, consistency: &mut BTreeSet<Key>| match layer
+                .write(&key, offset, &value)
+            {
                 Err(Error::Operational(OperationalError::CommitValueMissing {
                     key: missing_key,
                     source: _,
-                })) if key == missing_key => (),
-                Err(Error::InvalidArgument(InvalidArgumentError::OffsetTooLarge)) => (),
-                result => result.expect("Writing to the Merkle layer should succeed."),
+                })) if key == missing_key => {
+                    // mark key as inconsistent
+                    consistency.insert(key);
+                }
+                Err(Error::InvalidArgument(InvalidArgumentError::OffsetTooLarge)) => {
+                    // mark key as inconsistent
+                    consistency.insert(key);
+                }
+                Ok(()) => {
+                    consistency.remove(&key);
+                }
+                Err(error) => panic!("Writing to the Merkle layer should succeed, got {error}"),
             },
         ))
     }
@@ -114,12 +130,20 @@ impl<KV> Command<KV> {
         KV: KeyValueStore,
     {
         Self(Box::new(
-            move |layer: &mut MerkleLayer<KV, Normal>| match layer.set(&key, &value) {
+            move |layer: &mut MerkleLayer<KV, Normal>, consistency: &mut BTreeSet<Key>| match layer
+                .set(&key, &value)
+            {
                 Err(OperationalError::CommitValueMissing {
                     key: missing_key,
                     source: _,
-                }) if key == missing_key => (),
-                result => result.expect("Setting on the Merkle layer should succeed."),
+                }) if key == missing_key => {
+                    // mark key as inconsistent
+                    consistency.insert(key);
+                }
+                Ok(()) => {
+                    consistency.remove(&key);
+                }
+                Err(error) => panic!("Setting in the Merkle layer should succeed, got {error}"),
             },
         ))
     }
@@ -129,11 +153,16 @@ impl<KV> Command<KV> {
     where
         KV: KeyValueStore,
     {
-        Self(Box::new(move |layer: &mut MerkleLayer<KV, Normal>| {
-            layer
-                .delete(&key)
-                .expect("Deleting from the Merkle layer should succeed.");
-        }))
+        Self(Box::new(
+            move |layer: &mut MerkleLayer<KV, Normal>, consistency: &mut BTreeSet<Key>| {
+                layer
+                    .delete(&key)
+                    .expect("Deleting from the Merkle layer should succeed.");
+
+                // delete always restores consistency
+                consistency.remove(&key);
+            },
+        ))
     }
 
     /// Construct a command that performs a [`MerkleLayer::try_clone_with`].
@@ -148,10 +177,17 @@ impl<KV> Command<KV> {
     {
         let (sender, receiver) = oneshot::channel();
 
-        let this = Self(Box::new(move |layer: &mut MerkleLayer<KV, Normal>| {
-            let result = layer.try_clone_with(store);
-            let _ = sender.send(result);
-        }));
+        let this = Self(Box::new(
+            move |layer: &mut MerkleLayer<KV, Normal>, consistency: &mut BTreeSet<Key>| {
+                assert!(
+                    consistency.is_empty(),
+                    "Inconsistent layer on clone: {consistency:?}"
+                );
+
+                let result = layer.try_clone_with(store);
+                let _ = sender.send(result);
+            },
+        ));
 
         let receive = || {
             receiver
@@ -169,10 +205,17 @@ impl<KV> Command<KV> {
     {
         let (sender, receiver) = oneshot::channel();
 
-        let this = Self(Box::new(move |layer: &mut MerkleLayer<KV, Normal>| {
-            let result = layer.hash();
-            let _ = sender.send(result);
-        }));
+        let this = Self(Box::new(
+            move |layer: &mut MerkleLayer<KV, Normal>, consistency: &mut BTreeSet<Key>| {
+                assert!(
+                    consistency.is_empty(),
+                    "Inconsistent layer on hash: {consistency:?}"
+                );
+
+                let result = layer.hash();
+                let _ = sender.send(result);
+            },
+        ));
 
         let receive = || {
             receiver
@@ -192,10 +235,17 @@ impl<KV> Command<KV> {
     {
         let (sender, receiver) = oneshot::channel();
 
-        let this = Self(Box::new(move |layer: &mut MerkleLayer<KV, Normal>| {
-            let result = layer.commit(&options);
-            let _ = sender.send(result);
-        }));
+        let this = Self(Box::new(
+            move |layer: &mut MerkleLayer<KV, Normal>, consistency: &mut BTreeSet<Key>| {
+                assert!(
+                    consistency.is_empty(),
+                    "Inconsistent layer on commit: {consistency:?}"
+                );
+
+                let result = layer.commit(&options);
+                let _ = sender.send(result);
+            },
+        ));
 
         let receive = || {
             receiver
@@ -238,10 +288,12 @@ impl<KV> MerkleWorker<KV> {
 
         async_handle.spawn(async move {
             let mut layer = layer;
+            let mut consistency = BTreeSet::new();
+
             let mut receiver: mpsc::UnboundedReceiver<Command<KV>> = receiver;
 
             while let Some(cmd) = receiver.recv().await {
-                cmd.apply(&mut layer);
+                cmd.apply(&mut layer, &mut consistency);
             }
         });
 


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

Closes RV-987

# What

Handle data race in `merkle worker` that caused the worker to crash.

# Why

This race condition could _absolutely_ happen in production - it musn't cause the worker to crash. This would cause downtime in the sequencer, for example.

# How

Move towards an eventual consistency model: where the layer _must_ be fully consistent, assert that it is.
Where potentially expected errors occur as a result of the race condition, allow them to fail gracefully.

The consistency-checking layer is optional, but included for more confidence. The `BTreeSet` introduces ~5% overhead, whereas a `HashSet` introduced closer to `~15%` overhead

# Manually Testing

```
make all
```

The first commit fixes a logic issue with the database/database_checkout benches.
```
cargo bench -p octez-riscv-durable-storage --bench database
cargo bench -p octez-riscv-durable-storage --bench database_checkout
```
After the first commit, the database bench succeeds, the checkout one fails (fairly consistently) as a result of the race condition.

The final two commits, you can run the `database_checkout` end to end.



# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
