### PR TITLE
ci: put `check-format` first on  `make check`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ NIGHTLY_VERSION = nightly-2026-02-24
 
 all: riscv/all sandbox/all jstz/all dummy/all page-cache-tester/all etherlink/all docs/all
 
-check: riscv/check durable/check jstz/check dummy/check dummy-no-std/check page-cache-tester/check etherlink/check assets/check docs/check check-format
+check: check-format riscv/check durable/check jstz/check dummy/check dummy-no-std/check page-cache-tester/check etherlink/check assets/check docs/check
 
 build: sandbox/build jstz/build dummy/build dummy-no-std/build page-cache-tester/build etherlink/build
 


### PR DESCRIPTION
# What

`make check` should run formatting check first

# Why

This can often fail when formatting wasn't run locally first. It's the least expensive check out of the list, and so makes sense to run at the start to save ci/waiting times if it was going to fail.