### PR TITLE
feat(dursto): Support multi-step proofs for Single Database.

### DIFF
--- a/durable-storage/src/avl/node.rs
+++ b/durable-storage/src/avl/node.rs
@@ -90,7 +90,6 @@ impl Node<LazyTreeId, LazyDataId, Normal> {
     }
 
     /// Resolve the data field on a lazy node.
-    #[cfg(test)]
     pub(crate) fn resolve_data(
         &self,
         resolver: &impl AvlResolver<super::resolver::LazyNodeId, LazyDataId, LazyTreeId, Normal>,

--- a/durable-storage/src/avl/resolver.rs
+++ b/durable-storage/src/avl/resolver.rs
@@ -75,6 +75,9 @@ pub trait Resolver<Id, Value> {
 
     /// Resolve an identifier to a mutable value.
     fn resolve_mut<'a>(&mut self, id: &'a mut Id) -> Result<&'a mut Value, OperationalError>;
+
+    /// Add a node about to be deleted to the resolver's tracking.
+    fn track_deleted_node(&mut self, _id: &Id) {}
 }
 
 /// Trait for resolving data identifiers to bytes.
@@ -280,11 +283,10 @@ impl LazyNodeId {
     /// The returned [`ProveNodeId`] keeps the original lazy identifier for hash lookups and
     /// storage-backed resolution, while leaving its prove-mode cache empty until a
     /// [`ProveResolver`] materialises the node.
-    pub(crate) fn into_proof<R>(self, resolver: &ProveResolver<R>) -> ProveNodeId {
+    pub(crate) fn into_proof(self) -> ProveNodeId {
         ProveNodeId {
-            node: self.clone(),
-            inner: OnceLock::new(),
-            deleted_nodes: resolver.deleted_nodes.clone(),
+            lazy_id: Some(self.clone()),
+            cache: OnceLock::new(),
         }
     }
 }
@@ -697,43 +699,20 @@ impl<'inner> DataResolver<Bytes<Prove<'inner>>, Prove<'inner>> for CachedOnlyRes
 /// Identifier for a node resolved in [`Prove`] mode.
 ///
 /// This wrapper keeps the original [`LazyNodeId`] to allow delegating hash computation and
-/// storage access to a lazy resolver. Once resolved, it caches the prove-mode projection of the
-/// node in `inner` so repeated accesses do not rebuild it.
+/// storage access to a lazy resolver. Once resolved, it caches the prove-mode projection
+///  so repeated accesses do not rebuild it.
 #[derive(Clone, Debug)]
 pub struct ProveNodeId {
-    inner: OnceLock<Rc<ProveNode>>,
-    node: LazyNodeId,
-    deleted_nodes: Rc<RefCell<BTreeMap<Hash, DeletedNodeFields>>>,
+    cache: OnceLock<Rc<ProveNode>>,
+    lazy_id: Option<LazyNodeId>,
 }
 
-impl Drop for ProveNodeId {
-    fn drop(&mut self) {
-        // Nodes that were resolved during the step carry a prove-mode projection that needs
-        // to be available for the `MerkleLayer`-level fold after the step finishes. Non-resolved
-        // nodes are not relevant for the fold.
-        let Some(inner) = self.inner.get() else {
-            return;
-        };
-        let hash = Hash::from_foldable(&self.node);
-        let node = inner.as_ref();
-        let fields = DeletedNodeFields {
-            meta: node.meta().clone(),
-            data: node.data().clone(),
-        };
-
-        self.deleted_nodes.borrow_mut().insert(hash, fields);
-    }
-}
-
-// TODO RV-895: This method is implemented to satisfy trait-bounds in `tree::upsert`.
-// The current implementation around proofs for created nodes during proof-generation
-// needs to be fixed.
+// This id is for a node created during proof generation, so it has no lazy identifier.
 impl From<ProveNode> for ProveNodeId {
     fn from(node: ProveNode) -> Self {
         ProveNodeId {
-            inner: OnceLock::from(Rc::new(node)),
-            node: LazyNodeId::from(Hash::hash_bytes(&[])),
-            deleted_nodes: Rc::new(RefCell::new(BTreeMap::new())),
+            cache: OnceLock::from(Rc::new(node)),
+            lazy_id: None,
         }
     }
 }
@@ -744,15 +723,19 @@ impl ProveNodeId {
     /// Used by the `MerkleLayer`-level fold to extract per-field read flags from a node that
     /// was resolved during the proof step.
     pub(crate) fn cached_node(&self) -> Option<&ProveNode> {
-        self.inner.get().map(|rc| rc.as_ref())
+        self.cache.get().map(|rc| rc.as_ref())
     }
 }
 
 impl Foldable<HashFold> for ProveNodeId {
     fn fold(&self, builder: HashFold) -> <HashFold as Fold>::Folded {
-        match self.inner.get() {
+        match self.cache.get() {
             Some(inner) => *inner.hash(),
-            None => self.node.fold(builder),
+            None => self
+                .lazy_id
+                .as_ref()
+                .expect("LazyNodeId must be present if this Node is not cached.")
+                .fold(builder),
         }
     }
 }
@@ -909,17 +892,21 @@ where
         + Resolver<LazyTreeId, Tree<LazyNodeId>>,
 {
     fn resolve<'b>(&self, id: &'b ProveNodeId) -> Result<&'b ProveNode, OperationalError> {
-        if let Some(inner) = id.inner.get() {
+        if let Some(inner) = id.cache.get() {
             return Ok(inner);
         }
 
-        let resolved = self.resolve_and_track_node(&id.node)?;
-        let result_node: ProveNode = resolved.clone().into_proof();
-        id.inner
-            .set(Rc::new(result_node))
+        let lazy_id = id
+            .lazy_id
+            .as_ref()
+            .expect("Any node that is not cached must have the lazy id present.");
+        let resolved_node = self.resolve_and_track_node(lazy_id)?;
+        let prove_node: ProveNode = resolved_node.clone().into_proof();
+        id.cache
+            .set(Rc::new(prove_node))
             .map_err(|_| OperationalError::ResolverInvariantViolated)?;
 
-        Ok(id.inner.wait())
+        Ok(id.cache.wait())
     }
 
     fn resolve_mut<'b>(
@@ -928,21 +915,48 @@ where
     ) -> Result<&'b mut ProveNode, OperationalError> {
         {
             // SAFETY: Rust doesn't understand that the reference on `id.inner` is dropped on return.
-            let inner_mut = unsafe { &mut *(&mut id.inner as *mut OnceLock<_>) };
+            let inner_mut = unsafe { &mut *(&mut id.cache as *mut OnceLock<_>) };
             if let Some(inner) = inner_mut.get_mut() {
                 return Ok(Rc::make_mut(inner));
             }
         }
 
-        let resolved = self.resolve_and_track_node(&id.node)?;
-        let result_node: ProveNode = resolved.clone().into_proof();
-        id.inner
-            .set(Rc::new(result_node))
+        let lazy_id = id
+            .lazy_id
+            .as_ref()
+            .expect("Any node that is not cached must have the lazy id present.");
+        let resolved_node = self.resolve_and_track_node(lazy_id)?;
+        let prove_node: ProveNode = resolved_node.clone().into_proof();
+        id.cache
+            .set(Rc::new(prove_node))
             .map_err(|_| OperationalError::ResolverInvariantViolated)?;
 
         Ok(Rc::make_mut(
-            id.inner.get_mut().expect("inner was just set"),
+            id.cache.get_mut().expect("inner was just set"),
         ))
+    }
+
+    /// Nodes that were resolved during the step carry a prove-mode projection that needs
+    /// to be available for the `MerkleLayer`-level fold after the step finishes.
+    fn track_deleted_node(&mut self, id: &ProveNodeId) {
+        let prove_node = id
+            .cache
+            .get()
+            .expect("A node can only be deleted if it was resolved during the step");
+
+        let Some(lazy_id) = &id.lazy_id else {
+            // Nodes created during the proof step have no lazy identifier and also
+            // do not need to be tracked, since they are not part of the initial tree.
+            return;
+        };
+        let hash = Hash::from_foldable(lazy_id);
+        let node = prove_node.as_ref();
+        let fields = DeletedNodeFields {
+            meta: node.meta().clone(),
+            data: node.data().clone(),
+        };
+
+        self.deleted_nodes.borrow_mut().insert(hash, fields);
     }
 }
 
@@ -956,7 +970,7 @@ where
         }
 
         let resolved = self.resolve_and_track_tree(&id.tree)?;
-        let result_tree: Tree<ProveNodeId> = resolved.clone().into_proof(self);
+        let result_tree: Tree<ProveNodeId> = resolved.clone().into_proof();
         id.inner
             .set(result_tree)
             .map_err(|_| OperationalError::ResolverInvariantViolated)?;
@@ -977,7 +991,7 @@ where
         }
 
         let resolved = self.resolve_and_track_tree(&id.tree)?;
-        let result_tree: Tree<ProveNodeId> = resolved.clone().into_proof(self);
+        let result_tree: Tree<ProveNodeId> = resolved.clone().into_proof();
         id.inner
             .set(result_tree)
             .map_err(|_| OperationalError::ResolverInvariantViolated)?;
@@ -1647,7 +1661,7 @@ mod tests {
         let prove_resolver = ProveResolver::start(lazy_resolver, None);
         let lazy_node_id = lazy_tree.root().expect("tree should have a root");
 
-        let prove_id = lazy_node_id.clone().into_proof(&prove_resolver);
+        let prove_id = lazy_node_id.clone().into_proof();
 
         prove_resolver
             .resolve(&prove_id)
@@ -1664,7 +1678,7 @@ mod tests {
         let expected_hash = Hash::from_foldable(lazy_root);
 
         let prove_resolver = ProveResolver::start(lazy_resolver, None);
-        let prove_id = lazy_root.clone().into_proof(&prove_resolver);
+        let prove_id = lazy_root.clone().into_proof();
 
         // Hash before resolve (delegates to lazy path).
         let hash_before = Hash::from_foldable(&prove_id);
@@ -1696,7 +1710,7 @@ mod tests {
             .root()
             .expect("tree should have a root")
             .clone()
-            .into_proof(&prove_resolver);
+            .into_proof();
 
         // Resolve root node.
         let prove_node = prove_resolver
@@ -1733,7 +1747,7 @@ mod tests {
             .root()
             .expect("tree should have a root")
             .clone()
-            .into_proof(&prove_resolver);
+            .into_proof();
 
         prove_resolver
             .resolve(&prove_id)
@@ -1761,7 +1775,7 @@ mod tests {
             .root()
             .expect("tree should have a root")
             .clone()
-            .into_proof(&prove_resolver);
+            .into_proof();
 
         let node = prove_resolver
             .resolve_mut(&mut prove_id)
@@ -1794,7 +1808,7 @@ mod tests {
 
         // Now get the same hash via the prove resolver path.
         let prove_resolver = ProveResolver::start(lazy_resolver, None);
-        let prove_root_id = lazy_root.clone().into_proof(&prove_resolver);
+        let prove_root_id = lazy_root.clone().into_proof();
         let prove_node = prove_resolver
             .resolve(&prove_root_id)
             .expect("resolve should succeed");

--- a/durable-storage/src/avl/tree.rs
+++ b/durable-storage/src/avl/tree.rs
@@ -35,7 +35,6 @@ use super::resolver::VerifyNodeId;
 use crate::avl::resolver::AvlResolver;
 use crate::avl::resolver::LazyNodeId;
 use crate::avl::resolver::NodeResolver;
-use crate::avl::resolver::ProveResolver;
 use crate::errors::Error;
 use crate::errors::InvalidArgumentError;
 use crate::errors::OperationalError;
@@ -59,8 +58,8 @@ impl Tree<LazyNodeId> {
     /// Converts the [`Tree`] to [`Prove`] mode.
     ///
     /// [`Prove`]: octez_riscv_data::mode::Prove
-    pub(crate) fn into_proof<R>(self, resolver: &ProveResolver<R>) -> Tree<ProveNodeId> {
-        Tree(self.0.map(|id| id.into_proof(resolver)))
+    pub(crate) fn into_proof(self) -> Tree<ProveNodeId> {
+        Tree(self.0.map(|id| id.into_proof()))
     }
 }
 
@@ -114,28 +113,31 @@ impl<NodeId> Tree<NodeId> {
 
         let resolved_node = resolver.resolve(node)?;
         match resolved_node.key().cmp(key) {
-            Ordering::Equal => match (
-                resolved_node.left_ref(resolver)?.root(),
-                resolved_node.right_ref(resolver)?.root(),
-            ) {
-                (None, None) => {
-                    self.take();
-                    Ok(true)
+            Ordering::Equal => {
+                resolver.track_deleted_node(node);
+                match (
+                    resolved_node.left_ref(resolver)?.root(),
+                    resolved_node.right_ref(resolver)?.root(),
+                ) {
+                    (None, None) => {
+                        self.take();
+                        Ok(true)
+                    }
+                    (Some(left), None) => {
+                        *node = left.clone();
+                        Ok(true)
+                    }
+                    (None, Some(right)) => {
+                        *node = right.clone();
+                        Ok(true)
+                    }
+                    (Some(_), Some(_)) => {
+                        let (new_node, shrank) = Node::replace_with_successor(node, resolver)?;
+                        *node = new_node;
+                        Ok(shrank)
+                    }
                 }
-                (Some(left), None) => {
-                    *node = left.clone();
-                    Ok(true)
-                }
-                (None, Some(right)) => {
-                    *node = right.clone();
-                    Ok(true)
-                }
-                (Some(_), Some(_)) => {
-                    let (new_node, shrank) = Node::replace_with_successor(node, resolver)?;
-                    *node = new_node;
-                    Ok(shrank)
-                }
-            },
+            }
             Ordering::Greater => {
                 let node_mut = resolver.resolve_mut(node)?;
                 let left_shrank = node_mut.left_mut(resolver)?.delete(key, resolver)?;

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -110,7 +110,7 @@ impl<KV> MerkleLayer<KV, Normal> {
             LazyResolver::new(self.inner.persistence.clone()),
             Some(root_tree_hash),
         );
-        let working_tree = initial_tree.clone().into_proof(&resolver);
+        let working_tree = initial_tree.clone().into_proof();
         let initial_tree_id = LazyTreeId::from(initial_tree);
 
         MerkleLayer {

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -701,6 +701,7 @@ mod tests {
     use std::sync::Arc;
 
     use octez_riscv_data::components::bytes::Bytes;
+    use octez_riscv_data::components::bytes::BytesMode;
     use octez_riscv_data::merkle_proof::FromProof;
     use octez_riscv_data::merkle_proof::ProofError;
     use octez_riscv_data::merkle_proof::proof_tree::MerkleProof;
@@ -803,23 +804,47 @@ mod tests {
         /// Only applied to keys that are known to exist.
         /// The offset must be `<= existing_data_len` for the write to succeed.
         Write(Key, usize, Vec<u8>),
+        /// Read up to `count` bytes starting at `offset`. A missing key reads zero bytes; reads
+        /// past the end clamp to the data length. Recording the read range is what makes the
+        /// data resolvable in Verify mode.
+        Read(Key, usize, usize),
     }
 
-    fn apply_operation<KV: KeyValueStore, M: MerkleLayerMode>(
+    /// Apply `op` against `ml`. Returns `Some(bytes)` for [`Operation::Read`] so callers can
+    /// compare read results across modes, and `None` for state-mutating ops.
+    fn apply_operation<KV: KeyValueStore, M: MerkleLayerMode + BytesMode>(
         ml: &mut MerkleLayer<KV, M>,
         op: &Operation,
-    ) {
+    ) -> Option<Vec<u8>> {
         match op {
             Operation::Set(key, data) => {
                 ml.set(key, data).expect("set should succeed");
+                None
             }
             Operation::Delete(key) => {
                 ml.delete(key).expect("delete should succeed");
+                None
             }
             Operation::Write(key, offset, data) => {
                 ml.write(key, *offset, data).expect("write should succeed");
-            } // TODO RV-895: add `get` to step op
+                None
+            }
+            Operation::Read(key, offset, count) => {
+                let mut buf = vec![0u8; *count];
+                let n = ml
+                    .get(key)
+                    .expect("get should succeed")
+                    .map_or(0, |data| data.read(*offset, &mut buf));
+                buf.truncate(n);
+                Some(buf)
+            }
         }
+    }
+
+    /// Derive a data length in the range [1, 8] from the key bytes. Used to generate
+    /// variable-length data for testing.
+    fn setup_data_len(key_bytes: &[u8; 2]) -> usize {
+        (key_bytes[0] as usize % 8) + 1
     }
 
     /// Core assertion: prove-mode proof and hash are consistent with Normal mode and the proof
@@ -843,7 +868,7 @@ mod tests {
 
         for bytes in setup_keys {
             let key = Key::new(bytes).expect("key should be valid");
-            let data = [bytes[0]; 10];
+            let data = vec![bytes[0]; setup_data_len(bytes)];
             normal_ml.set(&key, &data).expect("set should succeed");
         }
 
@@ -851,9 +876,10 @@ mod tests {
 
         // ---- Prove: start proof and execute operations ----
         let mut prove_ml = normal_ml.start_proof();
-        for op in operations {
-            apply_operation(&mut prove_ml, op);
-        }
+        let prove_reads: Vec<Vec<u8>> = operations
+            .iter()
+            .filter_map(|op| apply_operation(&mut prove_ml, op))
+            .collect();
         let prove_final_hash = prove_ml.hash();
 
         // ---- Generate proof ----
@@ -866,16 +892,23 @@ mod tests {
             "proof root hash must match initial Normal-mode hash"
         );
 
-        // ---- Normal: replay same operations for reference hash ----
-        for op in operations {
-            apply_operation(&mut normal_ml, op);
-        }
+        // ---- Normal: replay same operations for reference hash and read values ----
+        let normal_reads: Vec<Vec<u8>> = operations
+            .iter()
+            .filter_map(|op| apply_operation(&mut normal_ml, op))
+            .collect();
         let normal_final_hash = normal_ml.hash();
 
-        // Property 2: prove-mode final hash == Normal-mode final hash.
+        // Property 2a: prove-mode final hash == Normal-mode final hash.
         assert_eq!(
             normal_final_hash, prove_final_hash,
             "prove-mode final hash must match Normal-mode final hash"
+        );
+
+        // Property 2b: prove-mode reads return the same bytes as Normal-mode reads.
+        assert_eq!(
+            normal_reads, prove_reads,
+            "prove-mode reads must return the same bytes as Normal-mode reads"
         );
 
         // ---- Verify: deserialise the proof and replay the same operations ----
@@ -890,11 +923,12 @@ mod tests {
         );
 
         let operations_for_verify = operations.to_vec();
-        let verify_final_hash = catch_not_found(move || {
-            for op in &operations_for_verify {
-                apply_operation(&mut verify_ml, op);
-            }
-            verify_ml.hash()
+        let (verify_final_hash, verify_reads) = catch_not_found(move || {
+            let reads: Vec<Vec<u8>> = operations_for_verify
+                .iter()
+                .filter_map(|op| apply_operation(&mut verify_ml, op))
+                .collect();
+            (verify_ml.hash(), reads)
         })
         .expect("verify replay should not trigger not_found — proof must cover all accesses");
 
@@ -902,6 +936,12 @@ mod tests {
         assert_eq!(
             prove_final_hash, verify_final_hash,
             "verify-mode replay must reach the same final hash as prove mode"
+        );
+
+        // Property 3c: verify-mode reads return the same bytes as prove-mode reads.
+        assert_eq!(
+            prove_reads, verify_reads,
+            "verify-mode reads must return the same bytes as prove-mode reads"
         );
     }
 
@@ -2259,23 +2299,52 @@ mod tests {
             .map(|b| Key::new(b).expect("key should be valid"))
             .collect();
 
+        // Track each key's current data length so generated ops stay valid as state evolves.
+        // Initial lengths mirror the per-key length used during setup.
+        let mut lengths: std::collections::HashMap<Key, usize> = setup_keys
+            .iter()
+            .zip(keys.iter())
+            .map(|(bytes, k)| (k.clone(), setup_data_len(bytes)))
+            .collect();
+
         let mut operations = Vec::new();
-        // TODO RV-985: Expand to more operations in each test.
-        // This is currently limited to one operation, as this is the minimum requirement,
-        // and proof semantics are not supported for more than one operation yet.
-        let ops_count = 1;
+        let ops_count = seed % 20;
         for i in 0..ops_count {
             let key = keys[i % keys.len()].clone();
             let data = vec![seed as u8; 5];
-            match (i + seed) % 3 {
-                0 => operations.push(Operation::Set(key, data)),
-                1 => operations.push(Operation::Delete(key)),
-                _ => {
-                    // All setup keys have data set to 10 bytes long.
-                    // Data length is 5 bytes, so valid offsets are 0..=5.
-                    let offset = (i + seed) % 5;
-                    operations.push(Operation::Write(key, offset, data));
+            match (i + seed) % 4 {
+                0 => {
+                    lengths.insert(key.clone(), data.len());
+                    operations.push(Operation::Set(key, data));
                 }
+                1 => {
+                    lengths.remove(&key);
+                    operations.push(Operation::Delete(key));
+                }
+                2 => match lengths.get(&key).copied() {
+                    Some(len) => {
+                        let offset = (i + seed) % (len + 1);
+                        lengths.insert(key.clone(), std::cmp::max(len, offset + data.len()));
+                        operations.push(Operation::Write(key, offset, data));
+                    }
+                    None => {
+                        lengths.insert(key.clone(), data.len());
+                        operations.push(Operation::Set(key, data));
+                    }
+                },
+                _ => match lengths.get(&key).copied() {
+                    Some(len) => {
+                        // Vary offset across in-bounds, end-of-data and one past the end so the
+                        // read clamps to the data length and zero-byte cases are exercised.
+                        let offset = (i + seed) % (len + 2);
+                        let count = 1 + ((i + seed) % 7);
+                        operations.push(Operation::Read(key, offset, count));
+                    }
+                     None => {
+                        lengths.insert(key.clone(), data.len());
+                        operations.push(Operation::Set(key, data));
+                    }
+                },
             }
         }
 
@@ -2286,21 +2355,16 @@ mod tests {
     kv_test!(prove_verify_round_trips_writes_only, KV,
     [
         setup_keys in prop::collection::vec(any::<[u8; 2]>(), 1..30),
-        // Setup keys are written with their own 2-byte representation as data, so the only
-        // valid offsets for an in-place / appending write are 0..=2.
-        offsets in prop::collection::vec(0usize..=2, 1..30),
+        offsets in prop::collection::vec(any::<usize>(), 1..30),
     ], {
-        let keys: Vec<Key> = setup_keys
-            .iter()
-            .map(|b| Key::new(b).expect("key should be valid"))
-            .collect();
-
-        let step_ops: Vec<Operation> = keys
+        let step_ops: Vec<Operation> = setup_keys
             .iter()
             .enumerate()
-            .map(|(i, key)| {
-                let offset = offsets[i % offsets.len()];
-                Operation::Write(key.clone(), offset, vec![0xAA; 1 + (i % 8)])
+            .map(|(i, bytes)| {
+                let key = Key::new(bytes).expect("key should be valid");
+                // The offset must be valid for the existing data length.
+                let offset = offsets[i % offsets.len()] % (setup_data_len(bytes) + 1);
+                Operation::Write(key, offset, vec![0xAA; 1 + (i % 8)])
             })
             .collect();
 
@@ -2335,8 +2399,6 @@ mod tests {
             .iter()
             // ensure we don't accidentally mix insertions with overwritting old keys
             // - the proof system doesn't currently support this
-            // TODO (RV-985): remove this line
-            .filter(|bytes| !setup_keys.contains(bytes))
             .enumerate()
             .map(|(i, bytes)| {
                 let key = Key::new(bytes).expect("key should be valid");
@@ -2347,36 +2409,31 @@ mod tests {
         assert_prove_mode_correct::<KV>(&setup_keys, &step_ops);
     });
 
-    kv_test!(prove_verify_round_trip_reads_only, KV,
+    // Reads via [`Operation::Read`] do not change the hash, but they record byte ranges in the
+    // proof so Verify mode can satisfy the same reads without triggering `not_found`.
+    kv_test!(prove_verify_round_trips_reads, KV,
     [
         setup_keys in prop::collection::vec(any::<[u8; 2]>(), 1..30),
-        read_indices in prop::collection::vec(any::<usize>(), 1..15),
+        // Setup lengths vary per key (see `setup_data_len`); the upper bound exceeds the maximum
+        // setup length so we also cover the past-the-end clamp case.
+        offsets in prop::collection::vec(0usize..=12, 1..30),
+        counts in prop::collection::vec(1usize..=15, 1..30),
     ], {
-        let (_keepalive, repo) = KV::setup_repo();
-        let mut normal_ml = new_merkle_layer::<KV>(&repo);
+        let keys: Vec<Key> = setup_keys
+            .iter()
+            .map(|b| Key::new(b).expect("key should be valid"))
+            .collect();
 
-        for bytes in &setup_keys {
-            let key = Key::new(bytes).expect("key should be valid");
-            normal_ml.set(&key, bytes).expect("set should succeed");
-        }
+        let step_ops: Vec<Operation> = keys
+            .iter()
+            .enumerate()
+            .map(|(i, key)| {
+                let offset = offsets[i % offsets.len()];
+                let count = counts[i % counts.len()];
+                Operation::Read(key.clone(), offset, count)
+            })
+            .collect();
 
-        let normal_hash = normal_ml.hash();
-        let prove_ml = normal_ml.start_proof();
-
-        for &i in &read_indices {
-            let key = Key::new(&setup_keys[i % setup_keys.len()]).expect("key should be valid");
-            let _ = prove_ml.get(&key).expect("get should succeed");
-        }
-
-        prop_assert_eq!(
-            normal_hash,
-            prove_ml.hash(),
-        );
-
-        let proof = MerkleProof::from_foldable(&prove_ml);
-        prop_assert_eq!(
-            normal_hash,
-            proof.root_hash(),
-        );
+        assert_prove_mode_correct::<KV>(&setup_keys, &step_ops);
     });
 }

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -193,6 +193,14 @@ impl<KV, M: MerkleLayerMode> MerkleLayer<KV, M> {
     {
         M::write(self, key, offset, data)
     }
+
+    /// Returns an immutable reference to the data stored for a given [Key].
+    pub(crate) fn get(&self, key: &Key) -> Result<Option<&Bytes<M>>, OperationalError>
+    where
+        KV: KeyValueStore,
+    {
+        M::get(self, key)
+    }
 }
 
 /// Modes that implements this trait support Merkle layer operations
@@ -226,6 +234,12 @@ pub trait MerkleLayerMode: Mode {
         offset: usize,
         data: &[u8],
     ) -> Result<(), Error>;
+
+    /// See [`MerkleLayer::get`]
+    fn get<'a, KV: KeyValueStore>(
+        this: &'a MerkleLayer<KV, Self>,
+        key: &Key,
+    ) -> Result<Option<&'a Bytes<Self>>, OperationalError>;
 }
 
 impl MerkleLayerMode for Normal {
@@ -264,6 +278,18 @@ impl MerkleLayerMode for Normal {
         data: &[u8],
     ) -> Result<(), Error> {
         this.inner.write(key, offset, data)
+    }
+
+    fn get<'a, KV: KeyValueStore>(
+        this: &'a MerkleLayer<KV, Self>,
+        key: &Key,
+    ) -> Result<Option<&'a Bytes<Self>>, OperationalError> {
+        let Some(node_id) = this.inner.tree.get(key, &this.inner.resolver)? else {
+            return Ok(None);
+        };
+        let resolved_node = this.inner.resolver.resolve(node_id)?;
+        let data = resolved_node.resolve_data(&this.inner.resolver)?;
+        Ok(Some(data))
     }
 }
 
@@ -319,6 +345,17 @@ impl MerkleLayerMode for Prove<'static> {
             .write(key, offset, data, &mut this.inner.resolver)?;
         Ok(())
     }
+
+    fn get<'a, KV: KeyValueStore>(
+        this: &'a MerkleLayer<KV, Self>,
+        key: &Key,
+    ) -> Result<Option<&'a Bytes<Self>>, OperationalError> {
+        let Some(node_id) = this.inner.working_tree.get(key, &this.inner.resolver)? else {
+            return Ok(None);
+        };
+        let resolved_node = this.inner.resolver.resolve(node_id)?;
+        Ok(Some(resolved_node.data()))
+    }
 }
 
 impl MerkleLayerMode for Verify {
@@ -371,6 +408,17 @@ impl MerkleLayerMode for Verify {
             .tree
             .write(key, offset, data, &mut this.inner.resolver)?;
         Ok(())
+    }
+
+    fn get<'a, KV: KeyValueStore>(
+        this: &'a MerkleLayer<KV, Self>,
+        key: &Key,
+    ) -> Result<Option<&'a Bytes<Self>>, OperationalError> {
+        let Some(node_id) = this.inner.tree.get(key, &this.inner.resolver)? else {
+            return Ok(None);
+        };
+        let resolved_node = this.inner.resolver.resolve(node_id)?;
+        Ok(Some(resolved_node.data()))
     }
 }
 
@@ -630,37 +678,6 @@ impl<KV: KeyValueStore> Foldable<MerkleProofFold> for InitialNodeFold<'_, KV> {
     }
 }
 
-impl<KV> MerkleLayer<KV, Verify> {
-    /// Returns an immutable reference to the data stored for a given [Key].
-    pub(crate) fn get(&self, key: &Key) -> Result<Option<&Bytes<Verify>>, OperationalError> {
-        let node = self.inner.tree.get(key, &self.inner.resolver)?;
-        match node {
-            Some(node_id) => {
-                let resolved_node = self.inner.resolver.resolve(node_id)?;
-                Ok(Some(resolved_node.data()))
-            }
-            None => Ok(None),
-        }
-    }
-}
-
-impl<KV: KeyValueStore> MerkleLayer<KV, Prove<'static>> {
-    /// Returns an immutable reference to the data stored for a given ['Key'].
-    pub(crate) fn get(
-        &self,
-        key: &Key,
-    ) -> Result<Option<&Bytes<Prove<'static>>>, OperationalError> {
-        let node = self.inner.working_tree.get(key, &self.inner.resolver)?;
-        match node {
-            Some(node_id) => {
-                let resolved_node = self.inner.resolver.resolve(node_id)?;
-                Ok(Some(resolved_node.data()))
-            }
-            None => Ok(None),
-        }
-    }
-}
-
 /// Construct a verify-mode [`MerkleLayer`] for an empty initial state. Used in tests that exercise
 /// verify-mode mutation primitives in isolation.
 #[cfg(test)]
@@ -708,11 +725,9 @@ mod tests {
     use crate::avl::resolver::LazyTreeId;
     use crate::avl::resolver::ProveNodeId;
     use crate::avl::resolver::ProveResolver;
-    use crate::avl::resolver::Resolver;
     use crate::avl::resolver::VerifyResolver;
     use crate::avl::resolver::VerifyTreeId;
     use crate::avl::tree::Tree;
-    use crate::errors::OperationalError;
     use crate::key::Key;
     use crate::merkle_layer::VerifyImpl;
     use crate::storage::KeyValueStore;
@@ -728,19 +743,6 @@ mod tests {
         /// Clear all data from the [MerkleLayer].
         fn clear(&mut self) {
             self.inner.tree.take();
-        }
-
-        /// Returns an immutable reference to the data stored for a given [Key].
-        pub fn get(&mut self, key: &Key) -> Result<Option<&Bytes<Normal>>, OperationalError> {
-            let node = self.inner.tree.get(key, &self.inner.resolver)?;
-            match node {
-                Some(node_id) => {
-                    let resolved_node = self.inner.resolver.resolve(node_id)?;
-                    let data = resolved_node.resolve_data(&self.inner.resolver)?;
-                    Ok(Some(data))
-                }
-                None => Ok(None),
-            }
         }
     }
 
@@ -1760,7 +1762,7 @@ mod tests {
         let commit_opts = crate::storage::StoreOptions::default().with_deep().with_node_data();
         let commit_id = merkle_layer.commit(&commit_opts).expect("Commit operation should succeed");
 
-        let mut lazy_loaded = MerkleLayer::checkout(persistence, commit_id)
+        let lazy_loaded = MerkleLayer::checkout(persistence, commit_id)
             .expect("Lazy checkout should succeed");
         let loaded_hash = lazy_loaded.hash();
 


### PR DESCRIPTION
Relates to RV-985.
Part of RV-1004.

# What

Change the mechanism by which deleted nodes are added to the `deleted_nodes` list to a trait method on Resolver.
Expand current tests in Merkle Layer to including multi-step changes. 

# Why

Makes proof system more robust if it can support more complex changes. 

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
