### PR TITLE
feat(durable): add `Registry::try_start_proof`

### DIFF
--- a/data/src/components/vector.rs
+++ b/data/src/components/vector.rs
@@ -51,6 +51,7 @@ use crate::mode::Modal;
 use crate::mode::Mode;
 use crate::mode::Normal;
 use crate::mode::Provable;
+use crate::mode::ProvableExt;
 use crate::mode::Prove;
 use crate::mode::Verify;
 use crate::mode::utils::not_found;
@@ -252,17 +253,19 @@ impl<T: Foldable<PartialHashFold>> Foldable<PartialHashFold> for Vector<T, Verif
     }
 }
 
-impl<'normal, T: Provable<'normal>> Provable<'normal> for Vector<T, Normal> {
+impl<'normal, T: Provable<'normal>> ProvableExt<'normal, 'normal, Infallible>
+    for Vector<T, Normal>
+{
     type Prover = Vector<T::Prover, Prove<'normal>>;
 
-    fn start_proof(&'normal self) -> Self::Prover {
+    fn try_start_proof(&'normal self) -> Result<Self::Prover, Infallible> {
         let previous = self
             .vector
             .iter()
             .map(Provable::start_proof)
             .collect::<Vec<_>>()
             .into_boxed_slice();
-        Vector {
+        let vector = Vector {
             vector: ProveImpl {
                 active_previous: previous.len(),
                 previous,
@@ -270,7 +273,9 @@ impl<'normal, T: Provable<'normal>> Provable<'normal> for Vector<T, Normal> {
                 appended: Vec::new(),
                 read_length: Cell::new(false),
             },
-        }
+        };
+
+        Ok(vector)
     }
 }
 

--- a/data/src/components/vector.rs
+++ b/data/src/components/vector.rs
@@ -50,7 +50,6 @@ use crate::merkle_proof::sequence_as_tree_from_proof;
 use crate::mode::Modal;
 use crate::mode::Mode;
 use crate::mode::Normal;
-use crate::mode::Provable;
 use crate::mode::ProvableExt;
 use crate::mode::Prove;
 use crate::mode::Verify;
@@ -253,17 +252,17 @@ impl<T: Foldable<PartialHashFold>> Foldable<PartialHashFold> for Vector<T, Verif
     }
 }
 
-impl<'normal, T: Provable<'normal>> ProvableExt<'normal, 'normal, Infallible>
+impl<'normal, 'inner, E, T: ProvableExt<'normal, 'inner, E>> ProvableExt<'normal, 'inner, E>
     for Vector<T, Normal>
 {
-    type Prover = Vector<T::Prover, Prove<'normal>>;
+    type Prover = Vector<T::Prover, Prove<'inner>>;
 
-    fn try_start_proof(&'normal self) -> Result<Self::Prover, Infallible> {
+    fn try_start_proof(&'normal self) -> Result<Self::Prover, E> {
         let previous = self
             .vector
             .iter()
-            .map(Provable::start_proof)
-            .collect::<Vec<_>>()
+            .map(ProvableExt::try_start_proof)
+            .collect::<Result<Vec<_>, E>>()?
             .into_boxed_slice();
         let vector = Vector {
             vector: ProveImpl {

--- a/data/src/components/vector/tests.rs
+++ b/data/src/components/vector/tests.rs
@@ -36,6 +36,7 @@ use crate::merkle_proof::proof_tree::MerkleProof;
 use crate::merkle_proof::proof_tree::MerkleProofFold;
 use crate::mode::Normal;
 use crate::mode::Provable;
+use crate::mode::ProvableExt;
 use crate::mode::Prove;
 use crate::mode::Verify;
 use crate::mode_test;
@@ -401,7 +402,7 @@ where
         // We use a block expression to clearly delimit the lifetimes. Otherwise, the compiler will
         // freak out over using the `vector_normal` while `vector_prove` is still alive.
         let (verify_result, after_verify_hash) = {
-            let mut vector_prove = vector_normal.start_proof();
+            let Ok(mut vector_prove) = vector_normal.try_start_proof();
 
             // The initial hash of the Prove mode should match the Normal mode hash.
             let init_normal_hash = Hash::from_foldable(&vector_normal);

--- a/data/src/mode.rs
+++ b/data/src/mode.rs
@@ -124,3 +124,24 @@ pub trait Provable<'normal> {
     /// Start proving.
     fn start_proof(&'normal self) -> Self::Prover;
 }
+
+/// Types that implement this can be switched to [`Prove`] mode,
+/// but this operation may fail.
+///
+/// Unlike `Provable`, `Prover` may have a lifetime potentially
+/// decoupled from `'normal` - such as `'static`.
+pub trait ProvableExt<'normal, 'prover, E> {
+    /// Variant of [`Self`] in [`Prove`] mode
+    type Prover: 'prover;
+
+    /// Attempt to start proving.
+    fn try_start_proof(&'normal self) -> Result<Self::Prover, E>;
+}
+
+impl<'normal, P: Provable<'normal>> ProvableExt<'normal, 'normal, Infallible> for P {
+    type Prover = <P as Provable<'normal>>::Prover;
+
+    fn try_start_proof(&'normal self) -> Result<Self::Prover, Infallible> {
+        Ok(<P as Provable<'normal>>::start_proof(self))
+    }
+}

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -661,15 +661,6 @@ pub(crate) mod tests {
         (runtime, keepalive, repo, database)
     }
 
-    /// Wrap an existing Prove-mode [`MerkleLayer`] into a [`Database`].
-    pub(crate) fn from_prove_layer<KV: KeyValueStore>(
-        merkle: MerkleLayer<KV, Prove<'static>>,
-    ) -> Database<KV, Prove<'static>> {
-        Database {
-            inner: super::ProveImpl { merkle },
-        }
-    }
-
     /// Generate a Merkle proof from `database` and produce a Verify-mode database that replays
     /// the same data via that proof.
     pub(crate) fn to_verify<KV: KeyValueStore>(

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -22,6 +22,7 @@ use octez_riscv_data::hash::HashFold;
 use octez_riscv_data::mode::Modal;
 use octez_riscv_data::mode::Mode;
 use octez_riscv_data::mode::Normal;
+use octez_riscv_data::mode::ProvableExt;
 use octez_riscv_data::mode::Prove;
 use octez_riscv_data::mode::Verify;
 use perfect_derive::perfect_derive;
@@ -268,6 +269,22 @@ impl<KV: BackgroundKeyValueStore, M: DatabaseMode> Database<KV, M> {
 impl<KV: KeyValueStore> Foldable<HashFold> for Database<KV, Normal> {
     fn fold(&self, _builder: HashFold) -> Hash {
         self.inner.merkle.hash().expect("Hashing should not fail")
+    }
+}
+
+impl<'normal, KV: BackgroundKeyValueStore> ProvableExt<'normal, 'static, OperationalError>
+    for Database<KV, Normal>
+{
+    type Prover = Database<KV, Prove<'static>>;
+
+    fn try_start_proof(&'normal self) -> Result<Self::Prover, OperationalError> {
+        let NormalImpl { persistent, merkle } = &self.inner;
+
+        let merkle = merkle.start_proof(persistent.clone())?;
+
+        Ok(Database {
+            inner: ProveImpl { merkle },
+        })
     }
 }
 
@@ -576,6 +593,7 @@ pub(crate) mod tests {
 
     use bytes::Bytes;
     use octez_riscv_data::mode::Normal;
+    use octez_riscv_data::mode::ProvableExt;
     use octez_riscv_data::mode::Prove;
     use octez_riscv_data::mode::Verify;
     use octez_riscv_data::mode::utils::catch_not_found;
@@ -2029,23 +2047,36 @@ pub(crate) mod tests {
     });
 
     kv_test!(test_prove_database_read_bytes_records_only_accessed_range, KV: BackgroundKeyValueStore, {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .build()
+            .expect("Creating a Tokio runtime should succeed");
+        let handle = runtime.handle();
+        let (_keepalive, repo) = KV::setup_repo();
+
         let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
 
-        // Build an 8192-byte value (two PAGE_SIZE pages) directly through MerkleLayer<Normal>,
-        // bypassing Database's per-call MAX_FILE_CHUNK_SIZE limit.
-        let value: Vec<u8> = (0..8192u32).map(|i| (i & 0xff) as u8).collect();
-        let (_keepalive, persistence) = new_persistence::<KV>();
-        let mut normal_ml = MerkleLayer::<KV, Normal>::new(persistence);
-        normal_ml
-            .set(&key, &value)
-            .expect("populating the normal layer should succeed");
+        // Build an 8192-byte value (two PAGE_SIZE pages)
+        let value: Vec<u8> = (0..(4 * (MAX_FILE_CHUNK_SIZE as u32)))
+            .map(|i| (i & 0xff) as u8)
+            .collect();
+
+        let value_iter = &mut value.iter().cloned();
+
+        let mut normal_db = new_database::<KV>(handle, &repo);
+        for i in 0..4 {
+            let offset = i * MAX_FILE_CHUNK_SIZE;
+            let bytes: Vec<u8> = value_iter.take(MAX_FILE_CHUNK_SIZE).collect();
+            normal_db
+                .write(key.clone(), offset, Bytes::from(bytes))
+                .expect("Writing to the db should succeed");
+        }
 
         // Convert to Prove and read a small range entirely contained in page 1.
-        let prove_db: TracedDatabase<KV, Prove<'static>> = TracedDatabase::from(Database {
-            inner: super::ProveImpl {
-                merkle: normal_ml.start_proof(),
-            },
-        });
+        let prove_db: TracedDatabase<KV, Prove<'static>> = normal_db
+            .try_start_proof()
+            .expect("starting proof should succeed");
+
         let read_offset = 5000usize;
         let read_len = 4usize;
         let read_back = prove_db

--- a/durable-storage/src/database/traced_database.rs
+++ b/durable-storage/src/database/traced_database.rs
@@ -13,6 +13,8 @@ use bytes::Bytes;
 use octez_riscv_data::hash::Hash;
 use octez_riscv_data::mode::Mode;
 use octez_riscv_data::mode::Normal;
+use octez_riscv_data::mode::ProvableExt;
+use octez_riscv_data::mode::Prove;
 use octez_riscv_data::mode::Verify;
 use tokio::runtime::Handle;
 
@@ -283,6 +285,19 @@ impl<KV, M: Mode> From<Database<KV, M>> for TracedDatabase<KV, M> {
             inner,
             trace: RefCell::new(Vec::new()),
         }
+    }
+}
+
+impl<'normal, KV: BackgroundKeyValueStore> ProvableExt<'normal, 'static, OperationalError>
+    for TracedDatabase<KV, Normal>
+{
+    type Prover = TracedDatabase<KV, Prove<'static>>;
+
+    fn try_start_proof(&'normal self) -> Result<Self::Prover, OperationalError> {
+        let prove_db = self.inner.try_start_proof()?;
+        let prover = TracedDatabase::from(prove_db);
+
+        Ok(prover)
     }
 }
 

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -94,6 +94,33 @@ impl<KV> MerkleLayer<KV, Normal> {
     {
         self.inner.commit(options)
     }
+
+    /// Snapshot the current tree and enter prove mode.
+    ///
+    /// The returned layer holds two trees: an immutable `initial_tree` (a cheap `Clone` of the
+    /// Normal-mode tree) and a `working_tree` derived from it via [`Tree::into_proof`]. Mutations
+    /// during the proof step run against the working tree; the initial tree drives the
+    /// [`MerkleProofFold`] that generates the proof.
+    ///
+    /// [`MerkleProofFold`]: octez_riscv_data::merkle_proof::proof_tree::MerkleProofFold
+    pub fn start_proof(&self) -> MerkleLayer<KV, Prove<'static>> {
+        let initial_tree = self.inner.tree.clone();
+        let root_tree_hash = initial_tree.hash();
+        let resolver = ProveResolver::start(
+            LazyResolver::new(self.inner.persistence.clone()),
+            Some(root_tree_hash),
+        );
+        let working_tree = initial_tree.clone().into_proof(&resolver);
+        let initial_tree_id = LazyTreeId::from(initial_tree);
+
+        MerkleLayer {
+            inner: ProveImpl {
+                initial_tree: initial_tree_id,
+                working_tree,
+                resolver,
+            },
+        }
+    }
 }
 
 impl<KV> MerkleLayer<KV, Prove<'static>> {
@@ -713,33 +740,6 @@ mod tests {
                     Ok(Some(data))
                 }
                 None => Ok(None),
-            }
-        }
-
-        /// Snapshot the current tree and enter prove mode.
-        ///
-        /// The returned layer holds two trees: an immutable `initial_tree` (a cheap `Clone` of the
-        /// Normal-mode tree) and a `working_tree` derived from it via [`Tree::into_proof`]. Mutations
-        /// during the proof step run against the working tree; the initial tree drives the
-        /// [`MerkleProofFold`] that generates the proof.
-        ///
-        /// [`MerkleProofFold`]: octez_riscv_data::merkle_proof::proof_tree::MerkleProofFold
-        pub fn start_proof(&self) -> MerkleLayer<KV, Prove<'static>> {
-            let initial_tree = self.inner.tree.clone();
-            let root_tree_hash = initial_tree.hash();
-            let resolver = ProveResolver::start(
-                LazyResolver::new(self.inner.persistence.clone()),
-                Some(root_tree_hash),
-            );
-            let working_tree = initial_tree.clone().into_proof(&resolver);
-            let initial_tree_id = LazyTreeId::from(initial_tree);
-
-            MerkleLayer {
-                inner: ProveImpl {
-                    initial_tree: initial_tree_id,
-                    working_tree,
-                    resolver,
-                },
             }
         }
     }

--- a/durable-storage/src/merkle_worker.rs
+++ b/durable-storage/src/merkle_worker.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use octez_riscv_data::hash::Hash;
 use octez_riscv_data::mode::Normal;
+use octez_riscv_data::mode::Prove;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
@@ -398,6 +399,24 @@ impl<KV> MerkleWorker<KV> {
             .map_err(|_| OperationalError::WorkerThreadDied)?;
 
         receive()
+    }
+
+    /// See [`MerkleLayer::clone_with`].
+    pub(crate) fn start_proof(
+        &self,
+        store: Arc<KV>,
+    ) -> Result<MerkleLayer<KV, Prove<'static>>, OperationalError>
+    where
+        KV: BackgroundKeyValueStore,
+    {
+        let (receive, command) = Command::new_clone_with(store);
+        self.sender
+            .send(command)
+            .map_err(|_error| OperationalError::WorkerThreadDied)?;
+
+        let layer = receive()?;
+
+        Ok(layer.start_proof())
     }
 }
 

--- a/durable-storage/src/registry.rs
+++ b/durable-storage/src/registry.rs
@@ -23,6 +23,7 @@ use octez_riscv_data::hash::Hash;
 use octez_riscv_data::mode::Modal;
 use octez_riscv_data::mode::Mode;
 use octez_riscv_data::mode::Normal;
+use octez_riscv_data::mode::ProvableExt;
 use octez_riscv_data::mode::Prove;
 use octez_riscv_data::mode::Verify;
 use octez_riscv_data::serialisation::deserialise;
@@ -73,6 +74,29 @@ impl<KV: BackgroundKeyValueStore> Registry<KV, Normal> {
             .build()
             .map_err(|error| OperationalError::WorkerRuntimeCreationFailed { error })?;
         Ok(Arc::new(runtime))
+    }
+}
+
+impl<'normal, KV> ProvableExt<'normal, 'static, OperationalError> for Registry<KV, Normal>
+where
+    KV: BackgroundKeyValueStore,
+    KV::Repo: Clone,
+{
+    type Prover = Registry<KV, Prove<'static>>;
+
+    fn try_start_proof(&'normal self) -> Result<Self::Prover, OperationalError> {
+        let Self {
+            databases,
+            inner: NormalImpl { repo, .. },
+        } = self;
+
+        let databases = databases.try_start_proof()?;
+        let repo = repo.clone();
+
+        Ok(Registry {
+            inner: ProveImpl { repo },
+            databases,
+        })
     }
 }
 
@@ -443,12 +467,12 @@ struct VerifyImpl<KV: KeyValueStore>(PhantomData<KV>);
 #[cfg(test)]
 pub(super) mod tests {
     use std::marker::PhantomData;
-    use std::sync::Arc;
 
     use bytes::Bytes;
     use octez_riscv_data::components::vector::VectorMode;
     use octez_riscv_data::hash::Hash;
     use octez_riscv_data::mode::Normal;
+    use octez_riscv_data::mode::ProvableExt;
     use octez_riscv_data::mode::Prove;
     use octez_riscv_data::mode::Verify;
     use octez_riscv_data::serialisation::deserialise;
@@ -459,17 +483,14 @@ pub(super) mod tests {
     use super::RegistryManifest;
     use super::VerifyImpl;
     use crate::commit::CommitId;
-    use crate::database::tests::from_prove_layer;
     use crate::database::tests::to_verify;
     use crate::errors::Error;
     use crate::errors::InvalidArgumentError;
     use crate::errors::OperationalError;
     use crate::key::Key;
-    use crate::merkle_layer::MerkleLayer;
     use crate::merkle_worker::BackgroundKeyValueStore;
     use crate::merkle_worker::BackgroundPersistentKeyValueStore;
     use crate::repo::RegistryRepo;
-    use crate::storage::KeyValueStore;
     use crate::storage::TestKeyValueStoreSetup;
     use crate::storage::kv_test;
 
@@ -1133,33 +1154,28 @@ pub(super) mod tests {
         let key_a = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
         let key_b = Key::new(&[2]).expect("Size less than KEY_MAX_SIZE");
 
-        let mut normal_a = MerkleLayer::<KV, Normal>::new(Arc::new(
-            KV::new(&repo).expect("Persistence creation should succeed"),
-        ));
+        let mut registry = setup_size_2_registry(repo);
 
-        normal_a
-            .set(&key_a, b"foo")
+        let db_0 = registry.database_mut(0)
+            .expect("database at index 0 exists");
+
+        db_0.set(key_a.clone(), Bytes::copy_from_slice(b"foo"))
             .expect("Setting in Normal mode should succeed");
+        let db_0_hash = db_0.hash().expect("Hashing should succeed");
 
-        let mut normal_b = MerkleLayer::<KV, Normal>::new(Arc::new(
-            KV::new(&repo).expect("Persistence creation should succeed"),
-        ));
+        let db_1 = registry.database_mut(1)
+            .expect("database at index 1 exists");
 
-        normal_b
-            .set(&key_b, b"bar")
+        db_1.set(key_b.clone(), Bytes::copy_from_slice(b"bar"))
             .expect("Setting in Normal mode should succeed");
+        let db_1_hash = db_1.hash().expect("Hashing should succeed");
 
-        let expected_hashes = [normal_a.hash(), normal_b.hash()];
+        let expected_hashes = [db_0_hash, db_1_hash];
 
-        let prove_databases = vec![
-            from_prove_layer::<KV>(normal_a.start_proof()),
-            from_prove_layer::<KV>(normal_b.start_proof()),
-        ];
+        let root_hash = Hash::from_foldable(&registry);
 
-        let prove_registry = Registry::<KV, Prove<'static>> {
-            inner: ProveImpl { repo },
-            databases: <Prove<'static> as VectorMode>::new(prove_databases),
-        };
+        let prove_registry = registry.try_start_proof()
+            .expect("Converting to prove mode should succeed");
 
         let prove_hashes_before = (0..prove_registry.len())
             .map(|i| {
@@ -1171,6 +1187,9 @@ pub(super) mod tests {
             })
             .collect::<Vec<_>>();
         assert_eq!(prove_hashes_before.as_slice(), expected_hashes);
+
+        let root_hash_prove_before = Hash::from_foldable(&registry);
+        assert_eq!(root_hash_prove_before, root_hash, "Converting to proof mode concerves root hash");
 
         prove_registry
             .database(0)
@@ -1190,10 +1209,13 @@ pub(super) mod tests {
                     .expect("Hashing should succeed.")
             })
             .collect::<Vec<_>>();
+        let root_hash_prove_after = Hash::from_foldable(&registry);
+
         assert_eq!(
             prove_hashes_after, prove_hashes_before,
             "Reads must not affect Prove-mode hashes."
         );
+        assert_eq!(root_hash_prove_after, root_hash_prove_before, "Reads must not affect Prove-mode hashes");
 
         let verify_databases = (0..prove_registry.len())
             .map(|i| to_verify::<KV>(prove_registry.database(i).expect("Database should exist.")))

--- a/pvm/src/machine_state/memory/protection.rs
+++ b/pvm/src/machine_state/memory/protection.rs
@@ -31,6 +31,7 @@ use octez_riscv_data::merkle_proof::SuspendedResult;
 use octez_riscv_data::mode::Mode;
 use octez_riscv_data::mode::Normal;
 use octez_riscv_data::mode::Provable;
+use octez_riscv_data::mode::ProvableExt;
 use octez_riscv_data::mode::Prove;
 use octez_riscv_data::mode::Verify;
 use perfect_derive::perfect_derive;
@@ -134,7 +135,7 @@ impl<'normal> Provable<'normal> for PagePermissions<Normal> {
     type Prover = PagePermissions<Prove<'normal>>;
 
     fn start_proof(&'normal self) -> Self::Prover {
-        let pages = self.pages.start_proof();
+        let Ok(pages) = self.pages.try_start_proof();
         PagePermissions { pages }
     }
 }

--- a/pvm/src/pvm/outbox.rs
+++ b/pvm/src/pvm/outbox.rs
@@ -53,6 +53,7 @@ use octez_riscv_data::merkle_proof::proof_tree::OwnedProofTree;
 use octez_riscv_data::mode::Mode;
 use octez_riscv_data::mode::Normal;
 use octez_riscv_data::mode::Provable;
+use octez_riscv_data::mode::ProvableExt;
 use octez_riscv_data::mode::Prove;
 use octez_riscv_data::mode::Verify;
 use octez_riscv_data::serialisation::deserialise_from;
@@ -204,9 +205,9 @@ impl<'normal> Provable<'normal> for Outbox<Normal> {
     type Prover = Outbox<Prove<'normal>>;
 
     fn start_proof(&'normal self) -> Self::Prover {
-        Outbox {
-            levels: self.levels.start_proof(),
-        }
+        let Ok(levels) = self.levels.try_start_proof();
+
+        Outbox { levels }
     }
 }
 
@@ -399,8 +400,10 @@ impl<'normal> Provable<'normal> for OutboxLevel<Normal> {
     type Prover = OutboxLevel<Prove<'normal>>;
 
     fn start_proof(&'normal self) -> Self::Prover {
+        let Ok(messages) = self.messages.try_start_proof();
+
         OutboxLevel {
-            messages: self.messages.start_proof(),
+            messages,
             level: self.level.start_proof(),
         }
     }


### PR DESCRIPTION
- Closes TZX-133
- Part of TZX-113

# What

Expose `Registry::try_start_proof` for converting a normal mode registry into a provable one

# Why

Required as part of the integration into octez

# How

We add a new extended variant of `Provable`: `ProvableExt` - which the database, and the vector used by the registry, both implement. 

This is done this way, to avoid having to update all `Provable` instances in the codebase at all, they all work with `ProvableExt` out the box, when it's needed.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
