### PR TITLE
test(data): improve UX for proof benchmark, adding CLAP args

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
             make-target: test
             title: Linux Tests
           - runs-on: ubuntu-latest
+            make-target: bench
+            title: Linux Component Benches
+          - runs-on: ubuntu-latest
             make-target: codecov.json
             code-coverage: true
             title: Code Coverage

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,6 +2495,7 @@ dependencies = [
  "bincode",
  "blake3",
  "bytes",
+ "clap",
  "derive_more",
  "goldenfile",
  "hex",

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,17 @@ rustfmt-check:
 
 test: jstz/test etherlink/test durable/test cargo-nextest-run cargo-test-doc
 
+bench:
+	@cargo bench --bench proof --features='unstable-test-utils' -- \
+		--metric length \
+		--metric verifytime \
+		--metric verifyallocs \
+		--metric verifybytesalloc \
+		--metric verifymaxalloc \
+		--metric verifymaxrollingallocs \
+		--metric verifymaxbytesalloc \
+		--attempts 200
+
 test-deps: dummy/build page-cache-tester/build dummy-no-std/build
 
 codecov.json: test-deps
@@ -106,4 +117,4 @@ docs/%:
 	@make -C docs ${@:docs/%=%}
 
 # Mark all non-pattern targets as phony to make sure they're always executed
-.PHONY: all build-deps build-deps-slim check check-nix check-format taplo-check-format rustfmt-check codecov.json audit build test test-deps clean cargo-nextest-run cargo-test-doc cargo-clean
+.PHONY: all build-deps build-deps-slim check check-nix check-format taplo-check-format rustfmt-check codecov.json audit build test test-deps clean cargo-nextest-run cargo-test-doc cargo-clean bench

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -13,7 +13,6 @@ unstable-test-utils = ["dep:proptest"]
 [dependencies]
 bincode.workspace = true
 blake3.workspace = true
-derive_more.workspace = true
 hex.workspace = true
 thiserror.workspace = true
 perfect-derive.workspace = true
@@ -22,6 +21,10 @@ memmap2.workspace = true
 range-collections.workspace = true
 bytes.workspace = true
 unty.workspace = true
+
+[dependencies.derive_more]
+workspace = true
+features = ["from_str"]
 
 [dependencies.proptest]
 workspace = true
@@ -32,6 +35,7 @@ proptest.workspace = true
 rand.workspace = true
 humansize.workspace = true
 goldenfile.workspace = true
+clap.workspace = true
 
 [[bench]]
 name = "proof"

--- a/data/benches/proof.rs
+++ b/data/benches/proof.rs
@@ -11,6 +11,8 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 use std::time::Instant;
 
+use clap::Parser;
+use derive_more::FromStr;
 use humansize::BINARY;
 use humansize::format_size;
 use octez_riscv_data::components::bytes::Bytes;
@@ -25,6 +27,35 @@ use octez_riscv_data::serialisation::serialise;
 use proptest::prelude::Strategy;
 use proptest::strategy::ValueTree;
 use proptest::test_runner::TestRunner;
+
+/// The different metrics that measure proof badness of different kinds.
+#[derive(FromStr, Parser, Debug, Clone)]
+enum ProofMetric {
+    Length,
+    VerifyTime,
+    VerifyAllocs,
+    VerifyBytesAlloc,
+    VerifyMaxAlloc,
+    VerifyMaxRollingAllocs,
+    VerifyMaxBytesAlloc,
+}
+
+/// Command line args to specify how long to search, and which metrics to consider.
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+    /// Proof metrics to explore.
+    #[arg(short, long)]
+    metric: Vec<ProofMetric>,
+
+    /// Number of attempts to make.
+    #[arg(short, long)]
+    attempts: usize,
+
+    /// This will be true: it's always there because of how `cargo bench` works.
+    #[arg(long)]
+    bench: bool,
+}
 
 /// A struct to count the allocations or deallocations, compiles summary statistics from a sequence
 /// of `Layout`s.
@@ -310,62 +341,76 @@ fn proof_max_rolling_bytes(state: &Bytes<Normal>, op: &BytesMutOp) -> usize {
 }
 
 fn main() {
-    let (worst_op, eval) = find_worst(
-        BytesMutOp::any(NDS_BYTES_LENGTH),
-        init_state,
-        proof_size,
-        1000,
-    );
-    println!("Biggest: {worst_op:?}, {}", format_size(eval, BINARY));
+    let args = Args::parse();
 
-    let (worst_op, eval) = find_worst(
-        BytesMutOp::any(NDS_BYTES_LENGTH),
-        init_state,
-        proof_time,
-        1000,
-    );
-    println!("Slowest: {worst_op:?}, {eval:?}");
-
-    let (worst_op, eval) = find_worst(
-        BytesMutOp::any(NDS_BYTES_LENGTH),
-        init_state,
-        proof_allocs,
-        1000,
-    );
-    println!("Most allocs: {worst_op:?}, {eval:?}");
-
-    let (worst_op, eval) = find_worst(
-        BytesMutOp::any(NDS_BYTES_LENGTH),
-        init_state,
-        proof_alloc_bytes,
-        1000,
-    );
-    println!("Most bytes: {worst_op:?}, {}", format_size(eval, BINARY));
-
-    let (worst_op, eval) = find_worst(
-        BytesMutOp::any(NDS_BYTES_LENGTH),
-        init_state,
-        proof_biggest_alloc,
-        1000,
-    );
-    println!("Biggest alloc: {worst_op:?}, {}", format_size(eval, BINARY));
-
-    let (worst_op, eval) = find_worst(
-        BytesMutOp::any(NDS_BYTES_LENGTH),
-        init_state,
-        proof_max_rolling_allocs,
-        1000,
-    );
-    println!("Most allocs at once: {worst_op:?}, {eval:?}");
-
-    let (worst_op, eval) = find_worst(
-        BytesMutOp::any(NDS_BYTES_LENGTH),
-        init_state,
-        proof_max_rolling_bytes,
-        1000,
-    );
-    println!(
-        "Most bytes allocated at once: {worst_op:?}, {}",
-        format_size(eval, BINARY)
-    );
+    for metric in args.metric {
+        match metric {
+            ProofMetric::Length => {
+                let (worst_op, eval) = find_worst(
+                    BytesMutOp::any(NDS_BYTES_LENGTH),
+                    init_state,
+                    proof_size,
+                    args.attempts,
+                );
+                println!("Biggest: {worst_op:?}, {}", format_size(eval, BINARY));
+            }
+            ProofMetric::VerifyTime => {
+                let (worst_op, eval) = find_worst(
+                    BytesMutOp::any(NDS_BYTES_LENGTH),
+                    init_state,
+                    proof_time,
+                    args.attempts,
+                );
+                println!("Slowest: {worst_op:?}, {eval:?}");
+            }
+            ProofMetric::VerifyAllocs => {
+                let (worst_op, eval) = find_worst(
+                    BytesMutOp::any(NDS_BYTES_LENGTH),
+                    init_state,
+                    proof_allocs,
+                    args.attempts,
+                );
+                println!("Most allocs: {worst_op:?}, {eval:?}");
+            }
+            ProofMetric::VerifyBytesAlloc => {
+                let (worst_op, eval) = find_worst(
+                    BytesMutOp::any(NDS_BYTES_LENGTH),
+                    init_state,
+                    proof_alloc_bytes,
+                    args.attempts,
+                );
+                println!("Most bytes: {worst_op:?}, {}", format_size(eval, BINARY));
+            }
+            ProofMetric::VerifyMaxAlloc => {
+                let (worst_op, eval) = find_worst(
+                    BytesMutOp::any(NDS_BYTES_LENGTH),
+                    init_state,
+                    proof_biggest_alloc,
+                    args.attempts,
+                );
+                println!("Biggest alloc: {worst_op:?}, {}", format_size(eval, BINARY));
+            }
+            ProofMetric::VerifyMaxRollingAllocs => {
+                let (worst_op, eval) = find_worst(
+                    BytesMutOp::any(NDS_BYTES_LENGTH),
+                    init_state,
+                    proof_max_rolling_allocs,
+                    args.attempts,
+                );
+                println!("Most allocs at once: {worst_op:?}, {eval:?}");
+            }
+            ProofMetric::VerifyMaxBytesAlloc => {
+                let (worst_op, eval) = find_worst(
+                    BytesMutOp::any(NDS_BYTES_LENGTH),
+                    init_state,
+                    proof_max_rolling_bytes,
+                    args.attempts,
+                );
+                println!(
+                    "Most bytes allocated at once: {worst_op:?}, {}",
+                    format_size(eval, BINARY)
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
Closes RV-1003.
Closes RV-988.

# What

Add command line arguments to the benchmark for exploring proofs. Add a (short) run of the benchmark in CI to prevent it getting stale.

# Why

At some point we'll want to run different configurations of this benchmark in more or less long-running CI tasks. It's also useful to be able to set it running locally with a very large number of attempts, or just run one out of the seven different metrics, etc.

# Manually Testing

E.g.

```
cargo bench --bench proof --features='unstable-test-utils' -- --metric verifytime --attempts 2000
```

# Tasks for the Author

- [ ] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [ ] Eliminate dead code and other spurious artefacts introduced in your changes.
- [ ] Document new public functions, methods and types.
- [ ] Make sure the documentation for updated functions, methods, and types is correct.
- [ ] Add tests for bugs that have been fixed.
- [ ] [Explain changes](#regressions) to regression test captures when applicable.
- [ ] Write commit messages in agreement with our guidelines.
- [ ] Self-review your changes to ensure they are high-quality.
- [ ] Complete all of the above before assigning this MR to reviewers.
