### PR TITLE
fix(bench): ensure database_write_all fully overwrites previous value

### DIFF
--- a/durable-storage/benches/erc20_core/mod.rs
+++ b/durable-storage/benches/erc20_core/mod.rs
@@ -270,10 +270,7 @@ pub fn bench_run(mut state: BenchmarkState<'_>) {
                     &mut state.read_buffer[..size],
                 ) {
                     Ok(read) => {
-                        assert_eq!(
-                            read, size,
-                            "Failed to read exactly {size} bytes from storage"
-                        );
+                        assert!(read <= size, "Read more than {size} bytes from storage");
                     }
                     Err(Error::InvalidArgument(InvalidArgumentError::KeyNotFound)) => {}
                     Err(e) => panic!("The read should succeed: {e:?}"),
@@ -333,7 +330,11 @@ fn database_write_all(
     if data.is_empty() {
         return database.set(key, Bytes::new());
     }
-    let mut offset = 0;
+
+    let set_len = data.len().min(MAX_FILE_CHUNK_SIZE);
+    database.set(key.clone(), Bytes::copy_from_slice(&data[..set_len]))?;
+
+    let mut offset = set_len;
     while offset < data.len() {
         let end = (offset + MAX_FILE_CHUNK_SIZE).min(data.len());
         database.write(


### PR DESCRIPTION


# What

Fix the performance of the `database` benchmark.

# Why

#1025, although fixing the benchmark from a fully broken state, introduced a major performance regression in the benchmark - which unfortunately I didn't spot myself, as the benchmark was previously in a broken state for myself.

# How

Ensure we actually overwrite values when using `write_all`. It appears that non-append writes are a very large performance hit in rocksdb (not yet fully uncovered why, but I suspect the symptom of `read` being slow is that rocksdb is stuck on processing previous writes still).

Worth noting: we now no longer read exactly `size` bytes from storage: it may be less, as the value might have been overwritten.

This is worth noting, and requires further investigation as to whether this means we're actually performing fewer reads than expected. (related to [RV-1006](https://linear.app/tezos/issue/RV-1006/database-bench-ensure-large-reads-are-accurately-measured))

# Manually Testing

```
BLOCK_FREQUENCY=100 ERC_20_TRANSACTION_COUNT=10000 PREPOPULATED_NODE_KEYS_COUNT=100 cargo bench  -p octez-riscv-durable-storage --bench database
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
