### PR TITLE
test(dursto): add end to end traced PBT for Database

### DIFF
--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -587,6 +587,11 @@ impl<KV: BackgroundKeyValueStore, M: DatabaseMode> Database<KV, M> {
 mod traced_database;
 
 #[cfg(test)]
+pub(crate) use self::traced_database::Trace;
+#[cfg(test)]
+pub(crate) use self::traced_database::TracedDatabase;
+
+#[cfg(test)]
 pub(crate) mod tests {
     use std::collections::HashSet;
     use std::sync::Arc;

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -2229,4 +2229,19 @@ pub(crate) mod tests {
 
         database.into_trace()
     });
+
+    kv_test!(test_database_end_to_end, KV: BackgroundPersistentKeyValueStore,
+    [
+        generated in crate::test_helpers::database_operations_strategy(1usize..100)
+    ],
+    {
+        // Every test iteration expects an empty repo, so not setting it in a `setup` block.
+        // This is because a repo preserves database commits from previous test runs, resulting
+        // in test failures when checking out a commit which isn't expected to exist succeeds.
+        let (_keepalive, repo) = KV::setup_repo();
+
+        let (keys, values, ops) = generated;
+        let operations = crate::test_helpers::make_database_operations(keys, values, ops);
+        crate::test_helpers::run_database_operations::<KV>(&repo, operations)
+    });
 }

--- a/durable-storage/src/registry.rs
+++ b/durable-storage/src/registry.rs
@@ -75,6 +75,12 @@ impl<KV: BackgroundKeyValueStore> Registry<KV, Normal> {
             .map_err(|error| OperationalError::WorkerRuntimeCreationFailed { error })?;
         Ok(Arc::new(runtime))
     }
+
+    /// Get a [`Handle`] to the registry's runtime.
+    #[cfg(any(test, feature = "unstable-test-utils"))]
+    pub(crate) fn handle(&self) -> &tokio::runtime::Handle {
+        self.inner.runtime.handle()
+    }
 }
 
 impl<'normal, KV> ProvableExt<'normal, 'static, OperationalError> for Registry<KV, Normal>
@@ -1443,14 +1449,16 @@ pub(super) mod tests {
 
     kv_test!(test_durable_storage_end_to_end, KV: BackgroundPersistentKeyValueStore,
     [
-        generated in crate::test_helpers::operations_strategy(1usize..100)
+        generated in crate::test_helpers::registry_operations_strategy(1usize..100)
     ],
     {
-        // Every test iteration expects an empty repo, so not setting it in a `setup` block
+        // Every test iteration expects an empty repo, so not setting it in a `setup` block.
+        // This is because a repo preserves registry commits from previous test runs, resulting
+        // in test failures when checking out a commit which isn't expected to exist succeeds.
         let (_keepalive, repo) = KV::setup_repo();
 
         let (keys, values, ops) = generated;
-        let operations = crate::test_helpers::make_operations(keys, values, ops);
+        let operations = crate::test_helpers::make_registry_operations(keys, values, ops);
         crate::test_helpers::run_operations::<KV>(repo, operations)
     });
 }

--- a/durable-storage/src/test_helpers.rs
+++ b/durable-storage/src/test_helpers.rs
@@ -7,8 +7,8 @@
 
 //! Shared utilities for end to end durable storage property-based tests
 //!
-//! Used by the integration test in `tests/integration_test.rs` and
-//! its in-crate `kv_test!` mirror in `registry.rs`.
+//! Used by the integration test in `tests/integration_test.rs` and in-crate
+//! `kv_test!`s for `registry.rs` and `database.rs`.
 
 use std::collections::HashMap;
 
@@ -18,17 +18,28 @@ use octez_riscv_data::mode::Normal;
 use proptest::prelude::*;
 use proptest::sample::Index;
 use tezos_smart_rollup_constants::core::MAX_FILE_CHUNK_SIZE;
+use tokio::runtime::Handle;
 
 use crate::commit::CommitId;
+use crate::database::Database;
+#[cfg(test)]
+use crate::database::Trace;
+#[cfg(test)]
+use crate::database::TracedDatabase;
+use crate::errors::Error;
+use crate::errors::OperationalError;
 use crate::key::KEY_MAX_SIZE;
 use crate::key::Key;
 use crate::merkle_worker::BackgroundPersistentKeyValueStore;
 use crate::registry::Registry;
 use crate::repo::RegistryRepo;
 
+/// Maximum size for the value argument of a sampled operation
+pub const VALUE_MAX_SIZE: usize = 10_000;
+
+/// Operations on a single [`Database`]
 #[derive(Debug, Clone)]
-pub enum Operation {
-    // Database operations
+pub enum DatabaseOperation {
     Set(Key, Bytes),
     Write(Key, usize, Bytes),
     Read(Key, usize, usize),
@@ -38,8 +49,12 @@ pub enum Operation {
     Hash,
     Commit,
     Checkout,
+}
 
-    // Registry operations
+/// Operations on a [`Registry`]
+#[derive(Debug, Clone)]
+pub enum Operation {
+    Database(DatabaseOperation),
     GrowRegistry,
     ShrinkRegistry,
     CopyDatabase,
@@ -47,11 +62,8 @@ pub enum Operation {
     ClearDatabase,
 }
 
-pub const VALUE_MAX_SIZE: usize = 10_000;
-
 #[derive(Debug, Clone)]
-pub enum OperationView {
-    // Database operations
+pub enum DatabaseOperationView {
     Set(Index, Index),
     Write(Index, usize, Index),
     Read(Index, usize, usize),
@@ -61,8 +73,11 @@ pub enum OperationView {
     Hash,
     Commit,
     Checkout,
+}
 
-    // Registry operations
+#[derive(Debug, Clone)]
+pub enum OperationView {
+    Database(DatabaseOperationView),
     GrowRegistry,
     ShrinkRegistry,
     CopyDatabase,
@@ -70,33 +85,49 @@ pub enum OperationView {
     ClearDatabase,
 }
 
-pub fn make_operations(
+fn make_database_operation(
+    keys: &[Key],
+    values: &[Bytes],
+    view: DatabaseOperationView,
+) -> DatabaseOperation {
+    match view {
+        DatabaseOperationView::Set(k_idx, v_idx) => DatabaseOperation::Set(
+            keys[k_idx.index(keys.len())].clone(),
+            values[v_idx.index(values.len())].clone(),
+        ),
+        DatabaseOperationView::Write(k_idx, offset, v_idx) => DatabaseOperation::Write(
+            keys[k_idx.index(keys.len())].clone(),
+            offset,
+            values[v_idx.index(values.len())].clone(),
+        ),
+        DatabaseOperationView::Read(k_idx, offset, len) => {
+            DatabaseOperation::Read(keys[k_idx.index(keys.len())].clone(), offset, len)
+        }
+        DatabaseOperationView::Delete(idx) => {
+            DatabaseOperation::Delete(keys[idx.index(keys.len())].clone())
+        }
+        DatabaseOperationView::Exists(idx) => {
+            DatabaseOperation::Exists(keys[idx.index(keys.len())].clone())
+        }
+        DatabaseOperationView::ValueLength(idx) => {
+            DatabaseOperation::ValueLength(keys[idx.index(keys.len())].clone())
+        }
+        DatabaseOperationView::Hash => DatabaseOperation::Hash,
+        DatabaseOperationView::Commit => DatabaseOperation::Commit,
+        DatabaseOperationView::Checkout => DatabaseOperation::Checkout,
+    }
+}
+
+pub fn make_registry_operations(
     keys: Vec<Key>,
     values: Vec<Bytes>,
     ops: Vec<OperationView>,
 ) -> Vec<Operation> {
     ops.into_iter()
         .map(|op| match op {
-            OperationView::Set(k_idx, v_idx) => Operation::Set(
-                keys[k_idx.index(keys.len())].clone(),
-                values[v_idx.index(values.len())].clone(),
-            ),
-            OperationView::Write(k_idx, offset, v_idx) => Operation::Write(
-                keys[k_idx.index(keys.len())].clone(),
-                offset,
-                values[v_idx.index(values.len())].clone(),
-            ),
-            OperationView::Read(k_idx, offset, len) => {
-                Operation::Read(keys[k_idx.index(keys.len())].clone(), offset, len)
+            OperationView::Database(view) => {
+                Operation::Database(make_database_operation(&keys, &values, view))
             }
-            OperationView::Delete(idx) => Operation::Delete(keys[idx.index(keys.len())].clone()),
-            OperationView::Exists(idx) => Operation::Exists(keys[idx.index(keys.len())].clone()),
-            OperationView::ValueLength(idx) => {
-                Operation::ValueLength(keys[idx.index(keys.len())].clone())
-            }
-            OperationView::Hash => Operation::Hash,
-            OperationView::Commit => Operation::Commit,
-            OperationView::Checkout => Operation::Checkout,
             OperationView::GrowRegistry => Operation::GrowRegistry,
             OperationView::ShrinkRegistry => Operation::ShrinkRegistry,
             OperationView::CopyDatabase => Operation::CopyDatabase,
@@ -115,58 +146,76 @@ fn value_strategy() -> impl Strategy<Value = Bytes> {
     proptest::collection::vec(any::<u8>(), 1usize..=VALUE_MAX_SIZE).prop_map(Bytes::from)
 }
 
-pub fn operations_strategy(
+fn database_operation_view_strategy() -> impl Strategy<Value = DatabaseOperationView> {
+    let set = (any::<Index>(), any::<Index>()).prop_map(|(k, v)| DatabaseOperationView::Set(k, v));
+
+    let read = (
+        any::<Index>(),
+        prop_oneof![
+            2 => Just(0),
+            1 => 1..=VALUE_MAX_SIZE,
+        ],
+        0..=VALUE_MAX_SIZE,
+    )
+        .prop_map(|(k, off, len)| DatabaseOperationView::Read(k, off, len));
+
+    // Writes biased towards valid offsets
+    let write_valid = (
+        any::<Index>(),
+        prop_oneof![
+            2 => Just(0),
+            1 => 1..=VALUE_MAX_SIZE,
+        ],
+        any::<Index>(),
+    )
+        .prop_map(|(k, off, v)| DatabaseOperationView::Write(k, off, v));
+
+    // Writes biased towards out-of-bounds offsets
+    let write_invalid = (any::<Index>(), VALUE_MAX_SIZE..=usize::MAX, any::<Index>())
+        .prop_map(|(k, off, v)| DatabaseOperationView::Write(k, off, v));
+
+    // The chosen frequencies emulate real workloads
+    prop_oneof![
+        20 => set,
+        20 => read,
+        3 => write_valid,
+        2 => write_invalid,
+
+        10 => any::<Index>().prop_map(DatabaseOperationView::Delete),
+        10 => any::<Index>().prop_map(DatabaseOperationView::Exists),
+        5 => any::<Index>().prop_map(DatabaseOperationView::ValueLength),
+        10 => Just(DatabaseOperationView::Hash),
+        3 => Just(DatabaseOperationView::Commit),
+        3 => Just(DatabaseOperationView::Checkout),
+    ]
+}
+
+pub fn database_operations_strategy(
+    length: impl Strategy<Value = usize>,
+) -> impl Strategy<Value = (Vec<Key>, Vec<Bytes>, Vec<DatabaseOperationView>)> {
+    length.prop_flat_map(|length| {
+        let count = length.div_ceil(10);
+        (
+            proptest::collection::vec(key_strategy(), count),
+            proptest::collection::vec(value_strategy(), count),
+            proptest::collection::vec(database_operation_view_strategy(), length),
+        )
+    })
+}
+
+pub fn registry_operations_strategy(
     length: impl Strategy<Value = usize>,
 ) -> impl Strategy<Value = (Vec<Key>, Vec<Bytes>, Vec<OperationView>)> {
     length.prop_flat_map(|length| {
         let count = length.div_ceil(10);
-        let set = (any::<Index>(), any::<Index>()).prop_map(|(k, v)| OperationView::Set(k, v));
-
-        let read = (
-            any::<Index>(),
-            prop_oneof![
-                2 => Just(0),
-                1 => 1..=VALUE_MAX_SIZE,
-            ],
-            0..=VALUE_MAX_SIZE,
-        )
-            .prop_map(|(k, off, len)| OperationView::Read(k, off, len));
-
-        // Writes biased towards valid offsets
-        let write_valid = (
-            any::<Index>(),
-            prop_oneof![
-                2 => Just(0),
-                1 => 1..=VALUE_MAX_SIZE,
-            ],
-            any::<Index>(),
-        )
-            .prop_map(|(k, off, v)| OperationView::Write(k, off, v));
-
-        // Writes biased towards out-of-bounds offsets
-        let write_invalid = (any::<Index>(), VALUE_MAX_SIZE..=usize::MAX, any::<Index>())
-            .prop_map(|(k, off, v)| OperationView::Write(k, off, v));
 
         (
             proptest::collection::vec(key_strategy(), count),
             proptest::collection::vec(value_strategy(), count),
-            // The chosen frequencies emulate real workloads
             proptest::collection::vec(
+                // The chosen frequencies emulate real workloads
                 prop_oneof![
-                    // Database operations
-                    20 => set,
-                    20 => read,
-                    3 => write_valid,
-                    2 => write_invalid,
-
-                    10 => any::<Index>().prop_map(OperationView::Delete),
-                    10 => any::<Index>().prop_map(OperationView::Exists),
-                    5 => any::<Index>().prop_map(OperationView::ValueLength),
-                    10 => Just(OperationView::Hash),
-                    3 => Just(OperationView::Commit),
-                    3 => Just(OperationView::Checkout),
-
-                    // Registry operations
+                    86 => database_operation_view_strategy().prop_map(OperationView::Database),
                     3 => Just(OperationView::GrowRegistry),
                     2 => Just(OperationView::ShrinkRegistry),
                     2 => Just(OperationView::CopyDatabase),
@@ -236,6 +285,228 @@ fn update_value(value: &mut Bytes, offset: usize, bytes: Bytes) {
     *value = Bytes::copy_from_slice(&new_value);
 }
 
+/// Abstracts the interface of [`Database`] so [`apply_database_operation`]
+/// can be used in both [`Registry`] (via [`Database`] references) and
+/// the `Database` tests which use [`TracedDatabase`] to capture a trace.
+trait DatabaseOps<KV: BackgroundPersistentKeyValueStore>: Sized {
+    fn set(&mut self, key: Key, data: Bytes) -> Result<(), Error>;
+
+    fn write(&mut self, key: Key, offset: usize, data: Bytes) -> Result<usize, Error>;
+
+    fn delete(&mut self, key: Key) -> Result<(), OperationalError>;
+
+    fn read(&self, key: &Key, offset: usize, output: &mut [u8]) -> Result<usize, Error>;
+
+    fn exists(&self, key: &Key) -> Result<bool, Error>;
+
+    fn value_length(&self, key: &Key) -> Result<usize, Error>;
+
+    fn hash(&self) -> Result<Hash, OperationalError>;
+
+    fn commit(&self, repo: &KV::Repo) -> Result<CommitId, OperationalError>;
+
+    fn checkout(handle: &Handle, repo: &KV::Repo, commit_id: CommitId) -> Result<Self, Error>;
+}
+
+impl<KV: BackgroundPersistentKeyValueStore> DatabaseOps<KV> for Database<KV, Normal> {
+    fn set(&mut self, key: Key, data: Bytes) -> Result<(), Error> {
+        Database::set(self, key, data)
+    }
+
+    fn write(&mut self, key: Key, offset: usize, data: Bytes) -> Result<usize, Error> {
+        Database::write(self, key, offset, data)
+    }
+
+    fn delete(&mut self, key: Key) -> Result<(), OperationalError> {
+        Database::delete(self, key)
+    }
+
+    fn read(&self, key: &Key, offset: usize, output: &mut [u8]) -> Result<usize, Error> {
+        Database::read(self, key, offset, output)
+    }
+
+    fn exists(&self, key: &Key) -> Result<bool, Error> {
+        Database::exists(self, key)
+    }
+
+    fn value_length(&self, key: &Key) -> Result<usize, Error> {
+        Database::value_length(self, key)
+    }
+
+    fn hash(&self) -> Result<Hash, OperationalError> {
+        Database::hash(self)
+    }
+
+    fn commit(&self, repo: &KV::Repo) -> Result<CommitId, OperationalError> {
+        Database::commit(self, repo)
+    }
+
+    fn checkout(handle: &Handle, repo: &KV::Repo, commit_id: CommitId) -> Result<Self, Error> {
+        Database::checkout(handle, repo, commit_id)
+    }
+}
+
+#[cfg(test)]
+impl<KV: BackgroundPersistentKeyValueStore> DatabaseOps<KV> for TracedDatabase<KV, Normal> {
+    fn set(&mut self, key: Key, data: Bytes) -> Result<(), Error> {
+        TracedDatabase::set(self, key, data)
+    }
+
+    fn write(&mut self, key: Key, offset: usize, data: Bytes) -> Result<usize, Error> {
+        TracedDatabase::write(self, key, offset, data)
+    }
+
+    fn delete(&mut self, key: Key) -> Result<(), OperationalError> {
+        TracedDatabase::delete(self, key)
+    }
+
+    fn read(&self, key: &Key, offset: usize, output: &mut [u8]) -> Result<usize, Error> {
+        TracedDatabase::read(self, key, offset, output)
+    }
+
+    fn exists(&self, key: &Key) -> Result<bool, Error> {
+        TracedDatabase::exists(self, key)
+    }
+
+    fn value_length(&self, key: &Key) -> Result<usize, Error> {
+        TracedDatabase::value_length(self, key)
+    }
+
+    fn hash(&self) -> Result<Hash, OperationalError> {
+        TracedDatabase::hash(self)
+    }
+
+    fn commit(&self, repo: &KV::Repo) -> Result<CommitId, OperationalError> {
+        TracedDatabase::commit(self, repo)
+    }
+
+    fn checkout(handle: &Handle, repo: &KV::Repo, commit_id: CommitId) -> Result<Self, Error> {
+        TracedDatabase::checkout(handle, repo, commit_id)
+    }
+}
+
+fn apply_database_operation<KV, D>(
+    database: &mut D,
+    golden: &mut GoldenData,
+    op: DatabaseOperation,
+    handle: &Handle,
+    repo: &KV::Repo,
+    checkout_candidates: &mut HashMap<Hash, bool>,
+) where
+    KV: BackgroundPersistentKeyValueStore,
+    D: DatabaseOps<KV>,
+{
+    match op {
+        DatabaseOperation::Set(key, bytes) => {
+            let data = Bytes::copy_from_slice(&bytes);
+            let result = database.set(key.clone(), data);
+
+            if bytes.len() <= MAX_FILE_CHUNK_SIZE {
+                assert!(
+                    result.is_ok(),
+                    "Set should have succeeded but failed: {:?}",
+                    result.err()
+                );
+
+                golden.seen.insert(key, bytes.clone());
+            } else {
+                assert!(result.is_err(), "Set should have failed but succeeded");
+            }
+        }
+        DatabaseOperation::Write(key, offset, bytes) => {
+            let data = Bytes::copy_from_slice(&bytes);
+            let result = database.write(key.clone(), offset, data);
+
+            let should_succeed = if let Some(map_value) = golden.seen.get_mut(&key) {
+                if offset > map_value.len()
+                    || offset.checked_add(bytes.len()).is_none()
+                    || bytes.len() > MAX_FILE_CHUNK_SIZE
+                {
+                    false
+                } else {
+                    update_value(map_value, offset, bytes);
+                    true
+                }
+            } else if offset > 0 || bytes.len() > MAX_FILE_CHUNK_SIZE {
+                false
+            } else {
+                golden.seen.insert(key, bytes);
+                true
+            };
+
+            if should_succeed {
+                assert!(
+                    result.is_ok(),
+                    "Write should have succeeded but failed: {:?}",
+                    result.err()
+                );
+            } else {
+                assert!(result.is_err(), "Write should have failed but succeeded");
+            }
+        }
+        DatabaseOperation::Read(key, offset, len) => {
+            let mut database_value = vec![0; len];
+
+            let mut cursor = 0;
+            let mut result = database.read(&key, offset + cursor, &mut database_value[cursor..]);
+
+            while let Ok(read) = result {
+                if read == 0 {
+                    break;
+                }
+                cursor += read;
+                result = database.read(&key, offset + cursor, &mut database_value[cursor..])
+            }
+
+            if let Some(map_value) = golden.seen.get(&key) {
+                if offset > map_value.len() || len > MAX_FILE_CHUNK_SIZE {
+                    assert!(result.is_err());
+                } else {
+                    let expected_len = std::cmp::min(len, map_value.len() - offset);
+                    assert!(cursor >= expected_len);
+                    assert_eq!(
+                        &database_value[..expected_len],
+                        &map_value[offset..offset + expected_len]
+                    );
+                }
+            } else {
+                assert!(result.is_err());
+            }
+        }
+        DatabaseOperation::Delete(key) => {
+            // The hash of the `Database` can differ even if the key-value pairs stored are
+            // the same, because deletion and reinsertion can cause the shape of the AVL
+            // tree to change.
+            let deleted = golden.seen.remove(&key).is_some();
+            if deleted {
+                golden.ambiguous_hash = true;
+            }
+
+            database.delete(key).expect("Deleting should succeed");
+        }
+        DatabaseOperation::Exists(key) => {
+            let in_database = database.exists(&key).expect("Writing should succeed");
+            let in_map = golden.seen.contains_key(&key);
+            assert_eq!(in_database, in_map);
+        }
+        DatabaseOperation::ValueLength(key) => {
+            let database_length = database.value_length(&key);
+            let map_value = golden.seen.get(&key);
+
+            match (database_length, map_value) {
+                (Ok(database_length), Some(map_value)) => {
+                    assert_eq!(database_length, map_value.len())
+                }
+                (Err(_), None) => (),
+                _ => panic!("The value exists in one map but not the other"),
+            }
+        }
+        DatabaseOperation::Hash | DatabaseOperation::Commit | DatabaseOperation::Checkout => {
+            unreachable!("Intercepted by `apply_database_operation`")
+        }
+    }
+}
+
 pub fn run_operations<KV>(repo: KV::Repo, operations: Vec<Operation>)
 where
     KV: BackgroundPersistentKeyValueStore,
@@ -251,149 +522,7 @@ where
 
     for operation in operations {
         match operation {
-            // Database operations
-            Operation::Set(key, bytes) => {
-                let index = get_index(&mut registry, &mut golden);
-
-                let data = Bytes::copy_from_slice(&bytes);
-
-                let result = registry
-                    .database_mut(index)
-                    .expect("The index is in bounds")
-                    .set(key.clone(), data);
-
-                if bytes.len() <= MAX_FILE_CHUNK_SIZE {
-                    assert!(
-                        result.is_ok(),
-                        "Set should have succeeded but failed: {:?}",
-                        result.err()
-                    );
-
-                    golden[index].seen.insert(key, bytes.clone());
-                } else {
-                    assert!(result.is_err(), "Set should have failed but succeeded");
-                }
-            }
-            Operation::Write(key, offset, bytes) => {
-                let data = Bytes::copy_from_slice(&bytes);
-                let index = get_index(&mut registry, &mut golden);
-
-                let result = registry
-                    .database_mut(index)
-                    .expect("The index is in bounds")
-                    .write(key.clone(), offset, data);
-
-                let should_succeed = if let Some(map_value) = golden[index].seen.get_mut(&key) {
-                    if offset > map_value.len()
-                        || offset.checked_add(bytes.len()).is_none()
-                        || bytes.len() > MAX_FILE_CHUNK_SIZE
-                    {
-                        false
-                    } else {
-                        update_value(map_value, offset, bytes);
-                        true
-                    }
-                } else if offset > 0 || bytes.len() > MAX_FILE_CHUNK_SIZE {
-                    false
-                } else {
-                    golden[index].seen.insert(key, bytes);
-                    true
-                };
-
-                if should_succeed {
-                    assert!(
-                        result.is_ok(),
-                        "Write should have succeeded but failed: {:?}",
-                        result.err()
-                    );
-                } else {
-                    assert!(result.is_err(), "Write should have failed but succeeded");
-                }
-            }
-            Operation::Read(key, offset, len) => {
-                let index = get_index(&mut registry, &mut golden);
-                let mut database_value = vec![0; len];
-
-                let mut cursor = 0;
-                let mut result = registry
-                    .database(index)
-                    .expect("The index is in bounds")
-                    .read(&key, offset + cursor, &mut database_value[cursor..]);
-
-                while let Ok(read) = result {
-                    if read == 0 {
-                        break;
-                    }
-                    cursor += read;
-                    result = registry
-                        .database(index)
-                        .expect("The index is in bounds")
-                        .read(&key, offset + cursor, &mut database_value[cursor..])
-                }
-
-                if let Some(map_value) = golden[index].seen.get(&key) {
-                    if offset > map_value.len() || len > MAX_FILE_CHUNK_SIZE {
-                        assert!(result.is_err());
-                    } else {
-                        let expected_len = std::cmp::min(len, map_value.len() - offset);
-                        assert!(cursor >= expected_len);
-                        assert_eq!(
-                            &database_value[..expected_len],
-                            &map_value[offset..offset + expected_len]
-                        );
-                    }
-                } else {
-                    assert!(result.is_err());
-                }
-            }
-            Operation::Delete(key) => {
-                let index = get_index(&mut registry, &mut golden);
-
-                // The hash of the `Database` can differ even if the key-value pairs stored are
-                // the same, because deletion and reinsertion can cause the shape of the AVL
-                // tree to change.
-                let deleted = golden[index].seen.remove(&key).is_some();
-                if deleted {
-                    golden[index].ambiguous_hash = true;
-                }
-
-                registry
-                    .database_mut(index)
-                    .expect("The index is in bounds")
-                    .delete(key)
-                    .expect("Deleting should succeed");
-            }
-            Operation::Exists(key) => {
-                let index = get_index(&mut registry, &mut golden);
-
-                let in_database = registry
-                    .database(index)
-                    .expect("The index is in bounds")
-                    .exists(&key)
-                    .expect("Writing should succeed");
-                let in_map = golden[index].seen.contains_key(&key);
-
-                assert_eq!(in_database, in_map);
-            }
-            Operation::ValueLength(key) => {
-                let index = get_index(&mut registry, &mut golden);
-
-                let database_length = registry
-                    .database(index)
-                    .expect("The index is in bounds")
-                    .value_length(&key);
-
-                let map_value = golden[index].seen.get(&key);
-
-                match (database_length, map_value) {
-                    (Ok(database_length), Some(map_value)) => {
-                        assert_eq!(database_length, map_value.len())
-                    }
-                    (Err(_), None) => (),
-                    _ => panic!("The value exists in one map but not the other"),
-                }
-            }
-            Operation::Hash => {
+            Operation::Database(DatabaseOperation::Hash) => {
                 let index = get_index(&mut registry, &mut golden);
 
                 let new_digest = registry
@@ -414,11 +543,11 @@ where
                     .entry(Hash::from_foldable(&registry))
                     .or_insert(false);
             }
-            Operation::Commit => {
+            Operation::Database(DatabaseOperation::Commit) => {
                 let commit_id = registry.commit().expect("Committing should succeed");
                 checkout_candidates.insert(*commit_id.as_hash(), true);
             }
-            Operation::Checkout => {
+            Operation::Database(DatabaseOperation::Checkout) => {
                 if !checkout_candidates.is_empty() {
                     let index = rand::random_range(0..checkout_candidates.len());
                     let (&commit_hash, &committed) = checkout_candidates
@@ -437,8 +566,20 @@ where
                     );
                 }
             }
-
-            // Registry operations
+            Operation::Database(op) => {
+                let index = get_index(&mut registry, &mut golden);
+                let handle = registry.handle().clone();
+                apply_database_operation::<KV, _>(
+                    registry
+                        .database_mut(index)
+                        .expect("The index is in bounds"),
+                    &mut golden[index],
+                    op,
+                    &handle,
+                    &checkout_repo,
+                    &mut checkout_candidates,
+                );
+            }
             Operation::GrowRegistry => grow_registry(&mut registry, &mut golden),
             Operation::ShrinkRegistry => {
                 // Make sure there's a database to drop

--- a/durable-storage/src/test_helpers.rs
+++ b/durable-storage/src/test_helpers.rs
@@ -243,13 +243,13 @@ pub fn registry_operations_strategy(
 }
 
 #[derive(Clone, Debug, Default)]
-struct GoldenData {
-    seen: HashMap<Key, Bytes>,
+struct DatabaseModel {
+    data: HashMap<Key, Bytes>,
     last: Option<(Hash, HashMap<Key, Bytes>)>,
     ambiguous_hash: bool,
 }
 
-fn grow_registry<KV>(registry: &mut Registry<KV, Normal>, golden: &mut Vec<GoldenData>)
+fn grow_registry<KV>(registry: &mut Registry<KV, Normal>, registry_model: &mut Vec<DatabaseModel>)
 where
     KV: BackgroundPersistentKeyValueStore,
     KV::Repo: RegistryRepo,
@@ -266,15 +266,18 @@ where
             .expect("Copying the database should succeed");
     }
 
-    if golden.is_empty() {
-        golden.resize(1, Default::default());
+    if registry_model.is_empty() {
+        registry_model.resize(1, Default::default());
     } else {
-        golden.push(golden[golden.len() - 1].clone());
+        registry_model.push(registry_model[registry_model.len() - 1].clone());
     }
 }
 
 /// Get the index of the current database, growing the registry until it has a valid index.
-fn get_index<KV>(registry: &mut Registry<KV, Normal>, golden: &mut Vec<GoldenData>) -> usize
+fn get_index<KV>(
+    registry: &mut Registry<KV, Normal>,
+    registry_model: &mut Vec<DatabaseModel>,
+) -> usize
 where
     KV: BackgroundPersistentKeyValueStore,
     KV::Repo: RegistryRepo,
@@ -282,8 +285,8 @@ where
     if let Some(index) = registry.len().checked_sub(1) {
         index
     } else {
-        grow_registry(registry, golden);
-        get_index(registry, golden)
+        grow_registry(registry, registry_model);
+        get_index(registry, registry_model)
     }
 }
 
@@ -401,7 +404,7 @@ impl<KV: BackgroundPersistentKeyValueStore> DatabaseOps<KV> for TracedDatabase<K
 
 fn apply_database_operation<KV, D>(
     database: &mut D,
-    golden: &mut GoldenData,
+    model: &mut DatabaseModel,
     op: DatabaseOperation,
     handle: &Handle,
     repo: &KV::Repo,
@@ -422,7 +425,7 @@ fn apply_database_operation<KV, D>(
                     result.err()
                 );
 
-                golden.seen.insert(key, bytes.clone());
+                model.data.insert(key, bytes.clone());
             } else {
                 assert!(result.is_err(), "Set should have failed but succeeded");
             }
@@ -431,7 +434,7 @@ fn apply_database_operation<KV, D>(
             let data = Bytes::copy_from_slice(&bytes);
             let result = database.write(key.clone(), offset, data);
 
-            let should_succeed = if let Some(map_value) = golden.seen.get_mut(&key) {
+            let should_succeed = if let Some(map_value) = model.data.get_mut(&key) {
                 if offset > map_value.len()
                     || offset.checked_add(bytes.len()).is_none()
                     || bytes.len() > MAX_FILE_CHUNK_SIZE
@@ -444,7 +447,7 @@ fn apply_database_operation<KV, D>(
             } else if offset > 0 || bytes.len() > MAX_FILE_CHUNK_SIZE {
                 false
             } else {
-                golden.seen.insert(key, bytes);
+                model.data.insert(key, bytes);
                 true
             };
 
@@ -472,7 +475,7 @@ fn apply_database_operation<KV, D>(
                 result = database.read(&key, offset + cursor, &mut database_value[cursor..])
             }
 
-            if let Some(map_value) = golden.seen.get(&key) {
+            if let Some(map_value) = model.data.get(&key) {
                 if offset > map_value.len() || len > MAX_FILE_CHUNK_SIZE {
                     assert!(result.is_err());
                 } else {
@@ -491,21 +494,21 @@ fn apply_database_operation<KV, D>(
             // The hash of the `Database` can differ even if the key-value pairs stored are
             // the same, because deletion and reinsertion can cause the shape of the AVL
             // tree to change.
-            let deleted = golden.seen.remove(&key).is_some();
+            let deleted = model.data.remove(&key).is_some();
             if deleted {
-                golden.ambiguous_hash = true;
+                model.ambiguous_hash = true;
             }
 
             database.delete(key).expect("Deleting should succeed");
         }
         DatabaseOperation::Exists(key) => {
             let in_database = database.exists(&key).expect("Writing should succeed");
-            let in_map = golden.seen.contains_key(&key);
+            let in_map = model.data.contains_key(&key);
             assert_eq!(in_database, in_map);
         }
         DatabaseOperation::ValueLength(key) => {
             let database_length = database.value_length(&key);
-            let map_value = golden.seen.get(&key);
+            let map_value = model.data.get(&key);
 
             match (database_length, map_value) {
                 (Ok(database_length), Some(map_value)) => {
@@ -518,11 +521,11 @@ fn apply_database_operation<KV, D>(
         DatabaseOperation::Hash => {
             let new_digest = database.hash().expect("Hash should succeed");
 
-            if let (Some((old_digest, old_map)), false) = (&golden.last, &golden.ambiguous_hash) {
-                assert_eq!(new_digest == *old_digest, golden.seen == *old_map);
+            if let (Some((old_digest, old_map)), false) = (&model.last, &model.ambiguous_hash) {
+                assert_eq!(new_digest == *old_digest, model.data == *old_map);
             }
 
-            golden.last = Some((new_digest, golden.seen.clone()));
+            model.last = Some((new_digest, model.data.clone()));
 
             checkout_candidates.entry(new_digest).or_insert(false);
         }
@@ -560,12 +563,12 @@ where
     let mut registry: Registry<KV, Normal> =
         Registry::new(repo).expect("Creating the registry should succeed");
 
-    let mut golden: Vec<GoldenData> = vec![];
+    let mut registry_model: Vec<DatabaseModel> = vec![];
 
     for operation in operations {
         match operation {
             Operation::Database(DatabaseOperation::Hash) => {
-                let index = get_index(&mut registry, &mut golden);
+                let index = get_index(&mut registry, &mut registry_model);
 
                 let new_digest = registry
                     .database(index)
@@ -573,13 +576,17 @@ where
                     .hash()
                     .expect("Hash should succeed");
 
-                if let (Some((old_digest, old_map)), false) =
-                    (&golden[index].last, &golden[index].ambiguous_hash)
-                {
-                    assert_eq!(new_digest == *old_digest, golden[index].seen == *old_map);
+                if let (Some((old_digest, old_map)), false) = (
+                    &registry_model[index].last,
+                    &registry_model[index].ambiguous_hash,
+                ) {
+                    assert_eq!(
+                        new_digest == *old_digest,
+                        registry_model[index].data == *old_map
+                    );
                 }
 
-                golden[index].last = Some((new_digest, golden[index].seen.clone()));
+                registry_model[index].last = Some((new_digest, registry_model[index].data.clone()));
 
                 checkout_candidates
                     .entry(Hash::from_foldable(&registry))
@@ -609,24 +616,24 @@ where
                 }
             }
             Operation::Database(op) => {
-                let index = get_index(&mut registry, &mut golden);
+                let index = get_index(&mut registry, &mut registry_model);
                 let handle = registry.handle().clone();
                 apply_database_operation::<KV, _>(
                     registry
                         .database_mut(index)
                         .expect("The index is in bounds"),
-                    &mut golden[index],
+                    &mut registry_model[index],
                     op,
                     &handle,
                     &checkout_repo,
                     &mut checkout_candidates,
                 );
             }
-            Operation::GrowRegistry => grow_registry(&mut registry, &mut golden),
+            Operation::GrowRegistry => grow_registry(&mut registry, &mut registry_model),
             Operation::ShrinkRegistry => {
                 // Make sure there's a database to drop
                 if registry.is_empty() {
-                    grow_registry(&mut registry, &mut golden);
+                    grow_registry(&mut registry, &mut registry_model);
                 };
 
                 let new_size = registry.len().saturating_sub(1);
@@ -634,23 +641,23 @@ where
                     .resize_tick(new_size)
                     .expect("Resizing the registry should succeed");
 
-                golden.truncate(new_size);
+                registry_model.truncate(new_size);
             }
             Operation::ClearDatabase => {
-                let index = get_index(&mut registry, &mut golden);
+                let index = get_index(&mut registry, &mut registry_model);
 
                 registry
                     .clear_database(index)
                     .expect("Clearing the database should be successful");
 
-                golden[index].seen.clear();
-                golden[index].ambiguous_hash = false;
-                golden[index].last = None;
+                registry_model[index].data.clear();
+                registry_model[index].ambiguous_hash = false;
+                registry_model[index].last = None;
             }
             Operation::CopyDatabase => {
                 let (src, dst) = {
                     while registry.len() < 2 {
-                        grow_registry(&mut registry, &mut golden);
+                        grow_registry(&mut registry, &mut registry_model);
                     }
                     (registry.len() - 2, registry.len() - 1)
                 };
@@ -659,12 +666,12 @@ where
                     .copy_database(src, dst)
                     .expect("Copying the database should be successful");
 
-                golden[dst] = golden[src].clone();
+                registry_model[dst] = registry_model[src].clone();
             }
             Operation::MoveDatabase => {
                 let (src, dst) = {
                     while registry.len() < 2 {
-                        grow_registry(&mut registry, &mut golden);
+                        grow_registry(&mut registry, &mut registry_model);
                     }
                     (registry.len() - 2, registry.len() - 1)
                 };
@@ -674,15 +681,15 @@ where
                     .expect("Moving the database should be successful");
 
                 let empty = Default::default();
-                let new_dst = std::mem::replace(&mut golden[src], empty);
-                golden[dst] = new_dst;
+                let new_dst = std::mem::replace(&mut registry_model[src], empty);
+                registry_model[dst] = new_dst;
             }
         }
     }
 }
 
 /// Run a sequence of [`DatabaseOperation`]s against a single [`TracedDatabase`],
-/// asserting against a golden in-memory model after each step, and return the recorded [`Trace`].
+/// asserting against a reference in-memory model after each step, and return the recorded [`Trace`].
 #[cfg(test)]
 pub(crate) fn run_database_operations<KV>(
     repo: &KV::Repo,
@@ -699,13 +706,13 @@ where
 
     let mut database = TracedDatabase::<KV, Normal>::try_new(handle, repo)
         .expect("Creating the database should succeed");
-    let mut golden = GoldenData::default();
+    let mut model = DatabaseModel::default();
     let mut checkout_candidates: HashMap<Hash, bool> = HashMap::new();
 
     for op in operations {
         apply_database_operation::<KV, _>(
             &mut database,
-            &mut golden,
+            &mut model,
             op,
             handle,
             repo,

--- a/durable-storage/src/test_helpers.rs
+++ b/durable-storage/src/test_helpers.rs
@@ -118,6 +118,20 @@ fn make_database_operation(
     }
 }
 
+/// Turn a set of [`DatabaseOperationView`]s into [`DatabaseOperation`]s
+/// on the given keys and values, where applicable
+pub fn make_database_operations(
+    keys: Vec<Key>,
+    values: Vec<Bytes>,
+    ops: Vec<DatabaseOperationView>,
+) -> Vec<DatabaseOperation> {
+    ops.into_iter()
+        .map(|op| make_database_operation(&keys, &values, op))
+        .collect()
+}
+
+/// Turn a set of [`OperationView`]s into [`Operation`]s on the given keys
+/// and values, where applicable
 pub fn make_registry_operations(
     keys: Vec<Key>,
     values: Vec<Bytes>,
@@ -501,8 +515,36 @@ fn apply_database_operation<KV, D>(
                 _ => panic!("The value exists in one map but not the other"),
             }
         }
-        DatabaseOperation::Hash | DatabaseOperation::Commit | DatabaseOperation::Checkout => {
-            unreachable!("Intercepted by `apply_database_operation`")
+        DatabaseOperation::Hash => {
+            let new_digest = database.hash().expect("Hash should succeed");
+
+            if let (Some((old_digest, old_map)), false) = (&golden.last, &golden.ambiguous_hash) {
+                assert_eq!(new_digest == *old_digest, golden.seen == *old_map);
+            }
+
+            golden.last = Some((new_digest, golden.seen.clone()));
+
+            checkout_candidates.entry(new_digest).or_insert(false);
+        }
+        DatabaseOperation::Commit => {
+            let commit_id = database.commit(repo).expect("Committing should succeed");
+            checkout_candidates.insert(*commit_id.as_hash(), true);
+        }
+        DatabaseOperation::Checkout => {
+            if !checkout_candidates.is_empty() {
+                let index = rand::random_range(0..checkout_candidates.len());
+                let (&commit_hash, &committed) = checkout_candidates
+                    .iter()
+                    .nth(index)
+                    .expect("Index is within bounds");
+                let checkout_result = D::checkout(handle, repo, CommitId::from(commit_hash));
+
+                assert_eq!(
+                    checkout_result.is_ok(),
+                    committed,
+                    "Checkout result did not match whether the commit id was committed"
+                );
+            }
         }
     }
 }
@@ -637,4 +679,39 @@ where
             }
         }
     }
+}
+
+/// Run a sequence of [`DatabaseOperation`]s against a single [`TracedDatabase`],
+/// asserting against a golden in-memory model after each step, and return the recorded [`Trace`].
+#[cfg(test)]
+pub(crate) fn run_database_operations<KV>(
+    repo: &KV::Repo,
+    operations: Vec<DatabaseOperation>,
+) -> Trace
+where
+    KV: BackgroundPersistentKeyValueStore,
+{
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .build()
+        .expect("Building the runtime should succeed");
+    let handle = runtime.handle();
+
+    let mut database = TracedDatabase::<KV, Normal>::try_new(handle, repo)
+        .expect("Creating the database should succeed");
+    let mut golden = GoldenData::default();
+    let mut checkout_candidates: HashMap<Hash, bool> = HashMap::new();
+
+    for op in operations {
+        apply_database_operation::<KV, _>(
+            &mut database,
+            &mut golden,
+            op,
+            handle,
+            repo,
+            &mut checkout_candidates,
+        );
+    }
+
+    database.into_trace()
 }

--- a/durable-storage/tests/integration_test.rs
+++ b/durable-storage/tests/integration_test.rs
@@ -2,9 +2,10 @@
 
 use bytes::Bytes;
 use octez_riscv_durable_storage::key::Key;
+use octez_riscv_durable_storage::test_helpers::DatabaseOperation;
 use octez_riscv_durable_storage::test_helpers::Operation;
-use octez_riscv_durable_storage::test_helpers::make_operations;
-use octez_riscv_durable_storage::test_helpers::operations_strategy;
+use octez_riscv_durable_storage::test_helpers::make_registry_operations;
+use octez_riscv_durable_storage::test_helpers::registry_operations_strategy;
 use octez_riscv_durable_storage::test_helpers::run_operations;
 use proptest::proptest;
 
@@ -40,18 +41,31 @@ cfg_if::cfg_if! {
 fn test_durable_storage_manual() {
     let operations = vec![
         Operation::GrowRegistry,
-        Operation::Set(Key::new(&[0]).unwrap(), Bytes::copy_from_slice(&[0; 10])),
-        Operation::Exists(Key::new(&[0]).unwrap()),
-        Operation::Write(Key::new(&[0]).unwrap(), 5, Bytes::copy_from_slice(&[0; 4])),
+        Operation::Database(DatabaseOperation::Set(
+            Key::new(&[0]).unwrap(),
+            Bytes::copy_from_slice(&[0; 10]),
+        )),
+        Operation::Database(DatabaseOperation::Exists(Key::new(&[0]).unwrap())),
+        Operation::Database(DatabaseOperation::Write(
+            Key::new(&[0]).unwrap(),
+            5,
+            Bytes::copy_from_slice(&[0; 4]),
+        )),
         Operation::GrowRegistry,
-        Operation::Set(Key::new(&[1]).unwrap(), Bytes::copy_from_slice(&[0; 10])),
-        Operation::Commit,
-        Operation::Checkout,
+        Operation::Database(DatabaseOperation::Set(
+            Key::new(&[1]).unwrap(),
+            Bytes::copy_from_slice(&[0; 10]),
+        )),
+        Operation::Database(DatabaseOperation::Commit),
+        Operation::Database(DatabaseOperation::Checkout),
         Operation::ShrinkRegistry,
-        Operation::Set(Key::new(&[2]).unwrap(), Bytes::copy_from_slice(&[0; 10])),
-        Operation::Exists(Key::new(&[1]).unwrap()),
-        Operation::Delete(Key::new(&[1]).unwrap()),
-        Operation::Exists(Key::new(&[1]).unwrap()),
+        Operation::Database(DatabaseOperation::Set(
+            Key::new(&[2]).unwrap(),
+            Bytes::copy_from_slice(&[0; 10]),
+        )),
+        Operation::Database(DatabaseOperation::Exists(Key::new(&[1]).unwrap())),
+        Operation::Database(DatabaseOperation::Delete(Key::new(&[1]).unwrap())),
+        Operation::Database(DatabaseOperation::Exists(Key::new(&[1]).unwrap())),
         Operation::ShrinkRegistry,
         Operation::ShrinkRegistry,
     ];
@@ -63,9 +77,9 @@ fn test_durable_storage_manual() {
 proptest! {
     #![proptest_config(proptest::test_runner::Config::with_cases(PROPTEST_CASES))]
     #[test]
-    fn test_durable_storage_prop((keys, values, ops) in operations_strategy(1usize..100)) {
+    fn test_durable_storage_prop((keys, values, ops) in registry_operations_strategy(1usize..100)) {
         let (_keepalive, repo) = setup_repo();
-        let operations = make_operations(keys, values, ops);
+        let operations = make_registry_operations(keys, values, ops);
         run_operations::<TestKv>(repo, operations);
     }
 }


### PR DESCRIPTION
Closes RV-978.

# What

Introduces an end-to-end property-based test for `Database` based on a strategy for `Database` operations and comparing traces across storage backends.

# Why

To gain confidence in the `Database` implementation and ensure consistent semantics irrespective of state backend.

# How

The addition of the `test_database_end_to_end` test is largely based on the already introduced `test_durable_storage_end_to_end` for the `Registry`. To this end, the database-specific parts of the registry operations strategy are split off in order to be used in the context of a single database, either `Database` directly (as part of a `Registry`) or `TracedDatabase` as part of the newly introduced test.

The existing `Registry` strategies and tests should be unchanged.

Note to reviewers: The diff for `durable-storage/src/test_helpers.rs` is not super helpful and obscures the fact that the implementation of `apply_database_operation` is largely based on the previous version of `run_operation`.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
