### PR TITLE
test(dursto): commit + checkout steps do not affect `Database` semantics

### DIFF
--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -2216,15 +2216,10 @@ pub(crate) mod tests {
         let mut database = new_database::<KV>(handle, &repo);
 
         // Force a per-backend divergence in the recorded trace
-        let value: &[u8] =
-            if std::any::type_name::<KV>().contains("InMemoryKeyValueStore") {
-                b"in-memory"
-            } else {
-                b"rocksdb"
-            };
+        let value = [KV::BACKEND as u8];
         let key = Key::new(b"divergence-probe").expect("Size less than KEY_MAX_SIZE");
         database
-            .set(key, Bytes::copy_from_slice(value))
+            .set(key, Bytes::copy_from_slice(&value))
             .expect("Setting should succeed");
 
         database.into_trace()
@@ -2232,7 +2227,7 @@ pub(crate) mod tests {
 
     kv_test!(test_database_end_to_end, KV: BackgroundPersistentKeyValueStore,
     [
-        generated in crate::test_helpers::database_operations_strategy(1usize..100)
+        generated in crate::test_helpers::database_operations_commit_checkout_strategy(1usize..100, 0.1)
     ],
     {
         // Every test iteration expects an empty repo, so not setting it in a `setup` block.
@@ -2240,7 +2235,14 @@ pub(crate) mod tests {
         // in test failures when checking out a commit which isn't expected to exist succeeds.
         let (_keepalive, repo) = KV::setup_repo();
 
-        let (keys, values, ops) = generated;
+        let (keys, values, ops_a, ops_b) = generated;
+
+        // Pick an operations vector so each backend exercises a different
+        // `CommitCheckoutRoundtrip` placement against the same base operations.
+        let ops = match KV::BACKEND {
+            crate::storage::Backend::Persistent => ops_a,
+            crate::storage::Backend::InMemory => ops_b,
+        };
         let operations = crate::test_helpers::make_database_operations(keys, values, ops);
         crate::test_helpers::run_database_operations::<KV>(&repo, operations)
     });

--- a/durable-storage/src/storage.rs
+++ b/durable-storage/src/storage.rs
@@ -115,6 +115,15 @@ cfg_if::cfg_if! {
 
 cfg_if::cfg_if! {
     if #[cfg(test)] {
+        /// Type of storage backend
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub(crate) enum Backend {
+            /// In-memory backend (`InMemoryKeyValueStore`)
+            InMemory,
+            /// Persistent backend (`PersistenceLayer`)
+            Persistent,
+        }
+
         // TODO: This trait currently duplicates the functionality of the `TestKeyValueStore` mechanism defined above.
         // Tests which use the `kv_test!` macro will be refactored to use `TestKeyValueStoreSetup`, which can supersede
         // `KeyValueStore` once all tests have been rewritten.
@@ -122,12 +131,17 @@ cfg_if::cfg_if! {
             /// Temporary directory handle that must stay in scope for the lifetime of the repo
             type Keepalive;
 
+            /// Allows tests to match on which backend is being used
+            const BACKEND: Backend;
+
             /// Create a test repository
             fn setup_repo() -> (Self::Keepalive, Self::Repo);
         }
 
         impl TestKeyValueStoreSetup for in_memory::InMemoryKeyValueStore {
             type Keepalive = ();
+
+            const BACKEND: Backend = Backend::InMemory;
 
             fn setup_repo() -> ((), in_memory::InMemoryRepo) {
                 ((), in_memory::InMemoryRepo::default())
@@ -137,6 +151,8 @@ cfg_if::cfg_if! {
         #[cfg(feature = "rocksdb")]
         impl TestKeyValueStoreSetup for crate::persistence_layer::PersistenceLayer {
             type Keepalive = octez_riscv_test_utils::TestableTmpdir;
+
+            const BACKEND: Backend = Backend::Persistent;
 
             fn setup_repo() -> (Self::Keepalive, Self::Repo) {
                 use crate::repo::DirectoryManager;

--- a/durable-storage/src/test_helpers.rs
+++ b/durable-storage/src/test_helpers.rs
@@ -49,6 +49,7 @@ pub enum DatabaseOperation {
     Hash,
     Commit,
     Checkout,
+    CommitCheckoutRoundtrip,
 }
 
 /// Operations on a [`Registry`]
@@ -73,6 +74,7 @@ pub enum DatabaseOperationView {
     Hash,
     Commit,
     Checkout,
+    CommitCheckoutRoundtrip,
 }
 
 #[derive(Debug, Clone)]
@@ -115,6 +117,9 @@ fn make_database_operation(
         DatabaseOperationView::Hash => DatabaseOperation::Hash,
         DatabaseOperationView::Commit => DatabaseOperation::Commit,
         DatabaseOperationView::Checkout => DatabaseOperation::Checkout,
+        DatabaseOperationView::CommitCheckoutRoundtrip => {
+            DatabaseOperation::CommitCheckoutRoundtrip
+        }
     }
 }
 
@@ -214,6 +219,66 @@ pub fn database_operations_strategy(
             proptest::collection::vec(value_strategy(), count),
             proptest::collection::vec(database_operation_view_strategy(), length),
         )
+    })
+}
+
+/// Produces `Some(CommitCheckoutRoundtrip)` with the given probability, `None` otherwise.
+fn maybe_roundtrip_strategy(prob: f32) -> impl Strategy<Value = Option<DatabaseOperationView>> {
+    assert!(
+        (0.0..=1.0).contains(&prob),
+        "expected a probability, got {prob}"
+    );
+    let (yes, no) = proptest::strategy::float_to_weight(prob.into());
+    prop_oneof![
+        yes => Just(Some(DatabaseOperationView::CommitCheckoutRoundtrip)),
+        no => Just(None),
+    ]
+}
+
+/// Like [`database_operations_strategy`] but produces two operation vectors sharing
+/// identical base operations, with independently sampled
+/// [`DatabaseOperationView::CommitCheckoutRoundtrip`]. Intended to check that 2 test runs
+/// with differently-placed commit - checkout roundtrips are observationally equivalent.
+pub fn database_operations_commit_checkout_strategy(
+    length: impl Strategy<Value = usize>,
+    roundtrip_probability: f32,
+) -> impl Strategy<
+    Value = (
+        Vec<Key>,
+        Vec<Bytes>,
+        Vec<DatabaseOperationView>,
+        Vec<DatabaseOperationView>,
+    ),
+> {
+    length.prop_flat_map(move |length| {
+        let count = length.div_ceil(10);
+        (
+            proptest::collection::vec(key_strategy(), count),
+            proptest::collection::vec(value_strategy(), count),
+            proptest::collection::vec(
+                (
+                    maybe_roundtrip_strategy(roundtrip_probability),
+                    maybe_roundtrip_strategy(roundtrip_probability),
+                    database_operation_view_strategy(),
+                ),
+                length,
+            ),
+        )
+            .prop_map(|(keys, values, ops)| {
+                let mut ops_a = Vec::with_capacity(ops.len() * 2);
+                let mut ops_b = Vec::with_capacity(ops.len() * 2);
+                for (pre_a, pre_b, op) in ops {
+                    if let Some(r) = pre_a {
+                        ops_a.push(r);
+                    }
+                    if let Some(r) = pre_b {
+                        ops_b.push(r);
+                    }
+                    ops_a.push(op.clone());
+                    ops_b.push(op);
+                }
+                (keys, values, ops_a, ops_b)
+            })
     })
 }
 
@@ -323,6 +388,15 @@ trait DatabaseOps<KV: BackgroundPersistentKeyValueStore>: Sized {
     fn commit(&self, repo: &KV::Repo) -> Result<CommitId, OperationalError>;
 
     fn checkout(handle: &Handle, repo: &KV::Repo, commit_id: CommitId) -> Result<Self, Error>;
+
+    /// Commit the database, then check out the resulting commit and replace
+    /// with the checked-out database. Tracing implementations must not record
+    /// these in the trace. Returns the resulting [`CommitId`].
+    fn commit_checkout_roundtrip(
+        &mut self,
+        handle: &Handle,
+        repo: &KV::Repo,
+    ) -> Result<CommitId, OperationalError>;
 }
 
 impl<KV: BackgroundPersistentKeyValueStore> DatabaseOps<KV> for Database<KV, Normal> {
@@ -360,6 +434,22 @@ impl<KV: BackgroundPersistentKeyValueStore> DatabaseOps<KV> for Database<KV, Nor
 
     fn checkout(handle: &Handle, repo: &KV::Repo, commit_id: CommitId) -> Result<Self, Error> {
         Database::checkout(handle, repo, commit_id)
+    }
+
+    fn commit_checkout_roundtrip(
+        &mut self,
+        handle: &Handle,
+        repo: &KV::Repo,
+    ) -> Result<CommitId, OperationalError> {
+        let commit_id = Database::commit(self, repo)?;
+        let checked_out_db = Database::checkout(handle, repo, commit_id).map_err(|e| match e {
+            Error::Operational(e) => e,
+            Error::InvalidArgument(e) => {
+                panic!("checking out an existing commit should succeed {e:?}")
+            }
+        })?;
+        *self = checked_out_db;
+        Ok(commit_id)
     }
 }
 
@@ -399,6 +489,15 @@ impl<KV: BackgroundPersistentKeyValueStore> DatabaseOps<KV> for TracedDatabase<K
 
     fn checkout(handle: &Handle, repo: &KV::Repo, commit_id: CommitId) -> Result<Self, Error> {
         TracedDatabase::checkout(handle, repo, commit_id)
+    }
+
+    fn commit_checkout_roundtrip(
+        &mut self,
+        handle: &Handle,
+        repo: &KV::Repo,
+    ) -> Result<CommitId, OperationalError> {
+        // Keep the trace but replace the inner database
+        self.inner_mut().commit_checkout_roundtrip(handle, repo)
     }
 }
 
@@ -549,6 +648,14 @@ fn apply_database_operation<KV, D>(
                 );
             }
         }
+        DatabaseOperation::CommitCheckoutRoundtrip => {
+            let commit_id = database
+                .commit_checkout_roundtrip(handle, repo)
+                .expect("Commit-checkout roundtrip should succeed");
+            // Register the resulting commit so a later `Checkout` operation
+            // does not see an unexpected success against this hash.
+            checkout_candidates.insert(*commit_id.as_hash(), true);
+        }
     }
 }
 
@@ -693,7 +800,7 @@ where
 #[cfg(test)]
 pub(crate) fn run_database_operations<KV>(
     repo: &KV::Repo,
-    operations: Vec<DatabaseOperation>,
+    mut operations: Vec<DatabaseOperation>,
 ) -> Trace
 where
     KV: BackgroundPersistentKeyValueStore,
@@ -708,6 +815,9 @@ where
         .expect("Creating the database should succeed");
     let mut model = DatabaseModel::default();
     let mut checkout_candidates: HashMap<Hash, bool> = HashMap::new();
+
+    // Force a final hash to be recorded in the trace
+    operations.push(DatabaseOperation::Hash);
 
     for op in operations {
         apply_database_operation::<KV, _>(


### PR DESCRIPTION
Closes RV-981.

# What

The `test_database_end_to_end` test checks that the same operations ran over `Database`s with different backends result in the same trace. This PR expands it to also check that inserting commit + checkout steps at different points in the execution of each run also results in the same trace. 

# Why

A step towards gaining confidence that a checked-out database behaves identically to the database which was committed.

# How

A `CommitCheckoutRoundtrip` variant is added to the `DatabaseOperation` test helper type. It is implemented by committing the database, then checking it out and replacing the original database with it. These steps are not produced in the proptest database operations strategy since its output is shared between the `kv_test!` runs. It is instead done using an RNG seeded differently for each backend. The seed is part of the proptest input though to allow reproducibility. 

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
