### PR TITLE
test(dursto): bias strategies towards valid operations in PBTs

### DIFF
--- a/durable-storage/src/test_helpers.rs
+++ b/durable-storage/src/test_helpers.rs
@@ -162,19 +162,32 @@ fn key_strategy() -> impl Strategy<Value = Key> {
 }
 
 fn value_strategy() -> impl Strategy<Value = Bytes> {
-    proptest::collection::vec(any::<u8>(), 1usize..=VALUE_MAX_SIZE).prop_map(Bytes::from)
+    // Bias towards lengths that fit within `MAX_FILE_CHUNK_SIZE` so most
+    // sampled operations exercise the success path, while also producing
+    // some oversized values.
+    prop_oneof![
+        9 => proptest::collection::vec(any::<u8>(), 1usize..=MAX_FILE_CHUNK_SIZE),
+        1 => proptest::collection::vec(any::<u8>(), (MAX_FILE_CHUNK_SIZE + 1)..=VALUE_MAX_SIZE),
+    ]
+    .prop_map(Bytes::from)
 }
 
 fn database_operation_view_strategy() -> impl Strategy<Value = DatabaseOperationView> {
     let set = (any::<Index>(), any::<Index>()).prop_map(|(k, v)| DatabaseOperationView::Set(k, v));
 
+    // Bias length and offset towards having most sampled operations
+    // exercise the success path, while also producing some which are out of bounds.
     let read = (
         any::<Index>(),
         prop_oneof![
-            2 => Just(0),
-            1 => 1..=VALUE_MAX_SIZE,
+            5 => Just(0),
+            4 => 1..=MAX_FILE_CHUNK_SIZE,
+            1 => (MAX_FILE_CHUNK_SIZE + 1)..=VALUE_MAX_SIZE,
         ],
-        0..=VALUE_MAX_SIZE,
+        prop_oneof![
+            9 => 0..=MAX_FILE_CHUNK_SIZE,
+            1 => (MAX_FILE_CHUNK_SIZE + 1)..=VALUE_MAX_SIZE,
+        ],
     )
         .prop_map(|(k, off, len)| DatabaseOperationView::Read(k, off, len));
 
@@ -197,8 +210,8 @@ fn database_operation_view_strategy() -> impl Strategy<Value = DatabaseOperation
     prop_oneof![
         20 => set,
         20 => read,
-        3 => write_valid,
-        2 => write_invalid,
+        4 => write_valid,
+        1 => write_invalid,
 
         10 => any::<Index>().prop_map(DatabaseOperationView::Delete),
         10 => any::<Index>().prop_map(DatabaseOperationView::Exists),


### PR DESCRIPTION
Closes TZX-139.

# What

Adjusts the way property-based test inputs for `Database` operations are generated to lower the proportion of reads and writes which are too large (larger than `MAX_FILE_CHUNK_SIZE`) and reads with an offset which is too large. More details in [TZX-139](https://linear.app/tezos/issue/TZX-139/review-sampling-distribution-for-values-in-end-to-end-property-based).

# Why

Confidence in the implementation of the failure paths exercised by these operations doesn't meaningfully increase with frequency. It makes more sense to cover more valid operations.

# How

`value_strategy` and `database_operation_view_strategy` no longer produce lengths uniformly at random in `0..VALUE_MAX_SIZE`, but are instead much more likely to produce them in the `0..MAX_FILE_CHUNK_SIZE` range. Offsets for reads are also adjusted to increase the change of producing a valid offset.

I opted to adjust the distribution rather than `VALUE_MAX_SIZE` so that very large values could still be produced.

# Manually Testing

```
make all
```

# Regressions

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
