### PR TITLE
feat(dursto): implement FromProof for Database

### DIFF
--- a/durable-storage/src/avl/tree.rs
+++ b/durable-storage/src/avl/tree.rs
@@ -21,9 +21,12 @@ use octez_riscv_data::hash::HashFold;
 use octez_riscv_data::hash::PartialHash;
 use octez_riscv_data::hash::PartialHashFold;
 use octez_riscv_data::merkle_proof::Deserialiser;
+use octez_riscv_data::merkle_proof::DeserialiserError;
 use octez_riscv_data::merkle_proof::DeserialiserNode;
 use octez_riscv_data::merkle_proof::FromProof;
 use octez_riscv_data::merkle_proof::Partial;
+use octez_riscv_data::merkle_proof::ProofError;
+use octez_riscv_data::merkle_proof::SuspendedResult;
 use octez_riscv_data::mode::utils::not_found;
 use octez_riscv_data::serialisation::deserialise;
 use octez_riscv_data::serialisation::serialise;
@@ -413,6 +416,23 @@ impl Foldable<PartialHashFold> for Tree<VerifyNodeId> {
         }
 
         node.done()
+    }
+}
+
+impl FromProof for Tree<VerifyNodeId> {
+    fn from_proof<Proof: Deserialiser>(proof: Proof) -> SuspendedResult<Proof, Self> {
+        let ctx = proof.into_node()?;
+        let (ctx, tree) = Tree::from_branches(ctx)?;
+        // The top-level fold for a Normal-mode `Tree<LazyNodeId>` always emits a node fold,
+        // so a well-formed proof's root deserialises as `Present`. `Blinded`/`Absent` here
+        // would mean the entire state has been hidden, which would make the `Tree` unusable
+        // for verification.
+        let Partial::Present(tree) = tree else {
+            return Err(Proof::Error::custom(ProofError::Custom(
+                "malformed proof - deserialising MAVL tree without being present.".into(),
+            )));
+        };
+        ctx.done(tree)
     }
 }
 

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -20,6 +20,10 @@ use octez_riscv_data::foldable::Fold;
 use octez_riscv_data::foldable::Foldable;
 use octez_riscv_data::hash::Hash;
 use octez_riscv_data::hash::HashFold;
+use octez_riscv_data::merkle_proof::Deserialiser;
+use octez_riscv_data::merkle_proof::FromProof;
+use octez_riscv_data::merkle_proof::Suspended;
+use octez_riscv_data::merkle_proof::SuspendedResult;
 use octez_riscv_data::merkle_proof::proof_tree::MerkleProofFold;
 use octez_riscv_data::mode::Modal;
 use octez_riscv_data::mode::Mode;
@@ -444,18 +448,14 @@ impl<KV> Database<KV, Verify> {
             },
         }
     }
+}
 
-    /// Construct a Verify-mode database by deserialising a [`MerkleProof`].
-    ///
-    /// [`MerkleProof`]: octez_riscv_data::merkle_proof::proof_tree::MerkleProof
-    #[cfg(test)]
-    pub(crate) fn from_proof(
-        proof: octez_riscv_data::merkle_proof::proof_tree::MerkleProof,
-    ) -> Result<Self, octez_riscv_data::merkle_proof::ProofError> {
-        let merkle = MerkleLayer::from_proof(proof)?;
-        Ok(Database {
+impl<KV> FromProof for Database<KV, Verify> {
+    fn from_proof<Proof: Deserialiser>(proof: Proof) -> SuspendedResult<Proof, Self> {
+        let suspended = <MerkleLayer<KV, Verify> as FromProof>::from_proof(proof)?;
+        Ok(suspended.map(|merkle| Database {
             inner: VerifyImpl { merkle },
-        })
+        }))
     }
 }
 

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -27,6 +27,12 @@ use octez_riscv_data::foldable::NodeFold;
 use octez_riscv_data::hash::Hash;
 use octez_riscv_data::hash::HashFold;
 use octez_riscv_data::hash::PartialHash;
+use octez_riscv_data::merkle_proof::Deserialiser;
+use octez_riscv_data::merkle_proof::DeserialiserError;
+use octez_riscv_data::merkle_proof::FromProof;
+use octez_riscv_data::merkle_proof::ProofError;
+use octez_riscv_data::merkle_proof::Suspended;
+use octez_riscv_data::merkle_proof::SuspendedResult;
 use octez_riscv_data::merkle_proof::proof_tree::MerkleProof;
 use octez_riscv_data::merkle_proof::proof_tree::MerkleProofFold;
 use octez_riscv_data::merkle_proof::proof_tree::MinimumPresence;
@@ -153,6 +159,25 @@ impl<KV> MerkleLayer<KV, Verify> {
                 original_proof: Arc::new(MerkleProof::leaf_blind(Hash::hash_bytes(&[]))),
             },
         }
+    }
+}
+
+impl<KV> FromProof for MerkleLayer<KV, Verify> {
+    fn from_proof<Proof: Deserialiser>(proof: Proof) -> SuspendedResult<Proof, Self> {
+        // Capture before consuming `proof`
+        let original_proof = proof
+            .capture_owned_proof()
+            .map(Arc::new)
+            .ok_or_else(|| Proof::Error::custom(ProofError::AbsentProof))?;
+
+        let suspended = Tree::<VerifyNodeId>::from_proof(proof)?;
+        Ok(suspended.map(move |tree| MerkleLayer {
+            inner: VerifyImpl {
+                tree,
+                resolver: VerifyResolver,
+                original_proof,
+            },
+        }))
     }
 }
 
@@ -726,11 +751,8 @@ mod tests {
     use crate::avl::resolver::LazyTreeId;
     use crate::avl::resolver::ProveNodeId;
     use crate::avl::resolver::ProveResolver;
-    use crate::avl::resolver::VerifyResolver;
-    use crate::avl::resolver::VerifyTreeId;
     use crate::avl::tree::Tree;
     use crate::key::Key;
-    use crate::merkle_layer::VerifyImpl;
     use crate::storage::KeyValueStore;
     use crate::storage::PersistentKeyValueStore;
     use crate::storage::TestKeyValueStoreSetup;
@@ -744,6 +766,14 @@ mod tests {
         /// Clear all data from the [MerkleLayer].
         fn clear(&mut self) {
             self.inner.tree.take();
+        }
+    }
+
+    impl<KV> MerkleLayer<KV, Verify> {
+        /// Construct a Verify-mode [`MerkleLayer`] by deserialising a [`MerkleProof`]
+        pub fn from_proof(proof: MerkleProof) -> Result<Self, ProofError> {
+            let suspended = <Self as FromProof>::from_proof(ProofTree::Present(&proof))?;
+            Ok(suspended.into_result())
         }
     }
 
@@ -764,32 +794,6 @@ mod tests {
         pub(crate) fn to_verify(&self) -> MerkleLayer<KV, Verify> {
             let proof = MerkleProof::from_foldable(self);
             MerkleLayer::from_proof(proof).expect("proof deserialization should succeed")
-        }
-    }
-
-    impl<KV> MerkleLayer<KV, Verify> {
-        /// Construct a Verify-mode [`MerkleLayer`] by deserialising a [`MerkleProof`].
-        ///
-        /// The proof is retained so [`MerkleLayer::hash`] can resolve `prev_hash` substitutions for
-        /// blinded subtrees that fold to [`PartialHash::Previous`].
-        pub fn from_proof(proof: MerkleProof) -> Result<Self, ProofError> {
-            let proof = Arc::new(proof);
-            let tree_id = VerifyTreeId::from_proof(ProofTree::Present(&proof))?.into_result();
-            let VerifyTreeId::Present { tree, .. } = tree_id else {
-                // The top-level fold for a Normal-mode `Tree<LazyNodeId>` always emits a node fold,
-                // so a well-formed proof's root deserialises as `Present`. `Blinded`/`Absent` here
-                // would mean the entire state has been hidden — an unusable verify layer.
-                return Err(ProofError::Custom(
-                    "malformed proof - deserialising MAVL tree without being present.".into(),
-                ));
-            };
-            Ok(MerkleLayer {
-                inner: VerifyImpl {
-                    tree,
-                    resolver: VerifyResolver,
-                    original_proof: proof,
-                },
-            })
         }
     }
 

--- a/durable-storage/src/test_helpers.rs
+++ b/durable-storage/src/test_helpers.rs
@@ -937,7 +937,11 @@ fn prove_and_verify_operation<KV: BackgroundKeyValueStore>(
 
     // Construct the Verify-mode database from the proof and verify
     let mut verify_db = TracedDatabase::from(
-        Database::<KV, Verify>::from_proof(proof).expect("proof should be valid"),
+        <Database<KV, Verify> as octez_riscv_data::merkle_proof::FromProof>::from_proof(
+            octez_riscv_data::merkle_proof::proof_tree::ProofTree::Present(&proof),
+        )
+        .expect("proof should be valid")
+        .into_result(),
     );
     assert_eq!(
         Hash::from_foldable(&verify_db),


### PR DESCRIPTION
# What

Implements `FromProof` for `Database<KV, Verify>`.

# Why

Needed in order to expose proof verification

# How

This also required implementing `FromProof` for `MerkleLayer` and its inner `Tree<VerifyNodeId>`. The latter implementations are mostly based on the `MerkleLayer<KV, Verify>::from_proof` test helper. This helper, along with the equivalent `Database` one, are now removed.


# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
