### PR TITLE
feat(dursto): define cfg aliases for test features at build time

### DIFF
--- a/durable-storage/benches/avl_tree.rs
+++ b/durable-storage/benches/avl_tree.rs
@@ -44,7 +44,7 @@ fn get_operations_batch(mut rng: &mut impl Rng, keys: &[Key], batch_size: usize)
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "rocksdb")] {
+    if #[cfg(rocksdb)] {
         use octez_riscv_durable_storage::persistence_layer::PersistenceLayer;
         use octez_riscv_test_utils::TestableTmpdir;
 

--- a/durable-storage/build.rs
+++ b/durable-storage/build.rs
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 Nomadic Labs <contact@nomadic-labs.com>
+//
+// SPDX-License-Identifier: MIT
+
+//! Emits cfg aliases for compound test/feature flags.
+//!
+//! - `test_utils`: alias for `feature = "unstable-test-utils"`. Thanks to the
+//!   self dev-dependency in `Cargo.toml`, the feature is always enabled in
+//!   test builds, so it is also equivalent to `any(test, feature = "unstable-test-utils")`.
+//!
+//! - `rocksdb`: alias for `feature = "rocksdb"`.
+//!
+//! - `rocksdb_test_utils`: alias for
+//!   `all(feature = "unstable-test-utils", feature = "rocksdb")`.
+
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(test_utils)");
+    println!("cargo::rustc-check-cfg=cfg(rocksdb)");
+    println!("cargo::rustc-check-cfg=cfg(rocksdb_test_utils)");
+
+    let test_utils = std::env::var_os("CARGO_FEATURE_UNSTABLE_TEST_UTILS").is_some();
+    let rocksdb = std::env::var_os("CARGO_FEATURE_ROCKSDB").is_some();
+
+    if test_utils {
+        println!("cargo::rustc-cfg=test_utils");
+    }
+
+    if rocksdb {
+        println!("cargo::rustc-cfg=rocksdb");
+    }
+
+    if test_utils && rocksdb {
+        println!("cargo::rustc-cfg=rocksdb_test_utils");
+    }
+}

--- a/durable-storage/src/commit.rs
+++ b/durable-storage/src/commit.rs
@@ -13,7 +13,7 @@ use octez_riscv_data::hash::Hash;
 /// from a `DirectoryManager`.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Encode, Decode, Hash)]
 #[cfg_attr(
-    feature = "unstable-test-utils",
+    test_utils,
     derive(serde::Serialize, serde::Deserialize),
     serde(transparent)
 )]

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -678,7 +678,7 @@ pub(crate) mod tests {
         })
     }
 
-    #[cfg(feature = "rocksdb")]
+    #[cfg(rocksdb)]
     fn new_persistent_database<KV>() -> (
         tokio::runtime::Runtime,
         KV::Keepalive,
@@ -1023,7 +1023,7 @@ pub(crate) mod tests {
         (original.into_trace(), checked_out.into_trace())
     });
 
-    #[cfg(feature = "rocksdb")]
+    #[cfg(rocksdb)]
     #[test]
     fn test_database_checkout_missing_root_blob_fails_operationally() {
         use rocksdb::ColumnFamilyDescriptor;
@@ -2235,7 +2235,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    #[cfg(feature = "rocksdb")]
+    #[cfg(rocksdb)]
     kv_test!(
         #[should_panic(expected = "trace mismatch")]
         test_database_trace_comparison_detects_divergence,

--- a/durable-storage/src/errors.rs
+++ b/durable-storage/src/errors.rs
@@ -25,7 +25,7 @@ pub enum OperationalError {
     #[error("Commit is missing data for the value of key {key:?}")]
     CommitValueMissing { key: Key, source: Box<Error> },
 
-    #[cfg(feature = "rocksdb")]
+    #[cfg(rocksdb)]
     #[error("Unable to create checkpoint: {error}")]
     CheckpointCreationFailed { error: rocksdb::Error },
 
@@ -47,15 +47,15 @@ pub enum OperationalError {
         error: std::io::Error,
     },
 
-    #[cfg(feature = "rocksdb")]
+    #[cfg(rocksdb)]
     #[error("Unable to open RocksDB: {error}")]
     OpenRocksDbFailed { error: rocksdb::Error },
 
-    #[cfg(feature = "rocksdb")]
+    #[cfg(rocksdb)]
     #[error("Failed to create column family {name}: {error}")]
     ColumnFamilyCreationFailed { name: String, error: rocksdb::Error },
 
-    #[cfg(feature = "rocksdb")]
+    #[cfg(rocksdb)]
     #[error("RocksDB lookup failed {key:?} in {column}: {error}")]
     GetFailed {
         column: String,
@@ -63,7 +63,7 @@ pub enum OperationalError {
         error: rocksdb::Error,
     },
 
-    #[cfg(feature = "rocksdb")]
+    #[cfg(rocksdb)]
     #[error("RocksDB update failed {key:?} in {column}: {error}")]
     PutFailed {
         column: String,
@@ -71,7 +71,7 @@ pub enum OperationalError {
         error: rocksdb::Error,
     },
 
-    #[cfg(feature = "rocksdb")]
+    #[cfg(rocksdb)]
     #[error("RocksDB delete failed {key:?} in {column}: {error}")]
     DeleteFailed {
         column: String,
@@ -79,7 +79,7 @@ pub enum OperationalError {
         error: rocksdb::Error,
     },
 
-    #[cfg(feature = "rocksdb")]
+    #[cfg(rocksdb)]
     #[error("RocksDB merge failed {key:?} at {offset}: {error}")]
     MergeFailed {
         key: Vec<u8>,

--- a/durable-storage/src/key.rs
+++ b/durable-storage/src/key.rs
@@ -67,14 +67,14 @@ impl<'de, Context> BorrowDecode<'de, Context> for Key {
     }
 }
 
-#[cfg(feature = "unstable-test-utils")]
+#[cfg(test_utils)]
 impl serde::Serialize for Key {
     fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         s.serialize_str(&hex::encode(&self.0))
     }
 }
 
-#[cfg(feature = "unstable-test-utils")]
+#[cfg(test_utils)]
 impl<'de> serde::Deserialize<'de> for Key {
     fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
         use serde::de::Error;

--- a/durable-storage/src/merkle_worker.rs
+++ b/durable-storage/src/merkle_worker.rs
@@ -465,7 +465,7 @@ mod tests {
             key: Key,
         },
         Hash,
-        #[cfg(feature = "rocksdb")]
+        #[cfg(rocksdb)]
         Commit,
         Clone,
     }
@@ -502,7 +502,7 @@ mod tests {
                     assert_eq!(hash1, hash2);
                 }
 
-                #[cfg(feature = "rocksdb")]
+                #[cfg(rocksdb)]
                 Self::Commit => {
                     let options = crate::storage::StoreOptions::default()
                         .with_deep()
@@ -546,14 +546,14 @@ mod tests {
 
             let hash = Just(TestCommand::Hash);
 
-            #[cfg(feature = "rocksdb")]
+            #[cfg(rocksdb)]
             let commit = Just(TestCommand::Commit);
 
             let clone = Just(TestCommand::Clone);
 
             // The frequencies are chosen to reflect a typical workload.
             cfg_if::cfg_if! {
-                if #[cfg(feature = "rocksdb")] {
+                if #[cfg(rocksdb)] {
                     proptest::prop_oneof![
                         250 => write,
                         250 => set,

--- a/durable-storage/src/persistence_layer.rs
+++ b/durable-storage/src/persistence_layer.rs
@@ -27,7 +27,7 @@
 //!          <rocksdb internals>
 //! ```
 
-#![cfg(feature = "rocksdb")]
+#![cfg(rocksdb)]
 
 use std::mem::ManuallyDrop;
 use std::path::Path;

--- a/durable-storage/src/registry.rs
+++ b/durable-storage/src/registry.rs
@@ -76,7 +76,7 @@ impl<KV: BackgroundKeyValueStore> Registry<KV, Normal> {
     }
 
     /// Get a [`Handle`] to the registry's runtime.
-    #[cfg(any(test, feature = "unstable-test-utils"))]
+    #[cfg(test_utils)]
     pub(crate) fn handle(&self) -> &tokio::runtime::Handle {
         self.inner.runtime.handle()
     }
@@ -1536,7 +1536,7 @@ pub(super) mod tests {
     });
 }
 
-#[cfg(feature = "rocksdb")]
+#[cfg(rocksdb)]
 #[cfg(test)]
 mod rocksdb_tests {
     use octez_riscv_data::mode::Normal;

--- a/durable-storage/src/storage.rs
+++ b/durable-storage/src/storage.rs
@@ -86,7 +86,7 @@ pub trait PersistentKeyValueStore: KeyValueStore + Sized {
 
 #[cfg(test)]
 cfg_if::cfg_if! {
-    if #[cfg(feature = "rocksdb")] {
+    if #[cfg(rocksdb)] {
         /// Key-value store backend used when the `rocksdb` feature is enabled.
         pub(crate) type TestKeyValueStore = crate::persistence_layer::PersistenceLayer;
 
@@ -148,7 +148,7 @@ cfg_if::cfg_if! {
             }
         }
 
-        #[cfg(feature = "rocksdb")]
+        #[cfg(rocksdb)]
         impl TestKeyValueStoreSetup for crate::persistence_layer::PersistenceLayer {
             type Keepalive = octez_riscv_test_utils::TestableTmpdir;
 
@@ -275,7 +275,7 @@ cfg_if::cfg_if! {
                         $setup
                     }
 
-                    #[cfg(feature = "rocksdb")]
+                    #[cfg(rocksdb)]
                     let rocksdb_setup =
                         _kv_test_setup::<$crate::persistence_layer::PersistenceLayer>();
 
@@ -283,7 +283,7 @@ cfg_if::cfg_if! {
                         _kv_test_setup::<$crate::storage::in_memory::InMemoryKeyValueStore>();
 
                     ::proptest::proptest!(|($($arg in $strat),*)| {
-                        #[cfg(feature = "rocksdb")]
+                        #[cfg(rocksdb)]
                         let rocksdb_trace = {
                             type $ty_name = $crate::persistence_layer::PersistenceLayer;
                             let $setup_values = &rocksdb_setup;
@@ -299,7 +299,7 @@ cfg_if::cfg_if! {
                             $body
                         };
 
-                        #[cfg(feature = "rocksdb")]
+                        #[cfg(rocksdb)]
                         ::proptest::prop_assert_eq!(
                             rocksdb_trace, _in_memory_trace,
                             "trace mismatch"
@@ -322,7 +322,7 @@ cfg_if::cfg_if! {
                             $crate::repo::RegistryRepo,
                     {}
 
-                    #[cfg(feature = "rocksdb")]
+                    #[cfg(rocksdb)]
                     let rocksdb_trace = {
                         type $ty_name = $crate::persistence_layer::PersistenceLayer;
                         _bound_check::<$ty_name>();
@@ -337,7 +337,7 @@ cfg_if::cfg_if! {
                         $body
                     };
 
-                    #[cfg(feature = "rocksdb")]
+                    #[cfg(rocksdb)]
                     assert_eq!(
                         rocksdb_trace, _in_memory_trace,
                         "trace mismatch"

--- a/durable-storage/src/storage/in_memory.rs
+++ b/durable-storage/src/storage/in_memory.rs
@@ -21,10 +21,10 @@ use crate::errors::OperationalError;
 /// Will never write to disk.
 #[derive(Debug, Default, Clone)]
 pub struct InMemoryRepo {
-    #[cfg(any(test, feature = "unstable-test-utils"))]
+    #[cfg(test_utils)]
     commits: std::sync::Arc<RwLock<HashMap<crate::commit::CommitId, InMemorySnapshot>>>,
 
-    #[cfg(any(test, feature = "unstable-test-utils"))]
+    #[cfg(test_utils)]
     registry_commits: std::sync::Arc<RwLock<HashMap<crate::commit::CommitId, Vec<u8>>>>,
 }
 
@@ -196,14 +196,14 @@ impl KeyValueStore for InMemoryKeyValueStore {
 }
 
 /// Test-only snapshot repository for [`InMemoryRepo`]
-#[cfg(any(test, feature = "unstable-test-utils"))]
+#[cfg(test_utils)]
 #[derive(Debug)]
 struct InMemorySnapshot {
     blobs: HashMap<Bytes, Bytes>,
     values: HashMap<Bytes, BytesMut>,
 }
 
-#[cfg(any(test, feature = "unstable-test-utils"))]
+#[cfg(test_utils)]
 impl super::PersistentKeyValueStore for InMemoryKeyValueStore {
     fn commit_to_path(&self, _path: &std::path::Path) -> Result<(), OperationalError> {
         unimplemented!("In-memory store cannot commit to disk")
@@ -254,7 +254,7 @@ impl super::PersistentKeyValueStore for InMemoryKeyValueStore {
     }
 }
 
-#[cfg(any(test, feature = "unstable-test-utils"))]
+#[cfg(test_utils)]
 impl crate::repo::RegistryRepo for InMemoryRepo {
     fn read_registry_commit(
         &self,

--- a/durable-storage/src/test_helpers.rs
+++ b/durable-storage/src/test_helpers.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-#![cfg(any(test, feature = "unstable-test-utils"))]
+#![cfg(test_utils)]
 
 //! Shared utilities for end to end durable storage property-based tests
 //!

--- a/durable-storage/tests/integration_test.rs
+++ b/durable-storage/tests/integration_test.rs
@@ -10,7 +10,7 @@ use octez_riscv_durable_storage::test_helpers::run_operations;
 use proptest::proptest;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "rocksdb")] {
+    if #[cfg(rocksdb)] {
         use octez_riscv_durable_storage::persistence_layer::PersistenceLayer;
         use octez_riscv_durable_storage::repo::DirectoryManager;
         use octez_riscv_test_utils::TestableTmpdir;


### PR DESCRIPTION
Closes RV-1002.

# What

Introduces 3 build-time cfg aliases:
- `#[cfg(test_utils)]` as an alias for `#[cfg(feature = "unstable-test-utils")]` (and also `#[cfg(any(test, feature = "unstable-test-utils"))]` because `test` always builds with the `unstable-test-utils` flag).
- `#[cfg(rocksdb)]` as an alias for `#[cfg(feature = "rocksdb")]`
- `#[cfg(rocksdb_test_utils)]` as an alias for `#[cfg(all(feature = "unstable-test-utils", feature = "rocksdb"))]`. This one is not yet used anywhere but will be used for the long tests binary.

# Why

Simplifies cfg attributes, especially in test code.

# How

As part of a newly introduced build script. All relevant attributes changed.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
