### PR TITLE
feat(registry): implement FromProof/PartialHashFold for Registry

### DIFF
--- a/data/src/merkle_proof.rs
+++ b/data/src/merkle_proof.rs
@@ -166,7 +166,8 @@ pub trait Deserialiser {
     /// retain their original sub-proof so they can fold against it later, even after the working
     /// tree has been structurally rearranged.
     ///
-    /// TODO RV-994: Investigate avoiding the extra allocation required for this.
+    // TODO RV-994: Investigate avoiding the extra allocation required for this.
+    // TODO TZX-161: StreamDeserialiser should allow capturing owned proof
     fn capture_owned_proof(&self) -> Option<MerkleProof> {
         None
     }

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -701,18 +701,6 @@ pub(crate) mod tests {
         (runtime, keepalive, repo, database)
     }
 
-    /// Generate a Merkle proof from `database` and produce a Verify-mode database that replays
-    /// the same data via that proof.
-    pub(crate) fn to_verify<KV: KeyValueStore>(
-        database: &Database<KV, Prove<'static>>,
-    ) -> Database<KV, Verify> {
-        Database {
-            inner: super::VerifyImpl {
-                merkle: database.inner.merkle.to_verify(),
-            },
-        }
-    }
-
     kv_test!(test_database_commit_and_checkout, KV: BackgroundPersistentKeyValueStore,
         setup_runtime |handle, repo| = {
             let runtime = tokio::runtime::Builder::new_multi_thread()

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -20,6 +20,8 @@ use octez_riscv_data::foldable::Fold;
 use octez_riscv_data::foldable::Foldable;
 use octez_riscv_data::hash::Hash;
 use octez_riscv_data::hash::HashFold;
+use octez_riscv_data::hash::PartialHash;
+use octez_riscv_data::hash::PartialHashFold;
 use octez_riscv_data::merkle_proof::Deserialiser;
 use octez_riscv_data::merkle_proof::FromProof;
 use octez_riscv_data::merkle_proof::Suspended;
@@ -290,9 +292,9 @@ impl<KV: KeyValueStore> Foldable<MerkleProofFold> for Database<KV, Prove<'_>> {
     }
 }
 
-impl<KV: KeyValueStore> Foldable<HashFold> for Database<KV, Verify> {
-    fn fold(&self, _builder: HashFold) -> Hash {
-        self.inner.merkle.hash()
+impl<KV: KeyValueStore> Foldable<PartialHashFold> for Database<KV, Verify> {
+    fn fold(&self, builder: PartialHashFold) -> PartialHash {
+        self.inner.merkle.fold(builder)
     }
 }
 

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -27,6 +27,7 @@ use octez_riscv_data::foldable::NodeFold;
 use octez_riscv_data::hash::Hash;
 use octez_riscv_data::hash::HashFold;
 use octez_riscv_data::hash::PartialHash;
+use octez_riscv_data::hash::PartialHashFold;
 use octez_riscv_data::merkle_proof::Deserialiser;
 use octez_riscv_data::merkle_proof::DeserialiserError;
 use octez_riscv_data::merkle_proof::FromProof;
@@ -547,6 +548,18 @@ struct VerifyImpl {
     /// Original proof the verify-mode tree was deserialised from. Required by [`MerkleLayer::hash`]
     /// to resolve `prev_hash` substitutions in [`PartialHashFold::previous`] for blinded subtrees.
     original_proof: Arc<MerkleProof>,
+}
+
+impl<KV> Foldable<PartialHashFold> for MerkleLayer<KV, Verify> {
+    fn fold(&self, builder: PartialHashFold) -> PartialHash {
+        // Override whatever proof the parent fold passed down with the proof this layer was
+        // deserialised from: it is the source of truth for the `prev_hash` substitutions performed
+        // by [`PartialHashFold::previous`] for blinded subtrees of this tree. This mirrors what
+        // [`MerkleLayer::hash`] does, but threads the parent fold's builder so the layer can be
+        // folded as a child of a larger state (e.g. a `Database` or `Registry`).
+        let builder = builder.with_proof(Some(self.inner.original_proof.clone()));
+        self.inner.tree.fold(builder)
+    }
 }
 
 /// Prove-mode backing state for a [`MerkleLayer`].

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -29,9 +29,7 @@ use octez_riscv_data::hash::HashFold;
 use octez_riscv_data::hash::PartialHash;
 use octez_riscv_data::hash::PartialHashFold;
 use octez_riscv_data::merkle_proof::Deserialiser;
-use octez_riscv_data::merkle_proof::DeserialiserError;
 use octez_riscv_data::merkle_proof::FromProof;
-use octez_riscv_data::merkle_proof::ProofError;
 use octez_riscv_data::merkle_proof::Suspended;
 use octez_riscv_data::merkle_proof::SuspendedResult;
 use octez_riscv_data::merkle_proof::proof_tree::MerkleProof;
@@ -42,6 +40,7 @@ use octez_riscv_data::mode::Mode;
 use octez_riscv_data::mode::Normal;
 use octez_riscv_data::mode::Prove;
 use octez_riscv_data::mode::Verify;
+use octez_riscv_data::mode::utils::not_found;
 use octez_riscv_data::serialisation::serialise;
 use perfect_derive::perfect_derive;
 
@@ -157,7 +156,7 @@ impl<KV> MerkleLayer<KV, Verify> {
             inner: VerifyImpl {
                 tree: Tree::default(),
                 resolver: VerifyResolver,
-                original_proof: Arc::new(MerkleProof::leaf_blind(Hash::hash_bytes(&[]))),
+                original_proof: Some(Arc::new(MerkleProof::leaf_blind(Hash::hash_bytes(&[])))),
             },
         }
     }
@@ -165,11 +164,16 @@ impl<KV> MerkleLayer<KV, Verify> {
 
 impl<KV> FromProof for MerkleLayer<KV, Verify> {
     fn from_proof<Proof: Deserialiser>(proof: Proof) -> SuspendedResult<Proof, Self> {
-        // Capture before consuming `proof`
-        let original_proof = proof
-            .capture_owned_proof()
-            .map(Arc::new)
-            .ok_or_else(|| Proof::Error::custom(ProofError::AbsentProof))?;
+        // Capture before consuming `proof`.
+        //
+        // This is `None` for deserialisers that cannot capture an owned proof (e.g. the stream
+        // deserialiser): the layer still deserialises structurally — which is required to
+        // reconstruct the proof tree from the raw bytes in the first place — but it cannot be
+        // hashed. To obtain a verifiable layer, deserialise a second time from the proof tree
+        // recovered by the first pass.
+        //
+        // TODO TZX-161: StreamDeserialiser should allow capturing owned proof
+        let original_proof = proof.capture_owned_proof().map(Arc::new);
 
         let suspended = Tree::<VerifyNodeId>::from_proof(proof)?;
         Ok(suspended.map(move |tree| MerkleLayer {
@@ -402,9 +406,15 @@ impl MerkleLayerMode for Verify {
         let tree_id = VerifyTreeId::Present {
             tree: this.inner.tree.clone(),
         };
-        PartialHash::from_foldable(Some((*this.inner.original_proof).clone()), &tree_id)
+        let original_proof = this
+            .inner
+            .original_proof
+            .as_ref()
+            .map(|proof| proof.as_ref().clone());
+        PartialHash::from_foldable(original_proof, &tree_id)
             .to_hash()
-            .expect("verify-mode hash should resolve to Present")
+            // SAFETY: `not_found` is safe to call because we're in `Verify` mode.
+            .unwrap_or_else(|| unsafe { not_found() })
     }
 
     fn delete<KV: KeyValueStore>(
@@ -547,7 +557,12 @@ struct VerifyImpl {
     resolver: VerifyResolver,
     /// Original proof the verify-mode tree was deserialised from. Required by [`MerkleLayer::hash`]
     /// to resolve `prev_hash` substitutions in [`PartialHashFold::previous`] for blinded subtrees.
-    original_proof: Arc<MerkleProof>,
+    ///
+    /// `None` when the layer was deserialised by a deserialiser that cannot capture an owned
+    /// proof (the stream deserialiser, see TZX-161). Such a layer deserialises structurally but
+    /// cannot be hashed; it must be re-deserialised from the proof tree recovered by the first
+    /// deserialisation pass.
+    original_proof: Option<Arc<MerkleProof>>,
 }
 
 impl<KV> Foldable<PartialHashFold> for MerkleLayer<KV, Verify> {
@@ -557,7 +572,7 @@ impl<KV> Foldable<PartialHashFold> for MerkleLayer<KV, Verify> {
         // by [`PartialHashFold::previous`] for blinded subtrees of this tree. This mirrors what
         // [`MerkleLayer::hash`] does, but threads the parent fold's builder so the layer can be
         // folded as a child of a larger state (e.g. a `Database` or `Registry`).
-        let builder = builder.with_proof(Some(self.inner.original_proof.clone()));
+        let builder = builder.with_proof(self.inner.original_proof.clone());
         self.inner.tree.fold(builder)
     }
 }

--- a/durable-storage/src/registry.rs
+++ b/durable-storage/src/registry.rs
@@ -506,13 +506,18 @@ pub(super) mod tests {
     use bytes::Bytes;
     use octez_riscv_data::components::vector::VectorMode;
     use octez_riscv_data::hash::Hash;
+    use octez_riscv_data::hash::PartialHash;
     use octez_riscv_data::merkle_proof::FromProof;
+    use octez_riscv_data::merkle_proof::proof::Proof;
+    use octez_riscv_data::merkle_proof::proof::deserialise_proof;
+    use octez_riscv_data::merkle_proof::proof::serialise_proof;
     use octez_riscv_data::merkle_proof::proof_tree::MerkleProof;
     use octez_riscv_data::merkle_proof::proof_tree::ProofPart;
     use octez_riscv_data::mode::Normal;
     use octez_riscv_data::mode::ProvableExt;
     use octez_riscv_data::mode::Prove;
     use octez_riscv_data::mode::Verify;
+    use octez_riscv_data::mode::utils::catch_not_found;
     use octez_riscv_data::serialisation::deserialise;
     use octez_riscv_data::serialisation::serialise;
 
@@ -1535,6 +1540,378 @@ pub(super) mod tests {
         assert_eq!(registry.len(), 1);
 
         assert!(registry.resize_tick(5).is_err());
+    });
+
+    /// Round-trip a registry [`Proof`] via bytes.
+    ///
+    /// Deserialising the bytes requires two passes over the registry state:
+    ///
+    /// 1. The stream pass parses the raw bytes — driven by the registry's [`FromProof`]
+    ///    shape — and reconstructs the proof tree. The registry it returns is structurally
+    ///    correct, but it cannot be hashed: the stream deserialiser cannot capture the owned
+    ///    sub-proofs that verify-mode hashing folds against (TZX-161).
+    /// 2. The reconstructed proof tree is deserialised again, this time with the proof-tree
+    ///    deserialiser, which does capture owned sub-proofs and therefore yields a verifiable
+    ///    registry.
+    ///
+    /// Returns the registries produced by both passes.
+    fn deserialise_proof_via_bytes<KV: BackgroundKeyValueStore>(
+        proof: &Proof,
+    ) -> (Registry<KV, Verify>, Registry<KV, Verify>) {
+        let bytes = serialise_proof(proof);
+
+        let (reconstructed_proof, stream_registry) =
+            deserialise_proof::<Registry<KV, Verify>, _>(bytes.into_iter())
+                .expect("Stream deserialisation of the proof bytes should succeed");
+        assert_eq!(
+            &reconstructed_proof, proof,
+            "The proof reconstructed from bytes should match the original"
+        );
+
+        let verify_registry =
+            Registry::<KV, Verify>::from_proof(ProofPart::Present(reconstructed_proof.tree()))
+                .expect("from_proof should succeed")
+                .into_result();
+
+        (stream_registry, verify_registry)
+    }
+
+    /// Recompute the registry root hash of a verify-mode registry.
+    ///
+    /// This relies on the databases all fitting in a single level in the tree,
+    /// (up to 4 currently). Additionally, the registry as a whole cannot be
+    /// blinded (ie at least one database must be used).
+    ///
+    /// Future full e2e tests should additionally pass the whole proof to
+    /// allow registry partial hash fold to function if these don't apply.
+    fn registry_root_hash_small<KV: BackgroundKeyValueStore>(
+        registry: &Registry<KV, Verify>,
+    ) -> Hash {
+        PartialHash::from_foldable(None, registry)
+            .to_hash()
+            .expect("Database captures owned proof, should be able to hash")
+    }
+
+    kv_test!(test_proof_via_bytes_end_to_end, KV: BackgroundKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+
+        let key_a = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
+        let key_b = Key::new(&[2]).expect("Size less than KEY_MAX_SIZE");
+        let key_c = Key::new(&[3]).expect("Size less than KEY_MAX_SIZE");
+
+        let mut registry = setup_size_2_registry::<KV>(repo);
+        populate_database_with_key_value::<KV>(&mut registry, 0, &[1], b"foo");
+        populate_database_with_key_value::<KV>(&mut registry, 1, &[2], b"bar");
+
+        let initial_root = Hash::from_foldable(&registry);
+
+        // The step: read a value from database 0, write a fresh key to database 1.
+        let mut prove_registry = registry
+            .try_start_proof()
+            .expect("Converting to prove mode should succeed");
+        prove_registry
+            .database(0)
+            .expect("Database should exist.")
+            .assert_database_value(&key_a, b"foo");
+        prove_registry
+            .database(1)
+            .expect("Database should exist.")
+            .assert_database_value(&key_b, b"bar");
+        prove_registry
+            .database_mut(1)
+            .expect("Database should exist.")
+            .set(key_c.clone(), Bytes::from_static(b"baz"))
+            .expect("Setting a value should succeed");
+
+        let final_root = Hash::from_foldable(&prove_registry);
+        let proof = prove_registry.produce_proof();
+
+        assert_eq!(
+            proof.initial_state_hash(),
+            initial_root,
+            "The proof must encode the registry's initial state"
+        );
+        assert_eq!(
+            proof.final_state_hash(),
+            final_root,
+            "The proof must carry the prove-mode final state hash"
+        );
+
+        let (_stream_registry, mut verify_registry) = deserialise_proof_via_bytes::<KV>(&proof);
+
+        assert_eq!(
+            registry_root_hash_small(&verify_registry),
+            initial_root,
+            "The verify-mode registry must start from the initial state hash"
+        );
+
+        // Replay the step.
+        verify_registry
+            .database(0)
+            .expect("Database should exist.")
+            .assert_database_value(&key_a, b"foo");
+        verify_registry
+            .database(1)
+            .expect("Database should exist.")
+            .assert_database_value(&key_b, b"bar");
+        verify_registry
+            .database_mut(1)
+            .expect("Database should exist.")
+            .set(key_c, Bytes::from_static(b"baz"))
+            .expect("Setting a value should succeed");
+
+        assert_eq!(
+            registry_root_hash_small(&verify_registry),
+            proof.final_state_hash(),
+            "Replaying the step in verify mode must reach the proof's final state hash"
+        );
+    });
+
+    // TODO (TZX-161): once the stream deserialiser can capture owned proofs, the first pass
+    // should become verifiable on its own and this test should be updated.
+    kv_test!(test_proof_via_bytes_requires_second_deserialisation, KV: BackgroundKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+
+        let key_a = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
+
+        let mut registry = setup_size_2_registry::<KV>(repo);
+        // Database 0 holds several keys so that reading one of them traverses nodes whose
+        // data stays unread — those fields are absent from the proof and can only be
+        // resolved against the captured owned proof.
+        populate_database_with_key_value::<KV>(&mut registry, 0, &[1], b"foo");
+        populate_database_with_key_value::<KV>(&mut registry, 0, &[4], b"unread");
+        populate_database_with_key_value::<KV>(&mut registry, 0, &[5], b"unread");
+        populate_database_with_key_value::<KV>(&mut registry, 1, &[2], b"bar");
+
+        let db_0_initial_hash = registry
+            .database(0)
+            .expect("Database should exist.")
+            .hash()
+            .expect("Hashing should succeed.");
+
+        // The step only reads one key from database 0.
+        let prove_registry = registry
+            .try_start_proof()
+            .expect("Converting to prove mode should succeed");
+        prove_registry
+            .database(0)
+            .expect("Database should exist.")
+            .assert_database_value(&key_a, b"foo");
+
+        let proof = prove_registry.produce_proof();
+        let (stream_registry, verify_registry) = deserialise_proof_via_bytes::<KV>(&proof);
+
+        // The stream-pass registry is structurally correct: recorded reads replay fine.
+        stream_registry
+            .database(0)
+            .expect("Database should exist.")
+            .assert_database_value(&key_a, b"foo");
+
+        // ... but it cannot be hashed, because the owned proof was not captured.
+        let stream_hash_attempt = catch_not_found(|| {
+            stream_registry
+                .database(0)
+                .expect("Database should exist.")
+                .hash()
+        });
+        assert!(
+            stream_hash_attempt.is_err(),
+            "Hashing a stream-deserialised database should fail: the owned proof was not captured"
+        );
+
+        // The second pass captured the owned proof, so the hash is available and matches the
+        // initial state.
+        assert_eq!(
+            verify_registry
+                .database(0)
+                .expect("Database should exist.")
+                .hash()
+                .expect("Hashing should succeed."),
+            db_0_initial_hash,
+            "The proof-tree pass must recover the partially-read database's hash"
+        );
+        assert_eq!(
+            registry_root_hash_small(&verify_registry),
+            proof.initial_state_hash(),
+            "The proof-tree pass must recover the registry's initial root hash"
+        );
+    });
+
+    kv_test!(test_proof_database_hash_queries_replay_in_verify_mode, KV: BackgroundKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+
+        let key_c = Key::new(&[3]).expect("Size less than KEY_MAX_SIZE");
+
+        let mut registry = setup_size_2_registry::<KV>(repo);
+        populate_database_with_key_value::<KV>(&mut registry, 0, &[1], b"foo");
+        populate_database_with_key_value::<KV>(&mut registry, 1, &[2], b"bar");
+
+        let mut prove_registry = registry
+            .try_start_proof()
+            .expect("Converting to prove mode should succeed");
+
+        // Query the hash of database 0 without accessing it otherwise.
+        let prove_hash_untouched = prove_registry
+            .database(0)
+            .expect("Database should exist.")
+            .hash()
+            .expect("Hashing should succeed.");
+
+        // Mutate database 1, then query its hash mid-step.
+        prove_registry
+            .database_mut(1)
+            .expect("Database should exist.")
+            .set(key_c.clone(), Bytes::from_static(b"baz"))
+            .expect("Setting a value should succeed");
+        let prove_hash_after_write = prove_registry
+            .database(1)
+            .expect("Database should exist.")
+            .hash()
+            .expect("Hashing should succeed.");
+
+        let proof = prove_registry.produce_proof();
+        let (_stream_registry, mut verify_registry) = deserialise_proof_via_bytes::<KV>(&proof);
+
+        // Replay: the same queries must give the same answers.
+        assert_eq!(
+            verify_registry
+                .database(0)
+                .expect("Database should exist.")
+                .hash()
+                .expect("Hashing should succeed."),
+            prove_hash_untouched,
+            "The verifier must reproduce the hash of the untouched database"
+        );
+
+        verify_registry
+            .database_mut(1)
+            .expect("Database should exist.")
+            .set(key_c, Bytes::from_static(b"baz"))
+            .expect("Setting a value should succeed");
+        assert_eq!(
+            verify_registry
+                .database(1)
+                .expect("Database should exist.")
+                .hash()
+                .expect("Hashing should succeed."),
+            prove_hash_after_write,
+            "The verifier must reproduce the mid-step hash of the written database"
+        );
+
+        assert_eq!(
+            registry_root_hash_small(&verify_registry),
+            proof.final_state_hash(),
+            "Replaying the step in verify mode must reach the proof's final state hash"
+        );
+    });
+
+    // Currently broken: prove-mode `copy_database` installs a clone whose initial tree and
+    // access tracking come from the *source* slot, so the produced proof encodes the wrong
+    // initial state for the destination slot.
+    // TODO (TZX-170): fix copy proof semantics
+    kv_test!(
+        #[ignore = "prove-mode copy_database breaks the proof's initial-state encoding"]
+        test_proof_copy_database_preserves_hash_invariants, KV: BackgroundKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+
+        let mut registry = setup_size_2_registry::<KV>(repo);
+        populate_database_with_key_value::<KV>(&mut registry, 0, &[1], b"foo");
+        populate_database_with_key_value::<KV>(&mut registry, 1, &[2], b"bar");
+
+        let initial_root = Hash::from_foldable(&registry);
+
+        let mut prove_registry = registry
+            .try_start_proof()
+            .expect("Converting to prove mode should succeed");
+        prove_registry
+            .copy_database(0, 1)
+            .expect("Copying should succeed");
+        let final_root = Hash::from_foldable(&prove_registry);
+
+        // Reference: the same step in Normal mode.
+        registry
+            .copy_database(0, 1)
+            .expect("Copying should succeed");
+        assert_eq!(
+            Hash::from_foldable(&registry),
+            final_root,
+            "Prove-mode copy must produce the Normal-mode final hash"
+        );
+
+        let proof = prove_registry.produce_proof();
+        assert_eq!(
+            proof.initial_state_hash(),
+            initial_root,
+            "The proof must encode the registry's true initial state"
+        );
+        assert_eq!(proof.final_state_hash(), final_root);
+
+        // Replaying the copy in verify mode must reach the final state hash.
+        let (_stream_registry, mut verify_registry) = deserialise_proof_via_bytes::<KV>(&proof);
+        assert_eq!(registry_root_hash_small(&verify_registry), initial_root);
+        verify_registry
+            .copy_database(0, 1)
+            .expect("Copying should succeed");
+        assert_eq!(
+            registry_root_hash_small(&verify_registry),
+            proof.final_state_hash(),
+            "Replaying the copy in verify mode must reach the proof's final state hash"
+        );
+    });
+
+    // Currently broken: prove-mode `move_database` replaces the source slot with an empty
+    // database whose initial tree is empty, and moves the source database — along with its
+    // initial tree — to the destination slot, so the produced proof encodes the wrong
+    // initial state for both slots.
+    // TODO (TZX-170): fix move proof semantics
+    kv_test!(
+        #[ignore = "prove-mode move_database breaks the proof's initial-state encoding"]
+        test_proof_move_database_preserves_hash_invariants, KV: BackgroundKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+
+        let mut registry = setup_size_2_registry::<KV>(repo);
+        populate_database_with_key_value::<KV>(&mut registry, 0, &[1], b"foo");
+        populate_database_with_key_value::<KV>(&mut registry, 1, &[2], b"bar");
+
+        let initial_root = Hash::from_foldable(&registry);
+
+        let mut prove_registry = registry
+            .try_start_proof()
+            .expect("Converting to prove mode should succeed");
+        prove_registry
+            .move_database(0, 1)
+            .expect("Moving should succeed");
+        let final_root = Hash::from_foldable(&prove_registry);
+
+        // Reference: the same step in Normal mode.
+        registry
+            .move_database(0, 1)
+            .expect("Moving should succeed");
+        assert_eq!(
+            Hash::from_foldable(&registry),
+            final_root,
+            "Prove-mode move must produce the Normal-mode final hash"
+        );
+
+        let proof = prove_registry.produce_proof();
+        assert_eq!(
+            proof.initial_state_hash(),
+            initial_root,
+            "The proof must encode the registry's true initial state"
+        );
+        assert_eq!(proof.final_state_hash(), final_root);
+
+        // Replaying the move in verify mode must reach the final state hash.
+        let (_stream_registry, mut verify_registry) = deserialise_proof_via_bytes::<KV>(&proof);
+        assert_eq!(registry_root_hash_small(&verify_registry), initial_root);
+        verify_registry
+            .move_database(0, 1)
+            .expect("Moving should succeed");
+        assert_eq!(
+            registry_root_hash_small(&verify_registry),
+            proof.final_state_hash(),
+            "Replaying the move in verify mode must reach the proof's final state hash"
+        );
     });
 
     kv_test!(test_durable_storage_end_to_end, KV: BackgroundPersistentKeyValueStore,

--- a/durable-storage/src/registry.rs
+++ b/durable-storage/src/registry.rs
@@ -19,6 +19,10 @@ use octez_riscv_data::components::vector::VectorMode;
 use octez_riscv_data::foldable::Fold;
 use octez_riscv_data::foldable::Foldable;
 use octez_riscv_data::hash::Hash;
+use octez_riscv_data::merkle_proof::Deserialiser;
+use octez_riscv_data::merkle_proof::FromProof;
+use octez_riscv_data::merkle_proof::Suspended;
+use octez_riscv_data::merkle_proof::SuspendedResult;
 use octez_riscv_data::merkle_proof::proof::Proof;
 use octez_riscv_data::merkle_proof::proof_tree::MerkleProof;
 use octez_riscv_data::mode::Modal;
@@ -341,6 +345,21 @@ where
     }
 }
 
+impl<KV: KeyValueStore> FromProof for Registry<KV, Verify> {
+    // TODO (TZX-161): for a verify mode Registry, the resulting registry state is currently
+    // only usable if `proof` is the ProofTree. Otherwise, if created using the stream
+    // deserialiser, verification will fail (as this does not support capturing the owned proof).
+    // Deserialising from raw bytes therefore requires two passes: a stream pass to reconstruct
+    // the proof tree, then a proof-tree pass to obtain a verifiable registry.
+    fn from_proof<Proof: Deserialiser>(proof: Proof) -> SuspendedResult<Proof, Self> {
+        let suspended = Vector::<Database<KV, Verify>, Verify>::from_proof(proof)?;
+        Ok(suspended.map(|databases| Self {
+            inner: VerifyImpl(PhantomData),
+            databases,
+        }))
+    }
+}
+
 /// Modal template for the [`Registry`]
 ///
 /// This is used to select the appropriate implementation for the mode.
@@ -487,6 +506,9 @@ pub(super) mod tests {
     use bytes::Bytes;
     use octez_riscv_data::components::vector::VectorMode;
     use octez_riscv_data::hash::Hash;
+    use octez_riscv_data::merkle_proof::FromProof;
+    use octez_riscv_data::merkle_proof::proof_tree::MerkleProof;
+    use octez_riscv_data::merkle_proof::proof_tree::ProofPart;
     use octez_riscv_data::mode::Normal;
     use octez_riscv_data::mode::ProvableExt;
     use octez_riscv_data::mode::Prove;
@@ -499,7 +521,6 @@ pub(super) mod tests {
     use super::RegistryManifest;
     use super::VerifyImpl;
     use crate::commit::CommitId;
-    use crate::database::tests::to_verify;
     use crate::errors::Error;
     use crate::errors::InvalidArgumentError;
     use crate::errors::OperationalError;
@@ -1232,7 +1253,7 @@ pub(super) mod tests {
         let key_a = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
         let key_b = Key::new(&[2]).expect("Size less than KEY_MAX_SIZE");
 
-        let mut registry = setup_size_2_registry(repo);
+        let mut registry = setup_size_2_registry::<KV>(repo);
 
         let db_0 = registry.database_mut(0)
             .expect("database at index 0 exists");
@@ -1296,14 +1317,10 @@ pub(super) mod tests {
         );
         assert_eq!(root_hash_prove_after, root_hash_prove_before, "Reads must not affect Prove-mode hashes");
 
-        let verify_databases = (0..prove_registry.len())
-            .map(|i| to_verify::<KV>(prove_registry.database(i).expect("Database should exist.")))
-            .collect();
-
-        let verify_registry = Registry::<KV, Verify> {
-            inner: VerifyImpl(PhantomData),
-            databases: <Verify as VectorMode>::new(verify_databases),
-        };
+        let proof = MerkleProof::from_foldable(&prove_registry);
+        let verify_registry = Registry::<KV, _>::from_proof(ProofPart::Present(&proof))
+            .expect("from_proof should succeed")
+            .into_result();
 
         let verify_hashes_before = (0..verify_registry.len())
             .map(|i| {

--- a/durable-storage/src/test_helpers.rs
+++ b/durable-storage/src/test_helpers.rs
@@ -918,6 +918,8 @@ fn prove_and_verify_operation<KV: BackgroundKeyValueStore>(
     database: &TracedDatabase<KV, Normal>,
     operation: &DatabaseOperation,
 ) {
+    use octez_riscv_data::hash::PartialHash;
+
     let pre_root_hash = Hash::from_foldable(database);
 
     // Produce a proof and record the trace of applying `operation`
@@ -944,12 +946,16 @@ fn prove_and_verify_operation<KV: BackgroundKeyValueStore>(
         .into_result(),
     );
     assert_eq!(
-        Hash::from_foldable(&verify_db),
+        PartialHash::from_foldable(None, &verify_db)
+            .to_hash()
+            .unwrap(),
         pre_root_hash,
         "the proof must reconstruct the pre-operation root hash"
     );
     apply_step(&mut verify_db, operation).expect("applying a step should succeed");
-    let verify_post_root_hash = Hash::from_foldable(&verify_db);
+    let verify_post_root_hash = PartialHash::from_foldable(None, &verify_db)
+        .to_hash()
+        .unwrap();
     let verify_step_trace = verify_db.into_trace();
 
     assert_eq!(


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

- Closes TZX-135
- Closes TZX-134

# What

Implement `FromProof` for `Registry`

# Why

- Required to deserialise a proof, and to recover the `Registry<Verify>` instance.
- Required to get the final root hash from verify mode additionally.
- added e2e tests to demonstrate the current state, and capture the remaining issues with single-step that need to be addressed.

# How

mostly done by the verify mode for `Vector`.

# Manually Testing

```
make all
```


# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
