### PR TITLE
fix(dursto): open databases read-only when checking out

### DIFF
--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -1052,6 +1052,9 @@ pub(crate) mod tests {
         commit_db
             .delete_cf(blob_cf, commit_id.as_hash().as_ref())
             .expect("Deleting the root blob should succeed");
+        commit_db
+            .flush_cf(blob_cf)
+            .expect("Flushing the blob column family should succeed");
         drop(commit_db);
 
         assert!(matches!(

--- a/durable-storage/src/persistence_layer.rs
+++ b/durable-storage/src/persistence_layer.rs
@@ -451,14 +451,15 @@ impl PersistentKeyValueStore for PersistenceLayer {
             return Err(OperationalError::CommitNotFound);
         };
 
-        // Open the previous commitment from the given source path
-        let read_only_database = rocksdb::DB::open_cf_descriptors(
+        // Open the previous commitment from the given source path in read-only mode
+        let read_only_database = rocksdb::DB::open_cf_descriptors_read_only(
             &rocksdb_checkpoint_options(),
             commit_path,
             [
                 ColumnFamilyDescriptor::new(BLOB_CF, rocksdb_checkpoint_options()),
                 ColumnFamilyDescriptor::new("default", rocksdb_checkpoint_options()),
             ],
+            false,
         )
         .map_err(|error| OperationalError::OpenRocksDbFailed { error })?;
 


### PR DESCRIPTION
Relates to RV-984

# What

Opens RocksDB databases as read-only when checking out.

# Why

Stumbled upon this while trying to diagnose an issue with the long tests (https://github.com/tezos/riscv-pvm/pull/1084) where I noticed that the size of a commit is (surprisingly) correlated to the the number of proptest cases executed. This happens because every test case starts with a checkout, which, in read-write mode, will result in a new `LOG` file, with the previous log file stored as`LOG.old.XXXX`. This balloons the size of a commit from ~1.5 MiB for 10 test cases to ~22 MiB for 256 test cases. With this fix, the initial commit drops to 0.24 MiB.

# How

By using `open_cf_descriptors_read_only` instead of `open_cf_descriptors` for checking out.

An alternative fix would have been to limit the number of log files that are kept using [`set_keep_log_file_num`](https://docs.rs/rocksdb/latest/rocksdb/struct.Options.html#method.set_keep_log_file_num). We could fall back on it if there's a good reason to keep opening DBs in read-write mode.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
