### PR TITLE
test(dursto): run Database long test nightly

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,103 @@
+name: Set up build environment
+description: >
+  Common build setup for the riscv-pvm workspace: free up disk space, install
+  Nix, restore the Nix/Rust/sccache caches, enter the Nix development shell and
+  build dependencies. The repository must already be checked out.
+
+inputs:
+  save-nix-cache:
+    description: Whether to save the Nix cache after the job.
+    default: "false"
+  prefetch-cargo:
+    description: Whether to prefetch Cargo downloads on a cache miss.
+    default: "false"
+
+outputs:
+  rust-cache-primary-key:
+    description: Primary key produced by the Rustup/Cargo cache restore.
+    value: ${{ steps.rust-cache.outputs.cache-primary-key }}
+  nix-cache-hit-primary-key:
+    description: Whether the Nix cache primary key was hit.
+    value: ${{ steps.nix-cache.outputs.hit-primary-key }}
+
+runs:
+  using: composite
+  steps:
+    - name: Aggressive cleanup
+      shell: bash
+      run: |
+        # Remove Java (JDKs)
+        sudo rm -rf /usr/lib/jvm
+
+        # Remove .NET SDKs
+        sudo rm -rf /usr/share/dotnet
+
+        # Remove Swift toolchain
+        sudo rm -rf /usr/share/swift
+
+        # Remove Haskell (GHC)
+        sudo rm -rf /usr/local/.ghcup
+
+        # Remove Android SDKs
+        sudo rm -rf /usr/local/lib/android
+
+        # Remove Azure CLI
+        sudo rm -rf /opt/az
+
+        # Remove PowerShell
+        sudo rm -rf /usr/local/share/powershell
+
+    - name: Nix setup
+      uses: nixbuild/nix-quick-install-action@v34
+      with:
+        nix_conf: |
+          keep-env-derivations = true
+          keep-derivations = true
+          keep-outputs = true
+          experimental-features = nix-command flakes
+
+    - name: Nix cache
+      id: nix-cache
+      uses: nix-community/cache-nix-action@v7
+      with:
+        primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}-v2
+        restore-prefixes-first-match: |
+          nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}-
+          nix-${{ runner.os }}-${{ runner.arch }}-
+        save: ${{ inputs.save-nix-cache }}
+
+    - name: Restore Rustup and Cargo cache
+      id: rust-cache
+      uses: actions/cache/restore@v5.0.5
+      with:
+        key: rust-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain*') }}-v2
+        restore-keys: |
+          rust-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain*') }}-
+          rust-${{ runner.os }}-${{ runner.arch }}-
+        path: |
+          ~/.rustup
+          ~/.cargo/bin
+          ~/.cargo/registry/index
+          ~/.cargo/registry/cache
+          ~/.cargo/git/db
+
+    - name: Rust compilation cache
+      uses: Mozilla-Actions/sccache-action@v0.0.10
+
+    - name: Pre-build Nix development shell
+      shell: bash
+      run: |
+        # Subsequent steps will have their environment configured using the $GITHUB_ENV variable.
+        nix run .#direnv -- allow .
+        nix run .#direnv -- export gha > "$GITHUB_ENV"
+
+    # All downloads should be cached. If there is a cache miss, we should ensure that the cache
+    # contains all downloads.
+    - name: Prefetch Cargo downloads
+      if: inputs.prefetch-cargo == 'true' && steps.rust-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: find . -iname Cargo.lock -execdir cargo fetch \;
+
+    - name: Build dependencies
+      shell: bash
+      run: make build-deps-slim

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
             make-target: check
             title: MacOS Checks
           - runs-on: ubuntu-latest
-            make-target: durable/long-test
+            make-target: durable/database-long-test
             title: Durable Storage Long Tests
 
     name: ${{ matrix.title }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,83 +61,15 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
 
     steps:
-      - name: Aggressive cleanup
-        run: |
-          # Remove Java (JDKs)
-          sudo rm -rf /usr/lib/jvm
-
-          # Remove .NET SDKs
-          sudo rm -rf /usr/share/dotnet
-
-          # Remove Swift toolchain
-          sudo rm -rf /usr/share/swift
-
-          # Remove Haskell (GHC)
-          sudo rm -rf /usr/local/.ghcup
-
-          # Remove Android SDKs
-          sudo rm -rf /usr/local/lib/android
-
-          # Remove Azure CLI
-          sudo rm -rf /opt/az
-
-          # Remove PowerShell
-          sudo rm -rf /usr/local/share/powershell
-
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Nix setup
-        uses: nixbuild/nix-quick-install-action@v34
+      - name: Set up build environment
+        id: setup
+        uses: ./.github/actions/setup
         with:
-          nix_conf: |
-            keep-env-derivations = true
-            keep-derivations = true
-            keep-outputs = true
-            experimental-features = nix-command flakes
-
-      - name: Nix cache
-        id: nix-cache
-        uses: nix-community/cache-nix-action@v7
-        with:
-          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}-v2
-          restore-prefixes-first-match: |
-            nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}-
-            nix-${{ runner.os }}-${{ runner.arch }}-
-          save: ${{ github.ref_name == 'main' }}
-
-      - name: Restore Rustup and Cargo cache
-        id: rust-cache
-        uses: actions/cache/restore@v5.0.5
-        with:
-          key: rust-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain*') }}-v2
-          restore-keys: |
-            rust-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/Cargo.lock', '**/rust-toolchain*') }}-
-            rust-${{ runner.os }}-${{ runner.arch }}-
-          path: |
-            ~/.rustup
-            ~/.cargo/bin
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/db
-
-      - name: Rust compilation cache
-        uses: Mozilla-Actions/sccache-action@v0.0.10
-
-      - name: Pre-build Nix development shell
-        run: |
-          # Subsequent steps will have their environment configured using the $GITHUB_ENV variable.
-          nix run .#direnv -- allow .
-          nix run .#direnv -- export gha > "$GITHUB_ENV"
-
-      # All downloads should be cached. If there is a cache miss, we should ensure that the cache
-      # contains all downloads.
-      - name: Prefetch Cargo downloads
-        if: steps.rust-cache.outputs.cache-hit != 'true' && github.ref_name == 'main'
-        run: find . -iname Cargo.lock -execdir cargo fetch \;
-
-      - name: Build dependencies
-        run: make build-deps-slim
+          save-nix-cache: ${{ github.ref_name == 'main' }}
+          prefetch-cargo: ${{ github.ref_name == 'main' }}
 
       - name: Run 'make ${{ matrix.make-target }}'
         run: make ${{ matrix.make-target }}
@@ -154,7 +86,7 @@ jobs:
         if: github.ref_name == 'main'
         uses: actions/cache/save@v5.0.5
         with:
-          key: ${{ steps.rust-cache.outputs.cache-primary-key }}
+          key: ${{ steps.setup.outputs.rust-cache-primary-key }}
           path: |
             ~/.rustup
             ~/.cargo/bin
@@ -165,5 +97,5 @@ jobs:
       # Only when the primary-key cache was not found do we actually produce a cache. In that case
       # we need to clean up the Nix store a little to save space.
       - name: Clean up Nix store
-        if: steps.nix-cache.outputs.hit-primary-key != 'true' && github.ref_name == 'main'
+        if: steps.setup.outputs.nix-cache-hit-primary-key != 'true' && github.ref_name == 'main'
         run: nix store gc

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,56 @@
+name: Nightly
+
+on:
+  # Run every day at ~01:16 UTC
+  # Avoids the start of the hour (https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule)
+  schedule:
+    - cron: "16 1 * * *"
+
+  # Allow manual runs from the Actions tab
+  workflow_dispatch:
+
+env:
+  # Make Cargo output pretty
+  CARGO_TERM_COLOR: "always"
+
+  # Enable Sccache
+  RUSTC_WRAPPER: "sccache"
+
+  # Make sure Sccache automatically uses the GitHub Actions cache
+  SCCACHE_GHA_ENABLED: "true"
+
+jobs:
+  long-test:
+    name: ${{ matrix.title }}
+    runs-on: ubuntu-latest
+
+    # Up to 6h including setup time
+    timeout-minutes: 360
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - title: Durable Storage Database Long Test
+            make-target: durable/database-long-test-nightly
+            artifact-name: durable-storage-database-long-test
+            out-dir: ${{ github.workspace }}/database-long-test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up build environment
+        uses: ./.github/actions/setup
+
+      - name: Run ${{ matrix.title }}
+        run: make ${{ matrix.make-target }} OUT_DIR='${{ matrix.out-dir }}'
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact-name }}-${{ github.run_id }}
+          path: ${{ matrix.out-dir }}/failure
+          if-no-files-found: warn
+          retention-days: 90

--- a/durable-storage/Makefile
+++ b/durable-storage/Makefile
@@ -20,8 +20,14 @@ reset-regressions:
 	@cargo run -p xtask -- gen-database-regression-inputs
 	@UPDATE_GOLDENFILES=1 cargo nextest run test_database_regression
 
-long-test:
+database-long-test:
 	@cargo run --release --features rocksdb,unstable-test-utils \
 		--bin database_long_test -- test --max-minutes 10 --keep-epochs 1
 
-.PHONY: all check test gen-regression-inputs long-test
+database-long-test-nightly:
+	@cargo run --release --features rocksdb,unstable-test-utils \
+		--bin database_long_test -- test \
+		--ops-per-epoch 2000 --cases-per-epoch 256 --keep-epochs 1 \
+		--max-minutes 300 $(if $(OUT_DIR),--out-dir "$(OUT_DIR)")
+
+.PHONY: all check test gen-regression-inputs database-long-test database-long-test-nightly

--- a/durable-storage/src/bin/database_long_test.rs
+++ b/durable-storage/src/bin/database_long_test.rs
@@ -57,6 +57,10 @@ enum Commands {
         /// commits are cleared after each successful epoch (default: keep everything).
         #[arg(long)]
         keep_epochs: Option<NonZeroUsize>,
+
+        /// Directory for run state and failure artifacts (default: a fresh tempdir).
+        #[arg(long)]
+        out_dir: Option<PathBuf>,
     },
     /// Replay the failing epoch described by `<DIR>/meta.json`.
     Replay {
@@ -74,6 +78,7 @@ fn main() -> Result<()> {
             max_minutes,
             epochs,
             keep_epochs,
+            out_dir,
         } => {
             let seed = match seed {
                 Some(seed) => {
@@ -94,6 +99,7 @@ fn main() -> Result<()> {
                 time_budget: max_minutes.map(|m| Duration::from_secs(m * 60)),
                 epochs,
                 keep_epochs,
+                out_dir,
             };
 
             run_long_test(config)

--- a/durable-storage/src/long_test/mod.rs
+++ b/durable-storage/src/long_test/mod.rs
@@ -23,6 +23,7 @@ use std::collections::VecDeque;
 use std::fs;
 use std::num::NonZeroUsize;
 use std::path::Path;
+use std::path::PathBuf;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -72,6 +73,8 @@ pub struct LongTestConfig {
     pub time_budget: Option<Duration>,
     /// Number of most recent epoch snapshots to keep. `None` keeps everything.
     pub keep_epochs: Option<NonZeroUsize>,
+    /// Directory for run state and failure artifacts. `None` uses a tempdir.
+    pub out_dir: Option<PathBuf>,
 }
 
 /// Metadata persisted alongside a failure which enables replaying it.
@@ -102,10 +105,17 @@ pub fn run_long_test(config: LongTestConfig) -> Result<()> {
     let ops_per_epoch = config.ops_per_epoch;
     let cases_per_epoch = config.cases_per_epoch;
     let keep_epochs = config.keep_epochs;
-    let out_dir = tempfile::Builder::new()
-        .prefix("database_long_test-")
-        .tempdir()?
-        .keep();
+    let out_dir = match config.out_dir {
+        Some(dir) => {
+            fs::create_dir_all(&dir)
+                .with_context(|| format!("creating directory {}", dir.display()))?;
+            dir
+        }
+        None => tempfile::Builder::new()
+            .prefix("database_long_test-")
+            .tempdir()?
+            .keep(),
+    };
 
     let mut rerun = format!(
         "cargo run --release --features rocksdb,unstable-test-utils --bin database_long_test -- \
@@ -474,6 +484,7 @@ mod tests {
             seed: None,
             time_budget: None,
             keep_epochs: Some(NonZeroUsize::new(2).expect("non-zero")),
+            out_dir: None,
         })
         .expect("the short long test run should succeed");
     }


### PR DESCRIPTION
Closes RV-1009. Closes RV-984.

# What

Runs the `Database` long test as a nightly test for ~5h.

# Why

To increase confidence in `Database` semantics and proof validity. Nightly tests run on GitHub runners are capped at 6h, including job setup time.

# How

The long test binary can now take an optional `--out-dir` argument for the working directory instead of using a default temporary directory. The nightly test definition uses it so it can recover the failure artifact if needed.

Setup for the PR CI is pulled into a new `actions/setup/action.yml` configuration, which is now shared between PR and nightly jobs. 

# Manually Testing

Passing the output directory for the test binary can be tested with a short run:

```
cargo run --release --features rocksdb,unstable-test-utils --bin database_long_test -- test --epochs 10 --ops-per-epoch 100 --cases-per-epoch 20 --out-dir XXXX
```

I don't think there's any way to test the nightly CI configuration locally.

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
