### PR TITLE
fix(metrics): incorrect encoding header when submitting metrics

### DIFF
--- a/tools/kernel-bench-utils/src/datadog.rs
+++ b/tools/kernel-bench-utils/src/datadog.rs
@@ -50,9 +50,12 @@ pub async fn submit_kernel_tps_benchmark(
     let configuration = datadog::Configuration::new();
     let api = MetricsAPI::with_config(configuration);
 
+    // Use GZIP. We don't pull in the zstd feature, but by default datadog-api-client still
+    // sets the header as ZSTD1, but silently doesn't compress it. Instead, we can use
+    // gzip, which is available.
     api.submit_metrics(
         payload,
-        SubmitMetricsOptionalParams::default().content_encoding(MetricContentEncoding::ZSTD1),
+        SubmitMetricsOptionalParams::default().content_encoding(MetricContentEncoding::GZIP),
     )
     .await?;
 


### PR DESCRIPTION
# What

Fix the failing benchmark run on main (which succeeds, but fails to push the metric to datadog).

# Why

So we can track the metrics again.

# How

`datadog-api-client` was silently setting `zstd1` compression in the headers, but not actually compressing the payload (silently, without an error) as the dependency was not enabled. Switch instead to `gzip`, which is a dependency we already have access to.

# Manually Testing

Can only test (realistically) by seeing if the main benchmark gets fixed.

