### PR TITLE
fix(ci): fix output directory path in nightly tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-name: Nightly
+name: Nightly Tests
 
 on:
   # Run every day at ~01:16 UTC
@@ -34,7 +34,7 @@ jobs:
           - title: Durable Storage Database Long Test
             make-target: durable/database-long-test-nightly
             artifact-name: durable-storage-database-long-test
-            out-dir: ${{ github.workspace }}/database-long-test
+            out-dir: database-long-test
 
     steps:
       - name: Checkout
@@ -44,13 +44,13 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Run ${{ matrix.title }}
-        run: make ${{ matrix.make-target }} OUT_DIR='${{ matrix.out-dir }}'
+        run: make ${{ matrix.make-target }} OUT_DIR='${{ github.workspace }}/${{ matrix.out-dir }}'
 
       - name: Upload failure artifacts
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact-name }}-${{ github.run_id }}
-          path: ${{ matrix.out-dir }}/failure
+          path: ${{ github.workspace }}/${{ matrix.out-dir }}/failure
           if-no-files-found: warn
           retention-days: 90


### PR DESCRIPTION
# What

Fixes output directory path in nightly tests, addressing this [failure](https://github.com/tezos/riscv-pvm/actions/runs/27821640430/job/82335936922).