### PR TITLE
feat(ci): run multiple nightly test configurations

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,6 +11,12 @@ inputs:
   prefetch-cargo:
     description: Whether to prefetch Cargo downloads on a cache miss.
     default: "false"
+  build-deps:
+    description: >
+      Whether to build workspace dependencies (make build-deps-slim). Set to
+      "false" when the environment is only needed to run a prebuilt binary,
+      like in the case of the nightly tests.
+    default: "true"
 
 outputs:
   rust-cache-primary-key:
@@ -99,5 +105,6 @@ runs:
       run: find . -iname Cargo.lock -execdir cargo fetch \;
 
     - name: Build dependencies
+      if: inputs.build-deps == 'true'
       shell: bash
       run: make build-deps-slim

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
             make-target: check
             title: MacOS Checks
           - runs-on: ubuntu-latest
-            make-target: durable/database-long-test
+            make-target: durable/run-database-long-test
             title: Durable Storage Long Tests
 
     name: ${{ matrix.title }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,38 +19,84 @@ env:
   # Make sure Sccache automatically uses the GitHub Actions cache
   SCCACHE_GHA_ENABLED: "true"
 
+  # Time budget (minutes) shared by every nightly run
+  MAX_MINUTES: "330"
+
 jobs:
-  long-test:
-    name: ${{ matrix.title }}
+  # Build the long-test binary once and share it with every matrix job below.
+  build:
+    name: "Build database long test binary"
     runs-on: ubuntu-latest
-
-    # Up to 6h including setup time
-    timeout-minutes: 360
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - title: Durable Storage Database Long Test
-            make-target: durable/database-long-test-nightly
-            artifact-name: durable-storage-database-long-test
-            out-dir: database-long-test
+    timeout-minutes: 90
 
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
+      # Save the Nix cache so the test jobs restore this job's dev shell on a
+      # cache miss, instead of each rebuilding the Nix store independently.
       - name: Set up build environment
         uses: ./.github/actions/setup
+        with:
+          save-nix-cache: true
 
-      - name: Run ${{ matrix.title }}
-        run: make ${{ matrix.make-target }} OUT_DIR='${{ github.workspace }}/${{ matrix.out-dir }}'
+      - name: Build database_long_test
+        run: make durable/build-database-long-test
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: database_long_test
+          path: target/release/database_long_test
+          if-no-files-found: error
+          retention-days: 1
+
+  long-test:
+    name: "Database long test ops=${{ matrix.config.ops }} cases=${{ matrix.config.cases }} #${{ matrix.replica }}"
+    needs: build
+    runs-on: ubuntu-latest
+
+    # Up to 6h
+    timeout-minutes: 360
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { ops: 2000,  cases: 256 }
+          - { ops: 4000,  cases: 128 }
+          - { ops: 8000,  cases: 64 }
+          - { ops: 16000, cases: 32 }
+        replica: [1, 2, 3, 4, 5]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Set up build environment
+        uses: ./.github/actions/setup
+        with:
+          build-deps: "false"
+
+      - name: Download binary
+        uses: actions/download-artifact@v7
+        with:
+          name: database_long_test
+
+      - name: Run long test
+        run: |
+          chmod +x ./database_long_test # upload-artifact strips the executable bit
+          ./database_long_test test \
+            --ops-per-epoch ${{ matrix.config.ops }} \
+            --cases-per-epoch ${{ matrix.config.cases }} \
+            --keep-epochs 1 \
+            --max-minutes ${{ env.MAX_MINUTES }} \
+            --out-dir '${{ github.workspace }}/run-${{ matrix.config.ops }}-${{ matrix.config.cases }}-${{ matrix.replica }}'
 
       - name: Upload failure artifacts
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.artifact-name }}-${{ github.run_id }}
-          path: ${{ github.workspace }}/${{ matrix.out-dir }}/failure
+          name: dursto-long-test-${{ matrix.config.ops }}-${{ matrix.config.cases }}-r${{ matrix.replica }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ github.workspace }}/run-${{ matrix.config.ops }}-${{ matrix.config.cases }}-${{ matrix.replica }}/failure
           if-no-files-found: warn
           retention-days: 90

--- a/durable-storage/Makefile
+++ b/durable-storage/Makefile
@@ -20,14 +20,11 @@ reset-regressions:
 	@cargo run -p xtask -- gen-database-regression-inputs
 	@UPDATE_GOLDENFILES=1 cargo nextest run test_database_regression
 
-database-long-test:
+build-database-long-test:
+	@cargo build --release --features rocksdb,unstable-test-utils --bin database_long_test
+
+run-database-long-test:
 	@cargo run --release --features rocksdb,unstable-test-utils \
 		--bin database_long_test -- test --max-minutes 10 --keep-epochs 1
 
-database-long-test-nightly:
-	@cargo run --release --features rocksdb,unstable-test-utils \
-		--bin database_long_test -- test \
-		--ops-per-epoch 2000 --cases-per-epoch 256 --keep-epochs 1 \
-		--max-minutes 300 $(if $(OUT_DIR),--out-dir "$(OUT_DIR)")
-
-.PHONY: all check test gen-regression-inputs database-long-test database-long-test-nightly
+.PHONY: all check test gen-regression-inputs run-database-long-test build-database-long-test


### PR DESCRIPTION
# What

Expands the NDS Database nightly test matrix from 1 to 20 tests, with varying test parameters (operations / epoch, test cases / epoch).

# Why

Expands nightly test coverage to the maximum number of tests that can actually run in parallel on GitHub runners.

# How

Introduces a build job before the actual test jobs which restores or rebuilds and saves the Nix cache and builds the test binary. Test jobs then restore the Nix cache and run the binary instead of each of them rebuilding independently.

Moving setup in a separate job also allows bumping the test job time from 5h to 5.5h since the 6h limit applies to individual jobs.

# Manually Testing

```
make all
```

A successful nightly workflow, with tests shortened to 10 minutes [here](https://github.com/tezos/riscv-pvm/actions/runs/28025366058). Each replica runs with a different seed, so tests with same parameters are not redundant.

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
