### PR TITLE
test(dursto): exercise commit-checkout roundtrips in Registry end to end test

### DIFF
--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -2373,7 +2373,7 @@ pub(crate) mod tests {
 
     kv_test!(test_database_end_to_end, KV: BackgroundPersistentKeyValueStore,
     [
-        generated in crate::test_helpers::database::database_operations_commit_checkout_strategy(1usize..100, 0.1)
+        generated in <crate::test_helpers::database::DatabaseOperationView as crate::test_helpers::OperationView>::operations_commit_checkout_strategy(1usize..100, 0.1)
     ],
     {
         // Every test iteration expects an empty repo, so not setting it in a `setup` block.

--- a/durable-storage/src/long_test/strategy.rs
+++ b/durable-storage/src/long_test/strategy.rs
@@ -45,7 +45,7 @@ fn pooled_key_strategy(pools: &KeyPools) -> BoxedStrategy<Key> {
     Union::new_weighted(arms).boxed()
 }
 
-// Distribution is based on that of `test_helpers::database::database_operation_view_strategy`
+// Distribution is based on that of `<DatabaseOperationView as OperationView>::view_strategy`
 fn database_op_strategy(pools: &KeyPools) -> BoxedStrategy<DatabaseOperation> {
     let set = (pooled_key_strategy(pools), value_strategy())
         .prop_map(|(k, v)| DatabaseOperation::Set(k, v));

--- a/durable-storage/src/registry.rs
+++ b/durable-storage/src/registry.rs
@@ -2177,7 +2177,7 @@ pub(super) mod tests {
 
     kv_test!(test_durable_storage_end_to_end, KV: BackgroundPersistentKeyValueStore,
     [
-        generated in crate::test_helpers::registry::registry_operations_strategy(1usize..100)
+        generated in <crate::test_helpers::registry::RegistryOperationView as crate::test_helpers::OperationView>::operations_strategy(1usize..100)
     ],
     {
         // Every test iteration expects an empty repo, so not setting it in a `setup` block.

--- a/durable-storage/src/registry.rs
+++ b/durable-storage/src/registry.rs
@@ -2177,7 +2177,7 @@ pub(super) mod tests {
 
     kv_test!(test_durable_storage_end_to_end, KV: BackgroundPersistentKeyValueStore,
     [
-        generated in <crate::test_helpers::registry::RegistryOperationView as crate::test_helpers::OperationView>::operations_strategy(1usize..100)
+        generated in <crate::test_helpers::registry::RegistryOperationView as crate::test_helpers::OperationView>::operations_commit_checkout_strategy(1usize..100, 0.1)
     ],
     {
         // Every test iteration expects an empty repo, so not setting it in a `setup` block.
@@ -2185,13 +2185,21 @@ pub(super) mod tests {
         // in test failures when checking out a commit which isn't expected to exist succeeds.
         let (_keepalive, repo) = KV::setup_repo();
 
-        let (keys, values, ops) = generated;
+        let (keys, values, ops_a, ops_b) = generated;
+
+        // Pick an operations vector so each backend exercises a different
+        // `CommitCheckoutRoundtrip` placement against the same base operations.
+        let ops = match KV::BACKEND {
+            crate::storage::Backend::Persistent => ops_a,
+            crate::storage::Backend::InMemory => ops_b,
+        };
         let operations = crate::test_helpers::registry::make_registry_operations(
             std::num::NonZeroUsize::new(1).expect("1 > 0"),
             keys,
             values,
             ops,
         );
+
         crate::test_helpers::registry::run_and_prove_registry_operations::<KV>(
             repo, operations,
         )

--- a/durable-storage/src/test_helpers.rs
+++ b/durable-storage/src/test_helpers.rs
@@ -16,3 +16,85 @@
 
 pub mod database;
 pub mod registry;
+
+use bytes::Bytes;
+use database::key_strategy;
+use database::value_strategy;
+use proptest::prelude::*;
+
+use crate::key::Key;
+
+/// A proptest-sampleable view of an operation which can be applied to an NDS component
+pub trait OperationView: Clone + std::fmt::Debug + 'static {
+    /// Strategy for a single operation, excluding the commit/checkout-roundtrip variant.
+    fn strategy() -> impl Strategy<Value = Self>;
+
+    /// Keys, values, and a base sequence of `length` operations
+    fn operations_strategy(
+        length: impl Strategy<Value = usize>,
+    ) -> impl Strategy<Value = (Vec<Key>, Vec<Bytes>, Vec<Self>)> {
+        length.prop_flat_map(|length| {
+            let count = length.div_ceil(10);
+            (
+                proptest::collection::vec(key_strategy(), count),
+                proptest::collection::vec(value_strategy(), count),
+                proptest::collection::vec(Self::strategy(), length),
+            )
+        })
+    }
+
+    /// The commit/checkout-roundtrip variant.
+    fn roundtrip() -> Self;
+
+    /// `Some` commit/checkout roundtrip with the given probability, `None` otherwise.
+    fn maybe_roundtrip_strategy(prob: f32) -> impl Strategy<Value = Option<Self>> {
+        assert!(
+            (0.0..=1.0).contains(&prob),
+            "expected a probability, got {prob}"
+        );
+        let (yes, no) = proptest::strategy::float_to_weight(prob.into());
+        prop_oneof![
+            yes => Just(Some(Self::roundtrip())),
+            no => Just(None),
+        ]
+    }
+
+    /// Two operation sequences sharing identical base operations, with independently
+    /// sampled commit/checkout roundtrips. Intended to check that 2 runs with
+    /// differently-placed roundtrips are observationally equivalent.
+    fn operations_commit_checkout_strategy(
+        length: impl Strategy<Value = usize>,
+        roundtrip_probability: f32,
+    ) -> impl Strategy<Value = (Vec<Key>, Vec<Bytes>, Vec<Self>, Vec<Self>)> {
+        length.prop_flat_map(move |length| {
+            let count = length.div_ceil(10);
+            (
+                proptest::collection::vec(key_strategy(), count),
+                proptest::collection::vec(value_strategy(), count),
+                proptest::collection::vec(
+                    (
+                        Self::maybe_roundtrip_strategy(roundtrip_probability),
+                        Self::maybe_roundtrip_strategy(roundtrip_probability),
+                        Self::strategy(),
+                    ),
+                    length,
+                ),
+            )
+                .prop_map(|(keys, values, ops)| {
+                    let mut ops_a = Vec::with_capacity(ops.len() * 2);
+                    let mut ops_b = Vec::with_capacity(ops.len() * 2);
+                    for (pre_a, pre_b, op) in ops {
+                        if let Some(r) = pre_a {
+                            ops_a.push(r);
+                        }
+                        if let Some(r) = pre_b {
+                            ops_b.push(r);
+                        }
+                        ops_a.push(op.clone());
+                        ops_b.push(op);
+                    }
+                    (keys, values, ops_a, ops_b)
+                })
+        })
+    }
+}

--- a/durable-storage/src/test_helpers/database.rs
+++ b/durable-storage/src/test_helpers/database.rs
@@ -40,6 +40,7 @@ use crate::key::KEY_MAX_SIZE;
 use crate::key::Key;
 use crate::merkle_worker::BackgroundKeyValueStore;
 use crate::merkle_worker::BackgroundPersistentKeyValueStore;
+use crate::test_helpers::OperationView;
 
 /// Maximum size for the value argument of a sampled operation
 pub(crate) const VALUE_MAX_SIZE: usize = 10_000;
@@ -146,127 +147,61 @@ pub(crate) fn value_strategy() -> impl Strategy<Value = Bytes> {
     .prop_map(Bytes::from)
 }
 
-pub(crate) fn database_operation_view_strategy() -> impl Strategy<Value = DatabaseOperationView> {
-    let set = (any::<Index>(), any::<Index>()).prop_map(|(k, v)| DatabaseOperationView::Set(k, v));
+impl OperationView for DatabaseOperationView {
+    fn strategy() -> impl Strategy<Value = Self> {
+        let set =
+            (any::<Index>(), any::<Index>()).prop_map(|(k, v)| DatabaseOperationView::Set(k, v));
 
-    // Bias length and offset towards having most sampled operations
-    // exercise the success path, while also producing some which are out of bounds.
-    let read = (
-        any::<Index>(),
-        prop_oneof![
-            5 => Just(0),
-            4 => 1..=MAX_FILE_CHUNK_SIZE,
-            1 => (MAX_FILE_CHUNK_SIZE + 1)..=VALUE_MAX_SIZE,
-        ],
-        prop_oneof![
-            9 => 0..=MAX_FILE_CHUNK_SIZE,
-            1 => (MAX_FILE_CHUNK_SIZE + 1)..=VALUE_MAX_SIZE,
-        ],
-    )
-        .prop_map(|(k, off, len)| DatabaseOperationView::Read(k, off, len));
-
-    // Writes biased towards valid offsets
-    let write_valid = (
-        any::<Index>(),
-        prop_oneof![
-            2 => Just(0),
-            1 => 1..=VALUE_MAX_SIZE,
-        ],
-        any::<Index>(),
-    )
-        .prop_map(|(k, off, v)| DatabaseOperationView::Write(k, off, v));
-
-    // Writes biased towards out-of-bounds offsets
-    let write_invalid = (any::<Index>(), VALUE_MAX_SIZE..=usize::MAX, any::<Index>())
-        .prop_map(|(k, off, v)| DatabaseOperationView::Write(k, off, v));
-
-    // The chosen frequencies emulate real workloads
-    prop_oneof![
-        20 => set,
-        20 => read,
-        4 => write_valid,
-        1 => write_invalid,
-
-        10 => any::<Index>().prop_map(DatabaseOperationView::Delete),
-        10 => any::<Index>().prop_map(DatabaseOperationView::Exists),
-        5 => any::<Index>().prop_map(DatabaseOperationView::ValueLength),
-        10 => Just(DatabaseOperationView::Hash),
-        3 => Just(DatabaseOperationView::Commit),
-        3 => Just(DatabaseOperationView::Checkout),
-    ]
-}
-
-pub fn database_operations_strategy(
-    length: impl Strategy<Value = usize>,
-) -> impl Strategy<Value = (Vec<Key>, Vec<Bytes>, Vec<DatabaseOperationView>)> {
-    length.prop_flat_map(|length| {
-        let count = length.div_ceil(10);
-        (
-            proptest::collection::vec(key_strategy(), count),
-            proptest::collection::vec(value_strategy(), count),
-            proptest::collection::vec(database_operation_view_strategy(), length),
+        // Bias length and offset towards having most sampled operations
+        // exercise the success path, while also producing some which are out of bounds.
+        let read = (
+            any::<Index>(),
+            prop_oneof![
+                5 => Just(0),
+                4 => 1..=MAX_FILE_CHUNK_SIZE,
+                1 => (MAX_FILE_CHUNK_SIZE + 1)..=VALUE_MAX_SIZE,
+            ],
+            prop_oneof![
+                9 => 0..=MAX_FILE_CHUNK_SIZE,
+                1 => (MAX_FILE_CHUNK_SIZE + 1)..=VALUE_MAX_SIZE,
+            ],
         )
-    })
-}
+            .prop_map(|(k, off, len)| DatabaseOperationView::Read(k, off, len));
 
-/// Produces `Some(CommitCheckoutRoundtrip)` with the given probability, `None` otherwise.
-fn maybe_roundtrip_strategy(prob: f32) -> impl Strategy<Value = Option<DatabaseOperationView>> {
-    assert!(
-        (0.0..=1.0).contains(&prob),
-        "expected a probability, got {prob}"
-    );
-    let (yes, no) = proptest::strategy::float_to_weight(prob.into());
-    prop_oneof![
-        yes => Just(Some(DatabaseOperationView::CommitCheckoutRoundtrip)),
-        no => Just(None),
-    ]
-}
-
-/// Like [`database_operations_strategy`] but produces two operation vectors sharing
-/// identical base operations, with independently sampled
-/// [`DatabaseOperationView::CommitCheckoutRoundtrip`]. Intended to check that 2 test runs
-/// with differently-placed commit - checkout roundtrips are observationally equivalent.
-pub fn database_operations_commit_checkout_strategy(
-    length: impl Strategy<Value = usize>,
-    roundtrip_probability: f32,
-) -> impl Strategy<
-    Value = (
-        Vec<Key>,
-        Vec<Bytes>,
-        Vec<DatabaseOperationView>,
-        Vec<DatabaseOperationView>,
-    ),
-> {
-    length.prop_flat_map(move |length| {
-        let count = length.div_ceil(10);
-        (
-            proptest::collection::vec(key_strategy(), count),
-            proptest::collection::vec(value_strategy(), count),
-            proptest::collection::vec(
-                (
-                    maybe_roundtrip_strategy(roundtrip_probability),
-                    maybe_roundtrip_strategy(roundtrip_probability),
-                    database_operation_view_strategy(),
-                ),
-                length,
-            ),
+        // Writes biased towards valid offsets
+        let write_valid = (
+            any::<Index>(),
+            prop_oneof![
+                2 => Just(0),
+                1 => 1..=VALUE_MAX_SIZE,
+            ],
+            any::<Index>(),
         )
-            .prop_map(|(keys, values, ops)| {
-                let mut ops_a = Vec::with_capacity(ops.len() * 2);
-                let mut ops_b = Vec::with_capacity(ops.len() * 2);
-                for (pre_a, pre_b, op) in ops {
-                    if let Some(r) = pre_a {
-                        ops_a.push(r);
-                    }
-                    if let Some(r) = pre_b {
-                        ops_b.push(r);
-                    }
-                    ops_a.push(op.clone());
-                    ops_b.push(op);
-                }
-                (keys, values, ops_a, ops_b)
-            })
-    })
+            .prop_map(|(k, off, v)| DatabaseOperationView::Write(k, off, v));
+
+        // Writes biased towards out-of-bounds offsets
+        let write_invalid = (any::<Index>(), VALUE_MAX_SIZE..=usize::MAX, any::<Index>())
+            .prop_map(|(k, off, v)| DatabaseOperationView::Write(k, off, v));
+
+        // The chosen frequencies emulate real workloads
+        prop_oneof![
+            20 => set,
+            20 => read,
+            4 => write_valid,
+            1 => write_invalid,
+
+            10 => any::<Index>().prop_map(DatabaseOperationView::Delete),
+            10 => any::<Index>().prop_map(DatabaseOperationView::Exists),
+            5 => any::<Index>().prop_map(DatabaseOperationView::ValueLength),
+            10 => Just(DatabaseOperationView::Hash),
+            3 => Just(DatabaseOperationView::Commit),
+            3 => Just(DatabaseOperationView::Checkout),
+        ]
+    }
+
+    fn roundtrip() -> Self {
+        DatabaseOperationView::CommitCheckoutRoundtrip
+    }
 }
 
 /// A reference model of the key-value store of a [`Database`]

--- a/durable-storage/src/test_helpers/registry.rs
+++ b/durable-storage/src/test_helpers/registry.rs
@@ -31,10 +31,7 @@ use super::database::DatabaseOperation;
 use super::database::DatabaseOperationView;
 use super::database::apply_database_operation_with_model;
 use super::database::apply_database_step;
-use super::database::database_operation_view_strategy;
-use super::database::key_strategy;
 use super::database::make_database_operation;
-use super::database::value_strategy;
 use crate::commit::CommitId;
 use crate::database::DatabaseMode;
 use crate::key::Key;
@@ -43,6 +40,7 @@ use crate::merkle_worker::BackgroundPersistentKeyValueStore;
 use crate::registry::Registry;
 use crate::registry::RegistryMode;
 use crate::repo::RegistryRepo;
+use crate::test_helpers::OperationView;
 
 /// Operations on a [`Registry`]
 #[derive(Debug, Clone)]
@@ -108,32 +106,25 @@ pub fn make_registry_operations(
         .collect()
 }
 
-pub fn registry_operations_strategy(
-    length: impl Strategy<Value = usize>,
-) -> impl Strategy<Value = (Vec<Key>, Vec<Bytes>, Vec<RegistryOperationView>)> {
-    length.prop_flat_map(|length| {
-        let count = length.div_ceil(10);
+impl OperationView for RegistryOperationView {
+    fn strategy() -> impl Strategy<Value = Self> {
+        // The chosen frequencies emulate real workloads
+        prop_oneof![
+            88 => (any::<Index>(), DatabaseOperationView::strategy())
+                .prop_map(|(i, v)| RegistryOperationView::Database(i, v)),
+            4 => Just(RegistryOperationView::GrowRegistry),
+            2 => Just(RegistryOperationView::ShrinkRegistry),
+            3 => (any::<Index>(), any::<Index>())
+                .prop_map(|(src, dst)| RegistryOperationView::CopyDatabase(src, dst)),
+            2 => (any::<Index>(), any::<Index>())
+                .prop_map(|(src, dst)| RegistryOperationView::MoveDatabase(src, dst)),
+            1 => any::<Index>().prop_map(RegistryOperationView::ClearDatabase),
+        ]
+    }
 
-        (
-            proptest::collection::vec(key_strategy(), count),
-            proptest::collection::vec(value_strategy(), count),
-            proptest::collection::vec(
-                // The chosen frequencies emulate real workloads
-                prop_oneof![
-                    88 => (any::<Index>(), database_operation_view_strategy())
-                        .prop_map(|(i, v)| OperationView::Database(i, v)),
-                    4 => Just(OperationView::GrowRegistry),
-                    2 => Just(OperationView::ShrinkRegistry),
-                    3 => (any::<Index>(), any::<Index>())
-                        .prop_map(|(src, dst)| OperationView::CopyDatabase(src, dst)),
-                    2 => (any::<Index>(), any::<Index>())
-                        .prop_map(|(src, dst)| OperationView::MoveDatabase(src, dst)),
-                    1 => any::<Index>().prop_map(OperationView::ClearDatabase),
-                ],
-                length,
-            ),
-        )
-    })
+    fn roundtrip() -> Self {
+        unimplemented!("commit-checkout roundtrips added in next commit")
+    }
 }
 
 fn grow_registry<KV, M>(registry: &mut Registry<KV, M>)

--- a/durable-storage/src/test_helpers/registry.rs
+++ b/durable-storage/src/test_helpers/registry.rs
@@ -51,6 +51,7 @@ pub enum RegistryOperation {
     CopyDatabase(usize, usize),
     MoveDatabase(usize, usize),
     ClearDatabase(usize),
+    CommitCheckoutRoundtrip,
 }
 
 #[derive(Debug, Clone)]
@@ -61,6 +62,7 @@ pub enum RegistryOperationView {
     CopyDatabase(Index, Index),
     MoveDatabase(Index, Index),
     ClearDatabase(Index),
+    CommitCheckoutRoundtrip,
 }
 
 /// Turn a set of [`RegistryOperationView`]s into [`RegistryOperation`]s on the given keys
@@ -102,6 +104,9 @@ pub fn make_registry_operations(
             RegistryOperationView::ClearDatabase(idx) => {
                 RegistryOperation::ClearDatabase(idx.index(len))
             }
+            RegistryOperationView::CommitCheckoutRoundtrip => {
+                RegistryOperation::CommitCheckoutRoundtrip
+            }
         })
         .collect()
 }
@@ -123,7 +128,7 @@ impl OperationView for RegistryOperationView {
     }
 
     fn roundtrip() -> Self {
-        unimplemented!("commit-checkout roundtrips added in next commit")
+        RegistryOperationView::CommitCheckoutRoundtrip
     }
 }
 
@@ -182,6 +187,7 @@ where
             | DatabaseOperation::Checkout
             | DatabaseOperation::CommitCheckoutRoundtrip,
         ) => return false,
+        RegistryOperation::CommitCheckoutRoundtrip => return false,
         RegistryOperation::Database(index, db_op) => {
             let database = registry
                 .database_mut(*index)
@@ -272,7 +278,18 @@ where
     )
 }
 
-pub fn run_and_prove_registry_operations<KV>(repo: KV::Repo, operations: Vec<RegistryOperation>)
+/// Initialises a Normal-mode [`Registry`] in the given `repo` and applies
+/// `operations` one by one. On each operation:
+/// - checks the result agrees with a reference model
+/// - proves and verifies a proof
+///
+/// Returns the final hash of the registry, which can be used to check that
+/// applying the same operations over registries configured with different
+/// backends results in the same final state.
+pub fn run_and_prove_registry_operations<KV>(
+    repo: KV::Repo,
+    operations: Vec<RegistryOperation>,
+) -> Hash
 where
     KV: BackgroundPersistentKeyValueStore,
     KV::Repo: RegistryRepo,
@@ -384,6 +401,15 @@ where
                     registry_model[dst] = std::mem::take(&mut registry_model[src]);
                 }
             }
+            RegistryOperation::CommitCheckoutRoundtrip => {
+                let commit_id = registry.commit().expect("Committing should succeed");
+                registry = Registry::checkout(checkout_repo.clone(), commit_id)
+                    .expect("Checking out the just-committed registry should succeed");
+                // State is preserved, so `registry_model` is left unchanged.
+                checkout_candidates.insert(*commit_id.as_hash(), true);
+            }
         }
     }
+
+    Hash::from_foldable(&registry)
 }

--- a/durable-storage/src/test_helpers/registry.rs
+++ b/durable-storage/src/test_helpers/registry.rs
@@ -46,7 +46,7 @@ use crate::repo::RegistryRepo;
 
 /// Operations on a [`Registry`]
 #[derive(Debug, Clone)]
-pub enum Operation {
+pub enum RegistryOperation {
     Database(usize, DatabaseOperation),
     GrowRegistry,
     ShrinkRegistry,
@@ -56,7 +56,7 @@ pub enum Operation {
 }
 
 #[derive(Debug, Clone)]
-pub enum OperationView {
+pub enum RegistryOperationView {
     Database(Index, DatabaseOperationView),
     GrowRegistry,
     ShrinkRegistry,
@@ -65,7 +65,7 @@ pub enum OperationView {
     ClearDatabase(Index),
 }
 
-/// Turn a set of [`OperationView`]s into [`Operation`]s on the given keys
+/// Turn a set of [`RegistryOperationView`]s into [`RegistryOperation`]s on the given keys
 /// and values, where applicable.
 ///
 /// Registry indices are resolved against the registry length computed
@@ -76,39 +76,41 @@ pub fn make_registry_operations(
     initial_registry_len: NonZeroUsize,
     keys: Vec<Key>,
     values: Vec<Bytes>,
-    ops: Vec<OperationView>,
-) -> Vec<Operation> {
+    ops: Vec<RegistryOperationView>,
+) -> Vec<RegistryOperation> {
     let mut len = initial_registry_len.get();
     ops.into_iter()
         .map(|op| match op {
-            OperationView::Database(idx, view) => Operation::Database(
+            RegistryOperationView::Database(idx, view) => RegistryOperation::Database(
                 idx.index(len),
                 make_database_operation(&keys, &values, view),
             ),
-            OperationView::GrowRegistry => {
+            RegistryOperationView::GrowRegistry => {
                 len += 1;
-                Operation::GrowRegistry
+                RegistryOperation::GrowRegistry
             }
-            OperationView::ShrinkRegistry => {
+            RegistryOperationView::ShrinkRegistry => {
                 if len > 1 {
                     len -= 1;
                 }
-                Operation::ShrinkRegistry
+                RegistryOperation::ShrinkRegistry
             }
-            OperationView::CopyDatabase(src, dst) => {
-                Operation::CopyDatabase(src.index(len), dst.index(len))
+            RegistryOperationView::CopyDatabase(src, dst) => {
+                RegistryOperation::CopyDatabase(src.index(len), dst.index(len))
             }
-            OperationView::MoveDatabase(src, dst) => {
-                Operation::MoveDatabase(src.index(len), dst.index(len))
+            RegistryOperationView::MoveDatabase(src, dst) => {
+                RegistryOperation::MoveDatabase(src.index(len), dst.index(len))
             }
-            OperationView::ClearDatabase(idx) => Operation::ClearDatabase(idx.index(len)),
+            RegistryOperationView::ClearDatabase(idx) => {
+                RegistryOperation::ClearDatabase(idx.index(len))
+            }
         })
         .collect()
 }
 
 pub fn registry_operations_strategy(
     length: impl Strategy<Value = usize>,
-) -> impl Strategy<Value = (Vec<Key>, Vec<Bytes>, Vec<OperationView>)> {
+) -> impl Strategy<Value = (Vec<Key>, Vec<Bytes>, Vec<RegistryOperationView>)> {
     length.prop_flat_map(|length| {
         let count = length.div_ceil(10);
 
@@ -168,31 +170,35 @@ fn grow_registry_with_model<KV>(
     }
 }
 
-/// Apply a single [`Operation`] to `registry`.
+/// Apply a single [`RegistryOperation`] to `registry`.
 ///
 /// Returns `true` if the step was provable. A no-op (e.g., a `ShrinkRegistry` when
 /// `registry` has size 1) is a provable step: a proof which fully blinds the registry
 /// is expected to be produced for it.
-fn apply_registry_step<KV, M>(registry: &mut Registry<KV, M>, op: &Operation, len: usize) -> bool
+fn apply_registry_step<KV, M>(
+    registry: &mut Registry<KV, M>,
+    op: &RegistryOperation,
+    len: usize,
+) -> bool
 where
     KV: BackgroundKeyValueStore,
     M: RegistryMode + DatabaseMode,
 {
     match op {
-        Operation::Database(
+        RegistryOperation::Database(
             _,
             DatabaseOperation::Commit
             | DatabaseOperation::Checkout
             | DatabaseOperation::CommitCheckoutRoundtrip,
         ) => return false,
-        Operation::Database(index, db_op) => {
+        RegistryOperation::Database(index, db_op) => {
             let database = registry
                 .database_mut(*index)
                 .expect("The index is in bounds");
             return apply_database_step(database, db_op).expect("applying a step should succeed");
         }
-        Operation::GrowRegistry => grow_registry(registry),
-        Operation::ShrinkRegistry => {
+        RegistryOperation::GrowRegistry => grow_registry(registry),
+        RegistryOperation::ShrinkRegistry => {
             if len <= 1 {
                 return true;
             }
@@ -200,17 +206,17 @@ where
                 .resize_tick(len - 1)
                 .expect("Resizing the registry should succeed");
         }
-        Operation::ClearDatabase(index) => {
+        RegistryOperation::ClearDatabase(index) => {
             registry
                 .clear_database(*index)
                 .expect("Clearing the database should be successful");
         }
-        Operation::CopyDatabase(src, dst) => {
+        RegistryOperation::CopyDatabase(src, dst) => {
             registry
                 .copy_database(*src, *dst)
                 .expect("Copying the database should be successful");
         }
-        Operation::MoveDatabase(src, dst) => {
+        RegistryOperation::MoveDatabase(src, dst) => {
             registry
                 .move_database(*src, *dst)
                 .expect("Moving the database should be successful");
@@ -220,8 +226,8 @@ where
     true
 }
 
-/// Generate and verify a proof for a single provable [`Operation`] applied to `registry`.
-fn prove_and_verify_registry_operation<KV>(registry: &Registry<KV, Normal>, op: &Operation)
+/// Generate and verify a proof for a single provable [`RegistryOperation`] applied to `registry`.
+fn prove_and_verify_registry_operation<KV>(registry: &Registry<KV, Normal>, op: &RegistryOperation)
 where
     KV: BackgroundKeyValueStore,
     KV::Repo: Clone,
@@ -275,7 +281,7 @@ where
     )
 }
 
-pub fn run_and_prove_registry_operations<KV>(repo: KV::Repo, operations: Vec<Operation>)
+pub fn run_and_prove_registry_operations<KV>(repo: KV::Repo, operations: Vec<RegistryOperation>)
 where
     KV: BackgroundPersistentKeyValueStore,
     KV::Repo: RegistryRepo,
@@ -295,7 +301,7 @@ where
         prove_and_verify_registry_operation(&registry, &operation);
 
         match operation {
-            Operation::Database(index, DatabaseOperation::Hash) => {
+            RegistryOperation::Database(index, DatabaseOperation::Hash) => {
                 let new_digest = registry
                     .database(index)
                     .expect("The index is in bounds")
@@ -308,11 +314,11 @@ where
                     .entry(Hash::from_foldable(&registry))
                     .or_insert(false);
             }
-            Operation::Database(_, DatabaseOperation::Commit) => {
+            RegistryOperation::Database(_, DatabaseOperation::Commit) => {
                 let commit_id = registry.commit().expect("Committing should succeed");
                 checkout_candidates.insert(*commit_id.as_hash(), true);
             }
-            Operation::Database(_, DatabaseOperation::Checkout) => {
+            RegistryOperation::Database(_, DatabaseOperation::Checkout) => {
                 if !checkout_candidates.is_empty() {
                     let index = rand::random_range(0..checkout_candidates.len());
                     let (&commit_hash, &committed) = checkout_candidates
@@ -331,7 +337,7 @@ where
                     );
                 }
             }
-            Operation::Database(index, op) => {
+            RegistryOperation::Database(index, op) => {
                 let handle = registry.handle().clone();
                 apply_database_operation_with_model::<KV, _>(
                     registry
@@ -344,8 +350,10 @@ where
                     &mut checkout_candidates,
                 );
             }
-            Operation::GrowRegistry => grow_registry_with_model(&mut registry, &mut registry_model),
-            Operation::ShrinkRegistry => {
+            RegistryOperation::GrowRegistry => {
+                grow_registry_with_model(&mut registry, &mut registry_model)
+            }
+            RegistryOperation::ShrinkRegistry => {
                 // Never shrink to an empty registry. This case becomes a no-op.
                 if registry.len() <= 1 {
                     continue;
@@ -358,7 +366,7 @@ where
 
                 registry_model.truncate(new_size);
             }
-            Operation::ClearDatabase(index) => {
+            RegistryOperation::ClearDatabase(index) => {
                 registry
                     .clear_database(index)
                     .expect("Clearing the database should be successful");
@@ -367,7 +375,7 @@ where
                 registry_model[index].ambiguous_hash = false;
                 registry_model[index].last = None;
             }
-            Operation::CopyDatabase(src, dst) => {
+            RegistryOperation::CopyDatabase(src, dst) => {
                 registry
                     .copy_database(src, dst)
                     .expect("Copying the database should be successful");
@@ -376,7 +384,7 @@ where
                     registry_model[dst] = registry_model[src].clone();
                 }
             }
-            Operation::MoveDatabase(src, dst) => {
+            RegistryOperation::MoveDatabase(src, dst) => {
                 registry
                     .move_database(src, dst)
                     .expect("Moving the database should be successful");

--- a/durable-storage/tests/integration_test.rs
+++ b/durable-storage/tests/integration_test.rs
@@ -3,7 +3,7 @@
 use bytes::Bytes;
 use octez_riscv_durable_storage::key::Key;
 use octez_riscv_durable_storage::test_helpers::database::DatabaseOperation;
-use octez_riscv_durable_storage::test_helpers::registry::Operation;
+use octez_riscv_durable_storage::test_helpers::registry::RegistryOperation;
 use octez_riscv_durable_storage::test_helpers::registry::make_registry_operations;
 use octez_riscv_durable_storage::test_helpers::registry::registry_operations_strategy;
 use octez_riscv_durable_storage::test_helpers::registry::run_and_prove_registry_operations;
@@ -40,33 +40,33 @@ cfg_if::cfg_if! {
 #[test]
 fn test_durable_storage_manual() {
     let operations = vec![
-        Operation::GrowRegistry,
-        Operation::Database(
+        RegistryOperation::GrowRegistry,
+        RegistryOperation::Database(
             0,
             DatabaseOperation::Set(Key::new(&[0]).unwrap(), Bytes::copy_from_slice(&[0; 10])),
         ),
-        Operation::Database(0, DatabaseOperation::Exists(Key::new(&[0]).unwrap())),
-        Operation::Database(
+        RegistryOperation::Database(0, DatabaseOperation::Exists(Key::new(&[0]).unwrap())),
+        RegistryOperation::Database(
             0,
             DatabaseOperation::Write(Key::new(&[0]).unwrap(), 5, Bytes::copy_from_slice(&[0; 4])),
         ),
-        Operation::GrowRegistry,
-        Operation::Database(
+        RegistryOperation::GrowRegistry,
+        RegistryOperation::Database(
             1,
             DatabaseOperation::Set(Key::new(&[1]).unwrap(), Bytes::copy_from_slice(&[0; 10])),
         ),
-        Operation::Database(0, DatabaseOperation::Commit),
-        Operation::Database(0, DatabaseOperation::Checkout),
-        Operation::ShrinkRegistry,
-        Operation::Database(
+        RegistryOperation::Database(0, DatabaseOperation::Commit),
+        RegistryOperation::Database(0, DatabaseOperation::Checkout),
+        RegistryOperation::ShrinkRegistry,
+        RegistryOperation::Database(
             0,
             DatabaseOperation::Set(Key::new(&[2]).unwrap(), Bytes::copy_from_slice(&[0; 10])),
         ),
-        Operation::Database(0, DatabaseOperation::Exists(Key::new(&[1]).unwrap())),
-        Operation::Database(0, DatabaseOperation::Delete(Key::new(&[1]).unwrap())),
-        Operation::Database(0, DatabaseOperation::Exists(Key::new(&[1]).unwrap())),
-        Operation::ShrinkRegistry,
-        Operation::ShrinkRegistry,
+        RegistryOperation::Database(0, DatabaseOperation::Exists(Key::new(&[1]).unwrap())),
+        RegistryOperation::Database(0, DatabaseOperation::Delete(Key::new(&[1]).unwrap())),
+        RegistryOperation::Database(0, DatabaseOperation::Exists(Key::new(&[1]).unwrap())),
+        RegistryOperation::ShrinkRegistry,
+        RegistryOperation::ShrinkRegistry,
     ];
 
     let (_keepalive, repo) = setup_repo();

--- a/durable-storage/tests/integration_test.rs
+++ b/durable-storage/tests/integration_test.rs
@@ -2,10 +2,11 @@
 
 use bytes::Bytes;
 use octez_riscv_durable_storage::key::Key;
+use octez_riscv_durable_storage::test_helpers::OperationView;
 use octez_riscv_durable_storage::test_helpers::database::DatabaseOperation;
 use octez_riscv_durable_storage::test_helpers::registry::RegistryOperation;
+use octez_riscv_durable_storage::test_helpers::registry::RegistryOperationView;
 use octez_riscv_durable_storage::test_helpers::registry::make_registry_operations;
-use octez_riscv_durable_storage::test_helpers::registry::registry_operations_strategy;
 use octez_riscv_durable_storage::test_helpers::registry::run_and_prove_registry_operations;
 use proptest::proptest;
 
@@ -76,7 +77,7 @@ fn test_durable_storage_manual() {
 proptest! {
     #![proptest_config(proptest::test_runner::Config::with_cases(PROPTEST_CASES))]
     #[test]
-    fn test_durable_storage_prop((keys, values, ops) in registry_operations_strategy(1usize..100)) {
+    fn test_durable_storage_prop((keys, values, ops) in RegistryOperationView::operations_strategy(1usize..100)) {
         let (_keepalive, repo) = setup_repo();
         let operations = make_registry_operations(
             std::num::NonZeroUsize::new(1).expect("1 > 0"),

--- a/durable-storage/xtask/src/main.rs
+++ b/durable-storage/xtask/src/main.rs
@@ -14,8 +14,9 @@ use anyhow::Result;
 use anyhow::bail;
 use clap::Parser;
 use clap::Subcommand;
+use octez_riscv_durable_storage::test_helpers::OperationView;
 use octez_riscv_durable_storage::test_helpers::database::DatabaseOperation;
-use octez_riscv_durable_storage::test_helpers::database::database_operations_strategy;
+use octez_riscv_durable_storage::test_helpers::database::DatabaseOperationView;
 use octez_riscv_durable_storage::test_helpers::database::make_database_operations;
 use proptest::prelude::Strategy;
 use proptest::strategy::ValueTree;
@@ -66,7 +67,7 @@ fn gen_database_regression_inputs(count: usize, out_dir: &Path) -> Result<()> {
     let mut runner = TestRunner::default();
 
     for i in 0..count {
-        let tree = database_operations_strategy(OPS_RANGE)
+        let tree = DatabaseOperationView::operations_strategy(OPS_RANGE)
             .new_tree(&mut runner)
             .map_err(|e| anyhow::anyhow!("{e}"))
             .with_context(|| format!("drawing input #{i}"))?;


### PR DESCRIPTION
Closes TZX-177.

# What

Introduces commit-checkout roundtrips in the Registry end to end test at different points in the 2 separate runs and checks they are equivalent.

# Why

To gain more confidence in the commit and checkout semantics of the durable storage and bring up to par with the Database test.

# How

Since most of the functionality has already been implemented for Database, much of this PR is a refactoring which allows it to be reused. The main change is the introduction of an `OperationView` trait which is implemented for both `DatabaseOperationView` and `RegistryOperationView` and defines strategies for sampling operations.

The actual test functionality implemented on top simply adds a `CommitCheckoutRoundtrip` variant to `RegistryOperationView` and expands the `test_durable_storage_end_to_end` test.

Registry does not have a traced equivalent like Database does so to check equivalence we rely on the `kv_test!` hash check between the 2 runs.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
