### PR TITLE
chore(ci): only write sccache on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ env:
   # Make sure Sccache automatically uses the GitHub Actions cache
   SCCACHE_GHA_ENABLED: "true"
 
+  # Only write Sccache on the main branch
+  SCCACHE_GHA_RW_MODE: ${{ github.ref_name == 'main' && 'READ_WRITE' || 'READ_ONLY' }}
+
   # Ensure the Nix formatter fails on changes
   TREEFMT_CI: "true"
 


### PR DESCRIPTION
# What

Only write sccache on main instead of on every run of every branch.

# Why

To avoid caches which are expensive to recompute, such as the Nix cache and MacOS cache, from being evicted too eagerly due to sccache entries taking too much space.

# How

Set `SCCACHE_GHA_RW_MODE` to be true on the main branch and false otherwise.

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
