### PR TITLE
fix(ci): don't abort if disk cleanup step fails on macOS runners

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -29,7 +29,8 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Aggressive cleanup
+    - name: Aggressive cleanup (Linux)
+      if: runner.os == 'Linux'
       shell: bash
       run: |
         # Remove Java (JDKs)
@@ -52,6 +53,13 @@ runs:
 
         # Remove PowerShell
         sudo rm -rf /usr/local/share/powershell
+
+    - name: Aggressive cleanup (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        # Remove Swift toolchain if possible
+        sudo rm -rf /usr/share/swift || true
 
     - name: Nix setup
       uses: nixbuild/nix-quick-install-action@v34


### PR DESCRIPTION
# What

Splits the `Aggressive cleanup` CI step between macOS and Linux depending on which paths can be removed on each machine type. Makes an error in the macOS step not abort the job.

# Why

The `MacOS Checks` PR job sometimes fails the disk cleanup step because GitHub might run it on a read-only machine. See [this job](https://github.com/tezos/riscv-pvm/actions/runs/28368360545/job/84039742786?pr=1113) for example. This results in intermittent, unwanted CI failures.

# Manually Testing

No way to test manually, inspect the log of the `MacOS Checks` job on this PR. A pass would only indicate the change is effective if it comes after an unsuccessful disk cleanup (like [here](https://github.com/tezos/riscv-pvm/actions/runs/28370057707/job/84045396632?pr=1114)).

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
