### PR TITLE
feat(ci): add Registry long tests to nightly tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,9 +23,9 @@ env:
   MAX_MINUTES: "330"
 
 jobs:
-  # Build the long-test binary once and share it with every matrix job below.
+  # Build the long_test binary once and share it with every matrix job below.
   build:
-    name: "Build database long test binary"
+    name: "Build nds long test binary"
     runs-on: ubuntu-latest
     timeout-minutes: 90
 
@@ -51,8 +51,8 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  long-test:
-    name: "Database long test ops=${{ matrix.config.ops }} cases=${{ matrix.config.cases }} #${{ matrix.replica }}"
+  nds-long-test:
+    name: "${{ matrix.test }} nds long test ops=${{ matrix.config.ops }} cases=${{ matrix.config.cases }} #${{ matrix.replica }}"
     needs: build
     runs-on: ubuntu-latest
 
@@ -67,7 +67,16 @@ jobs:
           - { ops: 4000,  cases: 128 }
           - { ops: 8000,  cases: 64 }
           - { ops: 16000, cases: 32 }
-        replica: [1, 2, 3, 4, 5]
+        test: [database, registry-stable]
+        replica: [1, 2]
+        include:
+          - test: database
+            args: database test
+          - test: registry-stable
+            args: registry test --keep-stable-size
+        exclude:
+          - test: database
+            replica: 2
 
     steps:
       - name: Checkout
@@ -82,21 +91,21 @@ jobs:
         with:
           name: long_test
 
-      - name: Run long test
+      - name: Run nds long test
         run: |
           chmod +x ./long_test # upload-artifact strips the executable bit
-          ./long_test database test \
+          ./long_test ${{ matrix.args }} \
             --ops-per-epoch ${{ matrix.config.ops }} \
             --cases-per-epoch ${{ matrix.config.cases }} \
             --keep-epochs 1 \
             --max-minutes ${{ env.MAX_MINUTES }} \
-            --out-dir '${{ github.workspace }}/run-${{ matrix.config.ops }}-${{ matrix.config.cases }}-${{ matrix.replica }}'
+            --out-dir '${{ github.workspace }}/run-${{ matrix.test }}-${{ matrix.config.ops }}-${{ matrix.config.cases }}-${{ matrix.replica }}'
 
       - name: Upload failure artifacts
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: dursto-long-test-${{ matrix.config.ops }}-${{ matrix.config.cases }}-r${{ matrix.replica }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ github.workspace }}/run-${{ matrix.config.ops }}-${{ matrix.config.cases }}-${{ matrix.replica }}/failure
+          name: dursto-long-test-${{ matrix.test }}-${{ matrix.config.ops }}-${{ matrix.config.cases }}-r${{ matrix.replica }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ github.workspace }}/run-${{ matrix.test }}-${{ matrix.config.ops }}-${{ matrix.config.cases }}-${{ matrix.replica }}/failure
           if-no-files-found: warn
           retention-days: 90


### PR DESCRIPTION
# What

Reassigns 16 of the 20 nightly tests to be `Registry` long tests by removing all `Database` test replicas. These have the same parameters as the remaining  `Database` tests but are split into 8 tests running with `--keep-stable-size` and 8 without.

TODO: The unconstrained `Registry` tests are much slower than those running with `--keep-stable-size`. This might mean that in spite of the 30-minute buffer, they might be cancelled at the end of the run mid-epoch, which would result in a failure. It might be necessary to adjust their parameters (test cases/epoch, ops/epoch) or to not run them altogether.

@thomasathorne : As discussed in the weekly meeting on Monday I have disabled the slower registry tests and left only the ones running with `--keep-stable-size`. 

# Why

To gain more confidence in the correctness of `Registry` semantics and proofs.

# Manually Testing

Cannot be tested locally. See a manually triggered run in CI [here](https://github.com/tezos/riscv-pvm/actions/runs/28792848535)

@thomasathorne : subsequent manually triggered run [here](https://github.com/tezos/riscv-pvm/actions/runs/29033865636) (without the unstable registry tests)

# Tasks for the Author

- [ ] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [ ] Eliminate dead code and other spurious artefacts introduced in your changes.
- [ ] Document new public functions, methods and types.
- [ ] Make sure the documentation for updated functions, methods, and types is correct.
- [ ] Add tests for bugs that have been fixed.
- [ ] [Explain changes](#regressions) to regression test captures when applicable.
- [ ] Write commit messages in agreement with our guidelines.
- [ ] Self-review your changes to ensure they are high-quality.
- [ ] Complete all of the above before assigning this MR to reviewers.
