### PR TITLE
refactor(data): thread `codec::Bincode` through all foldable traits/FromProof

### DIFF
--- a/data/src/codec.rs
+++ b/data/src/codec.rs
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2026 Trilitech <contact@trili.tech>
+//
+// SPDX-License-Identifier: MIT
+
+//! Leaf serialisation codecs.
+//!
+//! Hashing and merkle proofs reduce a state structure to a tree of *leaves*, where each leaf is the
+//! serialisation of some value. Historically that serialisation was always bincode. To let different
+//! consumers pick different leaf encodings (e.g. durable-storage on an alternative while the PVM stays on
+//! bincode) without duplicating the fold/proof machinery, the leaf boundary is abstracted over a
+//! [`LeafCodec`].
+//!
+//! A [`Fold`] (and the [proof deserialiser]) carries an associated [`LeafCodec`],
+//! and leaf values are (de)serialised through [`LeafEncode`]/[`LeafDecode`] parameterised by that codec.
+//! The [`Bincode`] codec reproduces the historical byte format exactly.
+//!
+//! [`Fold`]: crate::foldable::Fold
+//! [proof deserialiser]: crate::merkle_proof::Deserialiser
+
+use bincode::Decode;
+use bincode::Encode;
+use bincode::error::DecodeError;
+use bincode::error::EncodeError;
+
+use crate::serialisation::deserialise;
+use crate::serialisation::serialise;
+
+/// A leaf serialisation codec: the strategy used to turn a leaf value into bytes (and back) when
+/// folding/hashing or building/verifying proofs.
+pub trait LeafCodec {}
+
+/// The bincode codec — the historical leaf format.
+///
+/// Its [`LeafEncode`]/[`LeafDecode`] impls delegate to the bincode helpers, so output is
+/// byte-identical to the pre-codec code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Bincode;
+
+impl LeafCodec for Bincode {}
+
+/// Error raised while encoding a leaf value under some [`LeafCodec`].
+#[derive(Debug, thiserror::Error)]
+pub enum LeafEncodeError {
+    #[error("bincode encode error: {0}")]
+    Bincode(#[from] EncodeError),
+}
+
+/// Error raised while decoding a leaf value under some [`LeafCodec`].
+#[derive(Debug, thiserror::Error)]
+pub enum LeafDecodeError {
+    #[error("bincode decode error: {0}")]
+    Bincode(#[from] DecodeError),
+}
+
+/// A value that can be encoded as a hash/proof leaf under codec `C`.
+pub trait LeafEncode<C: LeafCodec> {
+    /// Encode `self` into the leaf byte representation for codec `C`.
+    fn leaf_encode(&self) -> Result<Vec<u8>, LeafEncodeError>;
+}
+
+/// A value that can be reconstructed from a hash/proof leaf's bytes under codec `C`.
+pub trait LeafDecode<C: LeafCodec>: Sized {
+    /// Decode the leaf byte representation for codec `C` from an exact byte slice.
+    fn leaf_decode(bytes: &[u8]) -> Result<Self, LeafDecodeError>;
+
+    /// Decode a leaf from the front of `bytes`, returning the value and the number of bytes
+    /// consumed.
+    ///
+    /// This is the streaming counterpart used by the byte-stream proof deserialiser, which lays
+    /// leaves back-to-back and needs to know where each one ends. For [`Bincode`] the archive is
+    /// self-delimiting so the length falls out of decoding; other codecs may need explicit framing.
+    fn leaf_decode_stream(bytes: &[u8]) -> Result<(Self, usize), LeafDecodeError>;
+}
+
+impl<T: Encode> LeafEncode<Bincode> for T {
+    fn leaf_encode(&self) -> Result<Vec<u8>, LeafEncodeError> {
+        Ok(serialise(self)?)
+    }
+}
+
+impl<T: Decode<()>> LeafDecode<Bincode> for T {
+    fn leaf_decode(bytes: &[u8]) -> Result<Self, LeafDecodeError> {
+        Ok(deserialise(bytes)?)
+    }
+
+    fn leaf_decode_stream(bytes: &[u8]) -> Result<(Self, usize), LeafDecodeError> {
+        // Decode from the front of the slice exactly as the stream deserialiser historically did
+        // (streaming read over `&[u8]`), computing the consumed length from how far the cursor
+        // advanced. This preserves the precise bincode error kind (e.g. `Io` on truncation).
+        let mut cursor: &[u8] = bytes;
+        let value = crate::serialisation::deserialise_from(&mut cursor)?;
+        let consumed = bytes.len() - cursor.len();
+        Ok((value, consumed))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Bincode;
+    use super::LeafDecode;
+    use super::LeafEncode;
+    use crate::serialisation::serialise;
+
+    #[test]
+    fn bincode_codec_matches_plain_bincode() {
+        let value: u64 = 0x0123_4567_89AB_CDEF;
+
+        // Encoding through the Bincode codec is byte-identical to calling `serialise` directly.
+        let via_codec = LeafEncode::<Bincode>::leaf_encode(&value).expect("encode ok");
+        let via_bincode = serialise(value).expect("serialise ok");
+        assert_eq!(via_codec, via_bincode);
+
+        // And it round-trips.
+        let decoded: u64 = LeafDecode::<Bincode>::leaf_decode(&via_codec).expect("decode ok");
+        assert_eq!(decoded, value);
+    }
+}

--- a/data/src/components/atom.rs
+++ b/data/src/components/atom.rs
@@ -21,6 +21,9 @@ use bincode::error::EncodeError;
 use perfect_derive::perfect_derive;
 
 use crate::clone::CloneState;
+use crate::codec::LeafCodec;
+use crate::codec::LeafDecode;
+use crate::codec::LeafEncode;
 use crate::foldable::Fold;
 use crate::foldable::FoldLeaf;
 use crate::foldable::Foldable;
@@ -45,7 +48,6 @@ use crate::mode::Prove;
 use crate::mode::Verify;
 use crate::mode::utils::Source;
 use crate::mode::utils::not_found;
-use crate::serialisation::serialise;
 
 /// Single value state component
 ///
@@ -173,15 +175,21 @@ impl<T: Default + 'static, M: AtomMode> Default for Atom<T, M> {
     }
 }
 
-impl<T: Encode, F: FoldLeaf> Foldable<F> for Atom<T, Normal> {
+impl<T, F: FoldLeaf> Foldable<F> for Atom<T, Normal>
+where
+    T: LeafEncode<F::Codec>,
+{
     fn fold(&self, builder: F) -> F::Folded {
         builder
-            .fold_leaf(self)
+            .fold_leaf(&self.atom)
             .expect("Should be able to serialise value in atom")
     }
 }
 
-impl<'normal, T: Encode + 'static, F: FoldLeaf> Foldable<F> for Atom<T, Prove<'normal>> {
+impl<'normal, T: 'static, F: FoldLeaf> Foldable<F> for Atom<T, Prove<'normal>>
+where
+    T: LeafEncode<F::Codec>,
+{
     fn fold(&self, builder: F) -> F::Folded {
         let value = self
             .atom
@@ -194,9 +202,13 @@ impl<'normal, T: Encode + 'static, F: FoldLeaf> Foldable<F> for Atom<T, Prove<'n
     }
 }
 
-impl<T: Encode + 'static> Foldable<MerkleProofFold> for Atom<T, Prove<'_>> {
-    fn fold(&self, builder: MerkleProofFold) -> <MerkleProofFold as Fold>::Folded {
-        let data = serialise(self.atom.previous.deref()).expect("Serialisation should not fail");
+impl<T: 'static, C: LeafCodec> Foldable<MerkleProofFold<C>> for Atom<T, Prove<'_>>
+where
+    T: LeafEncode<C>,
+{
+    fn fold(&self, builder: MerkleProofFold<C>) -> <MerkleProofFold<C> as Fold>::Folded {
+        let data = <T as LeafEncode<C>>::leaf_encode(self.atom.previous.deref())
+            .expect("Serialisation should not fail");
 
         // Determine whether the value has been read or written during proof generation. If so, we
         // must keep it in the Merkle tree (not blind it).
@@ -210,14 +222,15 @@ impl<T: Encode + 'static> Foldable<MerkleProofFold> for Atom<T, Prove<'_>> {
     }
 }
 
-impl<T: Encode + 'static> Foldable<PartialHashFold> for Atom<T, Verify> {
-    fn fold(&self, builder: PartialHashFold) -> PartialHash {
+impl<T: 'static, C: LeafCodec> Foldable<PartialHashFold<C>> for Atom<T, Verify>
+where
+    T: LeafEncode<C>,
+{
+    fn fold(&self, builder: PartialHashFold<C>) -> PartialHash {
         let hash = match &self.atom {
             Partial::Absent => return builder.previous(),
             Partial::Blinded(hash) => *hash,
-            Partial::Present(value) => {
-                Hash::hash_encodable(value).expect("Hashing should not fail")
-            }
+            Partial::Present(value) => Hash::hash_leaf(value).expect("Hashing should not fail"),
         };
         PartialHash::Present(hash)
     }
@@ -230,8 +243,8 @@ impl<T: Decode<()>> Unfoldable for Atom<T, Normal> {
     }
 }
 
-impl<T: Decode<()> + 'static> FromProof for Atom<T, Verify> {
-    fn from_proof<Proof: Deserialiser>(proof: Proof) -> SuspendedResult<Proof, Self> {
+impl<C: LeafCodec, T: LeafDecode<C> + 'static> FromProof<C> for Atom<T, Verify> {
+    fn from_proof<Proof: Deserialiser<Codec = C>>(proof: Proof) -> SuspendedResult<Proof, Self> {
         let result = proof.into_leaf()?.map(|value| Atom { atom: value });
         Ok(result)
     }

--- a/data/src/components/atom/tests.rs
+++ b/data/src/components/atom/tests.rs
@@ -257,7 +257,10 @@ fn proof_blinding() {
         let merkle_proof = MerkleProof::from_foldable(&proof_state);
 
         let verifier_state =
-            proof_tree::deserialise::<TestState<Verify>>(ProofTree::Present(&merkle_proof)).unwrap();
+            proof_tree::deserialise::<crate::codec::Bincode, TestState<Verify>>(
+                ProofTree::present(&merkle_proof),
+            )
+            .unwrap();
 
         // The first component of the state was present in the proof, can be
         // fully read, and contains the initial state.

--- a/data/src/components/bytes.rs
+++ b/data/src/components/bytes.rs
@@ -26,6 +26,9 @@ use perfect_derive::perfect_derive;
 use range_collections::RangeSet2;
 
 use crate::clone::CloneState;
+use crate::codec::LeafCodec;
+use crate::codec::LeafDecode;
+use crate::codec::LeafEncode;
 use crate::foldable::EncodeLeaf;
 use crate::foldable::Fold;
 use crate::foldable::FoldLeaf;
@@ -60,7 +63,6 @@ use crate::mode::utils::Source;
 use crate::mode::utils::not_found;
 use crate::partial_vec::PartialVec;
 use crate::partial_vec::RangeEntry;
-use crate::serialisation::serialise;
 
 /// Byte array state component
 #[perfect_derive(Debug)]
@@ -169,7 +171,11 @@ impl<M: BytesMode> Bytes<M> {
         builder: Build,
         length: usize,
         get_data: F,
-    ) -> <Build as Fold>::Folded {
+    ) -> <Build as Fold>::Folded
+    where
+        u64: LeafEncode<Build::Codec>,
+        for<'x> ChunkedPage<'x>: LeafEncode<Build::Codec>,
+    {
         let length_node = EncodeLeaf::new(length as u64, "Serialising length should not fail.");
 
         let get_item = move |range| {
@@ -179,7 +185,7 @@ impl<M: BytesMode> Bytes<M> {
                     chunks: &[data.borrow()],
                 };
                 builder
-                    .fold_leaf(page)
+                    .fold_leaf(&page)
                     .expect("Serialising page should not fail.")
             })
         };
@@ -314,7 +320,11 @@ impl<M: CloneBytesMode> CloneState for Bytes<M> {
     }
 }
 
-impl<F: FoldLeaf> Foldable<F> for Bytes<Normal> {
+impl<F: FoldLeaf> Foldable<F> for Bytes<Normal>
+where
+    u64: LeafEncode<F::Codec>,
+    for<'x> ChunkedPage<'x>: LeafEncode<F::Codec>,
+{
     fn fold(&self, builder: F) -> F::Folded {
         self.fold_with_fold_leaf(builder, self.bytes.len(), |addr_range| {
             &self.bytes[addr_range]
@@ -322,7 +332,11 @@ impl<F: FoldLeaf> Foldable<F> for Bytes<Normal> {
     }
 }
 
-impl<F: FoldLeaf> Foldable<F> for Bytes<Prove<'_>> {
+impl<F: FoldLeaf> Foldable<F> for Bytes<Prove<'_>>
+where
+    u64: LeafEncode<F::Codec>,
+    for<'x> ChunkedPage<'x>: LeafEncode<F::Codec>,
+{
     fn fold(&self, builder: F) -> F::Folded {
         self.fold_with_fold_leaf(builder, self.bytes.unrecorded_len(), |addr_range| {
             let previous_len = self.bytes.previous.len();
@@ -341,13 +355,18 @@ impl<F: FoldLeaf> Foldable<F> for Bytes<Prove<'_>> {
     }
 }
 
-impl Foldable<MerkleProofFold> for Bytes<Prove<'_>> {
-    fn fold(&self, builder: MerkleProofFold) -> <MerkleProofFold as Fold>::Folded {
+impl<C: LeafCodec> Foldable<MerkleProofFold<C>> for Bytes<Prove<'_>>
+where
+    u64: LeafEncode<C>,
+    for<'x> ChunkedPage<'x>: LeafEncode<C>,
+{
+    fn fold(&self, builder: MerkleProofFold<C>) -> <MerkleProofFold<C> as Fold>::Folded {
         // Reminder: Merkle trees generated in Prove mode capture the state at beginning of proof
         // generation. This means we need to use `previous` state for the length and data.
 
         let length = self.bytes.previous.len();
-        let length_data = serialise(length as u64).expect("Serialising length should not fail");
+        let length_data = LeafEncode::<C>::leaf_encode(&(length as u64))
+            .expect("Serialising length should not fail");
         let is_length_needed = self.bytes.need_length_in_proof();
         let length_constraint = if is_length_needed {
             MinimumPresence::Present
@@ -369,7 +388,8 @@ impl Foldable<MerkleProofFold> for Bytes<Prove<'_>> {
 
             // We need to serialise the data to be able to recover it later, given that it is
             // variably sized.
-            let leaf_data = serialise(page).expect("Serialising leaf data should not fail");
+            let leaf_data =
+                LeafEncode::<C>::leaf_encode(&page).expect("Serialising leaf data should not fail");
 
             MerkleProofFold::new_leaf(constraint, leaf_data)
         };
@@ -378,8 +398,12 @@ impl Foldable<MerkleProofFold> for Bytes<Prove<'_>> {
     }
 }
 
-impl Foldable<PartialHashFold> for Bytes<Verify> {
-    fn fold(&self, builder: PartialHashFold) -> PartialHash {
+impl<C: LeafCodec> Foldable<PartialHashFold<C>> for Bytes<Verify>
+where
+    u64: LeafEncode<C>,
+    for<'x> ChunkedPage<'x>: LeafEncode<C>,
+{
+    fn fold(&self, builder: PartialHashFold<C>) -> PartialHash {
         if self.bytes.is_completely_absent() {
             return builder.previous();
         }
@@ -394,8 +418,10 @@ impl Foldable<PartialHashFold> for Bytes<Verify> {
             return PartialHash::InvalidProof;
         };
 
-        let length_hash =
-            Hash::hash_encodable(length as u64).expect("Hashing length should not fail");
+        let length_hash = Hash::hash_bytes(
+            &LeafEncode::<C>::leaf_encode(&(length as u64))
+                .expect("Hashing length should not fail"),
+        );
         let length_node = PartialHash::Present(length_hash);
 
         let generator = |idx: usize| {
@@ -424,8 +450,10 @@ impl Foldable<PartialHashFold> for Bytes<Verify> {
                     let page = ChunkedPage {
                         chunks: chunks.as_slice(),
                     };
-                    let hash =
-                        Hash::hash_encodable(page).expect("Hashing encoded bytes should not fail");
+                    let hash = Hash::hash_bytes(
+                        &LeafEncode::<C>::leaf_encode(&page)
+                            .expect("Hashing encoded bytes should not fail"),
+                    );
                     PartialHash::Present(hash)
                 }
             }
@@ -472,8 +500,12 @@ impl Unfoldable for Bytes<Normal> {
     }
 }
 
-impl FromProof for Bytes<Verify> {
-    fn from_proof<Proof: Deserialiser>(
+impl<C: LeafCodec> FromProof<C> for Bytes<Verify>
+where
+    u64: LeafDecode<C>,
+    Page: LeafDecode<C>,
+{
+    fn from_proof<Proof: Deserialiser<Codec = C>>(
         proof: Proof,
     ) -> Result<<Proof as Deserialiser>::Suspended<Self>, <Proof as Deserialiser>::Error> {
         sequence_as_tree_from_proof::<u64, Self, _>(

--- a/data/src/components/data_space.rs
+++ b/data/src/components/data_space.rs
@@ -19,6 +19,8 @@ use super::bytes::Bytes;
 use super::bytes::ChunkedPage;
 use super::bytes::Page;
 use crate::clone::CloneState;
+use crate::codec::LeafCodec;
+use crate::codec::LeafEncode;
 use crate::foldable::EncodeLeaf;
 use crate::foldable::Fold;
 use crate::foldable::FoldLeaf;
@@ -228,7 +230,11 @@ impl<C> Decode<C> for DataSpace<Normal> {
     }
 }
 
-impl<F: FoldLeaf> Foldable<F> for DataSpace<Normal> {
+impl<F: FoldLeaf> Foldable<F> for DataSpace<Normal>
+where
+    u64: LeafEncode<F::Codec>,
+    for<'x> ChunkedPage<'x>: LeafEncode<F::Codec>,
+{
     fn fold(&self, builder: F) -> F::Folded {
         let length = self.data_space.len();
         let length_node = EncodeLeaf::new(length as u64, "Serialising length should not fail");
@@ -247,7 +253,7 @@ impl<F: FoldLeaf> Foldable<F> for DataSpace<Normal> {
             FoldableClosure::new(move |builder: F| {
                 let page = ChunkedPage { chunks: &[data] };
                 builder
-                    .fold_leaf(page)
+                    .fold_leaf(&page)
                     .expect("Serialising page data should not fail")
             })
         };
@@ -324,8 +330,11 @@ impl Unfoldable for DataSpace<Normal> {
     }
 }
 
-impl FromProof for DataSpace<Verify> {
-    fn from_proof<D: Deserialiser>(proof: D) -> SuspendedResult<D, Self> {
+impl<C: LeafCodec> FromProof<C> for DataSpace<Verify>
+where
+    Bytes<Verify>: FromProof<C>,
+{
+    fn from_proof<D: Deserialiser<Codec = C>>(proof: D) -> SuspendedResult<D, Self> {
         let bytes = Bytes::<Verify>::from_proof(proof)?;
         let bytes = bytes.map(|bytes| DataSpace { data_space: bytes });
         Ok(bytes)

--- a/data/src/components/data_space/tests.rs
+++ b/data/src/components/data_space/tests.rs
@@ -367,8 +367,11 @@ unsafe fn test_data_space_with_funs(
 
     // Instantiating the verifier state allows us to replay the computation and verify it does
     // the right things.
-    let (mut verify_cell, out_proof) =
-        proof_tree::deserialise::<DataSpace<Verify>>(ProofTree::Present(&proof_tree)).unwrap();
+    let (mut verify_cell, out_proof) = proof_tree::deserialise::<
+        crate::codec::Bincode,
+        DataSpace<Verify>,
+    >(ProofTree::present(&proof_tree))
+    .unwrap();
 
     let OwnedProofTree::Present(out_proof) = out_proof else {
         panic!("Expected present proof");

--- a/data/src/components/vector.rs
+++ b/data/src/components/vector.rs
@@ -22,6 +22,9 @@ use perfect_derive::perfect_derive;
 use range_collections::RangeSet2;
 
 use crate::clone::CloneState;
+use crate::codec::LeafCodec;
+use crate::codec::LeafDecode;
+use crate::codec::LeafEncode;
 use crate::foldable::EncodeLeaf;
 use crate::foldable::Fold;
 use crate::foldable::FoldLeaf;
@@ -55,7 +58,6 @@ use crate::mode::Prove;
 use crate::mode::Verify;
 use crate::mode::utils::not_found;
 use crate::partial_vec::PartialVec;
-use crate::serialisation::serialise;
 
 /// Vector state component
 ///
@@ -149,7 +151,10 @@ impl<T, M: VectorMode> Default for Vector<T, M> {
     }
 }
 
-impl<F: FoldLeaf, T: Foldable<F>> Foldable<F> for Vector<T, Normal> {
+impl<F: FoldLeaf, T: Foldable<F>> Foldable<F> for Vector<T, Normal>
+where
+    u64: LeafEncode<F::Codec>,
+{
     fn fold(&self, builder: F) -> F::Folded {
         let mut node = builder.into_node_fold();
 
@@ -165,7 +170,10 @@ impl<F: FoldLeaf, T: Foldable<F>> Foldable<F> for Vector<T, Normal> {
     }
 }
 
-impl<F: FoldLeaf, T: Foldable<F>> Foldable<F> for Vector<T, Prove<'_>> {
+impl<F: FoldLeaf, T: Foldable<F>> Foldable<F> for Vector<T, Prove<'_>>
+where
+    u64: LeafEncode<F::Codec>,
+{
     fn fold(&self, builder: F) -> F::Folded {
         let mut node = builder.into_node_fold();
 
@@ -181,15 +189,20 @@ impl<F: FoldLeaf, T: Foldable<F>> Foldable<F> for Vector<T, Prove<'_>> {
     }
 }
 
-impl<T: Foldable<MerkleProofFold>> Foldable<MerkleProofFold> for Vector<T, Prove<'_>> {
-    fn fold(&self, builder: MerkleProofFold) -> <MerkleProofFold as Fold>::Folded {
+impl<C: LeafCodec, T: Foldable<MerkleProofFold<C>>> Foldable<MerkleProofFold<C>>
+    for Vector<T, Prove<'_>>
+where
+    u64: LeafEncode<C>,
+{
+    fn fold(&self, builder: MerkleProofFold<C>) -> <MerkleProofFold<C> as Fold>::Folded {
         // Reminder: Merkle trees generated in Prove mode capture the state at beginning of proof
         // generation. This means we need to use `previous` state for the length and data.
 
         let mut node = builder.into_node_fold();
 
         let length = self.vector.previous.len();
-        let length_data = serialise(length as u64).expect("Serialising length should not fail");
+        let length_data = LeafEncode::<C>::leaf_encode(&(length as u64))
+            .expect("Serialising length should not fail");
         let is_length_needed = self.vector.need_length_in_proof();
         let length_constraint = if is_length_needed {
             MinimumPresence::Present
@@ -214,8 +227,12 @@ impl<T: Foldable<MerkleProofFold>> Foldable<MerkleProofFold> for Vector<T, Prove
     }
 }
 
-impl<T: Foldable<PartialHashFold>> Foldable<PartialHashFold> for Vector<T, Verify> {
-    fn fold(&self, builder: PartialHashFold) -> PartialHash {
+impl<C: LeafCodec, T: Foldable<PartialHashFold<C>>> Foldable<PartialHashFold<C>>
+    for Vector<T, Verify>
+where
+    u64: LeafEncode<C>,
+{
+    fn fold(&self, builder: PartialHashFold<C>) -> PartialHash {
         if self.vector.is_completely_absent() {
             return builder.previous();
         }
@@ -230,7 +247,9 @@ impl<T: Foldable<PartialHashFold>> Foldable<PartialHashFold> for Vector<T, Verif
 
         let mut node = builder.into_node_fold();
 
-        let length_hash = Hash::hash_encodable(length as u64).expect("Hashing should not fail");
+        let length_hash = Hash::hash_bytes(
+            &LeafEncode::<C>::leaf_encode(&(length as u64)).expect("Hashing should not fail"),
+        );
         let length_node = PartialHash::Present(length_hash);
         node.add(&length_node);
 
@@ -278,8 +297,11 @@ impl<'normal, 'inner, E, T: ProvableExt<'normal, 'inner, E>> ProvableExt<'normal
     }
 }
 
-impl<T: FromProof> FromProof for Vector<T, Verify> {
-    fn from_proof<Proof: Deserialiser>(proof: Proof) -> SuspendedResult<Proof, Self> {
+impl<C: LeafCodec, T: FromProof<C>> FromProof<C> for Vector<T, Verify>
+where
+    u64: LeafDecode<C>,
+{
+    fn from_proof<Proof: Deserialiser<Codec = C>>(proof: Proof) -> SuspendedResult<Proof, Self> {
         let with_length = |length: Partial<u64>| {
             let length = length.map_present(|len: u64| len as usize);
             let state = Vector {

--- a/data/src/components/vector/tests.rs
+++ b/data/src/components/vector/tests.rs
@@ -429,8 +429,11 @@ where
             let proof_bytes = serialise(proof_tree).unwrap();
 
             // Parsing the proof so we can see if the proof generation worked.
-            let (mut vector_verify, parsed_proof_tree) =
-                proof_binary::deserialise::<Vector<InnerVerify, Verify>>(&proof_bytes).unwrap();
+            let (mut vector_verify, parsed_proof_tree) = proof_binary::deserialise::<
+                crate::codec::Bincode,
+                Vector<InnerVerify, Verify>,
+            >(&proof_bytes)
+            .unwrap();
             let parsed_proof_tree = parsed_proof_tree.into_present();
 
             // The parsed state should have a state hash equal to that of the initial Normal/Prove state.

--- a/data/src/foldable.rs
+++ b/data/src/foldable.rs
@@ -8,11 +8,11 @@
 use std::sync::Arc;
 
 use bincode::Decode;
-use bincode::Encode;
 use bincode::error::DecodeError;
-use bincode::error::EncodeError;
 
-use crate::serialisation::serialise;
+use crate::codec::LeafCodec;
+use crate::codec::LeafEncode;
+use crate::codec::LeafEncodeError;
 
 pub mod seq_tree;
 
@@ -86,6 +86,12 @@ pub trait Fold {
     /// This type provides additional methods for folding nodes.
     type NodeFold: NodeFold<Parent = Self>;
 
+    /// The codec used to (de)serialise leaf values while folding.
+    ///
+    /// Threaded through so that leaf-encoding [`Foldable`] implementations can bound their leaves on
+    /// [`LeafEncode<Self::Codec>`] rather than a fixed serialisation format.
+    type Codec: LeafCodec;
+
     /// Start folding a node.
     fn into_node_fold(self) -> Self::NodeFold;
 }
@@ -104,9 +110,15 @@ pub trait NodeFold {
 
 /// Extension trait for `Fold` implementations that can treat leaves in a standard way.
 pub trait FoldLeaf: Fold + Sized {
-    /// Fold any serialisable value as a single leaf.
-    fn fold_leaf<T: Encode>(self, t: T) -> Result<<Self as Fold>::Folded, EncodeError> {
-        let bytes = serialise(t)?;
+    /// Fold any serialisable value as a single leaf, encoding it with this fold's [`Fold::Codec`].
+    ///
+    /// Takes the leaf by reference so the bound is on the owned type `T`. This matters for codecs
+    /// (rkyv) that do not implement their serialise trait for references.
+    fn fold_leaf<T: LeafEncode<Self::Codec> + ?Sized>(
+        self,
+        t: &T,
+    ) -> Result<<Self as Fold>::Folded, LeafEncodeError> {
+        let bytes = <T as LeafEncode<Self::Codec>>::leaf_encode(t)?;
         Ok(self.fold_leaf_raw(&bytes))
     }
 
@@ -126,7 +138,10 @@ impl<T> EncodeLeaf<T> {
     }
 }
 
-impl<F: FoldLeaf, T: Encode> Foldable<F> for EncodeLeaf<T> {
+impl<F: FoldLeaf, T> Foldable<F> for EncodeLeaf<T>
+where
+    T: LeafEncode<F::Codec>,
+{
     fn fold(&self, builder: F) -> <F as Fold>::Folded {
         builder.fold_leaf(&self.data).expect(self.err_msg)
     }

--- a/data/src/foldable/seq_tree.rs
+++ b/data/src/foldable/seq_tree.rs
@@ -6,6 +6,7 @@
 
 use derive_more::From;
 
+use crate::codec::LeafCodec;
 use crate::foldable::Fold;
 use crate::foldable::Foldable;
 use crate::foldable::NodeFold;
@@ -243,8 +244,10 @@ pub struct DepthAdjustedSeqAsTree<T> {
     pub current_depth: u32,
 }
 
-impl<T: Foldable<PartialHashFold>> Foldable<PartialHashFold> for DepthAdjustedSeqAsTree<T> {
-    fn fold(&self, mut builder: PartialHashFold) -> PartialHash {
+impl<C: LeafCodec, T: Foldable<PartialHashFold<C>>> Foldable<PartialHashFold<C>>
+    for DepthAdjustedSeqAsTree<T>
+{
+    fn fold(&self, mut builder: PartialHashFold<C>) -> PartialHash {
         // If the original depth is larger than the current depth, then we need to scope the proof
         // that underlies the `PartialHash::Blinded` to not exceed that depth. We can do that by
         // picking the first child of any node until we reach the original depth - thereby

--- a/data/src/foldable/tests.rs
+++ b/data/src/foldable/tests.rs
@@ -66,6 +66,8 @@ impl Fold for TestFolder {
 
     type NodeFold = TestNodeFolder;
 
+    type Codec = crate::codec::Bincode;
+
     fn into_node_fold(self) -> Self::NodeFold {
         TestNodeFolder {
             children: Vec::new(),

--- a/data/src/hash.rs
+++ b/data/src/hash.rs
@@ -7,6 +7,7 @@
 
 use std::borrow::Borrow;
 use std::collections::VecDeque;
+use std::marker::PhantomData;
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -16,6 +17,9 @@ use bincode::error::EncodeError;
 use perfect_derive::perfect_derive;
 use thiserror::Error;
 
+use crate::codec::Bincode;
+use crate::codec::LeafCodec;
+use crate::codec::LeafEncode;
 use crate::foldable::Fold;
 use crate::foldable::FoldLeaf;
 use crate::foldable::Foldable;
@@ -92,6 +96,16 @@ impl Hash {
         Ok(Hash { digest })
     }
 
+    /// Creates a [`struct@Hash`] from a leaf value, encoding it with the given [`LeafCodec`].
+    ///
+    /// This is the codec-generic counterpart of [`Hash::hash_encodable`] (which is fixed to
+    /// bincode); the resulting hash matches folding a single leaf under [`HashFold<C>`].
+    pub fn hash_leaf<C: LeafCodec, T: LeafEncode<C>>(
+        data: &T,
+    ) -> Result<Self, crate::codec::LeafEncodeError> {
+        Ok(Hash::hash_bytes(&<T as LeafEncode<C>>::leaf_encode(data)?))
+    }
+
     /// Creates a [`struct@Hash`] from a collection of iterables that can be
     /// [`Deref`]ed as a [`struct@Hash`]. Note that this method  is rehashing the
     /// hashes.
@@ -108,9 +122,14 @@ impl Hash {
         Hash { digest }
     }
 
-    /// Hash the underlying state of a foldable structure.
+    /// Hash the underlying state of a foldable structure (bincode leaf codec).
     pub fn from_foldable(foldable: &impl Foldable<HashFold>) -> Self {
-        foldable.fold(HashFold)
+        foldable.fold(HashFold::default())
+    }
+
+    /// Hash the underlying state of a foldable structure, using the given leaf [`LeafCodec`].
+    pub fn from_foldable_with<C: LeafCodec>(foldable: &impl Foldable<HashFold<C>>) -> Self {
+        foldable.fold(HashFold::<C>::default())
     }
 }
 
@@ -138,8 +157,8 @@ impl AsRef<[u8]> for Hash {
     }
 }
 
-impl Foldable<HashFold> for Hash {
-    fn fold(&self, _builder: HashFold) -> Hash {
+impl<C: LeafCodec> Foldable<HashFold<C>> for Hash {
+    fn fold(&self, _builder: HashFold<C>) -> Hash {
         *self
     }
 }
@@ -212,23 +231,34 @@ impl<Data: AsRef<[u8]>> HashedData<Data> {
 }
 
 /// [`Fold`] implementation producing a [`struct@Hash`]
-pub struct HashFold;
+///
+/// Parameterised by the leaf [`LeafCodec`]; defaults to [`Bincode`] so existing `HashFold`
+/// references keep the historical byte format.
+pub struct HashFold<C = Bincode> {
+    _codec: PhantomData<C>,
+}
 
-impl Fold for HashFold {
+impl<C> Default for HashFold<C> {
+    fn default() -> Self {
+        HashFold {
+            _codec: PhantomData,
+        }
+    }
+}
+
+impl<C: LeafCodec> Fold for HashFold<C> {
     type Folded = Hash;
 
-    type NodeFold = HashNodeFold;
+    type NodeFold = HashNodeFold<C>;
+
+    type Codec = C;
 
     fn into_node_fold(self) -> Self::NodeFold {
         HashNodeFold::default()
     }
 }
 
-impl FoldLeaf for HashFold {
-    fn fold_leaf<T: Encode>(self, t: T) -> Result<Hash, EncodeError> {
-        Hash::hash_encodable(t)
-    }
-
+impl<C: LeafCodec> FoldLeaf for HashFold<C> {
     fn fold_leaf_raw(self, bytes: &[u8]) -> Hash {
         Hash::hash_bytes(bytes)
     }
@@ -238,17 +268,27 @@ impl FoldLeaf for HashFold {
 ///
 /// It collects the hashes of all children and then combines them by hashing the concatenation of
 /// children's [`struct@Hash`] bytes.
-#[derive(Default)]
-pub struct HashNodeFold {
+pub struct HashNodeFold<C = Bincode> {
     /// Hasher used to combine children's hashes
     hasher: Hasher,
+
+    _codec: PhantomData<C>,
 }
 
-impl NodeFold for HashNodeFold {
-    type Parent = HashFold;
+impl<C> Default for HashNodeFold<C> {
+    fn default() -> Self {
+        HashNodeFold {
+            hasher: Hasher::default(),
+            _codec: PhantomData,
+        }
+    }
+}
 
-    fn add<F: Foldable<HashFold>>(&mut self, child: &F) {
-        let folded_child = child.fold(HashFold);
+impl<C: LeafCodec> NodeFold for HashNodeFold<C> {
+    type Parent = HashFold<C>;
+
+    fn add<F: Foldable<HashFold<C>>>(&mut self, child: &F) {
+        let folded_child = child.fold(HashFold::default());
         self.hasher.update(folded_child.as_ref());
     }
 
@@ -297,19 +337,28 @@ impl PartialHash {
         }
     }
 
-    /// Compute a [`PartialHash`] from a foldable structure.
+    /// Compute a [`PartialHash`] from a foldable structure (bincode leaf codec).
     pub fn from_foldable(
         proof: Option<MerkleProof>,
         foldable: &impl Foldable<PartialHashFold>,
     ) -> PartialHash {
+        Self::from_foldable_with(proof, foldable)
+    }
+
+    /// Compute a [`PartialHash`] from a foldable structure, using the given leaf [`LeafCodec`].
+    pub fn from_foldable_with<C: LeafCodec>(
+        proof: Option<MerkleProof>,
+        foldable: &impl Foldable<PartialHashFold<C>>,
+    ) -> PartialHash {
         foldable.fold(PartialHashFold {
             proof: proof.map(Arc::new),
+            _codec: PhantomData,
         })
     }
 }
 
-impl Foldable<PartialHashFold> for PartialHash {
-    fn fold(&self, builder: PartialHashFold) -> Self {
+impl<C: LeafCodec> Foldable<PartialHashFold<C>> for PartialHash {
+    fn fold(&self, builder: PartialHashFold<C>) -> Self {
         match self {
             PartialHash::Previous => builder.previous(),
             PartialHash::Present(hash) => builder.present(*hash),
@@ -319,16 +368,20 @@ impl Foldable<PartialHashFold> for PartialHash {
 }
 
 /// [`Fold`] implementation for computing the [`PartialHash`] of a state
-pub struct PartialHashFold {
+///
+/// Parameterised by the leaf [`LeafCodec`]; defaults to [`Bincode`].
+pub struct PartialHashFold<C = Bincode> {
     /// Original proof which is the source of previous hashes.
     ///
     /// Stored as `Arc` so that callers (notably the verify-mode AVL fold) can attach a node-local
     /// override cheaply: the override site only bumps the refcount instead of automatically
     /// deep-cloning the proof.
     proof: Option<Arc<MerkleProof>>,
+
+    _codec: PhantomData<C>,
 }
 
-impl PartialHashFold {
+impl<C: LeafCodec> PartialHashFold<C> {
     /// Mark the state as present with the given hash.
     pub fn present(self, hash: Hash) -> PartialHash {
         PartialHash::Present(hash)
@@ -350,8 +403,11 @@ impl PartialHashFold {
     /// Use when a sub-structure carries its own captured proof that should override whatever the
     /// parent fold passed down. Unlike [`PartialHashFold::map_reference_proof`], this does not
     /// require the existing proof to be `Some`.
-    pub fn with_proof(self, proof: Option<Arc<MerkleProof>>) -> PartialHashFold {
-        PartialHashFold { proof }
+    pub fn with_proof(self, proof: Option<Arc<MerkleProof>>) -> PartialHashFold<C> {
+        PartialHashFold {
+            proof,
+            _codec: PhantomData,
+        }
     }
 
     /// Modify the reference proof that `PartialHashFold` uses when traversing the described
@@ -363,20 +419,23 @@ impl PartialHashFold {
     pub fn map_reference_proof(
         self,
         proj: impl FnOnce(MerkleProof) -> Option<MerkleProof>,
-    ) -> PartialHashFold {
+    ) -> PartialHashFold<C> {
         PartialHashFold {
             proof: self
                 .proof
                 .and_then(|arc| proj(Arc::unwrap_or_clone(arc)))
                 .map(Arc::new),
+            _codec: PhantomData,
         }
     }
 }
 
-impl Fold for PartialHashFold {
+impl<C: LeafCodec> Fold for PartialHashFold<C> {
     type Folded = PartialHash;
 
-    type NodeFold = PartialHashNodeFold;
+    type NodeFold = PartialHashNodeFold<C>;
+
+    type Codec = C;
 
     fn into_node_fold(self) -> Self::NodeFold {
         let Some(tree) = self.proof else {
@@ -384,6 +443,7 @@ impl Fold for PartialHashFold {
                 node_hash: None,
                 children: VecDeque::new(),
                 child_hashes: VecDeque::new(),
+                _codec: PhantomData,
             };
         };
 
@@ -396,25 +456,28 @@ impl Fold for PartialHashFold {
                 node_hash: None,
                 children: VecDeque::from_iter(node.children),
                 child_hashes: VecDeque::new(),
+                _codec: PhantomData,
             },
 
             Tree::Leaf(MerkleProofLeaf::Read(_)) => PartialHashNodeFold {
                 node_hash: None,
                 children: VecDeque::new(),
                 child_hashes: VecDeque::new(),
+                _codec: PhantomData,
             },
 
             Tree::Leaf(MerkleProofLeaf::Blind(hash)) => PartialHashNodeFold {
                 node_hash: Some(hash),
                 children: VecDeque::new(),
                 child_hashes: VecDeque::new(),
+                _codec: PhantomData,
             },
         }
     }
 }
 
 /// [`NodeFold`] implementation for computing the [`PartialHash`] of a state
-pub struct PartialHashNodeFold {
+pub struct PartialHashNodeFold<C = Bincode> {
     /// Previous hash for this node, if available
     node_hash: Option<Hash>,
 
@@ -423,10 +486,12 @@ pub struct PartialHashNodeFold {
 
     /// Hash of each child seen so far
     child_hashes: VecDeque<PartialHash>,
+
+    _codec: PhantomData<C>,
 }
 
-impl NodeFold for PartialHashNodeFold {
-    type Parent = PartialHashFold;
+impl<C: LeafCodec> NodeFold for PartialHashNodeFold<C> {
+    type Parent = PartialHashFold<C>;
 
     fn add<F: Foldable<Self::Parent>>(&mut self, child: &F) {
         let hash = match self.children.pop_front() {
@@ -434,6 +499,7 @@ impl NodeFold for PartialHashNodeFold {
                 let prev_hash = tree.root_hash();
                 let hash = child.fold(PartialHashFold {
                     proof: Some(Arc::new(tree)),
+                    _codec: PhantomData,
                 });
 
                 // If the child is absent but we have the previous hash, we can use it here.
@@ -443,7 +509,10 @@ impl NodeFold for PartialHashNodeFold {
                 }
             }
 
-            None => child.fold(PartialHashFold { proof: None }),
+            None => child.fold(PartialHashFold {
+                proof: None,
+                _codec: PhantomData,
+            }),
         };
 
         self.child_hashes.push_back(hash);

--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 pub mod clone;
+pub mod codec;
 pub mod components;
 pub mod foldable;
 pub mod hash;

--- a/data/src/merkle_proof.rs
+++ b/data/src/merkle_proof.rs
@@ -12,9 +12,12 @@ pub mod tag;
 
 use std::error;
 
-use bincode::Decode;
 use bincode::error::DecodeError;
 
+use crate::codec::Bincode;
+use crate::codec::LeafCodec;
+use crate::codec::LeafDecode;
+use crate::codec::LeafDecodeError;
 use crate::foldable::Foldable;
 use crate::foldable::seq_tree::Many;
 use crate::foldable::seq_tree::tree_depth;
@@ -68,8 +71,8 @@ impl<T> Partial<T> {
     }
 }
 
-impl<T: Foldable<PartialHashFold>> Foldable<PartialHashFold> for Partial<T> {
-    fn fold(&self, builder: PartialHashFold) -> PartialHash {
+impl<C: LeafCodec, T: Foldable<PartialHashFold<C>>> Foldable<PartialHashFold<C>> for Partial<T> {
+    fn fold(&self, builder: PartialHashFold<C>) -> PartialHash {
         match self {
             Partial::Absent => builder.previous(),
             Partial::Blinded(hash) => builder.present(*hash),
@@ -89,6 +92,9 @@ pub trait DeserialiserError: error::Error {
 pub enum ProofError {
     #[error("Error during deserialisation: {0}")]
     Deserialise(#[from] DecodeError),
+
+    #[error("Error during leaf deserialisation: {0}")]
+    LeafDecode(#[from] LeafDecodeError),
 
     #[error("Deserialising as a stream and not all bytes were consumed")]
     RemainingBytes,
@@ -141,6 +147,9 @@ pub trait Deserialiser {
     /// Error type
     type Error: DeserialiserError;
 
+    /// The codec used to decode leaf values from the proof.
+    type Codec: LeafCodec;
+
     /// After deserialising a proof, a [`Suspended<R>`] computation is obtained.
     type Suspended<R>: Suspended<Output = R, Parent = Self>;
 
@@ -151,7 +160,7 @@ pub trait Deserialiser {
     fn into_leaf_raw<const LEN: usize>(self) -> SuspendedResult<Self, Partial<Box<[u8; LEN]>>>;
 
     /// It is expected for the proof to be a leaf. Parse the raw bytes of that leaf into a type `T`.
-    fn into_leaf<T: Decode<()>>(self) -> SuspendedResult<Self, Partial<T>>;
+    fn into_leaf<T: LeafDecode<Self::Codec>>(self) -> SuspendedResult<Self, Partial<T>>;
 
     /// It is expected for the proof to be a node. Obtain the deserialiser for the branch case.
     fn into_node(self) -> Result<Self::DeserialiserNode, Self::Error>;
@@ -191,7 +200,9 @@ pub trait DeserialiserNode: Sized {
 
     /// The next branch of the current node is deserialised using the [`FromProof`] implementation
     /// of type `T`.
-    fn next_branch<T: FromProof>(self) -> Result<(Self, T), <Self::Parent as Deserialiser>::Error> {
+    fn next_branch<T: FromProof<<Self::Parent as Deserialiser>::Codec>>(
+        self,
+    ) -> Result<(Self, T), <Self::Parent as Deserialiser>::Error> {
         self.next_branch_with(|deser| T::from_proof(deser))
     }
 
@@ -214,14 +225,17 @@ pub trait Suspended {
     ) -> <Self::Parent as Deserialiser>::Suspended<T>;
 }
 
-/// Trait for types that can be constructed from a Merkle proof
-pub trait FromProof: Sized {
+/// Trait for types that can be constructed from a Merkle proof whose leaves use codec `C`.
+///
+/// Parameterised by the leaf [`LeafCodec`]; defaults to [`Bincode`] so existing `FromProof`
+/// references keep the historical (bincode) proof format.
+pub trait FromProof<C: LeafCodec = Bincode>: Sized {
     /// Parse the given proof to construct an instance of `Self`.
-    fn from_proof<Proof: Deserialiser>(proof: Proof) -> SuspendedResult<Proof, Self>;
+    fn from_proof<Proof: Deserialiser<Codec = C>>(proof: Proof) -> SuspendedResult<Proof, Self>;
 }
 
-impl<A: FromProof, B: FromProof> FromProof for (A, B) {
-    fn from_proof<Proof: Deserialiser>(proof: Proof) -> SuspendedResult<Proof, Self> {
+impl<C: LeafCodec, A: FromProof<C>, B: FromProof<C>> FromProof<C> for (A, B) {
+    fn from_proof<Proof: Deserialiser<Codec = C>>(proof: Proof) -> SuspendedResult<Proof, Self> {
         let proof = proof.into_node()?;
 
         let (proof, a) = proof.next_branch()?;
@@ -231,8 +245,8 @@ impl<A: FromProof, B: FromProof> FromProof for (A, B) {
     }
 }
 
-impl<Item: FromProof, const LEN: usize> FromProof for [Item; LEN] {
-    fn from_proof<Proof: Deserialiser>(proof: Proof) -> SuspendedResult<Proof, Self> {
+impl<C: LeafCodec, Item: FromProof<C>, const LEN: usize> FromProof<C> for [Item; LEN] {
+    fn from_proof<Proof: Deserialiser<Codec = C>>(proof: Proof) -> SuspendedResult<Proof, Self> {
         let proof = proof.into_node()?;
 
         let mut items: [Option<Item>; LEN] = std::array::from_fn(|_| None);
@@ -247,8 +261,10 @@ impl<Item: FromProof, const LEN: usize> FromProof for [Item; LEN] {
     }
 }
 
-impl<Item: FromProof, const ARITY: usize, const LEN: usize> FromProof for Many<Item, ARITY, LEN> {
-    fn from_proof<Proof: Deserialiser>(proof: Proof) -> SuspendedResult<Proof, Self> {
+impl<C: LeafCodec, Item: FromProof<C>, const ARITY: usize, const LEN: usize> FromProof<C>
+    for Many<Item, ARITY, LEN>
+{
+    fn from_proof<Proof: Deserialiser<Codec = C>>(proof: Proof) -> SuspendedResult<Proof, Self> {
         let mut leaves = Vec::with_capacity(LEN);
 
         let result = descend_tree(proof, ARITY, LEN, &mut |_idx, proof| {
@@ -383,7 +399,7 @@ pub fn sequence_as_tree_from_proof<Length, State, Proof>(
     mut with_item: impl FnMut(&mut State, usize, Proof) -> SuspendedResult<Proof, ()>,
 ) -> SuspendedResult<Proof, State>
 where
-    Length: Decode<()>,
+    Length: LeafDecode<Proof::Codec>,
     Proof: Deserialiser,
 {
     let proof = proof.into_node()?;

--- a/data/src/merkle_proof/proof.rs
+++ b/data/src/merkle_proof/proof.rs
@@ -108,13 +108,13 @@ fn deserialise_final_hash(bytes: &mut impl Iterator<Item = u8>) -> Result<Hash, 
 /// `T` is any type that knows how to be built from the partial Merkle tree
 /// via [`FromProof`]; the choice of `T` selects the concrete shape the
 /// proof tree must match (PVM state, durable-storage registry, ...).
-pub fn deserialise_proof<T: FromProof, I: Iterator<Item = u8>>(
+pub fn deserialise_proof<C: crate::codec::LeafCodec, T: FromProof<C>, I: Iterator<Item = u8>>(
     mut bytes: I,
 ) -> Result<(Proof, T), ProofError> {
     let final_state_hash = deserialise_final_hash(&mut bytes)?;
 
     let (state, proof_tree) =
-        proof_binary::deserialise::<T>(bytes.collect::<Vec<u8>>().as_slice())?;
+        proof_binary::deserialise::<C, T>(bytes.collect::<Vec<u8>>().as_slice())?;
 
     let merkle_tree = match proof_tree {
         OwnedProofTree::Absent => return Err(ProofError::AbsentProof),

--- a/data/src/merkle_proof/proof_binary.rs
+++ b/data/src/merkle_proof/proof_binary.rs
@@ -5,10 +5,14 @@
 //! Binary Merkle tree proof format
 
 use std::io::Read;
+use std::marker::PhantomData;
 
 use bincode::Decode;
 use bincode::error::DecodeError;
 
+use crate::codec::Bincode;
+use crate::codec::LeafCodec;
+use crate::codec::LeafDecode;
 use crate::hash::Hash;
 use crate::merkle_proof::Deserialiser;
 use crate::merkle_proof::DeserialiserNode;
@@ -37,14 +41,16 @@ impl<'t> StreamInput<'t> {
         Ok(deserialise_from(&mut self.data)?)
     }
 
-    /// Like [`Self::deserialise`] but also returns the raw bytes that were used to deserialise `T`.
-    fn capture_deserialise<T: Decode<()>>(&mut self) -> Result<(T, &'t [u8]), ProofError> {
+    /// Like [`Self::deserialise`] but decodes a leaf value with codec `C` and also returns the raw
+    /// bytes that were consumed.
+    fn capture_deserialise<C: LeafCodec, T: LeafDecode<C>>(
+        &mut self,
+    ) -> Result<(T, &'t [u8]), ProofError> {
         let start_pos = self.data;
-        let data = self.deserialise::<T>()?;
-        let end_pos = self.data;
+        let (data, consumed) = <T as LeafDecode<C>>::leaf_decode_stream(self.data)?;
+        self.data = &self.data[consumed..];
 
-        let data_len = start_pos.len() - end_pos.len();
-        let raw_bytes = &start_pos[..data_len];
+        let raw_bytes = &start_pos[..consumed];
 
         Ok((data, raw_bytes))
     }
@@ -56,7 +62,10 @@ impl<'t> StreamInput<'t> {
 }
 
 /// Deserialiser for [`Deserialiser`] based on a stream of bytes.
-pub struct StreamDeserialiser<'t> {
+///
+/// Parameterised by the leaf codec; defaults to [`Bincode`]. Only leaf decoding depends on
+/// the codec — the tag/blind-hash structure is always bincode-encoded.
+pub struct StreamDeserialiser<'t, C = Bincode> {
     /// Context layers with regard to presence
     ///
     /// The last element describes the current node context. The first element describes the root
@@ -73,9 +82,11 @@ pub struct StreamDeserialiser<'t> {
     /// is because we require the ability to recover the tag source from a combinator for an
     /// absent node.
     input: StreamInput<'t>,
+
+    _codec: PhantomData<C>,
 }
 
-impl<'t> StreamDeserialiser<'t> {
+impl<'t, C: LeafCodec> StreamDeserialiser<'t, C> {
     /// Create a new deserialiser for a present context with the given tags.
     pub fn new_present(input: StreamInput<'t>) -> Self {
         Self::new(input, Partial::Present(()))
@@ -91,6 +102,7 @@ impl<'t> StreamDeserialiser<'t> {
         StreamDeserialiser {
             context: vec![context],
             input,
+            _codec: PhantomData,
         }
     }
 
@@ -125,12 +137,14 @@ impl<'t> StreamDeserialiser<'t> {
     }
 }
 
-impl<'t> Deserialiser for StreamDeserialiser<'t> {
+impl<'t, C: LeafCodec> Deserialiser for StreamDeserialiser<'t, C> {
     type Error = ProofError;
 
-    type Suspended<R> = StreamParserComb<'t, R>;
+    type Codec = C;
 
-    type DeserialiserNode = StreamBranchComb<'t>;
+    type Suspended<R> = StreamParserComb<'t, C, R>;
+
+    type DeserialiserNode = StreamBranchComb<'t, C>;
 
     fn into_leaf_raw<const LEN: usize>(
         mut self,
@@ -180,7 +194,7 @@ impl<'t> Deserialiser for StreamDeserialiser<'t> {
         })
     }
 
-    fn into_leaf<T: Decode<()>>(mut self) -> Result<Self::Suspended<Partial<T>>, ProofError> {
+    fn into_leaf<T: LeafDecode<C>>(mut self) -> Result<Self::Suspended<Partial<T>>, ProofError> {
         if self.is_absent_or_blinded() {
             let this = StreamParserComb {
                 result: Partial::Absent,
@@ -202,7 +216,7 @@ impl<'t> Deserialiser for StreamDeserialiser<'t> {
                     (result, proof)
                 }
                 LeafTag::Read => {
-                    let (data, raw_bytes) = self.input.capture_deserialise::<T>()?;
+                    let (data, raw_bytes) = self.input.capture_deserialise::<C, T>()?;
                     let result = Partial::Present(data);
                     let proof = Partial::Present(raw_bytes.to_vec());
                     (result, proof)
@@ -254,7 +268,7 @@ impl<'t> Deserialiser for StreamDeserialiser<'t> {
 }
 
 /// Parser combinator for [`StreamDeserialiser`] deserialiser.
-pub struct StreamParserComb<'t, R> {
+pub struct StreamParserComb<'t, C, R> {
     /// Parser result
     result: R,
 
@@ -262,10 +276,10 @@ pub struct StreamParserComb<'t, R> {
     proof: OwnedProofTree,
 
     /// Parent deserialiser
-    deser: StreamDeserialiser<'t>,
+    deser: StreamDeserialiser<'t, C>,
 }
 
-impl<R> StreamParserComb<'_, R> {
+impl<C, R> StreamParserComb<'_, C, R> {
     /// Deserialise the input and return the result if all bytes have been consumed.
     pub fn into_result(self) -> Result<(R, OwnedProofTree), ProofError> {
         if !self.deser.input.is_empty() {
@@ -278,10 +292,10 @@ impl<R> StreamParserComb<'_, R> {
     }
 }
 
-impl<'t, R> Suspended for StreamParserComb<'t, R> {
+impl<'t, C: LeafCodec, R> Suspended for StreamParserComb<'t, C, R> {
     type Output = R;
 
-    type Parent = StreamDeserialiser<'t>;
+    type Parent = StreamDeserialiser<'t, C>;
 
     fn map<T>(
         self,
@@ -296,16 +310,16 @@ impl<'t, R> Suspended for StreamParserComb<'t, R> {
 }
 
 /// Branch combinator for [`StreamDeserialiser`] deserialiser.
-pub struct StreamBranchComb<'t> {
+pub struct StreamBranchComb<'t, C> {
     /// Children of the node within the Merkle proof
     proof_children: Vec<OwnedProofTree>,
 
     /// Parent deserialiser
-    deser: StreamDeserialiser<'t>,
+    deser: StreamDeserialiser<'t, C>,
 }
 
-impl<'t> DeserialiserNode for StreamBranchComb<'t> {
-    type Parent = StreamDeserialiser<'t>;
+impl<'t, C: LeafCodec> DeserialiserNode for StreamBranchComb<'t, C> {
+    type Parent = StreamDeserialiser<'t, C>;
 
     fn presence(&self) -> Partial<()> {
         self.deser.presence()
@@ -353,11 +367,11 @@ impl<'t> DeserialiserNode for StreamBranchComb<'t> {
 ///
 /// Convenience function to bundle deserialisation and execution of the suspended function for the]
 /// binary proof format deserialisation.
-pub fn deserialise<T: FromProof>(
+pub fn deserialise<C: LeafCodec, T: FromProof<C>>(
     proof_tree_raw_bytes: &[u8],
 ) -> Result<(T, OwnedProofTree), ProofError> {
     let input = StreamInput::new(proof_tree_raw_bytes);
-    let context = StreamDeserialiser::new_present(input);
+    let context = StreamDeserialiser::<C>::new_present(input);
 
     let result = T::from_proof(context)?;
 

--- a/data/src/merkle_proof/proof_tree.rs
+++ b/data/src/merkle_proof/proof_tree.rs
@@ -4,7 +4,6 @@
 use std::borrow::Borrow;
 use std::marker::PhantomData;
 
-use bincode::Decode;
 use bincode::enc::write::Writer;
 
 use super::Deserialiser;
@@ -15,11 +14,13 @@ use super::ProofError;
 use super::Suspended;
 use super::tag::LeafTag;
 use super::tag::Tag;
+use crate::codec::Bincode;
+use crate::codec::LeafCodec;
+use crate::codec::LeafDecode;
 use crate::foldable::Fold;
 use crate::foldable::Foldable;
 use crate::foldable::NodeFold;
 use crate::hash::Hash;
-use crate::serialisation;
 use crate::tree::Tree;
 
 /// Merkle proof tree structure.
@@ -91,9 +92,15 @@ impl MerkleProof {
         matches!(self, MerkleProof::Leaf(MerkleProofLeaf::Blind(_)))
     }
 
-    /// Fold the given data structure into a compressed Merkle proof tree.
+    /// Fold the given data structure into a compressed Merkle proof tree (bincode leaf codec).
     pub fn from_foldable(foldable: &impl Foldable<MerkleProofFold>) -> Self {
         foldable.fold(MerkleProofFold::new()).tree
+    }
+
+    /// Fold the given data structure into a compressed Merkle proof tree, using the given leaf
+    /// [`LeafCodec`].
+    pub fn from_foldable_with<C: LeafCodec>(foldable: &impl Foldable<MerkleProofFold<C>>) -> Self {
+        foldable.fold(MerkleProofFold::<C>::new()).tree
     }
 
     /// Blind the tree as much as feasible. In general, this will fully blind the tree.
@@ -247,8 +254,8 @@ impl CompressibleMerkleProof {
     }
 }
 
-impl Foldable<MerkleProofFold> for CompressibleMerkleProof {
-    fn fold(&self, _builder: MerkleProofFold) -> <MerkleProofFold as Fold>::Folded {
+impl<C: LeafCodec> Foldable<MerkleProofFold<C>> for CompressibleMerkleProof {
+    fn fold(&self, _builder: MerkleProofFold<C>) -> <MerkleProofFold<C> as Fold>::Folded {
         if self.constraint == MinimumPresence::Present || self.tree.is_blind() {
             return self.clone();
         }
@@ -275,8 +282,10 @@ pub struct ForceMinimumPresence<T> {
     pub inner: T,
 }
 
-impl<T: Foldable<MerkleProofFold>> Foldable<MerkleProofFold> for ForceMinimumPresence<T> {
-    fn fold(&self, builder: MerkleProofFold) -> <MerkleProofFold as Fold>::Folded {
+impl<C: LeafCodec, T: Foldable<MerkleProofFold<C>>> Foldable<MerkleProofFold<C>>
+    for ForceMinimumPresence<T>
+{
+    fn fold(&self, builder: MerkleProofFold<C>) -> <MerkleProofFold<C> as Fold>::Folded {
         let mut proof = self.inner.fold(builder);
         proof.constraint = self.min_constraint.max(proof.constraint);
         proof
@@ -284,16 +293,20 @@ impl<T: Foldable<MerkleProofFold>> Foldable<MerkleProofFold> for ForceMinimumPre
 }
 
 /// [`Fold`] for creating a [`MerkleProof`] tree from a foldable structure
-pub struct MerkleProofFold {
-    _private: (),
+///
+/// Parameterised by the leaf [`LeafCodec`]; defaults to [`Bincode`].
+pub struct MerkleProofFold<C = Bincode> {
+    _codec: PhantomData<C>,
 }
 
-impl MerkleProofFold {
+impl<C: LeafCodec> MerkleProofFold<C> {
     /// Create a new fold builder for Merkle proofs.
     ///
     /// NOTE: This should be private! We don't want users to create this directly.
     fn new() -> Self {
-        MerkleProofFold { _private: () }
+        MerkleProofFold {
+            _codec: PhantomData,
+        }
     }
 
     /// Fold into a Merkle tree proof leaf.
@@ -332,26 +345,31 @@ impl MerkleProofFold {
     }
 }
 
-impl Fold for MerkleProofFold {
+impl<C: LeafCodec> Fold for MerkleProofFold<C> {
     type Folded = CompressibleMerkleProof;
 
-    type NodeFold = MerkleProofNodeFold;
+    type NodeFold = MerkleProofNodeFold<C>;
+
+    type Codec = C;
 
     fn into_node_fold(self) -> Self::NodeFold {
         MerkleProofNodeFold {
             children: Vec::new(),
+            _codec: PhantomData,
         }
     }
 }
 
 /// [`NodeFold`] for creating a [`MerkleProof`] node from a foldable structure
-pub struct MerkleProofNodeFold {
+pub struct MerkleProofNodeFold<C = Bincode> {
     /// Children of the node that is being folded
     children: Vec<CompressibleMerkleProof>,
+
+    _codec: PhantomData<C>,
 }
 
-impl NodeFold for MerkleProofNodeFold {
-    type Parent = MerkleProofFold;
+impl<C: LeafCodec> NodeFold for MerkleProofNodeFold<C> {
+    type Parent = MerkleProofFold<C>;
 
     fn add<F: Foldable<Self::Parent>>(&mut self, child: &F) {
         let child_info = child.fold(MerkleProofFold::new());
@@ -453,13 +471,35 @@ impl<T> ProofPart<T> {
     }
 }
 
-/// Part of a Merkle proof tree
-pub type ProofTree<'a> = ProofPart<&'a MerkleProof>;
+/// Part of a Merkle proof tree, viewed as a deserialiser parameterised by the leaf [`LeafCodec`].
+///
+/// Defaults to [`Bincode`]. Only leaf decoding depends on the codec; the tree structure is shared.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ProofTree<'a, C = Bincode> {
+    part: ProofPart<&'a MerkleProof>,
+    _codec: PhantomData<C>,
+}
 
-impl<'a> ProofTree<'a> {
+impl<'a, C> ProofTree<'a, C> {
+    /// A present proof tree backed by the given [`MerkleProof`].
+    pub fn present(tree: &'a MerkleProof) -> Self {
+        ProofTree {
+            part: ProofPart::Present(tree),
+            _codec: PhantomData,
+        }
+    }
+
+    /// An absent proof tree.
+    pub fn absent() -> Self {
+        ProofTree {
+            part: ProofPart::Absent,
+            _codec: PhantomData,
+        }
+    }
+
     /// Deserialise the proof tree as a leaf.
-    pub fn as_leaf(self) -> Result<Partial<&'a [u8]>, ProofError> {
-        let Self::Present(tree) = self else {
+    fn as_leaf(&self) -> Result<Partial<&'a [u8]>, ProofError> {
+        let ProofPart::Present(tree) = self.part else {
             return Ok(Partial::Absent);
         };
 
@@ -473,8 +513,8 @@ impl<'a> ProofTree<'a> {
     }
 
     /// Deserialise the proof tree as a node.
-    pub fn as_node(self) -> Result<Partial<Vec<Self>>, ProofError> {
-        let Self::Present(tree) = self else {
+    fn as_node(&self) -> Result<Partial<Vec<Self>>, ProofError> {
+        let ProofPart::Present(tree) = self.part else {
             return Ok(Partial::Absent);
         };
 
@@ -483,19 +523,24 @@ impl<'a> ProofTree<'a> {
                 MerkleProofLeaf::Blind(hash) => Partial::Blinded(*hash),
                 MerkleProofLeaf::Read(_) => return Err(ProofError::UnexpectedLeaf),
             },
-            Tree::Node(node) => {
-                Partial::Present(node.children.iter().map(ProofPart::Present).collect())
-            }
+            Tree::Node(node) => Partial::Present(
+                node.children
+                    .iter()
+                    .map(|c| ProofTree::present(c))
+                    .collect(),
+            ),
         };
 
         Ok(node)
     }
 }
 
-impl<'t> Deserialiser for ProofTree<'t> {
+impl<'t, C: LeafCodec> Deserialiser for ProofTree<'t, C> {
     type Error = ProofError;
 
-    type Suspended<R> = ProofTreeResult<'t, R>;
+    type Codec = C;
+
+    type Suspended<R> = ProofTreeResult<'t, C, R>;
 
     type DeserialiserNode = Partial<std::vec::IntoIter<Self>>;
 
@@ -517,10 +562,10 @@ impl<'t> Deserialiser for ProofTree<'t> {
             .map(ProofTreeResult::new)
     }
 
-    fn into_leaf<T: Decode<()>>(self) -> Result<Self::Suspended<Partial<T>>, Self::Error> {
+    fn into_leaf<T: LeafDecode<C>>(self) -> Result<Self::Suspended<Partial<T>>, Self::Error> {
         let result = self
             .as_leaf()?
-            .map_present_fallible(serialisation::deserialise)?;
+            .map_present_fallible(<T as LeafDecode<C>>::leaf_decode)?;
         Ok(ProofTreeResult::new(result))
     }
 
@@ -529,9 +574,9 @@ impl<'t> Deserialiser for ProofTree<'t> {
     }
 
     fn capture_owned_proof(&self) -> Option<MerkleProof> {
-        match self {
+        match self.part {
             ProofPart::Absent => None,
-            ProofPart::Present(proof) => Some((*proof).clone()),
+            ProofPart::Present(proof) => Some(proof.clone()),
         }
     }
 }
@@ -578,8 +623,8 @@ impl OwnedProofTree {
     }
 }
 
-impl<'t, BS: Iterator<Item = ProofTree<'t>>> DeserialiserNode for Partial<BS> {
-    type Parent = ProofTree<'t>;
+impl<'t, C: LeafCodec, BS: Iterator<Item = ProofTree<'t, C>>> DeserialiserNode for Partial<BS> {
+    type Parent = ProofTree<'t, C>;
 
     fn presence(&self) -> Partial<()> {
         match self {
@@ -600,7 +645,7 @@ impl<'t, BS: Iterator<Item = ProofTree<'t>>> DeserialiserNode for Partial<BS> {
     ) -> Result<(Self, T), ProofError> {
         let next_branch = match self {
             // If the node is absent or blinded, the branch to be deserialised as a tree is absent.
-            Partial::Absent | Partial::Blinded(_) => ProofTree::Absent,
+            Partial::Absent | Partial::Blinded(_) => ProofTree::absent(),
             Partial::Present(ref mut branches) => {
                 branches.next().ok_or(ProofError::BadNumberOfBranches {
                     expected: 1,
@@ -632,12 +677,12 @@ impl<'t, BS: Iterator<Item = ProofTree<'t>>> DeserialiserNode for Partial<BS> {
 }
 
 /// Result of parsing a [`ProofTree`]
-pub struct ProofTreeResult<'t, R> {
+pub struct ProofTreeResult<'t, C, R> {
     result: R,
-    _pd: PhantomData<fn(ProofTree<'t>)>,
+    _pd: PhantomData<fn(ProofTree<'t, C>)>,
 }
 
-impl<R> ProofTreeResult<'_, R> {
+impl<C, R> ProofTreeResult<'_, C, R> {
     /// Construct a new result.
     fn new(result: R) -> Self {
         Self {
@@ -652,10 +697,10 @@ impl<R> ProofTreeResult<'_, R> {
     }
 }
 
-impl<'t, R> Suspended for ProofTreeResult<'t, R> {
+impl<'t, C: LeafCodec, R> Suspended for ProofTreeResult<'t, C, R> {
     type Output = R;
 
-    type Parent = ProofTree<'t>;
+    type Parent = ProofTree<'t, C>;
 
     fn map<T>(
         self,
@@ -669,8 +714,10 @@ impl<'t, R> Suspended for ProofTreeResult<'t, R> {
 }
 
 /// Given a [`ProofTree`] deserialise it as `T`.
-pub fn deserialise<T: FromProof>(proof: ProofTree) -> Result<(T, OwnedProofTree), ProofError> {
-    let owned_proof = match proof {
+pub fn deserialise<C: LeafCodec, T: FromProof<C>>(
+    proof: ProofTree<C>,
+) -> Result<(T, OwnedProofTree), ProofError> {
+    let owned_proof = match proof.part {
         ProofPart::Absent => OwnedProofTree::Absent,
         ProofPart::Present(proof) => OwnedProofTree::Present(proof.clone()),
     };

--- a/data/src/merkle_proof/tests.rs
+++ b/data/src/merkle_proof/tests.rs
@@ -5,13 +5,14 @@
 
 use std::num::NonZeroUsize;
 
-use bincode::Decode;
 use bincode::Encode;
 use proptest::proptest;
 use proptest::test_runner::TestCaseResult;
 
 use super::proof_tree::MerkleProofFold;
 use super::proof_tree::MinimumPresence;
+use crate::codec::Bincode;
+use crate::codec::LeafDecodeError;
 use crate::foldable::Fold;
 use crate::foldable::Foldable;
 use crate::foldable::seq_tree::IndexableSeqAsTree;
@@ -34,9 +35,13 @@ use crate::merkle_proof::tag::TAG_NODE;
 use crate::merkle_proof::tag::TAG_READ;
 use crate::serialisation::serialise;
 
-fn generic_computation<T: Into<i32> + Decode<()>, D: Deserialiser>(
+fn generic_computation<T, D: Deserialiser>(
     proof: D,
-) -> Result<<D as Deserialiser>::Suspended<i32>, D::Error> {
+) -> Result<<D as Deserialiser>::Suspended<i32>, D::Error>
+where
+    T: Into<i32> + crate::codec::LeafDecode<D::Codec>,
+    Hash: crate::codec::LeafDecode<D::Codec>,
+{
     // The tree structure:
     // Node (root)
     // ├── Leaf (type: Hash)
@@ -62,19 +67,30 @@ fn generic_computation<T: Into<i32> + Decode<()>, D: Deserialiser>(
 
 fn computation_i16<D: Deserialiser>(
     proof: D,
-) -> Result<<D as Deserialiser>::Suspended<i32>, D::Error> {
+) -> Result<<D as Deserialiser>::Suspended<i32>, D::Error>
+where
+    i16: crate::codec::LeafDecode<D::Codec>,
+    Hash: crate::codec::LeafDecode<D::Codec>,
+{
     generic_computation::<i16, D>(proof)
 }
 
 fn computation_bool<D: Deserialiser>(
     proof: D,
-) -> Result<<D as Deserialiser>::Suspended<i32>, D::Error> {
+) -> Result<<D as Deserialiser>::Suspended<i32>, D::Error>
+where
+    bool: crate::codec::LeafDecode<D::Codec>,
+    Hash: crate::codec::LeafDecode<D::Codec>,
+{
     generic_computation::<bool, D>(proof)
 }
 
 fn computation_leaves<D: Deserialiser>(
     proof: D,
-) -> Result<<D as Deserialiser>::Suspended<i32>, D::Error> {
+) -> Result<<D as Deserialiser>::Suspended<i32>, D::Error>
+where
+    i32: crate::codec::LeafDecode<D::Codec>,
+{
     // The tree structure
     // Node (root)
     // ├── Leaf 1 (type: i32)
@@ -109,17 +125,17 @@ fn computation_leaves<D: Deserialiser>(
 
 /// Execute a deserialising computation over an owned Merkle proof.
 fn run_owned_deserialiser<'t>(
-    deser: impl FnOnce(ProofTree<'t>) -> Result<ProofTreeResult<'t, i32>, ProofError>,
+    deser: impl FnOnce(ProofTree<'t>) -> Result<ProofTreeResult<'t, Bincode, i32>, ProofError>,
     merkle_proof: &'t MerkleProof,
 ) -> Result<i32, ProofError> {
-    let proof = ProofTree::Present(merkle_proof);
+    let proof = ProofTree::present(merkle_proof);
     let parsed_result = deser(proof)?;
     Ok(parsed_result.into_result())
 }
 
 /// Execute a deserialising computation over raw bytes.
 fn run_stream_deserialiser<'t>(
-    deser: impl FnOnce(StreamDeserialiser<'t>) -> Result<StreamParserComb<'t, i32>, ProofError>,
+    deser: impl FnOnce(StreamDeserialiser<'t>) -> Result<StreamParserComb<'t, Bincode, i32>, ProofError>,
     bytes: &'t [u8],
 ) -> Result<i32, ProofError> {
     let input = StreamInput::new(bytes);
@@ -130,7 +146,7 @@ fn run_stream_deserialiser<'t>(
 #[test]
 fn test_absent_computation() {
     // Root is absent already
-    let proof = ProofTree::Absent;
+    let proof: ProofTree<'_> = ProofTree::absent();
     let comp_fn = computation_i16(proof).unwrap();
     assert_eq!(comp_fn.into_result(), 0);
 
@@ -139,7 +155,7 @@ fn test_absent_computation() {
         MerkleProof::leaf_read(Hash::hash_bytes(&[0, 1, 2]).as_ref().to_vec()),
         MerkleProof::leaf_blind(Hash::hash_bytes(&[3, 4, 5])),
     ]);
-    let proof = ProofTree::Present(&merkle_proof);
+    let proof: ProofTree<'_> = ProofTree::present(&merkle_proof);
     let comp_fn = computation_i16(proof).unwrap();
     assert_eq!(comp_fn.into_result(), 0);
 }
@@ -185,10 +201,10 @@ fn test_not_enough_bytes_error() {
 
     // Corresponds to a bincode::Error & std::io::Error because the hash deserialisation is done by
     // serde/bincode.
-    if let ProofError::Deserialise(bincode::error::DecodeError::Io {
+    if let ProofError::LeafDecode(LeafDecodeError::Bincode(bincode::error::DecodeError::Io {
         inner: io_err,
         additional: 32,
-    }) = res
+    })) = res
     {
         assert_eq!(io_err.kind(), std::io::ErrorKind::UnexpectedEof);
     } else {
@@ -217,10 +233,10 @@ fn test_not_enough_bytes_error() {
 
     // In this case, the error happens earlier, at the tag deserialisation, so it is an error
     // thrown by our own `Deserialiser` traits.
-    if let ProofError::Deserialise(bincode::error::DecodeError::Io {
+    if let ProofError::LeafDecode(LeafDecodeError::Bincode(bincode::error::DecodeError::Io {
         inner: io_err,
         additional: 32,
-    }) = res
+    })) = res
     {
         assert_eq!(io_err.kind(), std::io::ErrorKind::UnexpectedEof);
     } else {
@@ -240,9 +256,9 @@ fn test_not_enough_bytes_error() {
     assert!(
         matches!(
             res,
-            Err(ProofError::Deserialise(
+            Err(ProofError::LeafDecode(LeafDecodeError::Bincode(
                 bincode::error::DecodeError::UnexpectedEnd { additional: 27 }
-            ))
+            )))
         ),
         "{res:?}"
     )
@@ -263,7 +279,7 @@ fn test_bad_bincode() {
 
     let res = run_stream_deserialiser(computation_bool, &raw_bytes_content);
 
-    assert!(matches!(res, Err(ProofError::Deserialise(_))));
+    assert!(matches!(res, Err(ProofError::LeafDecode(_))));
 
     let merkle_proof = MerkleProof::node_without_data(vec![
         MerkleProof::leaf_read(hash_read.to_vec()),
@@ -271,7 +287,7 @@ fn test_bad_bincode() {
     ]);
     let res = run_owned_deserialiser(computation_bool, &merkle_proof);
     eprintln!("Result: {res:?}");
-    assert!(matches!(res, Err(ProofError::Deserialise(_))));
+    assert!(matches!(res, Err(ProofError::LeafDecode(_))));
 }
 
 #[test]
@@ -302,14 +318,14 @@ fn test_blind_computation() {
         MerkleProof::leaf_blind(Hash::hash_bytes(&[0, 1, 2])),
         MerkleProof::node_without_data(vec![MerkleProof::leaf_blind(Hash::hash_bytes(&[0, 1, 2]))]),
     ]);
-    let comp_fn = computation_i16::<ProofTree>(ProofTree::Present(&absent_shape));
+    let comp_fn = computation_i16::<ProofTree>(ProofTree::present(&absent_shape));
 
     assert_eq!(comp_fn.unwrap().into_result(), -1);
 
     // For computation_2, the provided merkle proof will resolve as blinded
     // since root is blinded
     let merkle_proof = MerkleProof::leaf_blind(Hash::hash_bytes(&[6, 7, 8]));
-    let proof = ProofTree::Present(&merkle_proof);
+    let proof: ProofTree<'_> = ProofTree::present(&merkle_proof);
     let comp_fn = computation_leaves(proof).unwrap();
     assert_eq!(comp_fn.into_result(), -1);
 }
@@ -336,7 +352,7 @@ fn test_blind_computation_stream() {
     // For computation_2, the provided merkle proof will resolve as blinded
     // since root is blinded
     let merkle_proof = MerkleProof::leaf_blind(Hash::hash_bytes(&[6, 7, 8]));
-    let proof = ProofTree::Present(&merkle_proof);
+    let proof: ProofTree<'_> = ProofTree::present(&merkle_proof);
     let comp_fn = computation_leaves(proof).unwrap();
     assert_eq!(comp_fn.into_result(), -1);
 }
@@ -361,13 +377,13 @@ fn test_bad_structure() {
     ]);
 
     // Tree is missing branches
-    let comp_fn = computation_i16::<ProofTree>(ProofTree::Present(&bad_shape_1));
+    let comp_fn = computation_i16::<ProofTree>(ProofTree::present(&bad_shape_1));
     assert!(comp_fn.is_err_and(|e| matches!(e, ProofError::BadNumberOfBranches { .. })));
 
     // First 2 children of root are ok in shape (blinded) but the total number of children does not correspond
     // Ideally, we would like to have expected: 2, got: 5, but the implementation for `ProofTree`
     // does not track this information (the original number of children)
-    let comp_fn = computation_i16::<ProofTree>(ProofTree::Present(&bad_shape_2));
+    let comp_fn = computation_i16::<ProofTree>(ProofTree::present(&bad_shape_2));
     assert!(comp_fn.is_err_and(|e| {
         println!("{e:?}");
         matches!(
@@ -380,11 +396,11 @@ fn test_bad_structure() {
     }));
 
     // The first child is a node, but is expected to be a leaf
-    let comp_fn = computation_i16::<ProofTree>(ProofTree::Present(&bad_shape_3));
+    let comp_fn = computation_i16::<ProofTree>(ProofTree::present(&bad_shape_3));
     assert!(comp_fn.is_err_and(|e| matches!(e, ProofError::UnexpectedNode)));
 
     // The second child is a leaf, but is expected to be a node
-    let comp_fn = computation_i16::<ProofTree>(ProofTree::Present(&bad_shape_4));
+    let comp_fn = computation_i16::<ProofTree>(ProofTree::present(&bad_shape_4));
     assert!(comp_fn.is_err_and(|e| { matches!(e, ProofError::UnexpectedLeaf) }));
 }
 
@@ -446,7 +462,7 @@ fn test_valid_computation() {
         MerkleProof::leaf_blind(Hash::hash_bytes(&[9, 10, 11])),
     ]);
 
-    let proof = ProofTree::Present(&merkleproof);
+    let proof: ProofTree<'_> = ProofTree::present(&merkleproof);
     let comp_fn = computation_leaves(proof).unwrap();
     assert_eq!(comp_fn.into_result(), 0x140A_0000 + 0xC0005);
 }
@@ -504,20 +520,16 @@ fn test_descend_tree_trailing_remainder() {
 
     let mut visited = Vec::new();
 
-    descend_tree(
-        ProofTree::Present(&proof),
-        arity,
-        leaves,
-        &mut |idx, proof| {
-            let leaf = proof.into_leaf::<usize>()?;
-            Ok(leaf.map(|leaf| {
-                let Partial::Present(value) = leaf else {
-                    panic!("Expected a present leaf in this proof")
-                };
-                visited.push((idx, value));
-            }))
-        },
-    )
+    let proof_tree: ProofTree<'_> = ProofTree::present(&proof);
+    descend_tree(proof_tree, arity, leaves, &mut |idx, proof| {
+        let leaf = proof.into_leaf::<usize>()?;
+        Ok(leaf.map(|leaf| {
+            let Partial::Present(value) = leaf else {
+                panic!("Expected a present leaf in this proof")
+            };
+            visited.push((idx, value));
+        }))
+    })
     .map(ProofTreeResult::into_result)
     .expect("descend_tree should parse a 17-leaf arity-4 tree with trailing remainder");
 
@@ -532,20 +544,16 @@ fn round_trip_descend_tree_indexable_seq_as_tree() {
         let seq_as_tree = IndexableSeqAsTree::new(data.len(), arity.get(), &get_item);
         let proof = MerkleProof::from_foldable(&seq_as_tree);
 
-        descend_tree(
-            ProofTree::Present(&proof),
-            arity.get(),
-            data.len(),
-            &mut |idx, proof| {
-                let leaf = proof.into_leaf::<usize>()?;
-                Ok(leaf.map(|leaf| {
-                    let Partial::Present(value) = leaf else {
-                        panic!("Expected a present leaf in this proof")
-                    };
-                    assert_eq!(value, data[idx]);
-                }))
-            },
-        )
+        let proof_tree: ProofTree<'_> = ProofTree::present(&proof);
+        descend_tree(proof_tree, arity.get(), data.len(), &mut |idx, proof| {
+            let leaf = proof.into_leaf::<usize>()?;
+            Ok(leaf.map(|leaf| {
+                let Partial::Present(value) = leaf else {
+                    panic!("Expected a present leaf in this proof")
+                };
+                assert_eq!(value, data[idx]);
+            }))
+        })
         .unwrap()
         .into_result();
 

--- a/data/src/store/fold.rs
+++ b/data/src/store/fold.rs
@@ -41,6 +41,8 @@ impl<BS: BlobStore> Fold for BlobStoreFold<BS> {
 
     type NodeFold = BlobStoreNodeFold<BS>;
 
+    type Codec = crate::codec::Bincode;
+
     fn into_node_fold(self) -> BlobStoreNodeFold<BS> {
         BlobStoreNodeFold {
             store: self.store,

--- a/durable-storage/src/avl/node.rs
+++ b/durable-storage/src/avl/node.rs
@@ -208,10 +208,10 @@ impl<TreeId, DataId, M: AtomMode> Node<TreeId, DataId, M> {
         ctx: D,
     ) -> Result<(D, Self), <D::Parent as Deserialiser>::Error>
     where
-        Atom<i64, M>: FromProof,
-        Atom<Key, M>: FromProof,
-        DataId: FromProof,
-        TreeId: FromProof,
+        Atom<i64, M>: FromProof<<D::Parent as Deserialiser>::Codec>,
+        Atom<Key, M>: FromProof<<D::Parent as Deserialiser>::Codec>,
+        DataId: FromProof<<D::Parent as Deserialiser>::Codec>,
+        TreeId: FromProof<<D::Parent as Deserialiser>::Codec>,
     {
         let (ctx, balance_factor) = ctx.next_branch::<Atom<i64, M>>()?;
         let (ctx, key) = ctx.next_branch::<Atom<Key, M>>()?;

--- a/durable-storage/src/avl/resolver.rs
+++ b/durable-storage/src/avl/resolver.rs
@@ -36,6 +36,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::OnceLock;
 
+use octez_riscv_data::codec;
 use octez_riscv_data::components::atom::Atom;
 use octez_riscv_data::components::bytes::Bytes;
 use octez_riscv_data::foldable::Fold;
@@ -1114,7 +1115,9 @@ impl Foldable<PartialHashFold> for VerifyNodeId {
 }
 
 impl FromProof for VerifyNodeId {
-    fn from_proof<Proof: Deserialiser>(proof: Proof) -> SuspendedResult<Proof, Self> {
+    fn from_proof<Proof: Deserialiser<Codec = codec::Bincode>>(
+        proof: Proof,
+    ) -> SuspendedResult<Proof, Self> {
         // Capture the sub-proof BEFORE consuming `proof`; `into_node` moves it.
         let original_proof = proof.capture_owned_proof().map(Arc::new);
         let ctx = proof.into_node()?;
@@ -1155,7 +1158,9 @@ impl Foldable<PartialHashFold> for VerifyTreeId {
 }
 
 impl FromProof for VerifyTreeId {
-    fn from_proof<Proof: Deserialiser>(proof: Proof) -> SuspendedResult<Proof, Self> {
+    fn from_proof<Proof: Deserialiser<Codec = codec::Bincode>>(
+        proof: Proof,
+    ) -> SuspendedResult<Proof, Self> {
         let ctx = proof.into_node()?;
         let (ctx, partial) = Tree::from_branches(ctx)?;
         let tree_id = match partial {

--- a/durable-storage/src/avl/tree.rs
+++ b/durable-storage/src/avl/tree.rs
@@ -7,6 +7,8 @@
 use std::cmp::Ordering;
 use std::sync::LazyLock;
 
+use octez_riscv_data::codec;
+use octez_riscv_data::codec::LeafDecode;
 use octez_riscv_data::components::atom::AtomMode;
 use octez_riscv_data::components::bytes::Bytes;
 use octez_riscv_data::components::bytes::BytesMode;
@@ -65,7 +67,11 @@ impl<NodeId: FromProof> Tree<NodeId> {
     /// Parse a tree from a proof deserialiser node.
     pub(super) fn from_branches<D: DeserialiserNode>(
         ctx: D,
-    ) -> Result<(D, Partial<Self>), <D::Parent as Deserialiser>::Error> {
+    ) -> Result<(D, Partial<Self>), <D::Parent as Deserialiser>::Error>
+    where
+        NodeId: FromProof<<D::Parent as Deserialiser>::Codec>,
+        bool: LeafDecode<<D::Parent as Deserialiser>::Codec>,
+    {
         match ctx.presence() {
             Partial::Absent => Ok((ctx, Partial::Absent)),
             // TODO: RV-895: The proof should include the empty tree rather
@@ -419,7 +425,9 @@ impl Foldable<PartialHashFold> for Tree<VerifyNodeId> {
 }
 
 impl FromProof for Tree<VerifyNodeId> {
-    fn from_proof<Proof: Deserialiser>(proof: Proof) -> SuspendedResult<Proof, Self> {
+    fn from_proof<Proof: Deserialiser<Codec = codec::Bincode>>(
+        proof: Proof,
+    ) -> SuspendedResult<Proof, Self> {
         let ctx = proof.into_node()?;
         let (ctx, tree) = Tree::from_branches(ctx)?;
         // The top-level fold for a Normal-mode `Tree<LazyNodeId>` always emits a node fold,

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use bytes::BufMut;
 use bytes::Bytes;
+use octez_riscv_data::codec;
 use octez_riscv_data::foldable::Fold;
 use octez_riscv_data::foldable::Foldable;
 use octez_riscv_data::hash::Hash;
@@ -460,7 +461,9 @@ impl<KV> Database<KV, Verify> {
 }
 
 impl<KV> FromProof for Database<KV, Verify> {
-    fn from_proof<Proof: Deserialiser>(proof: Proof) -> SuspendedResult<Proof, Self> {
+    fn from_proof<Proof: Deserialiser<Codec = codec::Bincode>>(
+        proof: Proof,
+    ) -> SuspendedResult<Proof, Self> {
         let suspended = <MerkleLayer<KV, Verify> as FromProof>::from_proof(proof)?;
         Ok(suspended.map(|merkle| Database {
             inner: VerifyImpl { merkle },
@@ -635,7 +638,7 @@ pub(crate) mod tests {
     use octez_riscv_data::merkle_proof::FromProof;
     use octez_riscv_data::merkle_proof::proof_tree::MerkleProof;
     use octez_riscv_data::merkle_proof::proof_tree::MerkleProofLeaf;
-    use octez_riscv_data::merkle_proof::proof_tree::ProofPart;
+    use octez_riscv_data::merkle_proof::proof_tree::ProofTree;
     use octez_riscv_data::mode::Normal;
     use octez_riscv_data::mode::ProvableExt;
     use octez_riscv_data::mode::Prove;
@@ -2249,7 +2252,7 @@ pub(crate) mod tests {
             matches!(proof, octez_riscv_data::tree::Tree::Leaf(MerkleProofLeaf::Blind(_))),
             "database should be fully blinded");
 
-        let mut verify = Database::<KV, Verify>::from_proof(ProofPart::Present(&proof))
+        let mut verify = Database::<KV, Verify>::from_proof(ProofTree::present(&proof))
             .expect("Can convert blinded leaf proof into blinded verify database")
             .into_result();
 

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -20,6 +20,7 @@ use std::convert::Infallible;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
+use octez_riscv_data::codec;
 use octez_riscv_data::components::bytes::Bytes;
 use octez_riscv_data::foldable::Fold;
 use octez_riscv_data::foldable::Foldable;
@@ -179,7 +180,9 @@ impl<KV> MerkleLayer<KV, Verify> {
 }
 
 impl<KV> FromProof for MerkleLayer<KV, Verify> {
-    fn from_proof<Proof: Deserialiser>(proof: Proof) -> SuspendedResult<Proof, Self> {
+    fn from_proof<Proof: Deserialiser<Codec = codec::Bincode>>(
+        proof: Proof,
+    ) -> SuspendedResult<Proof, Self> {
         // Capture before consuming `proof`.
         //
         // This is `None` for deserialisers that cannot capture an owned proof (e.g. the stream
@@ -847,7 +850,7 @@ mod tests {
     impl<KV> MerkleLayer<KV, Verify> {
         /// Construct a Verify-mode [`MerkleLayer`] by deserialising a [`MerkleProof`]
         pub fn from_proof(proof: MerkleProof) -> Result<Self, ProofError> {
-            let suspended = <Self as FromProof>::from_proof(ProofTree::Present(&proof))?;
+            let suspended = <Self as FromProof>::from_proof(ProofTree::present(&proof))?;
             Ok(suspended.into_result())
         }
     }

--- a/durable-storage/src/registry.rs
+++ b/durable-storage/src/registry.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 
 use bincode::Decode;
 use bincode::Encode;
+use octez_riscv_data::codec;
 use octez_riscv_data::components::vector::Vector;
 use octez_riscv_data::components::vector::VectorMode;
 use octez_riscv_data::foldable::Fold;
@@ -358,7 +359,9 @@ impl<KV: KeyValueStore> FromProof for Registry<KV, Verify> {
     // deserialiser, verification will fail (as this does not support capturing the owned proof).
     // Deserialising from raw bytes therefore requires two passes: a stream pass to reconstruct
     // the proof tree, then a proof-tree pass to obtain a verifiable registry.
-    fn from_proof<Proof: Deserialiser>(proof: Proof) -> SuspendedResult<Proof, Self> {
+    fn from_proof<Proof: Deserialiser<Codec = codec::Bincode>>(
+        proof: Proof,
+    ) -> SuspendedResult<Proof, Self> {
         let suspended = Vector::<Database<KV, Verify>, Verify>::from_proof(proof)?;
         Ok(suspended.map(|databases| Self {
             inner: VerifyImpl(PhantomData),
@@ -611,6 +614,7 @@ pub(super) mod tests {
     use std::marker::PhantomData;
 
     use bytes::Bytes;
+    use octez_riscv_data::codec;
     use octez_riscv_data::components::vector::VectorMode;
     use octez_riscv_data::hash::Hash;
     use octez_riscv_data::hash::PartialHash;
@@ -620,7 +624,7 @@ pub(super) mod tests {
     use octez_riscv_data::merkle_proof::proof::serialise_proof;
     use octez_riscv_data::merkle_proof::proof_tree::MerkleProof;
     use octez_riscv_data::merkle_proof::proof_tree::MerkleProofLeaf;
-    use octez_riscv_data::merkle_proof::proof_tree::ProofPart;
+    use octez_riscv_data::merkle_proof::proof_tree::ProofTree;
     use octez_riscv_data::mode::Normal;
     use octez_riscv_data::mode::ProvableExt;
     use octez_riscv_data::mode::Prove;
@@ -1431,7 +1435,7 @@ pub(super) mod tests {
         assert_eq!(root_hash_prove_after, root_hash_prove_before, "Reads must not affect Prove-mode hashes");
 
         let proof = MerkleProof::from_foldable(&prove_registry);
-        let verify_registry = Registry::<KV, _>::from_proof(ProofPart::Present(&proof))
+        let verify_registry = Registry::<KV, _>::from_proof(ProofTree::present(&proof))
             .expect("from_proof should succeed")
             .into_result();
 
@@ -1669,7 +1673,7 @@ pub(super) mod tests {
         let bytes = serialise_proof(proof);
 
         let (reconstructed_proof, stream_registry) =
-            deserialise_proof::<Registry<KV, Verify>, _>(bytes.into_iter())
+            deserialise_proof::<codec::Bincode, Registry<KV, Verify>, _>(bytes.into_iter())
                 .expect("Stream deserialisation of the proof bytes should succeed");
         assert_eq!(
             &reconstructed_proof, proof,
@@ -1677,7 +1681,7 @@ pub(super) mod tests {
         );
 
         let verify_registry =
-            Registry::<KV, Verify>::from_proof(ProofPart::Present(reconstructed_proof.tree()))
+            Registry::<KV, Verify>::from_proof(ProofTree::present(reconstructed_proof.tree()))
                 .expect("from_proof should succeed")
                 .into_result();
 

--- a/durable-storage/src/test_helpers/database.rs
+++ b/durable-storage/src/test_helpers/database.rs
@@ -735,7 +735,7 @@ pub(crate) fn prove_and_verify_database_operation<KV: BackgroundKeyValueStore>(
     // Construct the Verify-mode database from the proof and verify
     let mut verify_db = TracedDatabase::from(
         <Database<KV, Verify> as octez_riscv_data::merkle_proof::FromProof>::from_proof(
-            octez_riscv_data::merkle_proof::proof_tree::ProofTree::Present(&proof),
+            octez_riscv_data::merkle_proof::proof_tree::ProofTree::present(&proof),
         )
         .expect("proof should be valid")
         .into_result(),

--- a/durable-storage/src/test_helpers/registry.rs
+++ b/durable-storage/src/test_helpers/registry.rs
@@ -14,12 +14,13 @@ use std::collections::HashMap;
 use std::num::NonZeroUsize;
 
 use bytes::Bytes;
+use octez_riscv_data::codec;
 use octez_riscv_data::hash::Hash;
 use octez_riscv_data::hash::PartialHash;
 use octez_riscv_data::merkle_proof::FromProof;
 use octez_riscv_data::merkle_proof::proof::deserialise_proof;
 use octez_riscv_data::merkle_proof::proof::serialise_proof;
-use octez_riscv_data::merkle_proof::proof_tree::ProofPart;
+use octez_riscv_data::merkle_proof::proof_tree::ProofTree;
 use octez_riscv_data::mode::Normal;
 use octez_riscv_data::mode::ProvableExt;
 use octez_riscv_data::mode::Verify;
@@ -257,13 +258,13 @@ where
 
     let bytes = serialise_proof(&proof);
     let (reconstructed, _stream) =
-        deserialise_proof::<Registry<KV, Verify>, _>(bytes.clone().into_iter())
+        deserialise_proof::<codec::Bincode, Registry<KV, Verify>, _>(bytes.clone().into_iter())
             .expect("Stream deserialisation of the proof bytes should succeed");
     assert_eq!(
         reconstructed, proof,
         "The proof reconstructed from bytes should match the original"
     );
-    let mut verify = Registry::<KV, Verify>::from_proof(ProofPart::Present(reconstructed.tree()))
+    let mut verify = Registry::<KV, Verify>::from_proof(ProofTree::present(reconstructed.tree()))
         .expect("from_proof should succeed")
         .into_result();
 

--- a/pvm/src/machine_state.rs
+++ b/pvm/src/machine_state.rs
@@ -32,6 +32,7 @@ use memory::MemoryGovernanceError;
 use memory::Permissions;
 use memory::listener::MemoryGovernanceListener;
 use octez_riscv_data::clone::CloneState;
+use octez_riscv_data::codec;
 use octez_riscv_data::components::atom::AtomMode;
 use octez_riscv_data::components::atom::CloneAtomMode;
 use octez_riscv_data::components::atom::EncodeAtomMode;
@@ -211,7 +212,7 @@ impl<MC> FromProof for MachineCoreState<MC, Verify>
 where
     MC: MemoryConfig,
 {
-    fn from_proof<D: octez_riscv_data::merkle_proof::Deserialiser>(
+    fn from_proof<D: octez_riscv_data::merkle_proof::Deserialiser<Codec = codec::Bincode>>(
         proof: D,
     ) -> octez_riscv_data::merkle_proof::SuspendedResult<D, Self> {
         let proof = proof.into_node()?;
@@ -374,9 +375,10 @@ impl<MC> FromProof for MachineState<MC, EmptyPageCache, Verify>
 where
     MC: MemoryConfig,
 {
-    fn from_proof<D: octez_riscv_data::merkle_proof::Deserialiser>(
-        proof: D,
-    ) -> octez_riscv_data::merkle_proof::SuspendedResult<D, Self> {
+    fn from_proof<D>(proof: D) -> octez_riscv_data::merkle_proof::SuspendedResult<D, Self>
+    where
+        D: octez_riscv_data::merkle_proof::Deserialiser<Codec = codec::Bincode>,
+    {
         let result = MachineCoreState::from_proof(proof)?;
         let result = result.map(|core| Self {
             core,

--- a/pvm/src/machine_state/csregisters.rs
+++ b/pvm/src/machine_state/csregisters.rs
@@ -15,6 +15,7 @@ use bincode::error::DecodeError;
 use bincode::error::EncodeError;
 use num_enum::TryFromPrimitive;
 use octez_riscv_data::clone::CloneState;
+use octez_riscv_data::codec;
 use octez_riscv_data::components::atom::Atom;
 use octez_riscv_data::components::atom::AtomMode;
 use octez_riscv_data::components::atom::CloneAtomMode;
@@ -404,7 +405,7 @@ impl Unfoldable for CSRegisters<Normal> {
 }
 
 impl FromProof for CSRegisters<Verify> {
-    fn from_proof<D: Deserialiser>(proof: D) -> SuspendedResult<D, Self> {
+    fn from_proof<D: Deserialiser<Codec = codec::Bincode>>(proof: D) -> SuspendedResult<D, Self> {
         let proof = proof.into_node()?;
 
         let (proof, fflags) = proof.next_branch()?;

--- a/pvm/src/machine_state/hart_state.rs
+++ b/pvm/src/machine_state/hart_state.rs
@@ -10,6 +10,7 @@ use bincode::enc::Encoder;
 use bincode::error::DecodeError;
 use bincode::error::EncodeError;
 use octez_riscv_data::clone::CloneState;
+use octez_riscv_data::codec;
 use octez_riscv_data::components::atom::Atom;
 use octez_riscv_data::components::atom::AtomMode;
 use octez_riscv_data::components::atom::CloneAtomMode;
@@ -140,7 +141,7 @@ impl Unfoldable for HartState<Normal> {
 }
 
 impl FromProof for HartState<Verify> {
-    fn from_proof<D: Deserialiser>(proof: D) -> SuspendedResult<D, Self> {
+    fn from_proof<D: Deserialiser<Codec = codec::Bincode>>(proof: D) -> SuspendedResult<D, Self> {
         let proof = proof.into_node()?;
 
         let (proof, xregisters) = proof.next_branch()?;

--- a/pvm/src/machine_state/memory.rs
+++ b/pvm/src/machine_state/memory.rs
@@ -14,6 +14,7 @@ use std::num::NonZeroUsize;
 use bincode::enc::Encoder;
 use bincode::error::EncodeError;
 use listener::MemoryGovernanceListener;
+use octez_riscv_data::codec;
 use octez_riscv_data::components::atom::AtomMode;
 use octez_riscv_data::components::atom::CloneAtomMode;
 use octez_riscv_data::components::atom::EncodeAtomMode;
@@ -334,7 +335,7 @@ pub trait MemoryConfig: Send + Sync + Sized + 'static {
     type State<M: Mode>: Memory<M>;
 
     /// Parse the proof to obtain a memory instance.
-    fn state_from_proof<D: merkle_proof::Deserialiser>(
+    fn state_from_proof<D: merkle_proof::Deserialiser<Codec = codec::Bincode>>(
         proof: D,
     ) -> merkle_proof::SuspendedResult<D, Self::State<Verify>>;
 

--- a/pvm/src/machine_state/memory/buddy.rs
+++ b/pvm/src/machine_state/memory/buddy.rs
@@ -23,6 +23,7 @@ mod leaf;
 mod proxy;
 use bincode::enc::Encoder;
 use bincode::error::EncodeError;
+use octez_riscv_data::codec;
 use octez_riscv_data::components::atom::AtomMode;
 use octez_riscv_data::components::atom::CloneAtomMode;
 use octez_riscv_data::components::atom::EncodeAtomMode;
@@ -43,7 +44,9 @@ pub trait BuddyConfig: 'static {
     fn start_proof(instance: &Self::Buddy<Normal>) -> Self::Buddy<Prove<'_>>;
 
     /// Parse a proof to obtain the Buddy memory manager state.
-    fn buddy_from_proof<D: Deserialiser>(proof: D) -> SuspendedResult<D, Self::Buddy<Verify>>;
+    fn buddy_from_proof<D: Deserialiser<Codec = codec::Bincode>>(
+        proof: D,
+    ) -> SuspendedResult<D, Self::Buddy<Verify>>;
 }
 
 /// Buddy-style memory manager

--- a/pvm/src/machine_state/memory/buddy/branch.rs
+++ b/pvm/src/machine_state/memory/buddy/branch.rs
@@ -12,6 +12,7 @@ use bincode::de::Decoder;
 use bincode::enc::Encoder;
 use bincode::error::DecodeError;
 use bincode::error::EncodeError;
+use octez_riscv_data::codec;
 use octez_riscv_data::components::atom::Atom;
 use octez_riscv_data::components::atom::AtomMode;
 use octez_riscv_data::components::atom::CloneAtomMode;
@@ -72,7 +73,9 @@ impl<B: BuddyConfig> BuddyConfig for BuddyBranch2Config<B> {
         }
     }
 
-    fn buddy_from_proof<D: Deserialiser>(proof: D) -> SuspendedResult<D, Self::Buddy<Verify>> {
+    fn buddy_from_proof<D: Deserialiser<Codec = codec::Bincode>>(
+        proof: D,
+    ) -> SuspendedResult<D, Self::Buddy<Verify>> {
         let proof = proof.into_node()?;
 
         let (proof, free_info) = proof.next_branch()?;

--- a/pvm/src/machine_state/memory/buddy/branch_combinations.rs
+++ b/pvm/src/machine_state/memory/buddy/branch_combinations.rs
@@ -79,7 +79,10 @@ macro_rules! combined_buddy_branch {
                     $name(inner)
                 }
 
-                fn buddy_from_proof<D: Deserialiser>(proof: D) -> SuspendedResult<D, Self::Buddy<Verify>> {
+                fn buddy_from_proof<D>(proof: D) -> SuspendedResult<D, Self::Buddy<Verify>>
+                where
+                    D: Deserialiser<Codec = octez_riscv_data::codec::Bincode>
+                {
                     let result = <[<$buddy1 Config>]<[<$buddy2 Config>]<B>> as BuddyConfig>::buddy_from_proof(proof)?;
                     let result = result.map(|inner| $name(inner));
                     Ok(result)

--- a/pvm/src/machine_state/memory/buddy/leaf.rs
+++ b/pvm/src/machine_state/memory/buddy/leaf.rs
@@ -10,6 +10,7 @@ use bincode::de::Decoder;
 use bincode::enc::Encoder;
 use bincode::error::DecodeError;
 use bincode::error::EncodeError;
+use octez_riscv_data::codec;
 use octez_riscv_data::components::atom::Atom;
 use octez_riscv_data::components::atom::AtomMode;
 use octez_riscv_data::components::atom::CloneAtomMode;
@@ -46,7 +47,9 @@ impl<const PAGES: u64> BuddyConfig for BuddyLeafConfig<PAGES> {
         }
     }
 
-    fn buddy_from_proof<D: Deserialiser>(proof: D) -> SuspendedResult<D, Self::Buddy<Verify>> {
+    fn buddy_from_proof<D: Deserialiser<Codec = codec::Bincode>>(
+        proof: D,
+    ) -> SuspendedResult<D, Self::Buddy<Verify>> {
         let result = Atom::from_proof(proof)?;
         let result = result.map(|set| BuddyLeaf { set });
         Ok(result)

--- a/pvm/src/machine_state/memory/buddy/proxy.rs
+++ b/pvm/src/machine_state/memory/buddy/proxy.rs
@@ -4,6 +4,7 @@
 
 //! Simplified [`BuddyConfig`] selection using const-generics
 
+use octez_riscv_data::codec;
 use octez_riscv_data::merkle_proof;
 use octez_riscv_data::mode::Mode;
 use octez_riscv_data::mode::Normal;
@@ -33,7 +34,7 @@ where
         <PickConfig<PAGES> as BuddyConfig>::start_proof(instance)
     }
 
-    fn buddy_from_proof<D: merkle_proof::Deserialiser>(
+    fn buddy_from_proof<D: merkle_proof::Deserialiser<Codec = codec::Bincode>>(
         proof: D,
     ) -> merkle_proof::SuspendedResult<D, Self::Buddy<Verify>> {
         <PickConfig<PAGES> as BuddyConfig>::buddy_from_proof(proof)

--- a/pvm/src/machine_state/memory/config.rs
+++ b/pvm/src/machine_state/memory/config.rs
@@ -4,6 +4,7 @@
 
 use std::num::NonZeroUsize;
 
+use octez_riscv_data::codec;
 use octez_riscv_data::merkle_proof;
 use octez_riscv_data::merkle_proof::DeserialiserNode;
 use octez_riscv_data::mode::Mode;
@@ -30,7 +31,7 @@ where
     type State<M: Mode> =
         MemoryImpl<PAGES, TOTAL_BYTES, <BuddyConfigProxy<PAGES> as BuddyConfig>::Buddy<M>, M>;
 
-    fn state_from_proof<D: merkle_proof::Deserialiser>(
+    fn state_from_proof<D: merkle_proof::Deserialiser<Codec = codec::Bincode>>(
         proof: D,
     ) -> merkle_proof::SuspendedResult<D, Self::State<Verify>> {
         let proof = proof.into_node()?;

--- a/pvm/src/machine_state/memory/protection.rs
+++ b/pvm/src/machine_state/memory/protection.rs
@@ -11,6 +11,7 @@ use bincode::enc::Encoder;
 use bincode::error::DecodeError;
 use bincode::error::EncodeError;
 use octez_riscv_data::clone::CloneState;
+use octez_riscv_data::codec;
 use octez_riscv_data::components::atom::Atom;
 use octez_riscv_data::components::atom::AtomMode;
 use octez_riscv_data::components::atom::CloneAtomMode;
@@ -173,7 +174,7 @@ where
 }
 
 impl FromProof for PagePermissions<Verify> {
-    fn from_proof<D: Deserialiser>(proof: D) -> SuspendedResult<D, Self> {
+    fn from_proof<D: Deserialiser<Codec = codec::Bincode>>(proof: D) -> SuspendedResult<D, Self> {
         Vector::from_proof(proof).map(|result| result.map(|pages| Self { pages }))
     }
 }

--- a/pvm/src/machine_state/registers.rs
+++ b/pvm/src/machine_state/registers.rs
@@ -25,6 +25,7 @@ use bincode::enc::Encoder;
 use bincode::error::DecodeError;
 use bincode::error::EncodeError;
 use octez_riscv_data::clone::CloneState;
+use octez_riscv_data::codec;
 use octez_riscv_data::components::atom::Atom;
 use octez_riscv_data::components::atom::AtomMode;
 use octez_riscv_data::components::atom::CloneAtomMode;
@@ -301,7 +302,7 @@ impl Unfoldable for XRegisters<Normal> {
 }
 
 impl FromProof for XRegisters<Verify> {
-    fn from_proof<D: Deserialiser>(proof: D) -> SuspendedResult<D, Self> {
+    fn from_proof<D: Deserialiser<Codec = codec::Bincode>>(proof: D) -> SuspendedResult<D, Self> {
         let result = Atom::from_proof(proof)?;
         let result = result.map(|registers| XRegisters { registers });
         Ok(result)
@@ -706,7 +707,7 @@ impl Unfoldable for FRegisters<Normal> {
 }
 
 impl FromProof for FRegisters<Verify> {
-    fn from_proof<D: Deserialiser>(proof: D) -> SuspendedResult<D, Self> {
+    fn from_proof<D: Deserialiser<Codec = codec::Bincode>>(proof: D) -> SuspendedResult<D, Self> {
         let result = Atom::from_proof(proof)?;
         let result = result.map(|registers| Self { registers });
         Ok(result)

--- a/pvm/src/machine_state/reservation_set.rs
+++ b/pvm/src/machine_state/reservation_set.rs
@@ -16,6 +16,7 @@ use bincode::enc::Encoder;
 use bincode::error::DecodeError;
 use bincode::error::EncodeError;
 use octez_riscv_data::clone::CloneState;
+use octez_riscv_data::codec;
 use octez_riscv_data::components::atom::Atom;
 use octez_riscv_data::components::atom::AtomMode;
 use octez_riscv_data::components::atom::CloneAtomMode;
@@ -163,7 +164,7 @@ impl Unfoldable for ReservationSet<Normal> {
 }
 
 impl FromProof for ReservationSet<Verify> {
-    fn from_proof<D: Deserialiser>(proof: D) -> SuspendedResult<D, Self> {
+    fn from_proof<D: Deserialiser<Codec = codec::Bincode>>(proof: D) -> SuspendedResult<D, Self> {
         let result = Atom::from_proof(proof)?;
         let result = result.map(|start_addr| Self { start_addr });
         Ok(result)

--- a/pvm/src/pvm/common.rs
+++ b/pvm/src/pvm/common.rs
@@ -14,6 +14,7 @@ use bincode::enc::Encoder;
 use bincode::error::DecodeError;
 use bincode::error::EncodeError;
 use octez_riscv_data::clone::CloneState;
+use octez_riscv_data::codec;
 use octez_riscv_data::components::atom::Atom;
 use octez_riscv_data::components::atom::AtomMode;
 use octez_riscv_data::components::atom::CloneAtomMode;
@@ -463,7 +464,7 @@ where
 }
 
 impl<MC: MemoryConfig, DS: FromProof> FromProof for Pvm<MC, EmptyPageCache, DS, Verify> {
-    fn from_proof<D: Deserialiser>(proof: D) -> SuspendedResult<D, Self> {
+    fn from_proof<D: Deserialiser<Codec = codec::Bincode>>(proof: D) -> SuspendedResult<D, Self> {
         let proof = proof.into_node()?;
 
         let (proof, system_state) = proof.next_branch()?;
@@ -520,7 +521,7 @@ where
 impl<MC: MemoryConfig, DS: FromProof> Pvm<MC, EmptyPageCache, DS, Verify> {
     /// Construct a PVM state from a Merkle proof.
     pub fn from_proof(proof: &MerkleProof) -> Option<Self> {
-        let (pvm, _) = proof_tree::deserialise(ProofTree::Present(proof)).ok()?;
+        let (pvm, _) = proof_tree::deserialise(ProofTree::present(proof)).ok()?;
         Some(pvm)
     }
 
@@ -537,7 +538,7 @@ impl<MC: MemoryConfig, DS: FromProof> Pvm<MC, EmptyPageCache, DS, Verify> {
     where
         DS: DurableStorage<Verify>,
     {
-        let proof_tree = ProofTree::Present(&outbox_proof.proof);
+        let proof_tree = ProofTree::present(&outbox_proof.proof);
 
         catch_not_found(move || {
             let (pvm, _): (Self, _) = proof_tree::deserialise(proof_tree)?;

--- a/pvm/src/pvm/linux.rs
+++ b/pvm/src/pvm/linux.rs
@@ -24,6 +24,7 @@ use bincode::enc::Encoder;
 use bincode::error::DecodeError;
 use bincode::error::EncodeError;
 use octez_riscv_data::clone::CloneState;
+use octez_riscv_data::codec;
 use octez_riscv_data::components::atom::Atom;
 use octez_riscv_data::components::atom::AtomMode;
 use octez_riscv_data::components::atom::CloneAtomMode;
@@ -1067,7 +1068,7 @@ impl Unfoldable for SupervisorState<Normal> {
 }
 
 impl FromProof for SupervisorState<Verify> {
-    fn from_proof<D: Deserialiser>(proof: D) -> SuspendedResult<D, Self> {
+    fn from_proof<D: Deserialiser<Codec = codec::Bincode>>(proof: D) -> SuspendedResult<D, Self> {
         let proof = proof.into_node()?;
 
         let (proof, tid_address) = proof.next_branch()?;

--- a/pvm/src/pvm/linux/signals.rs
+++ b/pvm/src/pvm/linux/signals.rs
@@ -16,6 +16,7 @@ use bincode::enc::Encoder;
 use bincode::error::DecodeError;
 use bincode::error::EncodeError;
 use octez_riscv_data::clone::CloneState;
+use octez_riscv_data::codec;
 use octez_riscv_data::components::atom::Atom;
 use octez_riscv_data::components::atom::AtomMode;
 use octez_riscv_data::components::atom::CloneAtomMode;
@@ -258,7 +259,7 @@ impl Unfoldable for SignalActions<Normal> {
 }
 
 impl FromProof for SignalActions<Verify> {
-    fn from_proof<D: Deserialiser>(proof: D) -> SuspendedResult<D, Self> {
+    fn from_proof<D: Deserialiser<Codec = codec::Bincode>>(proof: D) -> SuspendedResult<D, Self> {
         let proof = proof.into_node()?;
 
         let (proof, actions) = proof.next_branch()?;

--- a/pvm/src/pvm/outbox.rs
+++ b/pvm/src/pvm/outbox.rs
@@ -26,6 +26,7 @@ use bincode::enc::Encoder;
 use bincode::error::DecodeError;
 use bincode::error::EncodeError;
 use octez_riscv_data::clone::CloneState;
+use octez_riscv_data::codec;
 use octez_riscv_data::components::atom::Atom;
 use octez_riscv_data::components::atom::AtomMode;
 use octez_riscv_data::components::atom::CloneAtomMode;
@@ -136,6 +137,7 @@ impl OutboxProof {
     pub fn deserialise(mut bytes: &[u8]) -> Result<Self, ProofError> {
         let info: OutputInfo = deserialise_from(&mut bytes)?;
         let (_pvm, proof_tree) = proof_binary::deserialise::<
+            codec::Bincode,
             Pvm<NodePvmMemConfig, EmptyPageCache, DurableStorageDummy, Verify>,
         >(bytes)?;
 
@@ -250,7 +252,7 @@ impl Unfoldable for Outbox<Normal> {
 }
 
 impl FromProof for Outbox<Verify> {
-    fn from_proof<D: Deserialiser>(proof: D) -> SuspendedResult<D, Self> {
+    fn from_proof<D: Deserialiser<Codec = codec::Bincode>>(proof: D) -> SuspendedResult<D, Self> {
         let proof = proof.into_node()?;
         let (proof, levels) = proof.next_branch()?;
         proof.done(Outbox { levels })
@@ -452,7 +454,7 @@ impl Unfoldable for OutboxLevel<Normal> {
 }
 
 impl FromProof for OutboxLevel<Verify> {
-    fn from_proof<D: Deserialiser>(proof: D) -> SuspendedResult<D, Self> {
+    fn from_proof<D: Deserialiser<Codec = codec::Bincode>>(proof: D) -> SuspendedResult<D, Self> {
         let proof = proof.into_node()?;
         let (proof, messages) = proof.next_branch()?;
         let (proof, level) = proof.next_branch()?;

--- a/pvm/src/pvm/reveals.rs
+++ b/pvm/src/pvm/reveals.rs
@@ -9,6 +9,7 @@ use bincode::enc::Encoder;
 use bincode::error::DecodeError;
 use bincode::error::EncodeError;
 use octez_riscv_data::clone::CloneState;
+use octez_riscv_data::codec;
 use octez_riscv_data::components::atom::Atom;
 use octez_riscv_data::components::atom::AtomMode;
 use octez_riscv_data::components::atom::CloneAtomMode;
@@ -107,7 +108,7 @@ impl Unfoldable for RevealRequest<Normal> {
 }
 
 impl FromProof for RevealRequest<Verify> {
-    fn from_proof<D: Deserialiser>(proof: D) -> SuspendedResult<D, Self> {
+    fn from_proof<D: Deserialiser<Codec = codec::Bincode>>(proof: D) -> SuspendedResult<D, Self> {
         let proof = proof.into_node()?;
 
         let (proof, bytes) = proof.next_branch()?;

--- a/pvm/src/pvm/tezos.rs
+++ b/pvm/src/pvm/tezos.rs
@@ -21,6 +21,7 @@ use libsecp256k1::Message;
 use libsecp256k1::PublicKey;
 use libsecp256k1::Signature as SecpSig;
 use octez_riscv_data::clone::CloneState;
+use octez_riscv_data::codec;
 use octez_riscv_data::components::atom::Atom;
 use octez_riscv_data::components::atom::CloneAtomMode;
 use octez_riscv_data::components::atom::EncodeAtomMode;
@@ -180,7 +181,7 @@ impl Unfoldable for Tezos<Normal> {
 }
 
 impl FromProof for Tezos<Verify> {
-    fn from_proof<D: Deserialiser>(proof: D) -> SuspendedResult<D, Self> {
+    fn from_proof<D: Deserialiser<Codec = codec::Bincode>>(proof: D) -> SuspendedResult<D, Self> {
         let proof = proof.into_node()?;
 
         let (proof, outbox) = proof.next_branch()?;

--- a/pvm/src/state_backend.rs
+++ b/pvm/src/state_backend.rs
@@ -37,6 +37,7 @@ pub use elems::*;
 mod tests {
     use std::num::NonZeroUsize;
 
+    use octez_riscv_data::codec;
     use octez_riscv_data::components::atom::Atom;
     use octez_riscv_data::components::atom::AtomMode;
     use octez_riscv_data::components::data_space::DataSpace;
@@ -116,7 +117,7 @@ mod tests {
 
         // The Verify mode needs a proof, so we generate it from the Prove mode
         let proof_tree = MerkleProof::from_foldable(&mem_prove);
-        let proof_deser = ProofTree::Present(&proof_tree);
+        let proof_deser = ProofTree::present(&proof_tree);
         let mut mem_verify = DataSpace::from_proof(proof_deser).unwrap().into_result();
 
         unsafe {
@@ -186,9 +187,12 @@ mod tests {
         }
 
         impl FromProof for Foo<Verify> {
-            fn from_proof<Proof: octez_riscv_data::merkle_proof::Deserialiser>(
+            fn from_proof<Proof>(
                 proof: Proof,
-            ) -> octez_riscv_data::merkle_proof::SuspendedResult<Proof, Self> {
+            ) -> octez_riscv_data::merkle_proof::SuspendedResult<Proof, Self>
+            where
+                Proof: octez_riscv_data::merkle_proof::Deserialiser<Codec = codec::Bincode>,
+            {
                 let node = proof.into_node()?;
 
                 let (node, bar) = node.next_branch()?;
@@ -207,7 +211,7 @@ mod tests {
         operation(&mut foo_prove);
 
         let merkle_proof = MerkleProof::from_foldable(&foo_prove);
-        let proof_deser = ProofTree::Present(&merkle_proof);
+        let proof_deser = ProofTree::present(&merkle_proof);
 
         let expected_hash = Hash::from_foldable(&foo_prove);
 

--- a/pvm/src/state_backend/region.rs
+++ b/pvm/src/state_backend/region.rs
@@ -13,7 +13,7 @@ pub(crate) mod tests {
     use octez_riscv_data::hash::PartialHash;
     use octez_riscv_data::merkle_proof::proof_tree;
     use octez_riscv_data::merkle_proof::proof_tree::MerkleProof;
-    use octez_riscv_data::merkle_proof::proof_tree::ProofPart;
+    use octez_riscv_data::merkle_proof::proof_tree::ProofTree;
     use octez_riscv_data::mode::Mode;
     use octez_riscv_data::mode::Normal;
     use octez_riscv_data::mode::Provable;
@@ -93,7 +93,7 @@ pub(crate) mod tests {
             // Verify the proof and check the final hash
             catch_not_found(|| {
                 let mut verify_foo = {
-                    let (bar, qux) = proof_tree::deserialise(ProofPart::Present(&proof))
+                    let (bar, qux) = proof_tree::deserialise(ProofTree::present(&proof))
                         .unwrap()
                         .0;
                     Foo { bar, qux }

--- a/pvm/src/stepper/pvm.rs
+++ b/pvm/src/stepper/pvm.rs
@@ -9,6 +9,7 @@ use std::ops::Bound;
 use std::path::Path;
 
 use octez_riscv_data::clone::CloneState;
+use octez_riscv_data::codec;
 use octez_riscv_data::components::atom::AtomMode;
 use octez_riscv_data::components::atom::CloneAtomMode;
 use octez_riscv_data::components::data_space::CloneDataSpaceMode;
@@ -358,12 +359,12 @@ impl<H, MC: MemoryConfig, M: AtomMode + DataSpaceMode + VectorMode, PC: PageCach
         let (pvm, merkle_tree) = proof_binary::deserialise(&tree_serialisation)
             .map_err(ProofVerificationFailure::BadDeserialisation)?;
 
-        let deserialised_proof_tree = match merkle_tree {
-            OwnedProofTree::Present(ref merkle_tree) => ProofTree::Present(merkle_tree),
-            OwnedProofTree::Absent => ProofTree::Absent,
+        let deserialised_proof_tree: ProofTree<'_, codec::Bincode> = match merkle_tree {
+            OwnedProofTree::Present(ref merkle_tree) => ProofTree::present(merkle_tree),
+            OwnedProofTree::Absent => ProofTree::absent(),
         };
         debug_assert_eq!(
-            ProofTree::Present(proof.tree()),
+            ProofTree::present(proof.tree()),
             deserialised_proof_tree,
             "The Merkle proof tree obtained through deserialisation should match the original proof tree"
         );
@@ -382,13 +383,13 @@ impl<H, MC: MemoryConfig, M: AtomMode + DataSpaceMode + VectorMode, PC: PageCach
         DS: Foldable<PartialHashFold>,
         DS: FromProof + DurableStorage<Verify>,
     {
-        let proof_tree = ProofTree::Present(proof.tree());
+        let proof_tree = ProofTree::present(proof.tree());
         let (pvm, deserialised_proof_tree) = proof_tree::deserialise(proof_tree)
             .map_err(ProofVerificationFailure::BadDeserialisation)?;
 
         let gotten_proof_tree = match deserialised_proof_tree {
-            OwnedProofTree::Present(ref merkle_tree) => ProofTree::Present(merkle_tree),
-            OwnedProofTree::Absent => ProofTree::Absent,
+            OwnedProofTree::Present(ref merkle_tree) => ProofTree::present(merkle_tree),
+            OwnedProofTree::Absent => ProofTree::absent(),
         };
         debug_assert_eq!(
             proof_tree, gotten_proof_tree,
@@ -412,13 +413,13 @@ impl<H, MC: MemoryConfig, M: AtomMode + DataSpaceMode + VectorMode, PC: PageCach
         DS: Foldable<PartialHashFold>,
         DS: FromProof + DurableStorage<Verify>,
     {
-        let proof_tree = ProofTree::Present(proof.tree());
+        let proof_tree = ProofTree::present(proof.tree());
         let (pvm, deserialised_proof_tree) = proof_tree::deserialise(proof_tree)
             .map_err(ProofVerificationFailure::BadDeserialisation)?;
 
         let gotten_proof_tree = match deserialised_proof_tree {
-            OwnedProofTree::Present(ref merkle_tree) => ProofTree::Present(merkle_tree),
-            OwnedProofTree::Absent => ProofTree::Absent,
+            OwnedProofTree::Present(ref merkle_tree) => ProofTree::present(merkle_tree),
+            OwnedProofTree::Absent => ProofTree::absent(),
         };
         debug_assert_eq!(
             proof_tree, gotten_proof_tree,


### PR DESCRIPTION
<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

- Part of RV-1007

# What

Prepares the way for NDS to switch to a new encoding/decoding system in future (rather than the deprecated bincode)

# Why

To avoid having to change the PVM & the NDS in one go, we introduce the notion of `codec`, to allow NDS to select a different _leaf encoding_ system from the PVM, as the first step.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
