### PR TITLE
feat(durable): switch on-disk storage to use rkyv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2546,6 +2546,7 @@ dependencies = [
  "proptest",
  "rand 0.10.2",
  "range-collections",
+ "rkyv",
  "serde",
  "thiserror 2.0.18",
  "trait-set",
@@ -3330,9 +3331,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.17"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
+checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
 dependencies = [
  "bytecheck",
  "bytes",
@@ -3349,9 +3350,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.17"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
+checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3954,7 +3955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.0",
@@ -5346,18 +5347,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.53"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.53"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -21,6 +21,7 @@ memmap2.workspace = true
 range-collections.workspace = true
 bytes.workspace = true
 unty.workspace = true
+rkyv.workspace = true
 
 [dependencies.serde]
 workspace = true

--- a/data/src/hash.rs
+++ b/data/src/hash.rs
@@ -42,7 +42,21 @@ pub enum HashError {
 /// produced by a preset hash function, currently BLAKE3. It can be obtained
 /// by either hashing data directly or after hashing by converting from
 /// a suitably sized byte slice or vector.
-#[derive(Clone, Copy, PartialEq, Eq, Encode, Decode, Hash, PartialOrd, Ord, derive_more::Debug)]
+#[derive(
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Encode,
+    Decode,
+    Hash,
+    PartialOrd,
+    Ord,
+    derive_more::Debug,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
 #[debug("{}", self)]
 pub struct Hash {
     digest: [u8; Hash::DIGEST_SIZE],

--- a/durable-storage/Cargo.toml
+++ b/durable-storage/Cargo.toml
@@ -16,7 +16,6 @@ unstable-test-utils = [
   "dep:serde_with",
   "dep:anyhow",
   "dep:serde_json",
-  "dep:rkyv",
   "octez-riscv-data/unstable-test-utils",
 ]
 
@@ -31,6 +30,7 @@ hex.workspace = true
 perfect-derive.workspace = true
 octez-riscv-data.workspace = true
 rand.workspace = true
+rkyv.workspace = true
 tempfile.workspace = true
 tezos-smart-rollup-constants.workspace = true
 thiserror.workspace = true
@@ -54,10 +54,6 @@ workspace = true
 optional = true
 
 [dependencies.proptest]
-workspace = true
-optional = true
-
-[dependencies.rkyv]
 workspace = true
 optional = true
 

--- a/durable-storage/src/avl/node.rs
+++ b/durable-storage/src/avl/node.rs
@@ -25,8 +25,6 @@ use octez_riscv_data::merkle_proof::DeserialiserNode;
 use octez_riscv_data::merkle_proof::FromProof;
 use octez_riscv_data::mode::Mode;
 use octez_riscv_data::mode::Normal;
-use octez_riscv_data::serialisation::deserialise;
-use octez_riscv_data::serialisation::serialise;
 use perfect_derive::perfect_derive;
 
 use super::resolver::LazyDataId;
@@ -39,13 +37,21 @@ use crate::errors::Error;
 use crate::errors::InvalidArgumentError;
 use crate::errors::OperationalError;
 use crate::key::Key;
+use crate::rkyv_codec::rkyv_deserialise;
+use crate::rkyv_codec::rkyv_serialise;
 use crate::storage::KeyValueStore;
 use crate::storage::Loadable;
 use crate::storage::Storable;
 use crate::storage::StoreOptions;
 
 /// Metadata of a [`Node`] needed for accesses.
-#[derive(Clone, Default, Debug, Encode, Decode)]
+///
+/// `Meta` is serialised through two codecs: bincode (as a Merkle leaf, via the
+/// shared `data` crate's fold machinery, which keeps the Merkle hashes and
+/// proofs byte-identical) and rkyv (as part of the on-disk [`StoredNode`] blob).
+#[derive(
+    Clone, Default, Debug, Encode, Decode, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize,
+)]
 pub(crate) struct Meta {
     key: Key,
 
@@ -54,7 +60,7 @@ pub(crate) struct Meta {
 }
 
 /// This type is a compact serialised form of a [`Node`] with metadata and child subtree hashes.
-#[derive(Encode, Decode)]
+#[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 struct StoredNode {
     meta: Meta,
     data: Hash,
@@ -869,7 +875,7 @@ where
         };
 
         let &id = self.hash();
-        let bytes = serialise(repr)?;
+        let bytes = rkyv_serialise(&repr)?;
         store.blob_set(id, bytes)?;
 
         // Are we in charge of writing the value data to the KV store?
@@ -903,7 +909,7 @@ impl<TreeId: Loadable, DataId: DataLoadable> Loadable for Node<TreeId, DataId, N
                         root: id,
                         source: Box::new(error),
                     })?;
-            deserialise(bytes.as_ref())?
+            rkyv_deserialise(bytes.as_ref())?
         };
 
         let meta = Atom::new(meta);

--- a/durable-storage/src/avl/tree.rs
+++ b/durable-storage/src/avl/tree.rs
@@ -7,9 +7,6 @@
 use std::cmp::Ordering;
 use std::sync::LazyLock;
 
-use bincode::Decode;
-use bincode::de::Decoder;
-use bincode::error::DecodeError;
 use octez_riscv_data::components::atom::AtomMode;
 use octez_riscv_data::components::bytes::Bytes;
 use octez_riscv_data::components::bytes::BytesMode;
@@ -28,8 +25,6 @@ use octez_riscv_data::merkle_proof::Partial;
 use octez_riscv_data::merkle_proof::ProofError;
 use octez_riscv_data::merkle_proof::SuspendedResult;
 use octez_riscv_data::mode::utils::not_found;
-use octez_riscv_data::serialisation::deserialise;
-use octez_riscv_data::serialisation::serialise;
 use perfect_derive::perfect_derive;
 
 use super::node::Node;
@@ -42,6 +37,8 @@ use crate::errors::Error;
 use crate::errors::InvalidArgumentError;
 use crate::errors::OperationalError;
 use crate::key::Key;
+use crate::rkyv_codec::rkyv_deserialise;
+use crate::rkyv_codec::rkyv_serialise;
 use crate::storage::KeyValueStore;
 use crate::storage::Loadable;
 use crate::storage::Storable;
@@ -373,13 +370,6 @@ impl<NodeId> Tree<NodeId> {
     }
 }
 
-impl<C> Decode<C> for Tree<LazyNodeId> {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
-        let root_hash: Option<Hash> = Decode::decode(decoder)?;
-        Ok(Tree::from(root_hash.map(LazyNodeId::from)))
-    }
-}
-
 impl<NodeId: Foldable<HashFold>> Foldable<HashFold> for Tree<NodeId> {
     fn fold(&self, builder: HashFold) -> <HashFold as Fold>::Folded {
         let mut node = builder.into_node_fold();
@@ -452,7 +442,7 @@ impl<NodeId: Storable> Storable for Tree<NodeId> {
         }
 
         let id = self.hash();
-        let bytes = serialise(repr)?;
+        let bytes = rkyv_serialise(&repr)?;
         store.blob_set(id, bytes)?;
 
         if let Some(node) = &self.0
@@ -481,7 +471,7 @@ impl<NodeId: Loadable> Loadable for Tree<NodeId> {
                         root: id,
                         source: Box::new(error),
                     })?;
-            deserialise(bytes.as_ref())?
+            rkyv_deserialise(bytes.as_ref())?
         };
 
         repr.map(|node_id| NodeId::load(node_id, store))

--- a/durable-storage/src/commit.rs
+++ b/durable-storage/src/commit.rs
@@ -5,13 +5,13 @@
 //! Implementation of commit identifiers for the durable storage.
 //! A [`CommitId`] uniquely identifies a prior, immutable state.
 
-use bincode::Decode;
-use bincode::Encode;
 use octez_riscv_data::hash::Hash;
 
 /// [`CommitId`]'s are used to generate commits & to checkout specific commits
 /// from a `DirectoryManager`.
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Encode, Decode, Hash)]
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize,
+)]
 #[cfg_attr(
     test_utils,
     derive(serde::Serialize, serde::Deserialize),

--- a/durable-storage/src/errors.rs
+++ b/durable-storage/src/errors.rs
@@ -116,11 +116,8 @@ pub enum OperationalError {
     #[error("Encountered a poisoned lock")]
     LockPoisoned,
 
-    #[error("Error during decoding.")]
-    Decoding(#[from] bincode::error::DecodeError),
-
-    #[error("Error during encoding.")]
-    Encoding(#[from] bincode::error::EncodeError),
+    #[error("Error during rkyv (de)serialisation: {0}")]
+    Serialisation(#[from] rkyv::rancor::Error),
 }
 
 /// Errors that occur because of incorrect usage

--- a/durable-storage/src/key.rs
+++ b/durable-storage/src/key.rs
@@ -15,7 +15,23 @@ use crate::errors::InvalidArgumentError;
 pub const KEY_MAX_SIZE: usize = 256;
 
 /// A unique key used to store, retrieve and mutate data in durable storage.
-#[derive(Clone, Debug, Default, Encode, Eq, Hash, Ord, PartialEq, PartialOrd)]
+///
+/// `Key` is serialised through two codecs: bincode (as a Merkle leaf, via the
+/// shared `data` crate's fold machinery) and rkyv (as part of the on-disk
+/// `StoredNode` blob). Both decode paths preserve the [`KEY_MAX_SIZE`] check.
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    Encode,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    rkyv::Archive,
+    rkyv::Serialize,
+)]
 pub struct Key(Vec<u8>);
 
 impl Key {
@@ -64,6 +80,22 @@ impl<'de, Context> BorrowDecode<'de, Context> for Key {
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
         Key::decode(decoder)
+    }
+}
+
+// Manual implementation of rkyv's `Deserialize` to ensure that, as with bincode,
+// we never reconstruct a key that is formed of invalid bytes.
+impl<D> rkyv::Deserialize<Key, D> for ArchivedKey
+where
+    D: rkyv::rancor::Fallible + ?Sized,
+    D::Error: rkyv::rancor::Source,
+{
+    fn deserialize(&self, _deserializer: &mut D) -> Result<Key, D::Error> {
+        let bytes = self.0.as_slice().to_vec();
+
+        Key::check_bytes_validity(&bytes).map_err(rkyv::rancor::Source::new)?;
+
+        Ok(Key(bytes))
     }
 }
 
@@ -117,6 +149,42 @@ mod tests {
 
             assert_eq!(key, key_decoded_slice, "encode then borrow decode must produce the same key");
         }
+    }
+
+    proptest! {
+        #[test]
+        fn key_rkyv_encode_decode_ok(key_len in 0..=KEY_MAX_SIZE) {
+            use crate::rkyv_codec::rkyv_deserialise;
+            use crate::rkyv_codec::rkyv_serialise;
+
+            let bytes = vec![0; key_len];
+            let key = Key::new(&bytes).expect("Key is valid");
+
+            let serialised = rkyv_serialise(&key)
+                .expect("rkyv serialisation of a key should succeed");
+
+            let key_decoded: Key = rkyv_deserialise(&serialised)
+                .expect("rkyv decoding of a valid encoded key should succeed");
+
+            assert_eq!(key, key_decoded, "rkyv encode then decode must produce the same key");
+        }
+    }
+
+    #[test]
+    fn key_rkyv_decode_protects_key_too_large() {
+        use crate::rkyv_codec::rkyv_deserialise;
+        use crate::rkyv_codec::rkyv_serialise;
+
+        // NB the public api does not allow for such an invalid key.
+        let key = Key(vec![0; KEY_MAX_SIZE + 1]);
+
+        let bytes = rkyv_serialise(&key).expect("rkyv serialisation of a key should succeed");
+
+        let res: Result<Key, _> = rkyv_deserialise(&bytes);
+        assert!(
+            res.is_err(),
+            "rkyv decoding of a key that's too large should fail"
+        );
     }
 
     #[test]

--- a/durable-storage/src/lib.rs
+++ b/durable-storage/src/lib.rs
@@ -42,5 +42,6 @@ mod merkle_worker;
 pub mod persistence_layer;
 pub mod registry;
 pub mod repo;
+mod rkyv_codec;
 pub mod storage;
 pub mod test_helpers;

--- a/durable-storage/src/persistence_layer.rs
+++ b/durable-storage/src/persistence_layer.rs
@@ -32,8 +32,6 @@
 use std::mem::ManuallyDrop;
 use std::path::Path;
 
-use bincode::BorrowDecode;
-use bincode::Encode;
 use rocksdb::ColumnFamilyDescriptor;
 use rocksdb::MergeOperands;
 use rocksdb::checkpoint::Checkpoint;
@@ -44,17 +42,29 @@ use crate::errors::Error;
 use crate::errors::InvalidArgumentError;
 use crate::errors::OperationalError;
 use crate::repo::DirectoryManager;
+use crate::rkyv_codec::rkyv_deserialise;
+use crate::rkyv_codec::rkyv_serialise;
 use crate::storage::KeyValueStore;
 use crate::storage::PersistentKeyValueStore;
 
 /// The name of the column family used for storing blob-keyed data.
 const BLOB_CF: &str = "blob";
 
-#[derive(BorrowDecode, Encode)]
-struct OffsetWriteMergePayload<'a> {
-    offset: usize,
-    value: &'a [u8],
+/// A single offset-write operand.
+///
+/// `offset` is stored as a fixed-width `u64` so the on-disk format is
+/// architecture-independent.
+#[derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+struct OffsetWriteMergePayload {
+    offset: u64,
+    value: Vec<u8>,
 }
+
+/// Length, in bytes, of the little-endian length prefix that frames each
+/// serialised [`OffsetWriteMergePayload`]. rkyv archives are not self-delimiting,
+/// so operands are prefixed with their archive length to allow several to be
+/// concatenated in a single merge operand and parsed back apart.
+const MERGE_PAYLOAD_LEN_PREFIX: usize = size_of::<u64>();
 
 /// Defines an atomic merge operator used when writing with an offset.
 ///
@@ -99,14 +109,22 @@ fn offset_write_full_merge(
 
     for mut op in operands {
         while !op.is_empty() {
-            let decode = octez_riscv_data::serialisation::deserialise_borrowed(op);
-            let (payload, len): (OffsetWriteMergePayload, _) =
-                decode.expect("Should be a valid encoding");
+            // Each operand is framed as [len: u64 LE][rkyv archive of the payload].
+            let (len_bytes, tail) = op.split_at(MERGE_PAYLOAD_LEN_PREFIX);
+            let len = u64::from_le_bytes(
+                len_bytes
+                    .try_into()
+                    .expect("Operand should carry a full length prefix"),
+            ) as usize;
+            let (archive, tail) = tail.split_at(len);
 
-            // Advance the slice
-            op = &op[len..];
+            let payload: OffsetWriteMergePayload =
+                rkyv_deserialise(archive).expect("Should be a valid encoding");
 
-            let offset = payload.offset;
+            // Advance the slice past this framed payload.
+            op = tail;
+
+            let offset = payload.offset as usize;
             let data = payload.value;
 
             // This shouldn't happen: it's prevented by the `Database` API.
@@ -385,11 +403,17 @@ impl KeyValueStore for PersistenceLayer {
         // misuse.
 
         let payload_struct = OffsetWriteMergePayload {
-            offset,
-            value: value.as_ref(),
+            offset: offset as u64,
+            value: value.as_ref().to_vec(),
         };
-        let payload = octez_riscv_data::serialisation::serialise(payload_struct)
+        let archive = rkyv_serialise(&payload_struct)
             .expect("Merge operator serialisation should always succeed");
+
+        // Frame the archive with its little-endian length so several operands can
+        // be concatenated and parsed back apart during a full merge.
+        let mut payload = Vec::with_capacity(MERGE_PAYLOAD_LEN_PREFIX + archive.len());
+        payload.extend_from_slice(&(archive.len() as u64).to_le_bytes());
+        payload.extend_from_slice(&archive);
 
         self.db_instance
             .merge(key.as_ref(), payload)

--- a/durable-storage/src/registry.rs
+++ b/durable-storage/src/registry.rs
@@ -12,8 +12,6 @@ use std::convert::Infallible;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use bincode::Decode;
-use bincode::Encode;
 use octez_riscv_data::components::vector::Vector;
 use octez_riscv_data::components::vector::VectorMode;
 use octez_riscv_data::foldable::Fold;
@@ -31,8 +29,6 @@ use octez_riscv_data::mode::Normal;
 use octez_riscv_data::mode::ProvableExt;
 use octez_riscv_data::mode::Prove;
 use octez_riscv_data::mode::Verify;
-use octez_riscv_data::serialisation::deserialise;
-use octez_riscv_data::serialisation::serialise;
 use tokio::runtime::Runtime;
 
 use crate::avl::tree::Tree;
@@ -44,9 +40,11 @@ use crate::errors::OperationalError;
 use crate::merkle_worker::BackgroundKeyValueStore;
 use crate::merkle_worker::BackgroundPersistentKeyValueStore;
 use crate::repo::RegistryRepo;
+use crate::rkyv_codec::rkyv_deserialise;
+use crate::rkyv_codec::rkyv_serialise;
 use crate::storage::KeyValueStore;
 
-#[derive(Debug, Encode, Decode)]
+#[derive(Debug, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 /// Structure to store the result of serialising a registry.
 struct RegistryManifest {
     database_hashes: Vec<CommitId>,
@@ -157,7 +155,7 @@ where
         commit_id: &CommitId,
     ) -> Result<RegistryManifest, OperationalError> {
         let commit_bytes = repo.read_registry_commit(commit_id)?;
-        deserialise(&commit_bytes).map_err(OperationalError::from)
+        rkyv_deserialise(&commit_bytes).map_err(OperationalError::from)
     }
 
     fn checkout_databases(
@@ -189,7 +187,7 @@ where
 
         let manifest = RegistryManifest { database_hashes };
         let encoded =
-            serialise(&manifest).expect("Serialising the registry manifest should not fail");
+            rkyv_serialise(&manifest).expect("Serialising the registry manifest should not fail");
 
         self.inner
             .repo
@@ -617,7 +615,8 @@ pub(super) mod tests {
     use octez_riscv_data::mode::Prove;
     use octez_riscv_data::mode::Verify;
     use octez_riscv_data::mode::utils::catch_not_found;
-    use octez_riscv_data::serialisation::deserialise;
+    // `serialise` is still used to snapshot bincode-encoded Merkle *proofs* (the
+    // proof envelope stays on bincode); the registry manifest itself is rkyv.
     use octez_riscv_data::serialisation::serialise;
 
     use super::ProveImpl;
@@ -632,6 +631,8 @@ pub(super) mod tests {
     use crate::merkle_worker::BackgroundKeyValueStore;
     use crate::merkle_worker::BackgroundPersistentKeyValueStore;
     use crate::repo::RegistryRepo;
+    use crate::rkyv_codec::rkyv_deserialise;
+    use crate::rkyv_codec::rkyv_serialise;
     use crate::storage::TestKeyValueStoreSetup;
     use crate::storage::kv_test;
 
@@ -944,7 +945,7 @@ pub(super) mod tests {
                 .repo
                 .read_registry_commit(commit_id)
                 .expect("Manifest should be readable");
-            deserialise(&bytes).expect("Manifest should be deserialisable")
+            rkyv_deserialise(&bytes).expect("Manifest should be deserialisable")
         }
 
         /// Assert that the manifest written for `commit_id` contains the expected database commit IDs.
@@ -1104,7 +1105,7 @@ pub(super) mod tests {
 
         let fake_commit = CommitId::from(Hash::hash_bytes(b"fake-registry-commit"));
         let fake_manifest_bytes =
-            serialise(&manifest).expect("Manifest should be serialisable");
+            rkyv_serialise(&manifest).expect("Manifest should be serialisable");
         repo.write_registry_commit(&fake_commit, &fake_manifest_bytes)
             .expect("Writing the fake manifest should succeed");
 
@@ -2259,7 +2260,6 @@ pub(super) mod tests {
 #[cfg(test)]
 mod rocksdb_tests {
     use octez_riscv_data::mode::Normal;
-    use octez_riscv_data::serialisation::deserialise;
 
     use super::Registry;
     use super::RegistryManifest;
@@ -2267,6 +2267,7 @@ mod rocksdb_tests {
     use super::tests::setup_registry;
     use crate::errors::Error;
     use crate::errors::OperationalError;
+    use crate::rkyv_codec::rkyv_deserialise;
     use crate::storage::TestKeyValueStore;
     use crate::storage::setup_repo;
 
@@ -2284,7 +2285,7 @@ mod rocksdb_tests {
         let manifest_path = repo.registry_commit_file(&root_commit);
         let manifest_bytes = std::fs::read(&manifest_path).expect("Manifest should be readable");
         let manifest: RegistryManifest =
-            deserialise(&manifest_bytes).expect("Manifest should be deserialisable");
+            rkyv_deserialise(&manifest_bytes).expect("Manifest should be deserialisable");
         std::fs::remove_dir_all(repo.database_commit_dir(&manifest.database_hashes[0]))
             .expect("Database commit should be removable");
 

--- a/durable-storage/src/rkyv_codec.rs
+++ b/durable-storage/src/rkyv_codec.rs
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 Trilitech <contact@trili.tech>
+//
+// SPDX-License-Identifier: MIT
+
+//! durable-storage-local helpers for rkyv serialisation of on-disk blobs.
+//!
+//! These mirror the shape of the bincode `serialise`/`deserialise` helpers that
+//! previously lived in [`octez_riscv_data::serialisation`], but produce and
+//! consume rkyv archives. They are intentionally kept local to durable-storage:
+//! only the on-disk/blob format uses rkyv, while the shared `data` crate (and
+//! therefore the PVM) keeps bincode for its Merkle hashing and proofs.
+
+use rkyv::Archive;
+use rkyv::Deserialize;
+use rkyv::Serialize;
+use rkyv::api::high::HighDeserializer;
+use rkyv::api::high::HighSerializer;
+use rkyv::api::high::HighValidator;
+use rkyv::bytecheck::CheckBytes;
+use rkyv::rancor::Error;
+use rkyv::ser::allocator::ArenaHandle;
+use rkyv::util::AlignedVec;
+
+/// Serialise `value` into its rkyv byte representation.
+pub(crate) fn rkyv_serialise<T>(value: &T) -> Result<AlignedVec, Error>
+where
+    T: for<'a> Serialize<HighSerializer<AlignedVec, ArenaHandle<'a>, Error>>,
+{
+    rkyv::to_bytes::<Error>(value)
+}
+
+/// Deserialise a value of type `T` from its rkyv byte representation.
+///
+/// The input slice is first copied into an [`AlignedVec`], because rkyv's
+/// validated access requires the buffer to satisfy the archived type's
+/// alignment, and blob/RocksDB slices have arbitrary alignment.
+pub(crate) fn rkyv_deserialise<T>(bytes: &[u8]) -> Result<T, Error>
+where
+    T: Archive,
+    T::Archived:
+        for<'a> CheckBytes<HighValidator<'a, Error>> + Deserialize<T, HighDeserializer<Error>>,
+{
+    let mut aligned = AlignedVec::<16>::new();
+    aligned.extend_from_slice(bytes);
+    rkyv::from_bytes::<T, Error>(&aligned)
+}


### PR DESCRIPTION
- Part of RV-1007

# What

Migrate the on-disk storage portion of NDS from `bincode` (deprecated) to `rkyv`.

# Why



# How

<!--
    Explain how the MR achieves its goal. If this is trivial or if the code speaks for itself, you
    can omit this.
-->

# Manually Testing

```
make all
```

# Regressions

<!--
    Explain changes to regression test captures. If there are no changes to these, delete this
    section.
-->

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [ ] Eliminate dead code and other spurious artefacts introduced in your changes.
- [ ] Document new public functions, methods and types.
- [ ] Make sure the documentation for updated functions, methods, and types is correct.
- [ ] Add tests for bugs that have been fixed.
- [ ] [Explain changes](#regressions) to regression test captures when applicable.
- [ ] Write commit messages in agreement with our guidelines.
- [ ] Self-review your changes to ensure they are high-quality.
- [ ] Complete all of the above before assigning this MR to reviewers.
