### PR TITLE
fix(long-test): ensure long-test ends once time budget reached

### DIFF
--- a/durable-storage/src/long_test/harness.rs
+++ b/durable-storage/src/long_test/harness.rs
@@ -58,7 +58,8 @@ impl LongTestConfig {
             }
             if let Some(budget) = self.time_budget {
                 if start.elapsed() >= budget {
-                    eprintln!("time budget reached after {epoch} epochs")
+                    eprintln!("time budget reached after {epoch} epochs");
+                    break;
                 }
             }
 


### PR DESCRIPTION


# What

Ensure long-tests exit once time budget is reached. Fix issue introduced by a refactor in #1121

# Why

CI has long tests constrained to 10 minutes. These are instead being cancelled by github after multiple hours

# Manually Testing

```
cargo run --release --features rocksdb,unstable-test-utils --bin long_test -- database test --seed cc6507488135558805e823954193f5b798d443aa8f89c2435d9bdf5475a1d6bf --ops-per-epoch 1000 --cases-per-epoch 256 --keep-epochs 1 --max-minutes 1
```

should exit after 1 minute.


