### PR TITLE
chore(ci): bump nightly registry tests from 8 to 16

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -68,15 +68,20 @@ jobs:
           - { ops: 8000,  cases: 64 }
           - { ops: 16000, cases: 32 }
         test: [database, registry-stable]
-        replica: [1, 2]
+        replica: [1, 2, 3, 4]
         include:
           - test: database
             args: database test
           - test: registry-stable
             args: registry test --keep-stable-size
+        # Only run database tests on the first replica
         exclude:
           - test: database
             replica: 2
+          - test: database
+            replica: 3
+          - test: database
+            replica: 4
 
     steps:
       - name: Checkout


### PR DESCRIPTION
# What

Bumps nightly Registry tests from 8 to 16, in addition to the existing 4 Database tests.

# Why

Nightly workflows can run up to 20 jobs in parallel on GitHub runners, this takes advantage of that.

# Manually Testing

See a 10-minute capped run [here](https://github.com/tezos/riscv-pvm/actions/runs/29412236528).

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
