### PR TITLE
chore(durable): record decision w.r.t. versioning of databases

### DIFF
--- a/durable-storage/src/avl/tree.rs
+++ b/durable-storage/src/avl/tree.rs
@@ -80,6 +80,8 @@ impl<NodeId: FromProof> Tree<NodeId> {
             }
             Partial::Blinded(hash) => Ok((ctx, Partial::Blinded(hash))),
             Partial::Present(()) => {
+                // TODO (RV-996): leverage <bool> as a union tag to allow future versioning
+                //                of the database/merkle layer in a backwards-compatible way
                 let (ctx, present) = ctx.next_branch_with(|proof| proof.into_leaf::<bool>())?;
                 match present {
                     Partial::Present(true) => {

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -8,6 +8,7 @@
 //! This module provides a database type to unify operations between the Merkle layer and the
 //! key-value store.
 
+mod traced_database;
 pub(crate) mod value_ref;
 
 use std::convert::Infallible;
@@ -37,6 +38,10 @@ use perfect_derive::perfect_derive;
 use tezos_smart_rollup_constants::core::MAX_FILE_CHUNK_SIZE;
 use tokio::runtime::Handle;
 
+#[cfg(test)]
+pub(crate) use self::traced_database::Trace;
+#[cfg(any(test, rocksdb_test_utils))]
+pub(crate) use self::traced_database::TracedDatabase;
 use crate::avl::resolver::ProveNodeId;
 use crate::avl::tree::Tree;
 use crate::commit::CommitId;
@@ -620,13 +625,6 @@ impl<KV: BackgroundKeyValueStore, M: DatabaseMode> Database<KV, M> {
         assert_eq!(stored.as_slice(), expected);
     }
 }
-
-mod traced_database;
-
-#[cfg(test)]
-pub(crate) use self::traced_database::Trace;
-#[cfg(any(test, rocksdb_test_utils))]
-pub(crate) use self::traced_database::TracedDatabase;
 
 #[cfg(test)]
 pub(crate) mod tests {


### PR DESCRIPTION
Relates to RV-996

# What

Record an explanation of how we can re-use the byte for 'tree-is-empty-or-populated' for versioning in future.

# Why

Ensure we don't forget with an explicit TODO, while allowing us to de-prioritise the work to add explicit versioning.

