### PR TITLE
refactor(nds/test): return step outcome from database regression steps

### DIFF
--- a/durable-storage/src/test_helpers.rs
+++ b/durable-storage/src/test_helpers.rs
@@ -20,8 +20,11 @@ pub mod registry;
 use bytes::Bytes;
 use database::key_strategy;
 use database::value_strategy;
+use octez_riscv_data::hash::Hash;
 use proptest::prelude::*;
 
+use crate::errors::Error;
+use crate::errors::OperationalError;
 use crate::key::Key;
 
 /// Path to regression test inputs relative to the crate root
@@ -31,6 +34,54 @@ pub(crate) const REGRESSION_INPUTS_DIR: &str = "tests/inputs";
 /// Path to regression test expected outputs relative to the crate root
 #[cfg(test)]
 pub(crate) const REGRESSION_EXPECTED_DIR: &str = "tests/expected";
+
+/// The observable outcome of applying a single provable operation.
+///
+/// Captured so the result computed in [`Normal`], [`Prove`] and [`Verify`] mode can be
+/// compared for equality — the prove/verify harnesses otherwise only constrain state
+/// (root hashes), never the value an operation returns.
+///
+/// The representation is deliberately mode- and backend-independent: errors are stringified
+/// (matching the `{:?}` convention used by the operation traces) and byte payloads are owned,
+/// so the type implements [`PartialEq`], [`Serialize`] and [`Deserialize`].
+///
+/// [`Normal`]: octez_riscv_data::mode::Normal
+/// [`Prove`]: octez_riscv_data::mode::Prove
+/// [`Verify`]: octez_riscv_data::mode::Verify
+/// [`Serialize`]: serde::Serialize
+/// [`Deserialize`]: serde::Deserialize
+#[serde_with::serde_as]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub(crate) enum StepOutcome {
+    /// Result of `set` or `delete`.
+    Unit(Result<(), String>),
+    /// Result of `write` (bytes written) or `value_length`.
+    Length(Result<usize, String>),
+    /// Result of `read`: the bytes actually returned.
+    Read(
+        #[serde_as(as = "Result<serde_with::hex::Hex, serde_with::Same>")] Result<Vec<u8>, String>,
+    ),
+    /// Result of `exists`.
+    Exists(Result<bool, String>),
+    /// Result of `hash`: the root hash.
+    Hash(Result<Hash, String>),
+}
+
+/// Capture the observable outcome of an [`Error`]-returning operation.
+///
+/// Operational errors are propagated: they indicate a harness or implementation bug rather
+/// than an observable result. `Ok` values and invalid-argument errors are the operation's
+/// observable outcome and are captured via `wrap` (e.g. [`StepOutcome::Unit`]).
+pub(crate) fn outcome_from_value<T>(
+    result: Result<T, Error>,
+    wrap: impl FnOnce(Result<T, String>) -> StepOutcome,
+) -> Result<StepOutcome, OperationalError> {
+    match result {
+        Ok(value) => Ok(wrap(Ok(value))),
+        Err(Error::InvalidArgument(error)) => Ok(wrap(Err(format!("{error:?}")))),
+        Err(Error::Operational(error)) => Err(error),
+    }
+}
 
 /// A proptest-sampleable view of an operation which can be applied to an NDS component
 pub trait OperationView: Clone + std::fmt::Debug + 'static {

--- a/durable-storage/src/test_helpers/database.rs
+++ b/durable-storage/src/test_helpers/database.rs
@@ -41,6 +41,8 @@ use crate::key::Key;
 use crate::merkle_worker::BackgroundKeyValueStore;
 use crate::merkle_worker::BackgroundPersistentKeyValueStore;
 use crate::test_helpers::OperationView;
+use crate::test_helpers::StepOutcome;
+use crate::test_helpers::outcome_from_value;
 
 /// Maximum size for the value argument of a sampled operation
 pub(crate) const VALUE_MAX_SIZE: usize = 10_000;
@@ -644,63 +646,57 @@ where
     database.into_trace()
 }
 
-/// Apply a value `operation` to `database`, propagating operational errors and
-/// ignoring invalid-argument failures.
+/// Apply a value `operation` to `database`, capturing its observable outcome.
 ///
-/// Returns `true` if the operation was a provable step (everything except the
-/// persistence operations).
+/// Operational errors are propagated (they indicate a harness or implementation bug, not an
+/// observable result); invalid-argument failures and `Ok` values are captured in the returned
+/// [`StepOutcome`]. Returns `None` for the persistence operations, which are not provable
+/// steps.
 pub(crate) fn apply_database_step<D: DatabaseValueOps>(
     database: &mut D,
     operation: &DatabaseOperation,
-) -> Result<bool, OperationalError> {
-    fn result_operational<T>(result: Result<T, Error>) -> Result<(), OperationalError> {
-        match result {
-            Ok(_) | Err(Error::InvalidArgument(_)) => Ok(()),
-            Err(Error::Operational(e)) => Err(e),
-        }
-    }
-
-    match operation {
+) -> Result<Option<StepOutcome>, OperationalError> {
+    let outcome = match operation {
         DatabaseOperation::Set(key, data) => {
-            result_operational(database.set(key.clone(), data.clone()))?;
+            outcome_from_value(database.set(key.clone(), data.clone()), StepOutcome::Unit)?
         }
-        DatabaseOperation::Write(key, offset, data) => {
-            result_operational(database.write(key.clone(), *offset, data.clone()))?;
-        }
+        DatabaseOperation::Write(key, offset, data) => outcome_from_value(
+            database.write(key.clone(), *offset, data.clone()),
+            StepOutcome::Length,
+        )?,
         DatabaseOperation::Read(key, offset, len) => {
             let mut buffer = vec![0; *len];
             let mut cursor = 0;
             loop {
                 match database.read(key, offset + cursor, &mut buffer[cursor..]) {
-                    Ok(0) => break,
+                    Ok(0) => break StepOutcome::Read(Ok(buffer[..cursor].to_vec())),
                     Ok(read) => cursor += read,
-                    Err(e) => {
-                        result_operational::<()>(Err(e))?;
-                        break;
+                    Err(Error::InvalidArgument(error)) => {
+                        break StepOutcome::Read(Err(format!("{error:?}")));
                     }
+                    Err(Error::Operational(error)) => return Err(error),
                 }
             }
         }
         DatabaseOperation::Delete(key) => {
             database.delete(key.clone())?;
+            StepOutcome::Unit(Ok(()))
         }
         DatabaseOperation::Exists(key) => {
-            result_operational(database.exists(key))?;
+            outcome_from_value(database.exists(key), StepOutcome::Exists)?
         }
         DatabaseOperation::ValueLength(key) => {
-            result_operational(database.value_length(key))?;
+            outcome_from_value(database.value_length(key), StepOutcome::Length)?
         }
-        DatabaseOperation::Hash => {
-            database.hash()?;
-        }
+        DatabaseOperation::Hash => StepOutcome::Hash(Ok(database.hash()?)),
         DatabaseOperation::Commit
         | DatabaseOperation::Checkout
         | DatabaseOperation::CommitCheckoutRoundtrip => {
-            return Ok(false);
+            return Ok(None);
         }
-    }
+    };
 
-    Ok(true)
+    Ok(Some(outcome))
 }
 
 /// Generate and verify a proof for a single [`DatabaseOperation`] applied to `database`.
@@ -720,9 +716,7 @@ pub(crate) fn prove_and_verify_database_operation<KV: BackgroundKeyValueStore>(
         .expect("starting a proof should succeed");
 
     // Nothing to record or compare if the step was not provable
-    if !apply_database_step(&mut prover, operation).expect("applying a step should succeed") {
-        return None;
-    }
+    apply_database_step(&mut prover, operation).expect("applying a step should succeed")?;
 
     let post_root_hash = Hash::from_foldable(&prover);
     let proof = MerkleProof::from_foldable(&prover);

--- a/durable-storage/src/test_helpers/registry.rs
+++ b/durable-storage/src/test_helpers/registry.rs
@@ -191,7 +191,9 @@ where
             let database = registry
                 .database_mut(*index)
                 .expect("The index is in bounds");
-            return apply_database_step(database, db_op).expect("applying a step should succeed");
+            return apply_database_step(database, db_op)
+                .expect("applying a step should succeed")
+                .is_some();
         }
         RegistryOperation::GrowRegistry => grow_registry(registry),
         RegistryOperation::ShrinkRegistry => {


### PR DESCRIPTION
# What

Return a new `StepOutcome` from `apply_database_step`.

Breaking this out from exploratory work that is updating existing regressions (e.g. #1140). This is its own PR as subsequent changes to both database and registry rely on this new `StepOutcome` type.

# Why

This new type will be used subsequently to ensure the outcomes from proof steps agree against normal mode, which is currently not tested in the regressions (only hash equivalence is).

This is also moving towards refactoring the database proof-trace - which currently includes the proof steps inline in the rest of the steps, unlike the registry proof-trace, which includes the proof steps only, and inlines the full step within.

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
