### PR TITLE
feat(dursto): add upper-bound proof size model and check in tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -104,6 +104,7 @@ jobs:
             --cases-per-epoch ${{ matrix.config.cases }} \
             --keep-epochs 1 \
             --max-minutes ${{ env.MAX_MINUTES }} \
+            --fail-on-warning \
             --out-dir '${{ github.workspace }}/run-${{ matrix.test }}-${{ matrix.config.ops }}-${{ matrix.config.cases }}-${{ matrix.replica }}'
 
       - name: Upload failure artifacts

--- a/data/src/components/bytes.rs
+++ b/data/src/components/bytes.rs
@@ -1109,10 +1109,10 @@ fn clamp_range(total_len: usize, start: usize, len: usize) -> Range<usize> {
 }
 
 /// Arity of internal nodes in the Merkle tree that holds the pages
-pub(crate) const NODE_ARITY: usize = 4;
+pub const NODE_ARITY: usize = 4;
 
 /// Size of a page in bytes
-pub(crate) const PAGE_SIZE: usize = 4096;
+pub const PAGE_SIZE: usize = 4096;
 
 #[cfg(test)]
 pub(crate) mod tests;

--- a/data/src/components/vector.rs
+++ b/data/src/components/vector.rs
@@ -846,7 +846,7 @@ impl<T: CloneState> CloneState for VerifyImpl<T> {
 }
 
 /// Arity of internal nodes in the Merkle tree
-const NODE_ARITY: usize = 4;
+pub const NODE_ARITY: usize = 4;
 
 #[cfg(test)]
 mod tests;

--- a/durable-storage/Makefile
+++ b/durable-storage/Makefile
@@ -34,15 +34,17 @@ build-long-test:
 
 run-database-long-test:
 	@cargo run --release --features rocksdb,unstable-test-utils \
-		--bin long_test -- database test --max-minutes 10 --keep-epochs 1
+		--bin long_test -- database test --max-minutes 10 --keep-epochs 1 \
+		--fail-on-warning
 
 run-registry-long-test:
 	@cargo run --release --features rocksdb,unstable-test-utils \
-		--bin long_test -- registry test --max-minutes 10 --keep-epochs 1
+		--bin long_test -- registry test --max-minutes 10 --keep-epochs 1 \
+		--fail-on-warning
 
 run-registry-long-test-stable:
 	@cargo run --release --features rocksdb,unstable-test-utils \
 		--bin long_test -- registry test --max-minutes 10 --keep-epochs 1 \
-		--keep-stable-size
+		--keep-stable-size --fail-on-warning
 
 .PHONY: all check test gen-regression-inputs run-database-long-test reset-database-regressions reset-registry-regressions build-long-test run-registry-long-test run-registry-long-test-stable

--- a/durable-storage/src/bin/long_test.rs
+++ b/durable-storage/src/bin/long_test.rs
@@ -73,6 +73,11 @@ struct TestArgs {
     /// Directory for run state and failure artifacts (default: a fresh tempdir).
     #[arg(long)]
     out_dir: Option<PathBuf>,
+
+    /// Fail the test when a proof size exceeds the maximum, instead of printing
+    /// a warning.
+    #[arg(long)]
+    fail_on_warning: bool,
 }
 
 #[derive(Debug, Subcommand)]
@@ -131,6 +136,7 @@ fn config(args: TestArgs) -> Result<LongTestConfig> {
         epochs: args.epochs,
         keep_epochs: args.keep_epochs,
         out_dir: args.out_dir,
+        fail_on_warning: args.fail_on_warning,
     })
 }
 

--- a/durable-storage/src/long_test/database/mod.rs
+++ b/durable-storage/src/long_test/database/mod.rs
@@ -63,6 +63,7 @@ pub fn run_long_test(config: LongTestConfig) -> Result<()> {
     let ops_per_epoch = config.ops_per_epoch;
     let cases_per_epoch = config.cases_per_epoch;
     let keep_epochs = config.keep_epochs;
+    let fail_on_warning = config.fail_on_warning;
     let out_dir = match config.out_dir.clone() {
         Some(dir) => {
             fs::create_dir_all(&dir)
@@ -88,6 +89,9 @@ pub fn run_long_test(config: LongTestConfig) -> Result<()> {
     }
     if let Some(budget) = config.time_budget {
         rerun.push_str(&format!(" --max-minutes {}", budget.as_secs() / 60));
+    }
+    if config.fail_on_warning {
+        rerun.push_str(" --fail-on-warning");
     }
     eprintln!(
         "test directory: {} | ops/epoch: {ops_per_epoch} | cases/epoch: {cases_per_epoch}\n\
@@ -135,7 +139,14 @@ pub fn run_long_test(config: LongTestConfig) -> Result<()> {
         // Run the property test on this base.
         let strategy = ops_strategy(&base.model.pools(), ops_per_epoch);
         let result = runner.run(&strategy, |ops| {
-            run_case(handle, &in_memory_repo, &persistent_repo, &base, &ops);
+            run_case(
+                handle,
+                &in_memory_repo,
+                &persistent_repo,
+                &base,
+                &ops,
+                fail_on_warning,
+            );
             Ok(())
         });
 
@@ -189,6 +200,7 @@ pub fn run_long_test(config: LongTestConfig) -> Result<()> {
                     epoch,
                     ops_per_epoch,
                     cases_per_epoch,
+                    fail_on_warning,
                     base_commit: base.commit,
                     reason: reason.to_string(),
                     git_sha: std::env::var("GITHUB_SHA").unwrap_or_else(|_| "unknown".to_string()),
@@ -329,7 +341,14 @@ pub fn replay_failure(dir: &Path) -> Result<()> {
     // Apply the recorded operation sequence once and catch the resulting panic
     let ops: Vec<DatabaseOperation> = read_failure_file(dir, REGRESSION_FILE)?;
     let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        run_case(handle, &in_memory_repo, &persistent_repo, &base, &ops);
+        run_case(
+            handle,
+            &in_memory_repo,
+            &persistent_repo,
+            &base,
+            &ops,
+            meta.fail_on_warning,
+        );
     }));
 
     match outcome {
@@ -379,6 +398,7 @@ mod tests {
             time_budget: None,
             keep_epochs: Some(NonZeroUsize::new(2).expect("non-zero")),
             out_dir: None,
+            fail_on_warning: false,
         })
         .expect("the short long test run should succeed");
     }
@@ -441,6 +461,7 @@ mod tests {
             epoch: 0,
             ops_per_epoch: 1,
             cases_per_epoch: 1,
+            fail_on_warning: false,
             base_commit,
             reason: "test".to_string(),
             git_sha: "test".to_string(),

--- a/durable-storage/src/long_test/database/run_case.rs
+++ b/durable-storage/src/long_test/database/run_case.rs
@@ -31,6 +31,8 @@ use crate::test_helpers::database::DatabaseOperation;
 use crate::test_helpers::database::DatabaseReferenceModel;
 use crate::test_helpers::database::check_and_apply_value_operation;
 use crate::test_helpers::database::prove_and_verify_database_operation;
+use crate::test_helpers::proof_size::assert_proof_size;
+use crate::test_helpers::proof_size::database_operation_proof_size_bound;
 
 /// State carried while applying a sequence of operations to all targets.
 struct Targets {
@@ -72,10 +74,17 @@ fn checkout_targets(
 /// proof for every provable operation.
 fn apply_sequence(targets: &mut Targets, ops: &[DatabaseOperation], prove: bool) {
     for op in ops {
-        // Proofs are taken over the pre-operation state, so prove first.
+        // Proofs are taken over the pre-operation state, so prove first. The
+        // size bound is likewise computed over the pre-operation model.
         let proof_verify_out = if prove {
-            prove_and_verify_database_operation(targets.persistent_db.inner(), op)
-                .map(|(_proof, outcome)| outcome)
+            let bound = database_operation_proof_size_bound(&targets.model, op);
+            prove_and_verify_database_operation(targets.persistent_db.inner(), op).map(
+                |(proof, outcome)| {
+                    let bound = bound.expect("provable operations have a size bound");
+                    assert_proof_size(op, proof.len(), bound);
+                    outcome
+                },
+            )
         } else {
             None
         };

--- a/durable-storage/src/long_test/database/run_case.rs
+++ b/durable-storage/src/long_test/database/run_case.rs
@@ -71,8 +71,14 @@ fn checkout_targets(
 }
 
 /// Apply `ops` to all targets in lockstep, optionally producing and verifying a
-/// proof for every provable operation.
-fn apply_sequence(targets: &mut Targets, ops: &[DatabaseOperation], prove: bool) {
+/// proof for every provable operation. `fail_on_warning` escalates proof size
+/// warnings into failures.
+fn apply_sequence(
+    targets: &mut Targets,
+    ops: &[DatabaseOperation],
+    prove: bool,
+    fail_on_warning: bool,
+) {
     for op in ops {
         // Proofs are taken over the pre-operation state, so prove first. The
         // size bound is likewise computed over the pre-operation model.
@@ -81,7 +87,7 @@ fn apply_sequence(targets: &mut Targets, ops: &[DatabaseOperation], prove: bool)
             prove_and_verify_database_operation(targets.persistent_db.inner(), op).map(
                 |(proof, outcome)| {
                     let bound = bound.expect("provable operations have a size bound");
-                    assert_proof_size(op, proof.len(), bound);
+                    assert_proof_size(op, proof.len(), bound, fail_on_warning);
                     outcome
                 },
             )
@@ -148,9 +154,10 @@ pub fn run_case(
     persistent_repo: &DirectoryManager,
     base: &Base<LongTestModel>,
     ops: &[DatabaseOperation],
+    fail_on_warning: bool,
 ) {
     let mut targets = checkout_targets(handle, in_memory_repo, persistent_repo, base);
-    apply_sequence(&mut targets, ops, true);
+    apply_sequence(&mut targets, ops, true, fail_on_warning);
     check_consistency(targets);
 }
 
@@ -164,7 +171,7 @@ pub fn advance_base(
     ops: &[DatabaseOperation],
 ) -> Base<LongTestModel> {
     let mut targets = checkout_targets(handle, in_memory_repo, persistent_repo, base);
-    apply_sequence(&mut targets, ops, false);
+    apply_sequence(&mut targets, ops, false, false);
 
     let in_memory_commit = targets
         .in_memory_db

--- a/durable-storage/src/long_test/harness.rs
+++ b/durable-storage/src/long_test/harness.rs
@@ -43,6 +43,9 @@ pub struct LongTestConfig {
     pub keep_epochs: Option<NonZeroUsize>,
     /// Directory for run state and failure artifacts. `None` uses a tempdir.
     pub out_dir: Option<PathBuf>,
+    /// Fail the test when a proof size exceeds the maximum, instead of printing
+    /// a warning.
+    pub fail_on_warning: bool,
 }
 
 impl LongTestConfig {
@@ -94,6 +97,8 @@ pub(crate) struct FailureMeta {
     pub ops_per_epoch: usize,
     /// Test cases per epoch.
     pub cases_per_epoch: u32,
+    /// Whether warnings are escalated to failures.
+    pub fail_on_warning: bool,
     /// The commit identifying the failing epoch's starting state.
     pub base_commit: CommitId,
     /// Short description of the failure.

--- a/durable-storage/src/long_test/registry/gc.rs
+++ b/durable-storage/src/long_test/registry/gc.rs
@@ -181,6 +181,7 @@ mod tests {
                 time_budget: None,
                 keep_epochs: Some(NonZeroUsize::new(1).expect("non-zero")),
                 out_dir: Some(out_dir.clone()),
+                fail_on_warning: false,
             },
             2,
             false,

--- a/durable-storage/src/long_test/registry/mod.rs
+++ b/durable-storage/src/long_test/registry/mod.rs
@@ -82,6 +82,7 @@ pub fn run_long_test(
     let ops_per_epoch = config.ops_per_epoch;
     let cases_per_epoch = config.cases_per_epoch;
     let keep_epochs = config.keep_epochs;
+    let fail_on_warning = config.fail_on_warning;
     let out_dir = match config.out_dir.clone() {
         Some(dir) => {
             fs::create_dir_all(&dir)
@@ -110,6 +111,9 @@ pub fn run_long_test(
     }
     if keep_stable_size {
         rerun.push_str(" --keep-stable-size");
+    }
+    if config.fail_on_warning {
+        rerun.push_str(" --fail-on-warning");
     }
     eprintln!(
         "test directory: {} | ops/epoch: {ops_per_epoch} | cases/epoch: {cases_per_epoch} | \
@@ -152,7 +156,13 @@ pub fn run_long_test(
             ops_per_epoch,
         );
         let result = runner.run(&strategy, |ops| {
-            run_case(&in_memory_repo, &persistent_repo, &base, &ops);
+            run_case(
+                &in_memory_repo,
+                &persistent_repo,
+                &base,
+                &ops,
+                fail_on_warning,
+            );
             Ok(())
         });
 
@@ -195,6 +205,7 @@ pub fn run_long_test(
                     epoch,
                     ops_per_epoch,
                     cases_per_epoch,
+                    fail_on_warning,
                     base_commit: base.commit,
                     reason: reason.to_string(),
                     git_sha: std::env::var("GITHUB_SHA").unwrap_or_else(|_| "unknown".to_string()),
@@ -371,7 +382,13 @@ pub fn replay_failure(dir: &Path) -> Result<()> {
     let ops: Vec<RegistryOperation> = read_failure_file(dir, REGRESSION_FILE)?;
 
     let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        run_case(&in_memory_repo, &persistent_repo, &base, &ops);
+        run_case(
+            &in_memory_repo,
+            &persistent_repo,
+            &base,
+            &ops,
+            meta.fail_on_warning,
+        );
     }));
 
     match outcome {
@@ -418,6 +435,7 @@ mod tests {
             time_budget: None,
             keep_epochs: Some(NonZeroUsize::new(2).expect("non-zero")),
             out_dir: None,
+            fail_on_warning: false,
         }
     }
 
@@ -481,6 +499,7 @@ mod tests {
             epoch: 0,
             ops_per_epoch: 1,
             cases_per_epoch: 1,
+            fail_on_warning: false,
             base_commit,
             reason: "test".to_string(),
             git_sha: "test".to_string(),

--- a/durable-storage/src/long_test/registry/run_case.rs
+++ b/durable-storage/src/long_test/registry/run_case.rs
@@ -25,6 +25,8 @@ use crate::repo::DirectoryManager;
 use crate::storage::in_memory::InMemoryKeyValueStore;
 use crate::storage::in_memory::InMemoryRepo;
 use crate::test_helpers::database::check_and_apply_value_operation;
+use crate::test_helpers::proof_size::assert_proof_size;
+use crate::test_helpers::proof_size::registry_operation_proof_size_bound;
 use crate::test_helpers::registry::RegistryOperation;
 use crate::test_helpers::registry::grow_registry;
 use crate::test_helpers::registry::prove_and_verify_registry_operation;
@@ -107,9 +109,15 @@ fn checkout_targets(
 /// producing and verifying a proof for every provable operation.
 fn apply_sequence(targets: &mut Targets, ops: &[RegistryOperation], prove: bool) {
     for op in ops {
-        // Proofs are taken over the pre-operation state, so prove first.
+        // Proofs are taken over the pre-operation state, so prove first. The
+        // size bound is likewise computed over the pre-operation model.
         if prove {
-            prove_and_verify_registry_operation(&targets.persistent, op);
+            let bound = registry_operation_proof_size_bound(&targets.model.databases, op);
+            let proof = prove_and_verify_registry_operation(&targets.persistent, op);
+            if let Some(proof) = proof {
+                let bound = bound.expect("provable operations have a size bound");
+                assert_proof_size(op, proof.len(), bound);
+            }
         }
 
         apply_op_checked(&mut targets.in_memory, &targets.model, op);

--- a/durable-storage/src/long_test/registry/run_case.rs
+++ b/durable-storage/src/long_test/registry/run_case.rs
@@ -107,7 +107,13 @@ fn checkout_targets(
 
 /// Apply `ops` to both registries and the model in lockstep, optionally
 /// producing and verifying a proof for every provable operation.
-fn apply_sequence(targets: &mut Targets, ops: &[RegistryOperation], prove: bool) {
+/// `fail_on_warning` escalates proof size warnings into failures.
+fn apply_sequence(
+    targets: &mut Targets,
+    ops: &[RegistryOperation],
+    prove: bool,
+    fail_on_warning: bool,
+) {
     for op in ops {
         // Proofs are taken over the pre-operation state, so prove first. The
         // size bound is likewise computed over the pre-operation model.
@@ -116,7 +122,7 @@ fn apply_sequence(targets: &mut Targets, ops: &[RegistryOperation], prove: bool)
             let proof = prove_and_verify_registry_operation(&targets.persistent, op);
             if let Some(proof) = proof {
                 let bound = bound.expect("provable operations have a size bound");
-                assert_proof_size(op, proof.len(), bound);
+                assert_proof_size(op, proof.len(), bound, fail_on_warning);
             }
         }
 
@@ -133,9 +139,10 @@ pub fn run_case(
     persistent_repo: &DirectoryManager,
     base: &Base<RegistryLongTestModel>,
     ops: &[RegistryOperation],
+    fail_on_warning: bool,
 ) {
     let mut targets = checkout_targets(in_memory_repo, persistent_repo, base);
-    apply_sequence(&mut targets, ops, true);
+    apply_sequence(&mut targets, ops, true, fail_on_warning);
 
     let in_memory_root = Hash::from_foldable(&targets.in_memory);
     let persistent_root = Hash::from_foldable(&targets.persistent);
@@ -154,7 +161,7 @@ pub fn advance_base(
     ops: &[RegistryOperation],
 ) -> Base<RegistryLongTestModel> {
     let mut targets = checkout_targets(in_memory_repo, persistent_repo, base);
-    apply_sequence(&mut targets, ops, false);
+    apply_sequence(&mut targets, ops, false, false);
 
     let in_memory_commit = targets
         .in_memory

--- a/durable-storage/src/test_helpers.rs
+++ b/durable-storage/src/test_helpers.rs
@@ -15,6 +15,7 @@
 //! [`Registry`]: crate::registry::Registry
 
 pub mod database;
+pub(crate) mod proof_size;
 pub mod registry;
 
 use bytes::Bytes;

--- a/durable-storage/src/test_helpers/database.rs
+++ b/durable-storage/src/test_helpers/database.rs
@@ -43,6 +43,10 @@ use crate::merkle_worker::BackgroundPersistentKeyValueStore;
 use crate::test_helpers::OperationView;
 use crate::test_helpers::StepOutcome;
 use crate::test_helpers::outcome_from_value;
+#[cfg(test)]
+use crate::test_helpers::proof_size::assert_proof_size;
+#[cfg(test)]
+use crate::test_helpers::proof_size::database_operation_proof_size_bound;
 
 /// Maximum size for the value argument of a sampled operation
 pub(crate) const VALUE_MAX_SIZE: usize = 10_000;
@@ -811,7 +815,13 @@ where
 
     for operation in operations {
         // Provable operations are proven over their pre-operation state, so prove before applying.
+        // The size bound is likewise computed over the pre-operation model.
+        let bound = database_operation_proof_size_bound(&model, &operation);
         let proof_and_outcome = prove_and_verify_database_operation(&database, &operation);
+        if let Some((proof, _)) = &proof_and_outcome {
+            let bound = bound.expect("provable operations have a size bound");
+            assert_proof_size(&operation, proof.len(), bound);
+        }
 
         let normal_outcome = apply_database_operation_with_model::<KV, _>(
             &mut database,

--- a/durable-storage/src/test_helpers/database.rs
+++ b/durable-storage/src/test_helpers/database.rs
@@ -820,7 +820,7 @@ where
         let proof_and_outcome = prove_and_verify_database_operation(&database, &operation);
         if let Some((proof, _)) = &proof_and_outcome {
             let bound = bound.expect("provable operations have a size bound");
-            assert_proof_size(&operation, proof.len(), bound);
+            assert_proof_size(&operation, proof.len(), bound, false);
         }
 
         let normal_outcome = apply_database_operation_with_model::<KV, _>(

--- a/durable-storage/src/test_helpers/proof_size.rs
+++ b/durable-storage/src/test_helpers/proof_size.rs
@@ -1,0 +1,387 @@
+// SPDX-FileCopyrightText: 2026 Nomadic Labs <contact@nomadic-labs.com>
+//
+// SPDX-License-Identifier: MIT
+
+//! Model for upper bound on Regsitry and Database proof size
+//!
+//! Every Database proof is checked against the worst case model for the current
+//! number of keys in tree shape and key sizes: the deepest AVL shape (a
+//! Fibonacci-minimal tree), every key at [`KEY_MAX_SIZE`], and the most
+//! expensive rebalancing per operation type (one rotation for an insert,
+//! `floor((depth - 1) / 2)` for a delete). Operation value sizes are real:
+//! the lengths and the byte ranges an operation touches are taken from
+//! the [`DatabaseReferenceModel`].
+//!
+//! The bounds mirror the proof encoding: pre-order tree with a one-byte tag per
+//! node or leaf, a `Blind` leaf carrying a hash and a `Read` leaf carrying raw
+//! bytes (see the `Encode` impl in `octez_riscv_data::merkle_proof::proof_tree`).
+
+use std::collections::BTreeSet;
+use std::ops::Range;
+
+use octez_riscv_data::components::bytes::NODE_ARITY as BYTES_NODE_ARITY;
+use octez_riscv_data::components::bytes::PAGE_SIZE;
+use octez_riscv_data::components::vector::NODE_ARITY as VECTOR_NODE_ARITY;
+use octez_riscv_data::foldable::seq_tree::tree_depth;
+use octez_riscv_data::hash::Hash;
+
+use crate::key::KEY_MAX_SIZE;
+use crate::test_helpers::database::DatabaseOperation;
+use crate::test_helpers::database::DatabaseReferenceModel;
+use crate::test_helpers::registry::RegistryOperation;
+
+/// Serialised size of a proof tree tag. Tags are written as one byte each by the
+/// `Encode` impl of `octez_riscv_data::merkle_proof::proof_tree::MerkleProof`.
+const TAG_BYTES: usize = 1;
+
+/// A `Blind` leaf: tag plus [`Hash::DIGEST_SIZE`] bytes.
+const BLIND_LEAF: usize = TAG_BYTES + Hash::DIGEST_SIZE;
+
+/// An accessed AVL tree wrapper: proof node tag plus a `Read` leaf holding the
+/// one-byte present flag (see `fold_resolved_tree` in `crate::merkle_layer`).
+const TREE_WRAP: usize = TAG_BYTES + TAG_BYTES + size_of::<bool>();
+
+/// A `Read` leaf holding a `u64` length (fixed-int bincode encoding).
+const LEN_LEAF: usize = TAG_BYTES + size_of::<u64>();
+
+/// A `Read` leaf holding a node's `i64` balance factor (fixed-int bincode
+/// encoding).
+const BALANCE_FACTOR_LEAF: usize = TAG_BYTES + size_of::<i64>();
+
+/// A `Read` leaf holding a node's [`Key`]: a one-byte length
+/// prefix plus the key bytes (see the `Encode` impl in `crate::key`).
+///
+/// [`Key`]: crate::key::Key
+fn key_leaf(key_len: usize) -> usize {
+    assert!(key_len <= KEY_MAX_SIZE);
+    TAG_BYTES + 1 + key_len
+}
+
+/// An accessed node on the search path: tree wrapper, node tag, balance factor
+/// and key leaves, blinded data and one blinded sibling subtree. The balance
+/// factor is shorter than a hash so it is always included directly. The key is
+/// also always included in full, never blinded: generating the proof reads
+/// every accessed node's key. The subtree the path continues into is charged
+/// by its own level; the terminal node's second child is charged
+/// via [`terminal_blind`].
+fn avl_path_node(key_len: usize) -> usize {
+    TREE_WRAP + TAG_BYTES + BALANCE_FACTOR_LEAF + key_leaf(key_len) + 2 * BLIND_LEAF
+}
+
+/// An accessed node off the search path (touched by a rebalancing rotation):
+/// like [`avl_path_node`], but both children may be blinded.
+fn avl_extra_node() -> usize {
+    avl_path_node(KEY_MAX_SIZE) + BLIND_LEAF
+}
+
+/// The blinded second child of the last node on a path.
+const fn terminal_blind(path_len: usize) -> usize {
+    if path_len == 0 { 0 } else { BLIND_LEAF }
+}
+
+/// Worst-case depth of an AVL tree holding `entries` nodes: the largest height
+/// whose minimal node count `N(h) = N(h - 1) + N(h - 2) + 1` still fits. The
+/// counts are computed in `u128`, which cannot overflow before exceeding any
+/// `usize` entry count.
+fn max_avl_depth(entries: usize) -> usize {
+    let entries = entries as u128;
+    let (mut depth, mut prev, mut min_nodes) = (0, 0u128, 0u128);
+    loop {
+        let next = min_nodes + prev + 1;
+        if next > entries {
+            return depth;
+        }
+        (depth, prev, min_nodes) = (depth + 1, min_nodes, next);
+    }
+}
+
+/// Cost of a worst-case search path in a tree of the given depth, every key
+/// charged at [`KEY_MAX_SIZE`].
+fn avl_search_path(depth: usize) -> usize {
+    depth * avl_path_node(KEY_MAX_SIZE) + terminal_blind(depth)
+}
+
+/// Bound on an opened value subtree: the `Bytes` component folds as a node of
+/// a `u64` length leaf and a page tree of arity [`BYTES_NODE_ARITY`] with
+/// [`PAGE_SIZE`]-byte page leaves (each a tag, a `u64` chunk length and the
+/// page's content). `byte_ranges` are the value's byte ranges read or written
+/// by the operation; every touched page is charged its content plus one full
+/// branch of blinded siblings per tree layer. The branch charge deliberately
+/// over-counts: touched pages can share their upper layers in the real proof
+/// and siblings that are themselves touched are not blinded.
+fn value_open(value_len: usize, byte_ranges: &[Range<usize>]) -> usize {
+    let pages = value_len.div_ceil(PAGE_SIZE);
+    let depth = tree_depth(pages, BYTES_NODE_ARITY) as usize;
+    let touched = touched_pages(value_len, byte_ranges);
+
+    let page_leaves: usize = touched
+        .iter()
+        .map(|page| {
+            let content = PAGE_SIZE.min(value_len - page * PAGE_SIZE);
+            TAG_BYTES + size_of::<u64>() + content
+        })
+        .sum();
+    let layers = depth * touched.len() * (TAG_BYTES + (BYTES_NODE_ARITY - 1) * BLIND_LEAF);
+
+    TAG_BYTES + LEN_LEAF + (page_leaves + layers).max(BLIND_LEAF)
+}
+
+/// The pages of a value of `value_len` bytes touched by the given byte ranges,
+/// after clamping each range to the value's length.
+fn touched_pages(value_len: usize, byte_ranges: &[Range<usize>]) -> BTreeSet<usize> {
+    let mut pages = BTreeSet::new();
+    for range in byte_ranges {
+        let start = range.start.min(value_len);
+        let end = range.end.min(value_len);
+        if start < end {
+            pages.extend(start / PAGE_SIZE..=(end - 1) / PAGE_SIZE);
+        }
+    }
+    pages
+}
+
+/// The single-byte range read by `record_resize_boundary_dependency` (see
+/// `octez_riscv_data::components::bytes`) when a value is resized from
+/// `prev_len` to `new_len`.
+fn resize_boundary(prev_len: usize, new_len: usize) -> Range<usize> {
+    let boundary = prev_len.min(new_len);
+    if boundary == 0 || prev_len == new_len {
+        0..0
+    } else {
+        boundary - 1..boundary
+    }
+}
+
+/// The value byte ranges an operation reads or writes; empty ranges are
+/// ignored by [`value_open`].
+fn value_byte_ranges(op: &DatabaseOperation, value_len: usize) -> [Range<usize>; 2] {
+    match op {
+        DatabaseOperation::Read(_, offset, len) => [*offset..offset.saturating_add(*len), 0..0],
+        DatabaseOperation::Write(_, offset, data) => {
+            let end = offset.saturating_add(data.len());
+            [*offset..end, resize_boundary(value_len, end.max(value_len))]
+        }
+        // TODO TZX-197: once the prover stops including pages fully covered by
+        // writes, `Set` needs no pre-value content (the resize boundary byte is
+        // always inside the overwritten prefix); drop both ranges here.
+        DatabaseOperation::Set(_, data) => [0..data.len(), resize_boundary(value_len, data.len())],
+        _ => [0..0, 0..0],
+    }
+}
+
+/// Assert an actual serialised proof size is within the modelled bound.
+pub(crate) fn assert_proof_size(op: &impl std::fmt::Debug, actual: usize, bound: usize) {
+    assert!(
+        actual <= bound,
+        "proof size {actual} exceeds the modelled bound {bound} for {op:?}"
+    );
+}
+
+/// Bound on the serialised proof size of a database operation: the worst-case
+/// tree shape and key sizes admitted by the pre-operation model's entry count,
+/// with the model's real value sizes. `None` if the operation is not a provable
+/// step.
+pub(crate) fn database_operation_proof_size_bound(
+    model: &impl DatabaseReferenceModel,
+    op: &DatabaseOperation,
+) -> Option<usize> {
+    let key = match op {
+        DatabaseOperation::Commit
+        | DatabaseOperation::Checkout
+        | DatabaseOperation::CommitCheckoutRoundtrip => return None,
+        DatabaseOperation::Hash => return Some(BLIND_LEAF),
+        DatabaseOperation::Set(key, _)
+        | DatabaseOperation::Write(key, _, _)
+        | DatabaseOperation::Read(key, _, _)
+        | DatabaseOperation::Delete(key)
+        | DatabaseOperation::Exists(key)
+        | DatabaseOperation::ValueLength(key) => key,
+    };
+
+    let depth = max_avl_depth(model.data().len());
+    let exists = model.data().contains_key(key);
+    let mut cost = 0;
+
+    match op {
+        DatabaseOperation::Set(..) | DatabaseOperation::Write(..) if !exists => {
+            // A fresh insert rebalances at most once: one rotation touches
+            // up to two nodes off the search path.
+            cost += avl_search_path(depth) + 2 * avl_extra_node();
+        }
+        DatabaseOperation::Delete(_) if exists => {
+            // A delete also walks the in-order-successor path, but the
+            // successor is a descendant of the deleted node, so the union
+            // of both paths is a single root-to-leaf path. On the way back
+            // up, a rotation fires only at path nodes whose strictly
+            // shorter subtree the path descended into, and such a step
+            // descends two height levels while any other descends one: a
+            // path of `p` nodes with `s` rotations satisfies
+            // `p + s <= depth`. A rotation (up to two extra nodes) costs
+            // more than a path node, so the worst case takes the maximal
+            // `s = (depth - 1) / 2` with `p = depth - s`.
+            let rotations = (depth - 1) / 2;
+            cost += avl_search_path(depth - rotations);
+            cost += rotations * 2 * avl_extra_node();
+        }
+        _ => cost += avl_search_path(depth),
+    }
+
+    // Only operations that open the value subtree pay for it. `Delete`
+    // drops the node with its data child blinded (already charged by the
+    // path node) and `Exists` checks node presence alone, so neither
+    // reads the value or its length.
+    let opens_value = matches!(
+        op,
+        DatabaseOperation::Set(..)
+            | DatabaseOperation::Write(..)
+            | DatabaseOperation::Read(..)
+            | DatabaseOperation::ValueLength(_)
+    );
+
+    if exists && opens_value {
+        // The path node's blinded-data charge is deliberately kept even
+        // though the data child is opened and charged by `value_open`.
+        let value_len = model.data()[key].len();
+        cost += value_open(value_len, &value_byte_ranges(op, value_len));
+    }
+
+    // An untouched database is compressed to a single blinded leaf.
+    Some(cost.max(BLIND_LEAF))
+}
+
+/// Bound on the serialised proof size of a registry operation, computed over the
+/// pre-operation reference models (one per registry slot). `None` if the
+/// operation is not a provable step.
+///
+/// A registry proof is prefixed with the final state hash (see `serialise_proof`
+/// in `octez_riscv_data::merkle_proof::proof`) and folds as a node of a `u64`
+/// length leaf and a slot tree of arity [`VECTOR_NODE_ARITY`]; each touched slot
+/// costs one branch of blinded siblings per layer plus its blinded content.
+pub(crate) fn registry_operation_proof_size_bound<M: DatabaseReferenceModel>(
+    databases: &[M],
+    op: &RegistryOperation,
+) -> Option<usize> {
+    let depth = tree_depth(databases.len(), VECTOR_NODE_ARITY) as usize;
+    let slot_path = depth * (TAG_BYTES + (VECTOR_NODE_ARITY - 1) * BLIND_LEAF) + BLIND_LEAF;
+
+    let (touched_slots, inner) = match op {
+        RegistryOperation::CommitCheckoutRoundtrip => return None,
+        RegistryOperation::Database(index, db_op) => {
+            let model = databases.get(*index).expect("The index is in bounds");
+            (1, database_operation_proof_size_bound(model, db_op)?)
+        }
+        RegistryOperation::GrowRegistry
+        | RegistryOperation::ShrinkRegistry
+        | RegistryOperation::ClearDatabase(_) => (1, 0),
+        RegistryOperation::CopyDatabase(..) | RegistryOperation::MoveDatabase(..) => (2, 0),
+    };
+
+    Some(Hash::DIGEST_SIZE + TAG_BYTES + BLIND_LEAF + touched_slots * slot_path + inner)
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use tezos_smart_rollup_constants::core::MAX_FILE_CHUNK_SIZE;
+
+    use super::*;
+    use crate::key::Key;
+
+    #[test]
+    #[expect(
+        clippy::single_range_in_vec_init,
+        reason = "the arrays are slices of byte ranges, not range initialisers"
+    )]
+    fn touched_pages_track_page_size() {
+        let len = 4 * PAGE_SIZE + PAGE_SIZE / 2;
+
+        assert_eq!(touched_pages(len, &[0..1]), BTreeSet::from([0]));
+        assert_eq!(
+            touched_pages(len, &[PAGE_SIZE - 1..PAGE_SIZE + 1]),
+            BTreeSet::from([0, 1])
+        );
+        // Ranges are clamped to the value length.
+        assert_eq!(
+            touched_pages(len, &[len - 1..len + PAGE_SIZE]),
+            BTreeSet::from([4])
+        );
+        // Empty and out-of-bounds ranges touch nothing.
+        assert!(touched_pages(len, &[PAGE_SIZE..PAGE_SIZE, len..len + 1]).is_empty());
+    }
+
+    // The page counts behind the data cost of chunk-bounded operations,
+    // stated in terms of [`PAGE_SIZE`] and [`MAX_FILE_CHUNK_SIZE`] so they
+    // hold whatever values those parameters take: a `Write`'s data range may
+    // span `ceil(MAX_FILE_CHUNK_SIZE / PAGE_SIZE) + 1` pages when unaligned
+    // (its resize boundary byte never adds a page beyond the last old byte's),
+    // while a `Set` starts at offset zero and so always touches one page
+    // fewer.
+    #[test]
+    fn operation_page_counts_respect_chunk_and_page_parameters() {
+        let key = Key::new(b"key").expect("valid key");
+        let value_len = MAX_FILE_CHUNK_SIZE + 4 * PAGE_SIZE + PAGE_SIZE / 2;
+        let chunk_pages = MAX_FILE_CHUNK_SIZE.div_ceil(PAGE_SIZE);
+
+        let pages_for = |op: &DatabaseOperation| {
+            touched_pages(value_len, &value_byte_ranges(op, value_len)).len()
+        };
+
+        let max_write = [
+            0,
+            1,
+            PAGE_SIZE / 2,
+            PAGE_SIZE - 1,
+            PAGE_SIZE,
+            2 * PAGE_SIZE - 1,
+            value_len - 1,
+            value_len,
+        ]
+        .into_iter()
+        .map(|offset| {
+            let chunk = Bytes::from(vec![0u8; MAX_FILE_CHUNK_SIZE]);
+            let write = pages_for(&DatabaseOperation::Write(key.clone(), offset, chunk));
+            let read = pages_for(&DatabaseOperation::Read(
+                key.clone(),
+                offset,
+                MAX_FILE_CHUNK_SIZE,
+            ));
+            assert!(read <= write, "a read touches no more pages than a write");
+            write
+        })
+        .max()
+        .expect("the offset list is not empty");
+
+        let max_set = [1, MAX_FILE_CHUNK_SIZE]
+            .into_iter()
+            .map(|len| {
+                pages_for(&DatabaseOperation::Set(
+                    key.clone(),
+                    Bytes::from(vec![0u8; len]),
+                ))
+            })
+            .max()
+            .expect("the length list is not empty");
+
+        assert_eq!(max_write, chunk_pages + 1);
+        assert_eq!(max_set, chunk_pages);
+    }
+
+    #[test]
+    fn max_avl_depth_matches_minimal_tree_sizes() {
+        let expected = [
+            (0, 0),
+            (1, 1),
+            (2, 2),
+            (3, 2),
+            (4, 3),
+            (6, 3),
+            (7, 4),
+            (11, 4),
+            (12, 5),
+            (u64::MAX as usize, 91),
+        ];
+        for (entries, depth) in expected {
+            assert_eq!(max_avl_depth(entries), depth, "for {entries} entries");
+        }
+    }
+}

--- a/durable-storage/src/test_helpers/proof_size.rs
+++ b/durable-storage/src/test_helpers/proof_size.rs
@@ -169,12 +169,40 @@ fn value_byte_ranges(op: &DatabaseOperation, value_len: usize) -> [Range<usize>;
     }
 }
 
+/// Ceiling on serialised proof sizes. Proofs above it are reported by
+/// [`assert_proof_size`].
+const MAXIMUM_PROOF_SIZE: usize = 16 * 1024;
+
+/// Print a warning, or panic when `fail_on_warning` is set.
+fn report_over_maximum(fail_on_warning: bool, message: String) {
+    if fail_on_warning {
+        panic!("{message}");
+    }
+    eprintln!("warning: {message}");
+}
+
 /// Assert an actual serialised proof size is within the modelled bound.
-pub(crate) fn assert_proof_size(op: &impl std::fmt::Debug, actual: usize, bound: usize) {
+/// Sizes above [`MAXIMUM_PROOF_SIZE`] are reported as warnings, or as test
+/// failures when `fail_on_warning` is set.
+pub(crate) fn assert_proof_size(
+    op: &impl std::fmt::Debug,
+    actual: usize,
+    bound: usize,
+    fail_on_warning: bool,
+) {
     assert!(
         actual <= bound,
         "proof size {actual} exceeds the modelled bound {bound} for {op:?}"
     );
+
+    if actual > MAXIMUM_PROOF_SIZE {
+        report_over_maximum(
+            fail_on_warning,
+            format!(
+                "proof size {actual} exceeds MAXIMUM_PROOF_SIZE {MAXIMUM_PROOF_SIZE} for {op:?}"
+            ),
+        );
+    }
 }
 
 /// Bound on the serialised proof size of a database operation: the worst-case

--- a/durable-storage/src/test_helpers/registry.rs
+++ b/durable-storage/src/test_helpers/registry.rs
@@ -41,6 +41,8 @@ use crate::registry::Registry;
 use crate::registry::RegistryMode;
 use crate::repo::RegistryRepo;
 use crate::test_helpers::OperationView;
+use crate::test_helpers::proof_size::assert_proof_size;
+use crate::test_helpers::proof_size::registry_operation_proof_size_bound;
 
 /// Operations on a [`Registry`]
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -316,7 +318,11 @@ where
     grow_registry_with_model(&mut registry, &mut registry_model);
 
     for operation in operations {
+        // The size bound is computed over the pre-operation model.
+        let bound = registry_operation_proof_size_bound(&registry_model, &operation);
         if let Some(proof) = prove_and_verify_registry_operation(&registry, &operation) {
+            let bound = bound.expect("provable operations have a size bound");
+            assert_proof_size(&operation, proof.len(), bound);
             proof_steps.push(RegistryProofStep {
                 step: operation.clone(),
                 proof,
@@ -394,9 +400,7 @@ where
                     .clear_database(index)
                     .expect("Clearing the database should be successful");
 
-                registry_model[index].data.clear();
-                registry_model[index].ambiguous_hash = false;
-                registry_model[index].last = None;
+                registry_model[index] = DatabaseModel::default();
             }
             RegistryOperation::CopyDatabase(src, dst) => {
                 registry

--- a/durable-storage/src/test_helpers/registry.rs
+++ b/durable-storage/src/test_helpers/registry.rs
@@ -322,7 +322,7 @@ where
         let bound = registry_operation_proof_size_bound(&registry_model, &operation);
         if let Some(proof) = prove_and_verify_registry_operation(&registry, &operation) {
             let bound = bound.expect("provable operations have a size bound");
-            assert_proof_size(&operation, proof.len(), bound);
+            assert_proof_size(&operation, proof.len(), bound, false);
             proof_steps.push(RegistryProofStep {
                 step: operation.clone(),
                 proof,


### PR DESCRIPTION
Part of TZX-188.

# What

Introduces a proof size model, which, given the reference model for a Database or Registry and an operation on that Database or Registry, models the maximum expected size for the proof of that operation. 

An extra check is introduced in both regular and long tests: every proof is smaller than both its modelled bound and 16 KiB.

# Why

To introduce a meaningful check that produced proofs have the expected size and to model what we expect to be the least well-behaved proofs.

# How

The model makes the least favourable assumptions for every operation, for both Registry and Database: maximum size for keys and stored values, longest unblinded paths in the tree, no path sharing, maximum number of rotations where applicable. The goal is for the model to be a realistic, strict upper bound on proof size, against which we can compare actual proofs during testing.

The tightness of the bound was evaluated on a run of each of the Database (blue) and Registry (red) long tests. Every point can correspond to multiple samples.

<img width="1180" height="1182" alt="image" src="https://github.com/user-attachments/assets/2a243263-7538-4c6d-bf52-9ed993ffbb26" />


# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
