### PR TITLE
feat(nds): reduce resolution lookups and overall disk size for databases

### DIFF
--- a/durable-storage/src/avl/node.rs
+++ b/durable-storage/src/avl/node.rs
@@ -869,7 +869,8 @@ where
         options: &StoreOptions,
     ) -> Result<(), OperationalError> {
         // The stored representation is more compact. We don't include the `data` field, as that
-        // should be written to the KV store separately.
+        // should be written to the KV store separately. `left`/`right` are the hashes of the
+        // child *trees* (the same values folded into this node's hash).
         let repr = StoredNode {
             balance_factor: self.balance_factor.read(),
             key: self.key.deref().clone(),
@@ -878,9 +879,14 @@ where
             right: Hash::from_foldable(&self.right),
         };
 
-        let &id = self.hash();
+        // Persist the node body under the hash of the *tree* that holds it, rather than under
+        // the node's own hash. A present tree hashes as `H(present_flag, node_hash)`, so a
+        // resolver descending from a parent's child-tree hash reaches this body in a single
+        // lookup instead of first reading a tree->node pointer. The hashes themselves are
+        // unchanged, so commitments and proofs are unaffected.
+        let tree_hash = Tree::<Hash>::present_hash(*self.hash());
         let bytes = serialise(repr)?;
-        store.blob_set(id, bytes)?;
+        store.blob_set(tree_hash, bytes)?;
 
         // Are we in charge of writing the value data to the KV store?
         if options.node_data() {

--- a/durable-storage/src/avl/node.rs
+++ b/durable-storage/src/avl/node.rs
@@ -889,10 +889,8 @@ where
             store.set(key, value)?;
         }
 
-        if options.deep() {
-            self.left.store(store, options)?;
-            self.right.store(store, options)?;
-        }
+        self.left.store(store, options)?;
+        self.right.store(store, options)?;
 
         Ok(())
     }

--- a/durable-storage/src/avl/resolver.rs
+++ b/durable-storage/src/avl/resolver.rs
@@ -1245,17 +1245,13 @@ impl DataResolver<Bytes<Verify>, Verify> for VerifyResolver {
 
 #[cfg(test)]
 mod tests {
-    use std::borrow::Borrow;
     use std::sync::Arc;
     use std::sync::OnceLock;
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering;
 
     use octez_riscv_data::components::bytes::Bytes;
-    use octez_riscv_data::foldable::Foldable;
     use octez_riscv_data::hash::Hash;
-    use octez_riscv_data::hash::HashFold;
-    use octez_riscv_data::mode::Normal;
     use octez_riscv_data::mode::Verify;
     use octez_riscv_data::mode::utils::NotFound;
     use octez_riscv_data::mode::utils::catch_not_found;
@@ -1273,7 +1269,6 @@ mod tests {
     use super::VerifyResolver;
     use super::VerifyTreeId;
     use crate::avl::node::Node;
-    use crate::avl::resolver::AvlResolver;
     use crate::avl::tree::Tree;
     use crate::errors::Error;
     use crate::errors::OperationalError;
@@ -1354,45 +1349,17 @@ mod tests {
         }
     }
 
-    fn persist_tree<NodeId, DataId, TreeId, Res, KV>(
+    fn persist_tree<NodeId, KV>(
         tree: &Tree<NodeId>,
-        resolver: &Res,
         persistence_layer: &KV,
     ) where
         NodeId: Storable,
-        TreeId: Storable,
-        DataId: Foldable<HashFold> + Borrow<[u8]>,
         KV: KeyValueStore,
-        Res: AvlResolver<NodeId, DataId, TreeId, Normal>,
     {
-        let store_options = StoreOptions::default().with_shallow().with_node_data();
+        let store_options = StoreOptions::default().with_node_data();
 
         tree.store(persistence_layer, &store_options)
             .expect("persisting tree should succeed");
-
-        let Some(node_id) = tree.root() else {
-            return;
-        };
-
-        let node = resolver
-            .resolve(node_id)
-            .expect("resolving nodes should succeed");
-
-        node.store(persistence_layer, &store_options)
-            .expect("persisting node should succeed");
-
-        persist_tree(
-            node.left_ref(resolver)
-                .expect("left subtree should resolve"),
-            resolver,
-            persistence_layer,
-        );
-        persist_tree(
-            node.right_ref(resolver)
-                .expect("right subtree should resolve"),
-            resolver,
-            persistence_layer,
-        );
     }
 
     #[test]
@@ -1411,7 +1378,7 @@ mod tests {
         let root_hash = Hash::from_foldable(tree.root().expect("tree should have a root node"));
 
         let persistence_layer = Arc::new(CountingKeyValueStore::default());
-        persist_tree(&tree, &eager_resolver, persistence_layer.as_ref());
+        persist_tree(&tree, persistence_layer.as_ref());
 
         let lazy_resolver = LazyResolver::new(persistence_layer.clone());
         let lazy_tree: LazyTreeId = LazyTreeId::from(tree_hash);
@@ -1519,7 +1486,7 @@ mod tests {
         let root_hash = Hash::from_foldable(tree.root().expect("tree should have a root node"));
 
         let persistence_layer = Arc::new(CountingKeyValueStore::default());
-        persist_tree(&tree, &eager_resolver, persistence_layer.as_ref());
+        persist_tree(&tree, persistence_layer.as_ref());
 
         let mut node_id: LazyNodeId = LazyNodeId::from(root_hash);
         let mut lazy_resolver = LazyResolver::new(persistence_layer.clone());
@@ -1552,7 +1519,7 @@ mod tests {
         let root_hash = Hash::from_foldable(tree.root().expect("tree should have a root node"));
 
         let persistence_layer = Arc::new(CountingKeyValueStore::default());
-        persist_tree(&tree, &eager_resolver, persistence_layer.as_ref());
+        persist_tree(&tree, persistence_layer.as_ref());
 
         let mut lazy_tree: Tree<LazyNodeId> = Some(LazyNodeId::from(root_hash)).into();
         let mut lazy_resolver = LazyResolver::new(persistence_layer.clone());
@@ -1595,7 +1562,7 @@ mod tests {
         assert_eq!(data.as_slice(), b"root-mutated");
 
         let persisted_tree_hash = lazy_tree.hash();
-        persist_tree(&lazy_tree, &lazy_resolver, persistence_layer.as_ref());
+        persist_tree(&lazy_tree, persistence_layer.as_ref());
         assert_eq!(
             persistence_layer.blob_get_calls(),
             1,
@@ -1649,7 +1616,6 @@ mod tests {
         let persistence_layer = Arc::new(InMemoryKeyValueStore::default());
         persist_tree(
             &original_tree,
-            &original_resolver,
             persistence_layer.as_ref(),
         );
 
@@ -1695,7 +1661,7 @@ mod tests {
         let root_hash = Hash::from_foldable(tree.root().expect("tree should have a root node"));
 
         let persistence_layer = Arc::new(CountingKeyValueStore::default());
-        persist_tree(&tree, &resolver, persistence_layer.as_ref());
+        persist_tree(&tree, persistence_layer.as_ref());
 
         (root_hash, tree, persistence_layer)
     }

--- a/durable-storage/src/avl/resolver.rs
+++ b/durable-storage/src/avl/resolver.rs
@@ -297,9 +297,10 @@ impl From<Node<LazyTreeId, LazyDataId, Normal>> for LazyNodeId {
     }
 }
 
+#[cfg(test)]
 impl From<Hash> for LazyNodeId {
     fn from(hash: Hash) -> LazyNodeId {
-        LazyNodeId(hash.into())
+        LazyNodeId(LazyId::from(hash))
     }
 }
 
@@ -333,8 +334,12 @@ impl Storable for LazyNodeId {
 }
 
 impl Loadable for LazyNodeId {
-    fn load(id: Hash, _store: &impl KeyValueStore) -> Result<Self, OperationalError> {
-        Ok(Self::from(id))
+    fn load(id: Hash, store: &impl KeyValueStore) -> Result<Self, OperationalError> {
+        // `id` is the tree hash under which the node body is stored. Read it eagerly so that
+        // resolving the containing tree yields a fully-materialised node — with its children
+        // still lazy — in a single lookup, instead of deferring a second lookup for the body.
+        let node = Node::<LazyTreeId, LazyDataId, Normal>::load(id, store)?;
+        Ok(Self(LazyId::new(Arc::new(node))))
     }
 }
 
@@ -1349,10 +1354,8 @@ mod tests {
         }
     }
 
-    fn persist_tree<NodeId, KV>(
-        tree: &Tree<NodeId>,
-        persistence_layer: &KV,
-    ) where
+    fn persist_tree<NodeId, KV>(tree: &Tree<NodeId>, persistence_layer: &KV)
+    where
         NodeId: Storable,
         KV: KeyValueStore,
     {
@@ -1397,16 +1400,22 @@ mod tests {
         assert_eq!(
             persistence_layer.blob_get_calls(),
             1,
-            "resolving tree should load only the tree payload"
+            "resolving the tree reads the root node body (stored under the tree hash) \
+             in a single lookup"
         );
 
         let lazy_root = loaded_tree.root().expect("tree should have a root");
-        assert!(lazy_root.0.inner.get().is_none());
+        // The node body lives under the tree hash, so resolving the tree already materialised
+        // the root node. (Previously this required a second lookup keyed by the node hash.)
+        assert!(
+            lazy_root.0.inner.get().is_some(),
+            "resolving the tree eagerly materialises the root node"
+        );
         assert_eq!(Hash::from_foldable(&lazy_root), root_hash);
         assert_eq!(
             persistence_layer.blob_get_calls(),
             1,
-            "resolving tree should not eagerly load the root node payload"
+            "the root node is already loaded; folding it needs no further lookup"
         );
 
         let _ = lazy_resolver
@@ -1414,8 +1423,9 @@ mod tests {
             .expect("resolving root node should succeed");
         assert_eq!(
             persistence_layer.blob_get_calls(),
-            2,
-            "node payload should be loaded only when node is accessed"
+            1,
+            "the node was already materialised when its tree was resolved \
+             (this took a second lookup before storing nodes under the tree hash)"
         );
     }
 
@@ -1483,12 +1493,14 @@ mod tests {
         tree.set(&root_key, b"root", &mut eager_resolver)
             .expect("set should succeed");
 
-        let root_hash = Hash::from_foldable(tree.root().expect("tree should have a root node"));
+        // The node body is stored under the containing tree's hash, so a lazy node reference
+        // into storage is keyed by the tree hash.
+        let tree_hash = tree.hash();
 
         let persistence_layer = Arc::new(CountingKeyValueStore::default());
         persist_tree(&tree, persistence_layer.as_ref());
 
-        let mut node_id: LazyNodeId = LazyNodeId::from(root_hash);
+        let mut node_id: LazyNodeId = LazyNodeId::from(tree_hash);
         let mut lazy_resolver = LazyResolver::new(persistence_layer.clone());
 
         let _ = lazy_resolver
@@ -1516,12 +1528,13 @@ mod tests {
         tree.set(&root_key, b"root", &mut eager_resolver)
             .expect("set should succeed");
 
-        let root_hash = Hash::from_foldable(tree.root().expect("tree should have a root node"));
+        // Lazy references into storage are keyed by the tree hash (the node body lives there).
+        let tree_hash = tree.hash();
 
         let persistence_layer = Arc::new(CountingKeyValueStore::default());
         persist_tree(&tree, persistence_layer.as_ref());
 
-        let mut lazy_tree: Tree<LazyNodeId> = Some(LazyNodeId::from(root_hash)).into();
+        let mut lazy_tree: Tree<LazyNodeId> = Some(LazyNodeId::from(tree_hash)).into();
         let mut lazy_resolver = LazyResolver::new(persistence_layer.clone());
 
         {
@@ -1583,7 +1596,9 @@ mod tests {
         let reloaded_node = lazy_resolver
             .resolve(reloaded_root)
             .expect("resolving persisted mutated root node should succeed");
-        assert_eq!(persistence_layer.blob_get_calls(), 3);
+        // The root node was already materialised when its tree was resolved above, so no
+        // further lookup is needed here (this was a third lookup before the refactor).
+        assert_eq!(persistence_layer.blob_get_calls(), 2);
 
         let reloaded_node_data = reloaded_node
             .resolve_data(&lazy_resolver)
@@ -1610,16 +1625,14 @@ mod tests {
 
         let initial_tree_hash: Hash = original_tree.hash();
 
-        let persisted_root_hash =
-            Hash::from_foldable(original_tree.root().expect("tree should have a root node"));
+        // The node body is stored under the tree hash, so a lazy reference into storage is
+        // keyed by the tree hash.
+        let persisted_tree_hash = original_tree.hash();
 
         let persistence_layer = Arc::new(InMemoryKeyValueStore::default());
-        persist_tree(
-            &original_tree,
-            persistence_layer.as_ref(),
-        );
+        persist_tree(&original_tree, persistence_layer.as_ref());
 
-        let mut lazy_tree: Tree<LazyNodeId> = Some(LazyNodeId::from(persisted_root_hash)).into();
+        let mut lazy_tree: Tree<LazyNodeId> = Some(LazyNodeId::from(persisted_tree_hash)).into();
         let mut lazy_resolver = LazyResolver::new(persistence_layer);
 
         lazy_tree
@@ -1658,12 +1671,14 @@ mod tests {
         tree.set(&left_key, b"left", &mut resolver)
             .expect("set should succeed");
 
-        let root_hash = Hash::from_foldable(tree.root().expect("tree should have a root node"));
+        // A lazy reference into persisted storage is keyed by the *tree* hash, since the node
+        // body is now stored directly under it.
+        let tree_hash = tree.hash();
 
         let persistence_layer = Arc::new(CountingKeyValueStore::default());
         persist_tree(&tree, persistence_layer.as_ref());
 
-        (root_hash, tree, persistence_layer)
+        (tree_hash, tree, persistence_layer)
     }
 
     #[test]
@@ -1684,32 +1699,40 @@ mod tests {
 
     #[test]
     fn prove_resolver_hash_matches_lazy_resolver() {
-        let (root_hash, _, persistence_layer) = setup_prove_fixture();
-        let lazy_tree: Tree<LazyNodeId> = Some(LazyNodeId::from(root_hash)).into();
+        let (tree_hash, _, persistence_layer) = setup_prove_fixture();
+        let lazy_tree: Tree<LazyNodeId> = Some(LazyNodeId::from(tree_hash)).into();
         let lazy_resolver = LazyResolver::new(persistence_layer);
         let lazy_root = lazy_tree.root().expect("tree should have a root");
-
-        let expected_hash = Hash::from_foldable(lazy_root);
 
         let prove_resolver = ProveResolver::start(lazy_resolver);
         let prove_id = lazy_root.clone().into_proof();
 
-        // Hash before resolve (delegates to lazy path).
+        // Before resolve, both the prove id and the (unresolved) lazy id fold to the tree hash
+        // they were created from - the prove path delegates to the lazy path.
         let hash_before = Hash::from_foldable(&prove_id);
         assert_eq!(
-            hash_before, expected_hash,
-            "prove hash before resolve should match lazy hash"
+            hash_before,
+            Hash::from_foldable(lazy_root),
+            "prove hash before resolve should match the unresolved lazy hash"
         );
+        assert_eq!(hash_before, tree_hash);
 
-        // Resolve, then hash again (now computed from prove-mode inner).
+        // After resolve, the prove id folds to the resolved node's hash. Resolving the same
+        // node through the underlying lazy resolver must produce the same hash.
         prove_resolver
             .resolve(&prove_id)
             .expect("resolve should succeed");
-
         let hash_after = Hash::from_foldable(&prove_id);
+
+        let lazy_node_hash = Hash::from_foldable(
+            prove_resolver
+                .inner()
+                .resolve(lazy_root)
+                .expect("resolving the lazy node should succeed"),
+        );
         assert_eq!(
-            hash_after, expected_hash,
-            "prove hash after resolve should still match lazy hash"
+            hash_after, lazy_node_hash,
+            "prove hash after resolve should match the resolved lazy node hash"
         );
     }
 

--- a/durable-storage/src/avl/tree.rs
+++ b/durable-storage/src/avl/tree.rs
@@ -7,9 +7,6 @@
 use std::cmp::Ordering;
 use std::sync::LazyLock;
 
-use bincode::Decode;
-use bincode::de::Decoder;
-use bincode::error::DecodeError;
 use octez_riscv_data::components::atom::AtomMode;
 use octez_riscv_data::components::bytes::Bytes;
 use octez_riscv_data::components::bytes::BytesMode;
@@ -28,8 +25,6 @@ use octez_riscv_data::merkle_proof::Partial;
 use octez_riscv_data::merkle_proof::ProofError;
 use octez_riscv_data::merkle_proof::SuspendedResult;
 use octez_riscv_data::mode::utils::not_found;
-use octez_riscv_data::serialisation::deserialise;
-use octez_riscv_data::serialisation::serialise;
 use perfect_derive::perfect_derive;
 
 use super::node::Node;
@@ -214,6 +209,15 @@ impl<NodeId> Tree<NodeId> {
         Hash::from_foldable(self)
     }
 
+    /// The hash of a non-empty [`Tree`] whose root [`Node`] hashes to `node_hash`.
+    ///
+    /// A present tree folds as `H(present_flag, node_hash)`, so this reuses the
+    /// [`Foldable<HashFold>`] implementation (via a throwaway `Tree<Hash>`) to stay in
+    /// lock-step with it. This is the storage key under which the node body is persisted.
+    pub(crate) fn present_hash(node_hash: Hash) -> Hash {
+        Tree::<Hash>::from(Some(node_hash)).hash()
+    }
+
     /// Take the root [`Node`] out of this tree, leaving the [`Tree`] empty.
     pub(crate) const fn take(&mut self) -> Option<NodeId> {
         self.0.take()
@@ -375,13 +379,6 @@ impl<NodeId> Tree<NodeId> {
     }
 }
 
-impl<C> Decode<C> for Tree<LazyNodeId> {
-    fn decode<D: Decoder<Context = C>>(decoder: &mut D) -> Result<Self, DecodeError> {
-        let root_hash: Option<Hash> = Decode::decode(decoder)?;
-        Ok(Tree::from(root_hash.map(LazyNodeId::from)))
-    }
-}
-
 impl<NodeId: Foldable<HashFold>> Foldable<HashFold> for Tree<NodeId> {
     fn fold(&self, builder: HashFold) -> <HashFold as Fold>::Folded {
         let mut node = builder.into_node_fold();
@@ -444,24 +441,18 @@ impl<NodeId: Storable> Storable for Tree<NodeId> {
         store: &impl KeyValueStore,
         options: &StoreOptions,
     ) -> Result<(), OperationalError> {
-        let repr = self.0.as_ref().map(Hash::from_foldable);
-
-        // We don't store empty trees. All leaf nodes contain two empty trees. Adding two more
-        // redundant writes to all leaves is not desirable.
-        // The empty tree can be recovered during loading, as the hash of the empty tree is known.
-        if repr.is_none() {
-            return Ok(());
+        // We don't store empty trees. All leaf nodes contain two empty trees. Adding
+        // redundant writes to all leaves is not desirable. The empty tree can be recovered
+        // during loading, as the hash of the empty tree is known.
+        //
+        // A non-empty tree's root node persists its body *directly under this tree's hash*
+        // (see the `Storable` impl for `Node`). Storing the node by the parent tree hash
+        // removes the intermediate tree->node pointer that previously had to be read before
+        // the node itself, saving a lookup per level when resolving.
+        match &self.0 {
+            None => Ok(()),
+            Some(node) => node.store(store, options),
         }
-
-        let id = self.hash();
-        let bytes = serialise(repr)?;
-        store.blob_set(id, bytes)?;
-
-        if let Some(node) = &self.0 {
-            node.store(store, options)?;
-        }
-
-        Ok(())
     }
 }
 
@@ -473,20 +464,10 @@ impl<NodeId: Loadable> Loadable for Tree<NodeId> {
             return Ok(Self(None));
         }
 
-        let repr: Option<Hash> = {
-            let bytes =
-                store
-                    .blob_get(id)
-                    .map_err(|error| OperationalError::CommitDataMissing {
-                        root: id,
-                        source: Box::new(error),
-                    })?;
-            deserialise(bytes.as_ref())?
-        };
-
-        repr.map(|node_id| NodeId::load(node_id, store))
-            .transpose()
-            .map(Self)
+        // The root node's body is stored directly under this tree's hash. Hand the tree hash
+        // to the node loader: for `LazyNodeId` this reads the body in a single lookup and
+        // materialises the children lazily; for `ArcNodeId` it eagerly loads the whole subtree.
+        NodeId::load(id, store).map(|node| Self(Some(node)))
     }
 }
 

--- a/durable-storage/src/avl/tree.rs
+++ b/durable-storage/src/avl/tree.rs
@@ -457,9 +457,7 @@ impl<NodeId: Storable> Storable for Tree<NodeId> {
         let bytes = serialise(repr)?;
         store.blob_set(id, bytes)?;
 
-        if let Some(node) = &self.0
-            && options.deep()
-        {
+        if let Some(node) = &self.0 {
             node.store(store, options)?;
         }
 

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -140,7 +140,7 @@ impl<KV> Database<KV, Normal> {
     where
         KV: PersistentKeyValueStore,
     {
-        let commit_options = StoreOptions::default().with_deep().without_node_data();
+        let commit_options = StoreOptions::default().without_node_data();
         let commit_id = self.inner.merkle.commit(commit_options)?;
         self.inner.persistent.commit(repo, &commit_id)?;
 

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -1878,7 +1878,7 @@ mod tests {
         }
 
         let expected_hash = merkle_layer.hash();
-        let commit_opts = crate::storage::StoreOptions::default().with_deep().with_node_data();
+        let commit_opts = crate::storage::StoreOptions::default().with_node_data();
         let commit_id = merkle_layer.commit(&commit_opts).expect("Commit operation should succeed");
 
         let lazy_loaded = MerkleLayer::checkout(persistence, commit_id)
@@ -1946,7 +1946,7 @@ mod tests {
                 .expect("setting node should succeed");
         }
 
-        let commit_opts = StoreOptions::default().with_deep().with_node_data();
+        let commit_opts = StoreOptions::default().with_node_data();
         let commit_id = merkle_layer
             .commit(&commit_opts)
             .expect("The commit operation should not fail");
@@ -1957,7 +1957,7 @@ mod tests {
 
             node.store(
                 merkle_layer.inner.persistence.as_ref(),
-                &StoreOptions::default().with_shallow().with_node_data(),
+                &StoreOptions::default().with_node_data(),
             )
             .expect("Storing node should succeed");
 

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -1961,8 +1961,12 @@ mod tests {
             )
             .expect("Storing node should succeed");
 
+            // The node body is persisted under the hash of the tree that holds it, not under
+            // the node's own hash.
+            let node_tree_hash =
+                Tree::<octez_riscv_data::hash::Hash>::present_hash(*node.hash());
             let loaded_node: Node<LazyTreeId, Bytes<Normal>, Normal> =
-                Node::load(*node.hash(), merkle_layer.inner.persistence.as_ref())
+                Node::load(node_tree_hash, merkle_layer.inner.persistence.as_ref())
                     .expect("Loading node should succeed");
 
             assert_eq!(node.hash(), loaded_node.hash());

--- a/durable-storage/src/merkle_worker.rs
+++ b/durable-storage/src/merkle_worker.rs
@@ -504,9 +504,7 @@ mod tests {
 
                 #[cfg(rocksdb)]
                 Self::Commit => {
-                    let options = crate::storage::StoreOptions::default()
-                        .with_deep()
-                        .with_node_data();
+                    let options = crate::storage::StoreOptions::default().with_node_data();
                     let commit2 = layer.commit(&options).expect("Commit should succeed");
                     let commit1 = worker.commit(options).expect("Commit should succeed");
                     assert_eq!(commit1, commit2);

--- a/durable-storage/src/storage.rs
+++ b/durable-storage/src/storage.rs
@@ -351,42 +351,20 @@ cfg_if::cfg_if! {
 }
 
 /// Options for storing MAVL values in a [`KeyValueStore`]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct StoreOptions {
     /// Persist the key-value pairs from MAVL nodes
     node_data: bool,
-
-    /// Persist nested items
-    deep: bool,
 }
 
 impl StoreOptions {
-    /// When this is set, recursive child values will not be persisted.
-    pub fn with_shallow(self) -> Self {
-        Self {
-            node_data: self.node_data,
-            deep: false,
-        }
-    }
-
-    /// Also stores nested nodes and trees.
-    pub fn with_deep(self) -> Self {
-        Self {
-            node_data: self.node_data,
-            deep: true,
-        }
-    }
-
     /// Persists the key-value data of nodes.
     ///
     /// Turning this option on ensures the nodes are persisted completely. When using the
     /// [`crate::merkle_layer::MerkleLayer`] in isolation, this is necessary as there is no other
     /// component that will be writing the key-value data to the store.
     pub fn with_node_data(self) -> Self {
-        Self {
-            node_data: true,
-            deep: self.deep,
-        }
+        Self { node_data: true }
     }
 
     /// Do not persist key-value data of nodes.
@@ -396,29 +374,12 @@ impl StoreOptions {
     /// mutates the store directly ahead of commitments. At commitment time, you only need to
     /// persist the remaining tree and node structures.
     pub fn without_node_data(self) -> Self {
-        Self {
-            node_data: false,
-            deep: self.deep,
-        }
+        Self { node_data: false }
     }
 
     /// Returns whether node key-value data should be persisted.
     pub fn node_data(&self) -> bool {
         self.node_data
-    }
-
-    /// Returns whether nested values should be persisted recursively.
-    pub fn deep(&self) -> bool {
-        self.deep
-    }
-}
-
-impl Default for StoreOptions {
-    fn default() -> Self {
-        Self {
-            node_data: false,
-            deep: true,
-        }
     }
 }
 


### PR DESCRIPTION
- closes TZX-194

# What

 Replace the `tree_hash -> tree_content` and `node_hash -> node_content` mappings in the merkle column families, with just `tree_hash -> node_content` directly.

# Why

This saves a lookup whenever resolving a node. Additionally it saves disk space as an intermediate mapping is skipped.

Tree's have two variants: 
- `Tree(None)` (the empty tree)
- `Tree(Some(Node))` (populated trees)

# How

The empty tree variant is never persisted, as the hash is well known. 

Therefore all persisted trees are populated. All trees persisted have content `<true><node hash>`. Therefore, we can skip this intermediate mapping as we can recalculate the tree hash from just the child-node content.

This does require deleting `shallow_options` (at least for tree's - as they now must always persist the node). We _could_ keep the option for nodes, but as this option was test only (and only used in a couple places) I felt it made sense to just remove it entirely.

# Manually Testing

```
make all

# demonstrate the speedup - run this on `main` first.
# My machine - see a >60% improvement
cargo bench -p octez-riscv-durable-storage --bench avl_storage
```

# Regressions

None. We currently do not have regression tests for snapshots/databases.

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
