### PR TITLE
refactor(nds): split KeyValueStore into writeable and readable

### DIFF
--- a/durable-storage/benches/avl_storage.rs
+++ b/durable-storage/benches/avl_storage.rs
@@ -23,10 +23,10 @@ use octez_riscv_durable_storage::avl::resolver::LazyNodeId;
 use octez_riscv_durable_storage::avl::resolver::LazyResolver;
 use octez_riscv_durable_storage::avl::tree::Tree;
 use octez_riscv_durable_storage::key::Key;
-use octez_riscv_durable_storage::storage::KeyValueStore;
 use octez_riscv_durable_storage::storage::Loadable;
 use octez_riscv_durable_storage::storage::Storable;
 use octez_riscv_durable_storage::storage::StoreOptions;
+use octez_riscv_durable_storage::storage::WriteableKeyValueStore;
 use rand::prelude::*;
 use random::generate_keys;
 use random::generate_random_bytes_in_range;
@@ -49,7 +49,11 @@ fn key_count() -> usize {
 
 /// Build an AVL tree with `keys`, persist it (including value data) into `store`, and return
 /// the tree's root hash.
-fn build_and_persist<KV: KeyValueStore>(rng: &mut impl Rng, store: &Arc<KV>, keys: &[Key]) -> Hash {
+fn build_and_persist<KV: WriteableKeyValueStore>(
+    rng: &mut impl Rng,
+    store: &Arc<KV>,
+    keys: &[Key],
+) -> Hash {
     let mut resolver = LazyResolver::new(store.clone());
     let mut tree: Tree<LazyNodeId> = Tree::default();
     for key in keys {

--- a/durable-storage/benches/avl_tree.rs
+++ b/durable-storage/benches/avl_tree.rs
@@ -14,7 +14,8 @@ use criterion::criterion_main;
 use octez_riscv_durable_storage::avl::resolver::LazyResolver;
 use octez_riscv_durable_storage::avl::tree::Tree;
 use octez_riscv_durable_storage::key::Key;
-use octez_riscv_durable_storage::storage::KeyValueStore;
+use octez_riscv_durable_storage::storage::ReadableKeyValueStore;
+use octez_riscv_durable_storage::storage::WriteableKeyValueStore;
 use rand::prelude::*;
 use random::generate_keys;
 use random::generate_random_bytes_in_range;
@@ -49,7 +50,7 @@ cfg_if::cfg_if! {
         use octez_riscv_test_utils::TestableTmpdir;
 
         type TestKeyValueStore = PersistenceLayer;
-        type TestRepo = <TestKeyValueStore as KeyValueStore>::Repo;
+        type TestRepo = <TestKeyValueStore as ReadableKeyValueStore>::Repo;
 
         fn setup_repo() -> (TestableTmpdir, TestRepo) {
             use octez_riscv_durable_storage::repo::DirectoryManager;
@@ -64,7 +65,7 @@ cfg_if::cfg_if! {
         use octez_riscv_durable_storage::storage::in_memory::InMemoryRepo;
 
         type TestKeyValueStore = InMemoryKeyValueStore;
-        type TestRepo = <TestKeyValueStore as KeyValueStore>::Repo;
+        type TestRepo = <TestKeyValueStore as ReadableKeyValueStore>::Repo;
 
         fn setup_repo() -> ((), TestRepo) {
             ((), InMemoryRepo::default())

--- a/durable-storage/src/avl/node.rs
+++ b/durable-storage/src/avl/node.rs
@@ -39,10 +39,11 @@ use crate::errors::Error;
 use crate::errors::InvalidArgumentError;
 use crate::errors::OperationalError;
 use crate::key::Key;
-use crate::storage::KeyValueStore;
 use crate::storage::Loadable;
+use crate::storage::ReadableKeyValueStore;
 use crate::storage::Storable;
 use crate::storage::StoreOptions;
+use crate::storage::WriteableKeyValueStore;
 
 /// This type is a compact serialised form of a [`Node`] with metadata and child subtree hashes.
 #[derive(Encode, Decode)]
@@ -865,7 +866,7 @@ where
 {
     fn store(
         &self,
-        store: &impl KeyValueStore,
+        store: &impl WriteableKeyValueStore,
         options: &StoreOptions,
     ) -> Result<(), OperationalError> {
         // The stored representation is more compact. We don't include the `data` field, as that
@@ -903,7 +904,7 @@ where
 }
 
 impl<TreeId: Loadable, DataId: DataLoadable> Loadable for Node<TreeId, DataId, Normal> {
-    fn load(id: Hash, store: &impl KeyValueStore) -> Result<Self, OperationalError> {
+    fn load(id: Hash, store: &impl ReadableKeyValueStore) -> Result<Self, OperationalError> {
         let StoredNode {
             balance_factor,
             key,
@@ -962,14 +963,22 @@ where
 }
 
 /// Helper trait for node data that can be reconstructed
-/// from a [`KeyValueStore`] by content hash and key.
+/// from a [`ReadableKeyValueStore`] by content hash and key.
 trait DataLoadable: Sized {
     /// Load data identified by `id` and `key` from `store`.
-    fn load(id: Hash, key: &Key, store: &impl KeyValueStore) -> Result<Self, OperationalError>;
+    fn load(
+        id: Hash,
+        key: &Key,
+        store: &impl ReadableKeyValueStore,
+    ) -> Result<Self, OperationalError>;
 }
 
 impl DataLoadable for Bytes<Normal> {
-    fn load(_id: Hash, key: &Key, store: &impl KeyValueStore) -> Result<Self, OperationalError> {
+    fn load(
+        _id: Hash,
+        key: &Key,
+        store: &impl ReadableKeyValueStore,
+    ) -> Result<Self, OperationalError> {
         let data = {
             let bytes =
                 store
@@ -986,7 +995,11 @@ impl DataLoadable for Bytes<Normal> {
 }
 
 impl DataLoadable for LazyDataId {
-    fn load(id: Hash, key: &Key, store: &impl KeyValueStore) -> Result<Self, OperationalError> {
+    fn load(
+        id: Hash,
+        key: &Key,
+        store: &impl ReadableKeyValueStore,
+    ) -> Result<Self, OperationalError> {
         // TODO (RV-998): go all in on laziness
         let data = match store.get(key.as_ref()) {
             Ok(bytes) => {

--- a/durable-storage/src/avl/resolver.rs
+++ b/durable-storage/src/avl/resolver.rs
@@ -21,7 +21,7 @@
 //!
 //! # ArcResolver vs LazyResolver
 //! Use [`ArcResolver`] when values are already present and can be shared directly via [`Arc`]. Use
-//! [`LazyResolver`] when values are persisted in a [`KeyValueStore`] and should be fetched on
+//! [`LazyResolver`] when values are persisted in a [`WriteableKeyValueStore`] and should be fetched on
 //! demand.
 //!
 //! [`Tree`]: crate::avl::tree::Tree
@@ -63,10 +63,11 @@ use super::node::Node;
 use super::tree::Tree;
 use crate::errors::OperationalError;
 use crate::key::Key;
-use crate::storage::KeyValueStore;
 use crate::storage::Loadable;
+use crate::storage::ReadableKeyValueStore;
 use crate::storage::Storable;
 use crate::storage::StoreOptions;
+use crate::storage::WriteableKeyValueStore;
 
 /// Trait for resolving identifiers to values.
 pub trait Resolver<Id, Value> {
@@ -124,7 +125,7 @@ impl Foldable<HashFold> for ArcNodeId {
 impl Storable for ArcNodeId {
     fn store(
         &self,
-        store: &impl KeyValueStore,
+        store: &impl WriteableKeyValueStore,
         options: &StoreOptions,
     ) -> Result<(), OperationalError> {
         self.0.store(store, options)
@@ -132,7 +133,7 @@ impl Storable for ArcNodeId {
 }
 
 impl Loadable for ArcNodeId {
-    fn load(id: Hash, store: &impl KeyValueStore) -> Result<Self, OperationalError> {
+    fn load(id: Hash, store: &impl ReadableKeyValueStore) -> Result<Self, OperationalError> {
         Arc::load(id, store).map(Self)
     }
 }
@@ -150,7 +151,7 @@ impl Foldable<HashFold> for ArcTreeId {
 impl Storable for ArcTreeId {
     fn store(
         &self,
-        store: &impl KeyValueStore,
+        store: &impl WriteableKeyValueStore,
         options: &StoreOptions,
     ) -> Result<(), OperationalError> {
         self.0.store(store, options)
@@ -158,7 +159,7 @@ impl Storable for ArcTreeId {
 }
 
 impl Loadable for ArcTreeId {
-    fn load(id: Hash, store: &impl KeyValueStore) -> Result<Self, OperationalError> {
+    fn load(id: Hash, store: &impl ReadableKeyValueStore) -> Result<Self, OperationalError> {
         Tree::load(id, store).map(Self)
     }
 }
@@ -250,7 +251,7 @@ impl<Value> LazyId<Value> {
     /// Populate the inner value from the store.
     ///
     /// This does not check if the value is already loaded.
-    fn load(&self, store: &impl KeyValueStore) -> Result<(), OperationalError>
+    fn load(&self, store: &impl ReadableKeyValueStore) -> Result<(), OperationalError>
     where
         Value: Loadable,
     {
@@ -320,7 +321,7 @@ impl Foldable<HashFold> for LazyNodeId {
 impl Storable for LazyNodeId {
     fn store(
         &self,
-        store: &impl KeyValueStore,
+        store: &impl WriteableKeyValueStore,
         options: &StoreOptions,
     ) -> Result<(), OperationalError> {
         let Some(node) = self.0.inner.get() else {
@@ -334,7 +335,7 @@ impl Storable for LazyNodeId {
 }
 
 impl Loadable for LazyNodeId {
-    fn load(id: Hash, store: &impl KeyValueStore) -> Result<Self, OperationalError> {
+    fn load(id: Hash, store: &impl ReadableKeyValueStore) -> Result<Self, OperationalError> {
         // `id` is the tree hash under which the node body is stored. Read it eagerly so that
         // resolving the containing tree yields a fully-materialised node — with its children
         // still lazy — in a single lookup, instead of deferring a second lookup for the body.
@@ -362,7 +363,7 @@ impl LazyDataId {
     pub(crate) fn try_get(
         &self,
         key: &Key,
-        store: &impl KeyValueStore,
+        store: &impl ReadableKeyValueStore,
     ) -> Result<&Bytes<Normal>, OperationalError> {
         if let Some(bytes) = self.0.inner.get() {
             return Ok(bytes);
@@ -379,7 +380,7 @@ impl LazyDataId {
     fn try_get_mut(
         &mut self,
         key: &Key,
-        store: &impl KeyValueStore,
+        store: &impl ReadableKeyValueStore,
     ) -> Result<&mut Bytes<Normal>, OperationalError> {
         // evict the cached-hash, if any - the value will be mutated
         self.0.hash = None;
@@ -411,7 +412,7 @@ impl LazyDataId {
     fn try_load_inner(
         &self,
         key: &Key,
-        store: &impl KeyValueStore,
+        store: &impl ReadableKeyValueStore,
     ) -> Result<(), OperationalError> {
         let bytes = store
             .get(key)
@@ -524,7 +525,7 @@ impl Foldable<HashFold> for LazyTreeId {
 impl Storable for LazyTreeId {
     fn store(
         &self,
-        store: &impl KeyValueStore,
+        store: &impl WriteableKeyValueStore,
         options: &StoreOptions,
     ) -> Result<(), OperationalError> {
         let Some(tree) = self.0.inner.get() else {
@@ -538,12 +539,12 @@ impl Storable for LazyTreeId {
 }
 
 impl Loadable for LazyTreeId {
-    fn load(id: Hash, _store: &impl KeyValueStore) -> Result<Self, OperationalError> {
+    fn load(id: Hash, _store: &impl ReadableKeyValueStore) -> Result<Self, OperationalError> {
         Ok(Self::from(id))
     }
 }
 
-/// Resolver that lazily loads AVL nodes and trees from a [`KeyValueStore`].
+/// Resolver that lazily loads AVL nodes and trees from a [`ReadableKeyValueStore`].
 ///
 /// In contrast to [`ArcResolver`], this resolver can start from hash-only identifiers and defer
 /// storage reads until an identifier is resolved. Loaded values are cached in their corresponding
@@ -563,7 +564,7 @@ impl<KV> LazyResolver<KV> {
     }
 }
 
-impl<KV: KeyValueStore> Resolver<LazyNodeId, Node<LazyTreeId, LazyDataId, Normal>>
+impl<KV: ReadableKeyValueStore> Resolver<LazyNodeId, Node<LazyTreeId, LazyDataId, Normal>>
     for LazyResolver<KV>
 {
     fn resolve<'a>(
@@ -604,7 +605,7 @@ impl<KV: KeyValueStore> Resolver<LazyNodeId, Node<LazyTreeId, LazyDataId, Normal
     }
 }
 
-impl<KV: KeyValueStore> Resolver<LazyTreeId, Tree<LazyNodeId>> for LazyResolver<KV> {
+impl<KV: ReadableKeyValueStore> Resolver<LazyTreeId, Tree<LazyNodeId>> for LazyResolver<KV> {
     fn resolve<'a>(&self, id: &'a LazyTreeId) -> Result<&'a Tree<LazyNodeId>, OperationalError> {
         if let Some(value) = id.0.inner.get() {
             return Ok(value);
@@ -630,7 +631,7 @@ impl<KV: KeyValueStore> Resolver<LazyTreeId, Tree<LazyNodeId>> for LazyResolver<
     }
 }
 
-impl<KV: KeyValueStore> DataResolver<LazyDataId, Normal> for LazyResolver<KV> {
+impl<KV: ReadableKeyValueStore> DataResolver<LazyDataId, Normal> for LazyResolver<KV> {
     fn resolve_bytes<'a>(
         &self,
         id: &'a LazyDataId,
@@ -1282,9 +1283,10 @@ mod tests {
     use crate::errors::Error;
     use crate::errors::OperationalError;
     use crate::key::Key;
-    use crate::storage::KeyValueStore;
+    use crate::storage::ReadableKeyValueStore;
     use crate::storage::Storable;
     use crate::storage::StoreOptions;
+    use crate::storage::WriteableKeyValueStore;
     use crate::storage::in_memory::InMemoryKeyValueStore;
     use crate::storage::in_memory::InMemoryRepo;
 
@@ -1301,9 +1303,20 @@ mod tests {
         }
     }
 
-    impl KeyValueStore for CountingKeyValueStore {
+    impl ReadableKeyValueStore for CountingKeyValueStore {
         type Repo = InMemoryRepo;
 
+        fn blob_get(&self, key: impl AsRef<[u8]>) -> Result<impl AsRef<[u8]>, Error> {
+            self.blob_get_calls.fetch_add(1, Ordering::SeqCst);
+            self.inner.blob_get(key)
+        }
+
+        fn get(&self, key: impl AsRef<[u8]>) -> Result<impl AsRef<[u8]>, Error> {
+            self.inner.get(key)
+        }
+    }
+
+    impl WriteableKeyValueStore for CountingKeyValueStore {
         fn new(_repo: &Self::Repo) -> Result<Self, OperationalError> {
             Ok(Self::default())
         }
@@ -1313,11 +1326,6 @@ mod tests {
                 inner: self.inner.try_clone()?,
                 blob_get_calls: AtomicUsize::new(self.blob_get_calls()),
             })
-        }
-
-        fn blob_get(&self, key: impl AsRef<[u8]>) -> Result<impl AsRef<[u8]>, Error> {
-            self.blob_get_calls.fetch_add(1, Ordering::SeqCst);
-            self.inner.blob_get(key)
         }
 
         fn blob_set(
@@ -1330,10 +1338,6 @@ mod tests {
 
         fn blob_delete(&self, key: impl AsRef<[u8]>) -> Result<(), OperationalError> {
             self.inner.blob_delete(key)
-        }
-
-        fn get(&self, key: impl AsRef<[u8]>) -> Result<impl AsRef<[u8]>, Error> {
-            self.inner.get(key)
         }
 
         fn set(
@@ -1361,7 +1365,7 @@ mod tests {
     fn persist_tree<NodeId, KV>(tree: &Tree<NodeId>, persistence_layer: &KV)
     where
         NodeId: Storable,
-        KV: KeyValueStore,
+        KV: WriteableKeyValueStore,
     {
         let store_options = StoreOptions::default().with_node_data();
 

--- a/durable-storage/src/avl/tree.rs
+++ b/durable-storage/src/avl/tree.rs
@@ -39,10 +39,11 @@ use crate::errors::Error;
 use crate::errors::InvalidArgumentError;
 use crate::errors::OperationalError;
 use crate::key::Key;
-use crate::storage::KeyValueStore;
 use crate::storage::Loadable;
+use crate::storage::ReadableKeyValueStore;
 use crate::storage::Storable;
 use crate::storage::StoreOptions;
+use crate::storage::WriteableKeyValueStore;
 
 /// Hash of the empty AVL tree (`Tree::<NodeId>(None)`).
 /// The empty-tree hash is independent of the `NodeId` type parameter.
@@ -446,7 +447,7 @@ impl FromProof for Tree<VerifyNodeId> {
 impl<NodeId: Storable> Storable for Tree<NodeId> {
     fn store(
         &self,
-        store: &impl KeyValueStore,
+        store: &impl WriteableKeyValueStore,
         options: &StoreOptions,
     ) -> Result<(), OperationalError> {
         // We don't store empty trees. All leaf nodes contain two empty trees. Adding
@@ -465,7 +466,7 @@ impl<NodeId: Storable> Storable for Tree<NodeId> {
 }
 
 impl<NodeId: Loadable> Loadable for Tree<NodeId> {
-    fn load(id: Hash, store: &impl KeyValueStore) -> Result<Self, OperationalError> {
+    fn load(id: Hash, store: &impl ReadableKeyValueStore) -> Result<Self, OperationalError> {
         // Empty trees are not stored. We can short-circuit here, if we detect the requested hash
         // corresponds to the hash of the empty tree.
         if id == *EMPTY_TREE_HASH {

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -53,12 +53,13 @@ use crate::errors::InvalidArgumentError;
 use crate::errors::OperationalError;
 use crate::key::Key;
 use crate::merkle_layer::MerkleLayer;
-use crate::merkle_worker::BackgroundKeyValueStore;
 use crate::merkle_worker::BackgroundPersistentKeyValueStore;
+use crate::merkle_worker::BackgroundReadableKeyValueStore;
+use crate::merkle_worker::BackgroundWriteableKeyValueStore;
 use crate::merkle_worker::MerkleWorker;
 pub use crate::repo::DirectoryManager;
-use crate::storage::KeyValueStore;
 use crate::storage::PersistentKeyValueStore;
+use crate::storage::ReadableKeyValueStore;
 use crate::storage::StoreOptions;
 
 /// The maximum possible length of a value in durable storage.
@@ -84,7 +85,7 @@ impl<KV> Database<KV, Normal> {
     /// called.
     pub fn try_new(handle: &Handle, repo: &KV::Repo) -> Result<Self, OperationalError>
     where
-        KV: BackgroundKeyValueStore,
+        KV: BackgroundWriteableKeyValueStore,
     {
         let persistent = KV::new(repo)?;
         let persistent = Arc::new(persistent);
@@ -121,7 +122,7 @@ impl<KV> Database<KV, Normal> {
     /// [`Database::commit`] is called.
     pub fn try_clone_with(&self, handle: &Handle, repo: &KV::Repo) -> Result<Self, OperationalError>
     where
-        KV: BackgroundKeyValueStore,
+        KV: BackgroundWriteableKeyValueStore,
     {
         let persistent = self.inner.persistent.try_clone(repo)?;
         let persistent = Arc::new(persistent);
@@ -149,15 +150,7 @@ impl<KV> Database<KV, Normal> {
     }
 }
 
-impl<KV: BackgroundKeyValueStore, M: DatabaseMode> Database<KV, M> {
-    /// Remove a key from the database.
-    ///
-    /// Deleting a missing key succeeds and leaves the database unchanged.
-    /// TODO RV-943: Fix behaviour to returning an operational error when deleting a missing key.
-    pub fn delete(&mut self, key: Key) -> Result<(), OperationalError> {
-        M::delete(self, key)
-    }
-
+impl<KV: BackgroundReadableKeyValueStore, M: DatabaseMode> Database<KV, M> {
     /// Returns true if the provided key exists in the database, false if it does not.
     pub fn exists(&self, key: &Key) -> Result<bool, Error> {
         match self.get(key) {
@@ -220,6 +213,25 @@ impl<KV: BackgroundKeyValueStore, M: DatabaseMode> Database<KV, M> {
         Ok(buf)
     }
 
+    /// Retrieve the length of the value associated with the provided key.
+    ///
+    /// Fails if:
+    ///  - The key does not exist in the database.
+    pub fn value_length(&self, key: &Key) -> Result<usize, Error> {
+        Ok(self.get(key)?.len())
+    }
+
+    /// Retrieve the value associated with the provided key.
+    ///
+    /// Fails if:
+    ///  - The key does not exist in the database.
+    fn get(&self, key: &Key) -> Result<impl ValueRef, Error> {
+        M::get(self, key)
+    }
+}
+
+/// Operations which modify the database, and so require a store that can be written to.
+impl<KV: BackgroundWriteableKeyValueStore, M: DatabaseMode> Database<KV, M> {
     /// Inserts the value associated with the provided key, replacing any data already associated
     /// with the key.
     ///
@@ -265,48 +277,39 @@ impl<KV: BackgroundKeyValueStore, M: DatabaseMode> Database<KV, M> {
         M::write(self, key, offset, data)
     }
 
-    /// Retrieve the length of the value associated with the provided key.
+    /// Remove a key from the database.
     ///
-    /// Fails if:
-    ///  - The key does not exist in the database.
-    pub fn value_length(&self, key: &Key) -> Result<usize, Error> {
-        Ok(self.get(key)?.len())
-    }
-
-    /// Retrieve the value associated with the provided key.
-    ///
-    /// Fails if:
-    ///  - The key does not exist in the database.
-    fn get(&self, key: &Key) -> Result<impl ValueRef, Error> {
-        M::get(self, key)
+    /// Deleting a missing key succeeds and leaves the database unchanged.
+    pub fn delete(&mut self, key: Key) -> Result<(), OperationalError> {
+        M::delete(self, key)
     }
 }
 
-impl<KV: KeyValueStore> Foldable<HashFold> for Database<KV, Normal> {
+impl<KV: ReadableKeyValueStore> Foldable<HashFold> for Database<KV, Normal> {
     fn fold(&self, _builder: HashFold) -> Hash {
         self.inner.merkle.hash().expect("Hashing should not fail")
     }
 }
 
-impl<KV: KeyValueStore> Foldable<HashFold> for Database<KV, Prove<'_>> {
+impl<KV: ReadableKeyValueStore> Foldable<HashFold> for Database<KV, Prove<'_>> {
     fn fold(&self, _builder: HashFold) -> Hash {
         self.inner.merkle.hash()
     }
 }
 
-impl<KV: KeyValueStore> Foldable<MerkleProofFold> for Database<KV, Prove<'_>> {
+impl<KV: ReadableKeyValueStore> Foldable<MerkleProofFold> for Database<KV, Prove<'_>> {
     fn fold(&self, builder: MerkleProofFold) -> <MerkleProofFold as Fold>::Folded {
         self.inner.merkle.fold(builder)
     }
 }
 
-impl<KV: KeyValueStore> Foldable<PartialHashFold> for Database<KV, Verify> {
+impl<KV: ReadableKeyValueStore> Foldable<PartialHashFold> for Database<KV, Verify> {
     fn fold(&self, builder: PartialHashFold) -> PartialHash {
         self.inner.merkle.fold(builder)
     }
 }
 
-impl<'normal, KV: BackgroundKeyValueStore> ProvableExt<'normal, 'static, OperationalError>
+impl<'normal, KV: BackgroundReadableKeyValueStore> ProvableExt<'normal, 'static, OperationalError>
     for Database<KV, Normal>
 {
     type Prover = Database<KV, Prove<'static>>;
@@ -338,14 +341,14 @@ impl<KV> Modal for DatabaseTemplate<KV> {
 /// Modes that support the operational API exposed by [`Database`].
 pub trait DatabaseMode: Mode {
     /// See [`Database::set`]
-    fn set<KV: BackgroundKeyValueStore>(
+    fn set<KV: BackgroundWriteableKeyValueStore>(
         this: &mut Database<KV, Self>,
         key: Key,
         value: Bytes,
     ) -> Result<(), Error>;
 
     /// See [`Database::write`]
-    fn write<KV: BackgroundKeyValueStore>(
+    fn write<KV: BackgroundWriteableKeyValueStore>(
         this: &mut Database<KV, Self>,
         key: Key,
         offset: usize,
@@ -353,25 +356,25 @@ pub trait DatabaseMode: Mode {
     ) -> Result<usize, Error>;
 
     /// See [`Database::delete`]
-    fn delete<KV: BackgroundKeyValueStore>(
+    fn delete<KV: BackgroundWriteableKeyValueStore>(
         this: &mut Database<KV, Self>,
         key: Key,
     ) -> Result<(), OperationalError>;
 
     /// See [`Database::hash`]
-    fn hash<KV: BackgroundKeyValueStore>(
+    fn hash<KV: BackgroundReadableKeyValueStore>(
         this: &Database<KV, Self>,
     ) -> Result<Hash, OperationalError>;
 
     /// See [`Database::get`]
-    fn get<KV: BackgroundKeyValueStore>(
+    fn get<KV: BackgroundReadableKeyValueStore>(
         this: &Database<KV, Self>,
         key: &Key,
     ) -> Result<impl ValueRef, Error>;
 }
 
 impl DatabaseMode for Normal {
-    fn get<KV: BackgroundKeyValueStore>(
+    fn get<KV: BackgroundReadableKeyValueStore>(
         this: &Database<KV, Self>,
         key: &Key,
     ) -> Result<impl ValueRef, Error> {
@@ -379,7 +382,7 @@ impl DatabaseMode for Normal {
         Ok(AsRefValueRef(as_ref))
     }
 
-    fn set<KV: BackgroundKeyValueStore>(
+    fn set<KV: BackgroundWriteableKeyValueStore>(
         this: &mut Database<KV, Self>,
         key: Key,
         data: Bytes,
@@ -389,7 +392,7 @@ impl DatabaseMode for Normal {
         Ok(())
     }
 
-    fn write<KV: BackgroundKeyValueStore>(
+    fn write<KV: BackgroundWriteableKeyValueStore>(
         this: &mut Database<KV, Self>,
         key: Key,
         offset: usize,
@@ -401,7 +404,7 @@ impl DatabaseMode for Normal {
         Ok(written)
     }
 
-    fn delete<KV: BackgroundKeyValueStore>(
+    fn delete<KV: BackgroundWriteableKeyValueStore>(
         this: &mut Database<KV, Self>,
         key: Key,
     ) -> Result<(), OperationalError> {
@@ -410,7 +413,7 @@ impl DatabaseMode for Normal {
         Ok(())
     }
 
-    fn hash<KV: BackgroundKeyValueStore>(
+    fn hash<KV: BackgroundReadableKeyValueStore>(
         this: &Database<KV, Self>,
     ) -> Result<Hash, OperationalError> {
         this.inner.merkle.hash()
@@ -427,7 +430,7 @@ impl<KV> Database<KV, Prove<'static>> {
     /// An empty prove-mode database backed by the given persistence layer.
     pub(crate) fn empty(persistence: Arc<KV>) -> Self
     where
-        KV: KeyValueStore,
+        KV: ReadableKeyValueStore,
     {
         Database {
             inner: ProveImpl {
@@ -478,7 +481,7 @@ struct VerifyImpl<KV> {
 }
 
 impl DatabaseMode for Verify {
-    fn get<KV: BackgroundKeyValueStore>(
+    fn get<KV: BackgroundReadableKeyValueStore>(
         this: &Database<KV, Self>,
         key: &Key,
     ) -> Result<impl ValueRef, Error> {
@@ -513,7 +516,7 @@ impl DatabaseMode for Verify {
         Ok(Wrapper(bytes))
     }
 
-    fn set<KV: BackgroundKeyValueStore>(
+    fn set<KV: BackgroundWriteableKeyValueStore>(
         this: &mut Database<KV, Self>,
         key: Key,
         data: Bytes,
@@ -522,7 +525,7 @@ impl DatabaseMode for Verify {
         Ok(())
     }
 
-    fn write<KV: BackgroundKeyValueStore>(
+    fn write<KV: BackgroundWriteableKeyValueStore>(
         this: &mut Database<KV, Self>,
         key: Key,
         offset: usize,
@@ -533,14 +536,14 @@ impl DatabaseMode for Verify {
         Ok(written)
     }
 
-    fn delete<KV: BackgroundKeyValueStore>(
+    fn delete<KV: BackgroundWriteableKeyValueStore>(
         this: &mut Database<KV, Self>,
         key: Key,
     ) -> Result<(), OperationalError> {
         this.inner.merkle.delete(&key)
     }
 
-    fn hash<KV: BackgroundKeyValueStore>(
+    fn hash<KV: BackgroundReadableKeyValueStore>(
         this: &Database<KV, Self>,
     ) -> Result<Hash, OperationalError> {
         Ok(this.inner.merkle.hash())
@@ -553,7 +556,7 @@ struct ProveImpl<KV> {
 }
 
 impl DatabaseMode for Prove<'static> {
-    fn get<KV: BackgroundKeyValueStore>(
+    fn get<KV: BackgroundReadableKeyValueStore>(
         this: &Database<KV, Self>,
         key: &Key,
     ) -> Result<impl ValueRef, Error> {
@@ -582,7 +585,7 @@ impl DatabaseMode for Prove<'static> {
         Ok(Wrapper(bytes))
     }
 
-    fn set<KV: BackgroundKeyValueStore>(
+    fn set<KV: BackgroundWriteableKeyValueStore>(
         this: &mut Database<KV, Self>,
         key: Key,
         data: Bytes,
@@ -591,7 +594,7 @@ impl DatabaseMode for Prove<'static> {
         Ok(())
     }
 
-    fn write<KV: BackgroundKeyValueStore>(
+    fn write<KV: BackgroundWriteableKeyValueStore>(
         this: &mut Database<KV, Self>,
         key: Key,
         offset: usize,
@@ -602,14 +605,14 @@ impl DatabaseMode for Prove<'static> {
         Ok(written)
     }
 
-    fn delete<KV: BackgroundKeyValueStore>(
+    fn delete<KV: BackgroundWriteableKeyValueStore>(
         this: &mut Database<KV, Self>,
         key: Key,
     ) -> Result<(), OperationalError> {
         this.inner.merkle.delete(&key)
     }
 
-    fn hash<KV: BackgroundKeyValueStore>(
+    fn hash<KV: BackgroundReadableKeyValueStore>(
         this: &Database<KV, Self>,
     ) -> Result<Hash, OperationalError> {
         Ok(this.inner.merkle.hash())
@@ -617,7 +620,7 @@ impl DatabaseMode for Prove<'static> {
 }
 
 #[cfg(test)]
-impl<KV: BackgroundKeyValueStore, M: DatabaseMode> Database<KV, M> {
+impl<KV: BackgroundReadableKeyValueStore, M: DatabaseMode> Database<KV, M> {
     /// Assert that a database contains the expected value for a given key.
     pub(crate) fn assert_database_value(&self, key: &Key, expected: &[u8]) {
         let mut stored = vec![0; expected.len()];
@@ -658,26 +661,26 @@ pub(crate) mod tests {
     use crate::key::KEY_MAX_SIZE;
     use crate::key::Key;
     use crate::merkle_layer::MerkleLayer;
-    use crate::merkle_worker::BackgroundKeyValueStore;
     use crate::merkle_worker::BackgroundPersistentKeyValueStore;
-    use crate::storage::KeyValueStore;
+    use crate::merkle_worker::BackgroundWriteableKeyValueStore;
     use crate::storage::TestKeyValueStoreSetup;
+    use crate::storage::WriteableKeyValueStore;
     use crate::storage::kv_test;
 
-    fn new_database<KV: BackgroundKeyValueStore>(
+    fn new_database<KV: BackgroundWriteableKeyValueStore>(
         handle: &Handle,
         repo: &KV::Repo,
     ) -> TracedDatabase<KV> {
         TracedDatabase::try_new(handle, repo).expect("Creating a test database should succeed")
     }
 
-    fn new_verify_database<KV: KeyValueStore + TestKeyValueStoreSetup>(
+    fn new_verify_database<KV: WriteableKeyValueStore + TestKeyValueStoreSetup>(
         repo: &KV::Repo,
     ) -> TracedDatabase<KV, Verify> {
         TracedDatabase::<KV, Verify>::new_verify(repo)
     }
 
-    fn new_prove_database<KV: KeyValueStore>(
+    fn new_prove_database<KV: WriteableKeyValueStore>(
         persistence: Arc<KV>,
     ) -> TracedDatabase<KV, Prove<'static>> {
         TracedDatabase::from(Database {
@@ -695,7 +698,7 @@ pub(crate) mod tests {
         TracedDatabase<KV>,
     )
     where
-        KV: BackgroundKeyValueStore + TestKeyValueStoreSetup,
+        KV: BackgroundWriteableKeyValueStore + TestKeyValueStoreSetup,
     {
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(2)
@@ -743,7 +746,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_database_delete, KV: BackgroundKeyValueStore,
+    kv_test!(test_database_delete, KV: BackgroundWriteableKeyValueStore,
         setup_runtime |handle, repo| = {
             let runtime = tokio::runtime::Builder::new_multi_thread()
                 .build()
@@ -775,7 +778,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_database_delete_nonexistent, KV: BackgroundKeyValueStore, {
+    kv_test!(test_database_delete_nonexistent, KV: BackgroundWriteableKeyValueStore, {
         // Receiving the hash requires a separate worker thread
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(1)
@@ -1095,7 +1098,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_database_exists, KV: BackgroundKeyValueStore,
+    kv_test!(test_database_exists, KV: BackgroundWriteableKeyValueStore,
         setup_runtime |handle, repo| = {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .build()
@@ -1129,7 +1132,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_database_hash, KV: BackgroundKeyValueStore,
+    kv_test!(test_database_hash, KV: BackgroundWriteableKeyValueStore,
         setup_runtime |handle, repo| = {
             // Needs a thread for sending and a thread for receiving
             let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -1171,7 +1174,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_database_hash_revert, KV: BackgroundKeyValueStore, {
+    kv_test!(test_database_hash_revert, KV: BackgroundWriteableKeyValueStore, {
         // Needs a thread for sending and a thread for receiving
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(2)
@@ -1210,7 +1213,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_database_read, KV: BackgroundKeyValueStore,
+    kv_test!(test_database_read, KV: BackgroundWriteableKeyValueStore,
         setup_runtime |handle, repo| = {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .build()
@@ -1290,7 +1293,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_database_read_bytes, KV: BackgroundKeyValueStore,
+    kv_test!(test_database_read_bytes, KV: BackgroundWriteableKeyValueStore,
         setup_runtime |handle, repo| = {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .build()
@@ -1338,7 +1341,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_database_read_bytes_no_key, KV: BackgroundKeyValueStore, {
+    kv_test!(test_database_read_bytes_no_key, KV: BackgroundWriteableKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("Creating a Tokio runtime should succeed");
@@ -1357,7 +1360,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_database_read_no_key, KV: BackgroundKeyValueStore, {
+    kv_test!(test_database_read_no_key, KV: BackgroundWriteableKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("Creating a Tokio runtime should succeed");
@@ -1379,7 +1382,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_database_read_bytes_io_too_large, KV: BackgroundKeyValueStore, {
+    kv_test!(test_database_read_bytes_io_too_large, KV: BackgroundWriteableKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("Creating a Tokio runtime should succeed");
@@ -1401,7 +1404,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_database_read_io_too_large, KV: BackgroundKeyValueStore, {
+    kv_test!(test_database_read_io_too_large, KV: BackgroundWriteableKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("Creating a Tokio runtime should succeed");
@@ -1426,7 +1429,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_database_value_length, KV: BackgroundKeyValueStore,
+    kv_test!(test_database_value_length, KV: BackgroundWriteableKeyValueStore,
         setup_runtime |handle, repo| = {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .build()
@@ -1459,7 +1462,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_database_write, KV: BackgroundKeyValueStore,
+    kv_test!(test_database_write, KV: BackgroundWriteableKeyValueStore,
         setup_runtime |handle, repo| = {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .build()
@@ -1497,7 +1500,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_database_write_new_nonzero_offset, KV: BackgroundKeyValueStore, {
+    kv_test!(test_database_write_new_nonzero_offset, KV: BackgroundWriteableKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("Creating a Tokio runtime should succeed");
@@ -1521,7 +1524,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_database_write_io_too_large, KV: BackgroundKeyValueStore, {
+    kv_test!(test_database_write_io_too_large, KV: BackgroundWriteableKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("Creating a Tokio runtime should succeed");
@@ -1545,7 +1548,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_database_write_no_truncation, KV: BackgroundKeyValueStore, {
+    kv_test!(test_database_write_no_truncation, KV: BackgroundWriteableKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("Creating a Tokio runtime should succeed");
@@ -1572,7 +1575,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_database_write_offset_append, KV: BackgroundKeyValueStore, {
+    kv_test!(test_database_write_offset_append, KV: BackgroundWriteableKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("Creating a Tokio runtime should succeed");
@@ -1596,7 +1599,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_database_write_oversized_offset, KV: BackgroundKeyValueStore, {
+    kv_test!(test_database_write_oversized_offset, KV: BackgroundWriteableKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("Creating a Tokio runtime should succeed");
@@ -1613,7 +1616,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_database_set_io_too_large, KV: BackgroundKeyValueStore, {
+    kv_test!(test_database_set_io_too_large, KV: BackgroundWriteableKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("Creating a Tokio runtime should succeed");
@@ -1636,7 +1639,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_database_write_value_too_large, KV: BackgroundKeyValueStore, {
+    kv_test!(test_database_write_value_too_large, KV: BackgroundWriteableKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("Creating a Tokio runtime should succeed");
@@ -1723,7 +1726,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_verify_database_delete, KV: BackgroundKeyValueStore, {
+    kv_test!(test_verify_database_delete, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, repo) = KV::setup_repo();
         let mut database = new_verify_database::<KV>(&repo);
         let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
@@ -1760,7 +1763,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_verify_database_set_and_read, KV: BackgroundKeyValueStore,
+    kv_test!(test_verify_database_set_and_read, KV: BackgroundWriteableKeyValueStore,
         setup |repo| = { KV::setup_repo() },
     [
         data in prop::collection::vec(any::<u8>(), 0..200),
@@ -1780,7 +1783,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_verify_database_value_length, KV: BackgroundKeyValueStore,
+    kv_test!(test_verify_database_value_length, KV: BackgroundWriteableKeyValueStore,
         setup |repo| = { KV::setup_repo() },
     [
         data in prop::collection::vec(any::<u8>(), 0..200),
@@ -1802,7 +1805,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_verify_database_write_partial, KV: BackgroundKeyValueStore,
+    kv_test!(test_verify_database_write_partial, KV: BackgroundWriteableKeyValueStore,
         setup |repo| = { KV::setup_repo() },
     [
         initial in prop::collection::vec(any::<u8>(), 1..200),
@@ -1838,7 +1841,7 @@ pub(crate) mod tests {
 
     fn new_persistence<KV>() -> (KV::Keepalive, Arc<KV>)
     where
-        KV: BackgroundKeyValueStore + TestKeyValueStoreSetup,
+        KV: BackgroundWriteableKeyValueStore + TestKeyValueStoreSetup,
     {
         let (keepalive, repo) = KV::setup_repo();
         let persistence: Arc<KV> = KV::new(&repo)
@@ -1847,7 +1850,7 @@ pub(crate) mod tests {
         (keepalive, persistence)
     }
 
-    kv_test!(test_prove_database_delete, KV: BackgroundKeyValueStore, {
+    kv_test!(test_prove_database_delete, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, persistence) = new_persistence::<KV>();
         let mut database = new_prove_database::<KV>(persistence);
         let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
@@ -1884,7 +1887,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_prove_database_set_and_read, KV: BackgroundKeyValueStore,
+    kv_test!(test_prove_database_set_and_read, KV: BackgroundWriteableKeyValueStore,
         setup |repo| = { KV::setup_repo() },
     [
         data in prop::collection::vec(any::<u8>(), 0..200),
@@ -1907,7 +1910,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_prove_database_value_length, KV: BackgroundKeyValueStore,
+    kv_test!(test_prove_database_value_length, KV: BackgroundWriteableKeyValueStore,
         setup |repo| = { KV::setup_repo() },
     [
         data in prop::collection::vec(any::<u8>(), 0..200),
@@ -1932,7 +1935,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_prove_database_write_partial, KV: BackgroundKeyValueStore,
+    kv_test!(test_prove_database_write_partial, KV: BackgroundWriteableKeyValueStore,
         setup |repo| = { KV::setup_repo() },
     [
         initial in prop::collection::vec(any::<u8>(), 1..200),
@@ -1969,7 +1972,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_prove_database_missing_key, KV: BackgroundKeyValueStore, {
+    kv_test!(test_prove_database_missing_key, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, persistence) = new_persistence::<KV>();
         let mut database = new_prove_database::<KV>(persistence);
 
@@ -2023,7 +2026,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_prove_database_read_bytes_partial, KV: BackgroundKeyValueStore,
+    kv_test!(test_prove_database_read_bytes_partial, KV: BackgroundWriteableKeyValueStore,
         setup |repo| = { KV::setup_repo() },
     [
         data in prop::collection::vec(any::<u8>(), 3..200),
@@ -2075,7 +2078,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_prove_database_read_bytes_records_only_accessed_range, KV: BackgroundKeyValueStore, {
+    kv_test!(test_prove_database_read_bytes_records_only_accessed_range, KV: BackgroundWriteableKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(2)
             .build()
@@ -2151,7 +2154,7 @@ pub(crate) mod tests {
         prove_trace
     });
 
-    kv_test!(test_prove_database_write_append, KV: BackgroundKeyValueStore, {
+    kv_test!(test_prove_database_write_append, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, persistence) = new_persistence::<KV>();
         let mut database = new_prove_database::<KV>(persistence);
 
@@ -2197,7 +2200,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_prove_database_hash, KV: BackgroundKeyValueStore, {
+    kv_test!(test_prove_database_hash, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, persistence) = new_persistence::<KV>();
         let mut database = new_prove_database::<KV>(persistence);
 
@@ -2235,7 +2238,7 @@ pub(crate) mod tests {
         database.into_trace()
     });
 
-    kv_test!(test_empty_db_noop_proof_readable_and_writeable, KV: BackgroundKeyValueStore, {
+    kv_test!(test_empty_db_noop_proof_readable_and_writeable, KV: BackgroundWriteableKeyValueStore, {
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(2)
             .build()
@@ -2268,7 +2271,7 @@ pub(crate) mod tests {
     kv_test!(
         #[should_panic(expected = "trace mismatch")]
         test_database_trace_comparison_detects_divergence,
-        KV: BackgroundKeyValueStore,
+        KV: BackgroundWriteableKeyValueStore,
     {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()

--- a/durable-storage/src/database/traced_database.rs
+++ b/durable-storage/src/database/traced_database.rs
@@ -37,13 +37,13 @@ use crate::errors::OperationalError;
 use crate::key::Key;
 #[cfg(test)]
 use crate::merkle_layer::new_verify_layer;
-use crate::merkle_worker::BackgroundKeyValueStore;
 use crate::merkle_worker::BackgroundPersistentKeyValueStore;
-#[cfg(test)]
-use crate::storage::KeyValueStore;
+use crate::merkle_worker::BackgroundWriteableKeyValueStore;
 use crate::storage::PersistentKeyValueStore;
 #[cfg(test)]
 use crate::storage::TestKeyValueStoreSetup;
+#[cfg(test)]
+use crate::storage::WriteableKeyValueStore;
 
 /// A sequence of recorded [`Database`] operations
 pub(crate) type Trace = Vec<TraceEntry>;
@@ -104,7 +104,7 @@ pub(crate) struct TracedDatabase<KV, M: Mode = Normal> {
     trace: RefCell<Vec<TraceEntry>>,
 }
 
-impl<KV: BackgroundKeyValueStore> TracedDatabase<KV, Normal> {
+impl<KV: BackgroundWriteableKeyValueStore> TracedDatabase<KV, Normal> {
     /// Equivalent to [`Database::try_new`] which also records a [`TraceEntry`].
     #[cfg(test)]
     pub(crate) fn try_new(handle: &Handle, repo: &KV::Repo) -> Result<Self, OperationalError> {
@@ -155,7 +155,7 @@ impl<KV: BackgroundKeyValueStore> TracedDatabase<KV, Normal> {
 #[cfg(test)]
 impl<KV> TracedDatabase<KV, Verify>
 where
-    KV: KeyValueStore + TestKeyValueStoreSetup,
+    KV: WriteableKeyValueStore + TestKeyValueStoreSetup,
 {
     pub(crate) fn new_verify(repo: &KV::Repo) -> Self {
         TracedDatabase::from(Database {
@@ -166,7 +166,7 @@ where
     }
 }
 
-impl<KV: BackgroundKeyValueStore, M: DatabaseMode> TracedDatabase<KV, M> {
+impl<KV: BackgroundWriteableKeyValueStore, M: DatabaseMode> TracedDatabase<KV, M> {
     /// Equivalent to [`Database::set`] which also records a [`TraceEntry`].
     pub(crate) fn set(&mut self, key: Key, data: Bytes) -> Result<(), Error> {
         let result = self.inner.set(key.clone(), data.clone());
@@ -326,7 +326,7 @@ where
     }
 }
 
-impl<'normal, KV: BackgroundKeyValueStore> ProvableExt<'normal, 'static, OperationalError>
+impl<'normal, KV: BackgroundWriteableKeyValueStore> ProvableExt<'normal, 'static, OperationalError>
     for TracedDatabase<KV, Normal>
 {
     type Prover = TracedDatabase<KV, Prove<'static>>;

--- a/durable-storage/src/long_test/registry/run_case.rs
+++ b/durable-storage/src/long_test/registry/run_case.rs
@@ -21,7 +21,7 @@ use octez_riscv_data::mode::Normal;
 
 use super::model::RegistryLongTestModel;
 use crate::long_test::harness::Base;
-use crate::merkle_worker::BackgroundKeyValueStore;
+use crate::merkle_worker::BackgroundWriteableKeyValueStore;
 use crate::persistence_layer::PersistenceLayer;
 use crate::registry::Registry;
 use crate::repo::DirectoryManager;
@@ -58,7 +58,7 @@ fn apply_op_checked<KV>(
     op: &RegistryOperation,
 ) -> Option<StepOutcome>
 where
-    KV: BackgroundKeyValueStore,
+    KV: BackgroundWriteableKeyValueStore,
 {
     let outcome = match op {
         RegistryOperation::Database(index, db_op) => {

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -15,6 +15,12 @@
 //!
 //! [`MerkleLayer::clone_with`] enables forking snapshots. Clones share the underlying tree
 //! cheaply via an `Arc` and diverge upon mutation, using copy-on-write (CoW) semantics.
+//!
+//! *NB* perhaps counterintuitively, all operations (other than `commit`) only require the underlying
+//! KV store be _readable_, even for operations that mutate the AVL tree. This occurs because all these
+//! operations, including mutable ones, only ever load data from the store. The reason `commit` requires
+//! the store to be _writeable_, is precisely because this is the only place where the (possibly updated)
+//! in-memory store is persisted back to the underlying store.
 
 use std::convert::Infallible;
 use std::marker::PhantomData;
@@ -59,9 +65,9 @@ use crate::commit::CommitId;
 use crate::errors::Error;
 use crate::errors::OperationalError;
 use crate::key::Key;
-use crate::storage::KeyValueStore;
 use crate::storage::Loadable;
 use crate::storage::PersistentKeyValueStore;
+use crate::storage::ReadableKeyValueStore;
 use crate::storage::Storable;
 use crate::storage::StoreOptions;
 
@@ -76,7 +82,7 @@ impl<KV> MerkleLayer<KV, Normal> {
     /// Create a new, empty Merkle layer that will commit to the provided persistence layer.
     pub fn new(persistence: Arc<KV>) -> Self
     where
-        KV: KeyValueStore,
+        KV: ReadableKeyValueStore,
     {
         MerkleLayer {
             inner: NormalImpl::new(persistence),
@@ -86,7 +92,7 @@ impl<KV> MerkleLayer<KV, Normal> {
     /// Load the Merkle layer from the given key-value store.
     pub fn checkout(persistence: Arc<KV>, root: CommitId) -> Result<Self, Error>
     where
-        KV: KeyValueStore,
+        KV: ReadableKeyValueStore,
     {
         Ok(MerkleLayer {
             inner: NormalImpl::checkout(persistence, root)?,
@@ -94,6 +100,10 @@ impl<KV> MerkleLayer<KV, Normal> {
     }
 
     /// Generates a commitment for the [MerkleLayer].
+    ///
+    /// This is the only operation of the merkle layer that requires the underlying storage
+    /// be _writeable_ - as nowhere else does the merkle layer write-back to the underlying
+    /// storage.
     pub fn commit(&mut self, options: &StoreOptions) -> Result<CommitId, OperationalError>
     where
         KV: PersistentKeyValueStore,
@@ -129,7 +139,7 @@ impl<KV> MerkleLayer<KV, Prove<'static>> {
     /// An empty prove-mode Merkle layer backed by the given persistence layer.
     pub(crate) fn empty(persistence: Arc<KV>) -> Self
     where
-        KV: KeyValueStore,
+        KV: ReadableKeyValueStore,
     {
         MerkleLayer {
             inner: ProveImpl {
@@ -209,7 +219,7 @@ impl<KV, M: MerkleLayerMode> MerkleLayer<KV, M> {
     /// Clone the Merkle layer. The new layer will commit to the provided persistence layer.
     pub fn clone_with(&self, persistence: Arc<KV>) -> Self
     where
-        KV: KeyValueStore,
+        KV: ReadableKeyValueStore,
     {
         M::clone_with(self, persistence)
     }
@@ -222,7 +232,7 @@ impl<KV, M: MerkleLayerMode> MerkleLayer<KV, M> {
     /// Delete the data associated with a given [Key].
     pub fn delete(&mut self, key: &Key) -> Result<(), OperationalError>
     where
-        KV: KeyValueStore,
+        KV: ReadableKeyValueStore,
     {
         M::delete(self, key)
     }
@@ -230,7 +240,7 @@ impl<KV, M: MerkleLayerMode> MerkleLayer<KV, M> {
     /// Sets the data associated with a given [Key].
     pub fn set(&mut self, key: &Key, data: &[u8]) -> Result<(), OperationalError>
     where
-        KV: KeyValueStore,
+        KV: ReadableKeyValueStore,
     {
         M::set(self, key, data)
     }
@@ -238,7 +248,7 @@ impl<KV, M: MerkleLayerMode> MerkleLayer<KV, M> {
     /// Writes the data to the node associated with a given [Key] with the given offset.
     pub fn write(&mut self, key: &Key, offset: usize, data: &[u8]) -> Result<(), Error>
     where
-        KV: KeyValueStore,
+        KV: ReadableKeyValueStore,
     {
         M::write(self, key, offset, data)
     }
@@ -246,7 +256,7 @@ impl<KV, M: MerkleLayerMode> MerkleLayer<KV, M> {
     /// Returns an immutable reference to the data stored for a given [Key].
     pub(crate) fn get(&self, key: &Key) -> Result<Option<&Bytes<M>>, OperationalError>
     where
-        KV: KeyValueStore,
+        KV: ReadableKeyValueStore,
     {
         M::get(self, key)
     }
@@ -255,7 +265,7 @@ impl<KV, M: MerkleLayerMode> MerkleLayer<KV, M> {
 /// Modes that implements this trait support Merkle layer operations
 pub trait MerkleLayerMode: Mode {
     /// See [`MerkleLayer::clone_with`]
-    fn clone_with<KV: KeyValueStore>(
+    fn clone_with<KV: ReadableKeyValueStore>(
         this: &MerkleLayer<KV, Self>,
         persistence: Arc<KV>,
     ) -> MerkleLayer<KV, Self>;
@@ -264,20 +274,20 @@ pub trait MerkleLayerMode: Mode {
     fn hash<KV>(this: &MerkleLayer<KV, Self>) -> Hash;
 
     /// See [`MerkleLayer::delete`]
-    fn delete<KV: KeyValueStore>(
+    fn delete<KV: ReadableKeyValueStore>(
         this: &mut MerkleLayer<KV, Self>,
         key: &Key,
     ) -> Result<(), OperationalError>;
 
     /// See [`MerkleLayer::set`]
-    fn set<KV: KeyValueStore>(
+    fn set<KV: ReadableKeyValueStore>(
         this: &mut MerkleLayer<KV, Self>,
         key: &Key,
         data: &[u8],
     ) -> Result<(), OperationalError>;
 
     /// See [`MerkleLayer::write`]
-    fn write<KV: KeyValueStore>(
+    fn write<KV: ReadableKeyValueStore>(
         this: &mut MerkleLayer<KV, Self>,
         key: &Key,
         offset: usize,
@@ -285,14 +295,14 @@ pub trait MerkleLayerMode: Mode {
     ) -> Result<(), Error>;
 
     /// See [`MerkleLayer::get`]
-    fn get<'a, KV: KeyValueStore>(
+    fn get<'a, KV: ReadableKeyValueStore>(
         this: &'a MerkleLayer<KV, Self>,
         key: &Key,
     ) -> Result<Option<&'a Bytes<Self>>, OperationalError>;
 }
 
 impl MerkleLayerMode for Normal {
-    fn clone_with<KV: KeyValueStore>(
+    fn clone_with<KV: ReadableKeyValueStore>(
         this: &MerkleLayer<KV, Self>,
         persistence: Arc<KV>,
     ) -> MerkleLayer<KV, Self> {
@@ -305,14 +315,14 @@ impl MerkleLayerMode for Normal {
         this.inner.hash()
     }
 
-    fn delete<KV: KeyValueStore>(
+    fn delete<KV: ReadableKeyValueStore>(
         this: &mut MerkleLayer<KV, Self>,
         key: &Key,
     ) -> Result<(), OperationalError> {
         this.inner.delete(key)
     }
 
-    fn set<KV: KeyValueStore>(
+    fn set<KV: ReadableKeyValueStore>(
         this: &mut MerkleLayer<KV, Self>,
         key: &Key,
         data: &[u8],
@@ -320,7 +330,7 @@ impl MerkleLayerMode for Normal {
         this.inner.set(key, data)
     }
 
-    fn write<KV: KeyValueStore>(
+    fn write<KV: ReadableKeyValueStore>(
         this: &mut MerkleLayer<KV, Self>,
         key: &Key,
         offset: usize,
@@ -329,7 +339,7 @@ impl MerkleLayerMode for Normal {
         this.inner.write(key, offset, data)
     }
 
-    fn get<'a, KV: KeyValueStore>(
+    fn get<'a, KV: ReadableKeyValueStore>(
         this: &'a MerkleLayer<KV, Self>,
         key: &Key,
     ) -> Result<Option<&'a Bytes<Self>>, OperationalError> {
@@ -343,7 +353,7 @@ impl MerkleLayerMode for Normal {
 }
 
 impl MerkleLayerMode for Prove<'static> {
-    fn clone_with<KV: KeyValueStore>(
+    fn clone_with<KV: ReadableKeyValueStore>(
         this: &MerkleLayer<KV, Self>,
         persistence: Arc<KV>,
     ) -> MerkleLayer<KV, Self> {
@@ -362,7 +372,7 @@ impl MerkleLayerMode for Prove<'static> {
         this.inner.working_tree.hash()
     }
 
-    fn delete<KV: KeyValueStore>(
+    fn delete<KV: ReadableKeyValueStore>(
         this: &mut MerkleLayer<KV, Self>,
         key: &Key,
     ) -> Result<(), OperationalError> {
@@ -372,7 +382,7 @@ impl MerkleLayerMode for Prove<'static> {
         Ok(())
     }
 
-    fn set<KV: KeyValueStore>(
+    fn set<KV: ReadableKeyValueStore>(
         this: &mut MerkleLayer<KV, Self>,
         key: &Key,
         data: &[u8],
@@ -383,7 +393,7 @@ impl MerkleLayerMode for Prove<'static> {
         Ok(())
     }
 
-    fn write<KV: KeyValueStore>(
+    fn write<KV: ReadableKeyValueStore>(
         this: &mut MerkleLayer<KV, Self>,
         key: &Key,
         offset: usize,
@@ -395,7 +405,7 @@ impl MerkleLayerMode for Prove<'static> {
         Ok(())
     }
 
-    fn get<'a, KV: KeyValueStore>(
+    fn get<'a, KV: ReadableKeyValueStore>(
         this: &'a MerkleLayer<KV, Self>,
         key: &Key,
     ) -> Result<Option<&'a Bytes<Self>>, OperationalError> {
@@ -408,7 +418,7 @@ impl MerkleLayerMode for Prove<'static> {
 }
 
 impl MerkleLayerMode for Verify {
-    fn clone_with<KV: KeyValueStore>(
+    fn clone_with<KV: ReadableKeyValueStore>(
         this: &MerkleLayer<KV, Self>,
         _persistence: Arc<KV>,
     ) -> MerkleLayer<KV, Self> {
@@ -433,7 +443,7 @@ impl MerkleLayerMode for Verify {
             .unwrap_or_else(|| unsafe { not_found() })
     }
 
-    fn delete<KV: KeyValueStore>(
+    fn delete<KV: ReadableKeyValueStore>(
         this: &mut MerkleLayer<KV, Self>,
         key: &Key,
     ) -> Result<(), OperationalError> {
@@ -442,7 +452,7 @@ impl MerkleLayerMode for Verify {
         Ok(())
     }
 
-    fn set<KV: KeyValueStore>(
+    fn set<KV: ReadableKeyValueStore>(
         this: &mut MerkleLayer<KV, Self>,
         key: &Key,
         data: &[u8],
@@ -452,7 +462,7 @@ impl MerkleLayerMode for Verify {
         Ok(())
     }
 
-    fn write<KV: KeyValueStore>(
+    fn write<KV: ReadableKeyValueStore>(
         this: &mut MerkleLayer<KV, Self>,
         key: &Key,
         offset: usize,
@@ -463,7 +473,7 @@ impl MerkleLayerMode for Verify {
         Ok(())
     }
 
-    fn get<'a, KV: KeyValueStore>(
+    fn get<'a, KV: ReadableKeyValueStore>(
         this: &'a MerkleLayer<KV, Self>,
         key: &Key,
     ) -> Result<Option<&'a Bytes<Self>>, OperationalError> {
@@ -520,7 +530,7 @@ impl<KV> NormalImpl<KV> {
     /// Delete the data associated with a given [Key].
     fn delete(&mut self, key: &Key) -> Result<(), OperationalError>
     where
-        KV: KeyValueStore,
+        KV: ReadableKeyValueStore,
     {
         self.tree.delete(key, &mut self.resolver)?;
         Ok(())
@@ -529,7 +539,7 @@ impl<KV> NormalImpl<KV> {
     /// Sets the data associated with a given [Key].
     fn set(&mut self, key: &Key, data: &[u8]) -> Result<(), OperationalError>
     where
-        KV: KeyValueStore,
+        KV: ReadableKeyValueStore,
     {
         self.tree.set(key, data, &mut self.resolver)?;
         Ok(())
@@ -538,7 +548,7 @@ impl<KV> NormalImpl<KV> {
     /// Writes the data to the node associated with a given [Key] with the given offset.
     fn write(&mut self, key: &Key, offset: usize, data: &[u8]) -> Result<(), Error>
     where
-        KV: KeyValueStore,
+        KV: ReadableKeyValueStore,
     {
         self.tree.write(key, offset, data, &mut self.resolver)?;
         Ok(())
@@ -547,7 +557,7 @@ impl<KV> NormalImpl<KV> {
     /// Load the Merkle layer from the given key-value store with lazy node loading.
     fn checkout(persistence: Arc<KV>, root: CommitId) -> Result<Self, Error>
     where
-        KV: KeyValueStore,
+        KV: ReadableKeyValueStore,
     {
         let resolver = LazyResolver::new(persistence.clone());
         let tree = Tree::load(*root.as_hash(), persistence.as_ref())?;
@@ -613,13 +623,13 @@ struct ProveImpl<KV> {
     resolver: ProveResolver<LazyResolver<KV>>,
 }
 
-impl<KV: KeyValueStore> Foldable<HashFold> for MerkleLayer<KV, Prove<'_>> {
+impl<KV: ReadableKeyValueStore> Foldable<HashFold> for MerkleLayer<KV, Prove<'_>> {
     fn fold(&self, _builder: HashFold) -> <HashFold as Fold>::Folded {
         self.inner.working_tree.hash()
     }
 }
 
-impl<KV: KeyValueStore> Foldable<MerkleProofFold> for MerkleLayer<KV, Prove<'_>> {
+impl<KV: ReadableKeyValueStore> Foldable<MerkleProofFold> for MerkleLayer<KV, Prove<'_>> {
     fn fold(&self, builder: MerkleProofFold) -> <MerkleProofFold as Fold>::Folded {
         // If the database was not touched at all, then it is safely
         // blindable.
@@ -645,7 +655,7 @@ struct InitialTreeFold<'a, KV> {
     prove_impl: &'a ProveImpl<KV>,
 }
 
-impl<KV: KeyValueStore> Foldable<MerkleProofFold> for InitialTreeFold<'_, KV> {
+impl<KV: ReadableKeyValueStore> Foldable<MerkleProofFold> for InitialTreeFold<'_, KV> {
     fn fold(&self, builder: MerkleProofFold) -> <MerkleProofFold as Fold>::Folded {
         let root_hash = Hash::from_foldable(self.tree_id);
 
@@ -669,7 +679,7 @@ struct InitialNodeFold<'a, KV> {
     prove_impl: &'a ProveImpl<KV>,
 }
 
-impl<KV: KeyValueStore> Foldable<MerkleProofFold> for InitialNodeFold<'_, KV> {
+impl<KV: ReadableKeyValueStore> Foldable<MerkleProofFold> for InitialNodeFold<'_, KV> {
     fn fold(&self, builder: MerkleProofFold) -> <MerkleProofFold as Fold>::Folded {
         let hash = Hash::from_foldable(self.node_id);
 
@@ -750,7 +760,7 @@ impl<KV: KeyValueStore> Foldable<MerkleProofFold> for InitialNodeFold<'_, KV> {
 /// # Panics
 ///
 /// Panics if the subtree was not, in fact, resolved during the prove operations.
-fn fold_resolved_tree<KV: KeyValueStore>(
+fn fold_resolved_tree<KV: ReadableKeyValueStore>(
     tree_id: &LazyTreeId,
     prove_impl: &ProveImpl<KV>,
     builder: MerkleProofFold,
@@ -781,10 +791,15 @@ fn fold_resolved_tree<KV: KeyValueStore>(
     node_fold.done()
 }
 
+#[cfg(test)]
+use crate::storage::WriteableKeyValueStore;
+
 /// Construct a verify-mode [`MerkleLayer`] for an empty initial state. Used in tests that exercise
 /// verify-mode mutation primitives in isolation.
 #[cfg(test)]
-pub(crate) fn new_verify_layer<KV: KeyValueStore>(repo: &KV::Repo) -> MerkleLayer<KV, Verify> {
+pub(crate) fn new_verify_layer<KV: WriteableKeyValueStore>(
+    repo: &KV::Repo,
+) -> MerkleLayer<KV, Verify> {
     let normal_ml = new_merkle_layer::<KV>(repo);
     let prove_ml = normal_ml.start_proof();
     let proof = MerkleProof::from_foldable(&prove_ml);
@@ -792,7 +807,7 @@ pub(crate) fn new_verify_layer<KV: KeyValueStore>(repo: &KV::Repo) -> MerkleLaye
 }
 
 #[cfg(test)]
-fn new_merkle_layer<KV: KeyValueStore>(repo: &KV::Repo) -> MerkleLayer<KV, Normal> {
+fn new_merkle_layer<KV: WriteableKeyValueStore>(repo: &KV::Repo) -> MerkleLayer<KV, Normal> {
     let persistence_layer = KV::new(repo)
         .expect("Creating a persistence layer should succeed")
         .into();
@@ -831,12 +846,13 @@ mod tests {
     use crate::avl::resolver::ProveResolver;
     use crate::avl::tree::Tree;
     use crate::key::Key;
-    use crate::storage::KeyValueStore;
     use crate::storage::PersistentKeyValueStore;
+    use crate::storage::ReadableKeyValueStore;
     use crate::storage::TestKeyValueStoreSetup;
+    use crate::storage::WriteableKeyValueStore;
     use crate::storage::kv_test;
 
-    impl<KV: KeyValueStore> MerkleLayer<KV, Normal> {
+    impl<KV: ReadableKeyValueStore> MerkleLayer<KV, Normal> {
         fn tree(&self) -> &Tree<LazyNodeId> {
             &self.inner.tree
         }
@@ -855,7 +871,7 @@ mod tests {
         }
     }
 
-    impl<KV: KeyValueStore> MerkleLayer<KV, Prove<'static>> {
+    impl<KV: ReadableKeyValueStore> MerkleLayer<KV, Prove<'static>> {
         /// Construct a Prove-mode MerkleLayer from a tree, lazily resolving from `persistence`.
         pub(crate) fn from_prove_tree(persistence: Arc<KV>, tree: Tree<ProveNodeId>) -> Self {
             MerkleLayer {
@@ -894,7 +910,7 @@ mod tests {
 
     /// Apply `op` against `ml`. Returns `Some(bytes)` for [`Operation::Read`] so callers can
     /// compare read results across modes, and `None` for state-mutating ops.
-    fn apply_operation<KV: KeyValueStore, M: MerkleLayerMode + BytesMode>(
+    fn apply_operation<KV: ReadableKeyValueStore, M: MerkleLayerMode + BytesMode>(
         ml: &mut MerkleLayer<KV, M>,
         op: &Operation,
     ) -> Option<Vec<u8>> {
@@ -940,7 +956,7 @@ mod tests {
     /// 3. Replaying the same operation against the Verify-mode tree decoded from the proof
     ///    produces the same final hash as prove mode (the proof carries enough information for
     ///    full verification).
-    fn assert_prove_mode_correct<KV: KeyValueStore + TestKeyValueStoreSetup>(
+    fn assert_prove_mode_correct<KV: ReadableKeyValueStore + TestKeyValueStoreSetup>(
         setup_keys: &[[u8; 2]],
         operations: &[Operation],
     ) {
@@ -1508,7 +1524,7 @@ mod tests {
         ml.tree().check(&ml.inner.resolver).expect("the tree should be retrieved successfully.");
     });
 
-    fn test_mavl_delete_keys<KV: KeyValueStore>(repo: &KV::Repo, keys: &[Key]) {
+    fn test_mavl_delete_keys<KV: WriteableKeyValueStore>(repo: &KV::Repo, keys: &[Key]) {
         let data = bytes::Bytes::from("delete");
 
         let mut ml = new_merkle_layer::<KV>(repo);

--- a/durable-storage/src/merkle_worker.rs
+++ b/durable-storage/src/merkle_worker.rs
@@ -27,16 +27,20 @@ use crate::errors::InvalidArgumentError;
 use crate::errors::OperationalError;
 use crate::key::Key;
 use crate::merkle_layer::MerkleLayer;
-use crate::storage::KeyValueStore;
 use crate::storage::PersistentKeyValueStore;
+use crate::storage::ReadableKeyValueStore;
 use crate::storage::StoreOptions;
+use crate::storage::WriteableKeyValueStore;
 
 trait_set! {
-    /// [`KeyValueStore`] that can be used in a background thread
-    pub trait BackgroundKeyValueStore = KeyValueStore + Send + Sync + 'static;
+    /// [`ReadableKeyValueStore`] that can be used in a background thread
+    pub trait BackgroundReadableKeyValueStore = ReadableKeyValueStore + Send + Sync + 'static;
+
+    /// [`WriteableKeyValueStore`] that can be used in a background thread
+    pub trait BackgroundWriteableKeyValueStore = WriteableKeyValueStore + BackgroundReadableKeyValueStore;
 
     /// [`PersistentKeyValueStore`] that can be used in a background thread
-    pub trait BackgroundPersistentKeyValueStore = PersistentKeyValueStore + BackgroundKeyValueStore;
+    pub trait BackgroundPersistentKeyValueStore = PersistentKeyValueStore + BackgroundWriteableKeyValueStore;
 }
 
 /// Alias for the inner workings of the [`Command`] struct to make Clippy happy
@@ -48,13 +52,13 @@ type DynCommand<KV> = dyn FnOnce(&mut MerkleLayer<KV, Normal>, &mut BTreeSet<Key
 ///
 /// As these are handled in a background thread, there are potential race conditions between the
 /// background worker, and the persistence layer. The `MerkleLayer` resolves values lazily from the
-/// `KeyValueStore` - and as a result can attempt to perform operations over unexpected, or
+/// `WriteableKeyValueStore` - and as a result can attempt to perform operations over unexpected, or
 /// incorrectly shaped, values.
 ///
 /// ## Out-of-order delete
 ///
 /// One such race condition is that a delete operation may already have been performed in the
-/// `KeyValueStore`, prior to a _previous_ write/set on that value being handled in the Merkle
+/// `WriteableKeyValueStore`, prior to a _previous_ write/set on that value being handled in the Merkle
 /// layer. This can happen when, on the first `set/write`, the value needs to be resolved (loaded).
 /// This takes time to happen - and is fully possible (if many intermediate nodes need to be resolved
 /// first), that a subsequent delete operation has already been handled by the persistence layer.
@@ -100,7 +104,7 @@ impl<KV> Command<KV> {
     /// Construct a command that performs a [`MerkleLayer::write`].
     fn new_write(key: Key, offset: usize, value: Bytes) -> Self
     where
-        KV: KeyValueStore,
+        KV: ReadableKeyValueStore,
     {
         Self(Box::new(
             move |layer: &mut MerkleLayer<KV, Normal>, consistency: &mut BTreeSet<Key>| match layer
@@ -128,7 +132,7 @@ impl<KV> Command<KV> {
     /// Construct a command that performs a [`MerkleLayer::set`].
     fn new_set(key: Key, value: Bytes) -> Self
     where
-        KV: KeyValueStore,
+        KV: ReadableKeyValueStore,
     {
         Self(Box::new(
             move |layer: &mut MerkleLayer<KV, Normal>, consistency: &mut BTreeSet<Key>| match layer
@@ -152,7 +156,7 @@ impl<KV> Command<KV> {
     /// Construct a command that performs a [`MerkleLayer::delete`].
     fn new_delete(key: Key) -> Self
     where
-        KV: KeyValueStore,
+        KV: ReadableKeyValueStore,
     {
         Self(Box::new(
             move |layer: &mut MerkleLayer<KV, Normal>, consistency: &mut BTreeSet<Key>| {
@@ -174,7 +178,7 @@ impl<KV> Command<KV> {
         Self,
     )
     where
-        KV: BackgroundKeyValueStore,
+        KV: BackgroundReadableKeyValueStore,
     {
         let (sender, receiver) = oneshot::channel();
 
@@ -202,7 +206,7 @@ impl<KV> Command<KV> {
     /// Construct a command that performs a [`MerkleLayer::hash`].
     fn new_hash() -> (impl FnOnce() -> Result<Hash, OperationalError>, Self)
     where
-        KV: KeyValueStore,
+        KV: ReadableKeyValueStore,
     {
         let (sender, receiver) = oneshot::channel();
 
@@ -272,7 +276,7 @@ impl<KV> MerkleWorker<KV> {
     /// The provided handle is used to spawn the background worker thread.
     pub fn new(async_handle: &Handle, store: Arc<KV>) -> Self
     where
-        KV: BackgroundKeyValueStore,
+        KV: BackgroundReadableKeyValueStore,
     {
         let layer = MerkleLayer::new(store);
         MerkleWorker::from_layer(async_handle, layer)
@@ -308,7 +312,7 @@ impl<KV> MerkleWorker<KV> {
         store: Arc<KV>,
     ) -> Result<Self, OperationalError>
     where
-        KV: BackgroundKeyValueStore,
+        KV: BackgroundReadableKeyValueStore,
     {
         let (receive, command) = Command::new_clone_with(store);
         self.sender
@@ -329,7 +333,7 @@ impl<KV> MerkleWorker<KV> {
         value: Bytes,
     ) -> Result<(), OperationalError>
     where
-        KV: KeyValueStore,
+        KV: ReadableKeyValueStore,
     {
         let command = Command::new_write(key, offset, value);
         self.sender
@@ -340,7 +344,7 @@ impl<KV> MerkleWorker<KV> {
     /// Non-blocking version of [`MerkleLayer::set`].
     pub(crate) fn set(&self, key: Key, value: Bytes) -> Result<(), OperationalError>
     where
-        KV: KeyValueStore,
+        KV: ReadableKeyValueStore,
     {
         let command = Command::new_set(key, value);
         self.sender
@@ -351,7 +355,7 @@ impl<KV> MerkleWorker<KV> {
     /// Non-blocking version of [`MerkleLayer::delete`].
     pub(crate) fn delete(&self, key: Key) -> Result<(), OperationalError>
     where
-        KV: KeyValueStore,
+        KV: ReadableKeyValueStore,
     {
         let command = Command::new_delete(key);
         self.sender
@@ -362,7 +366,7 @@ impl<KV> MerkleWorker<KV> {
     /// See [`MerkleLayer::hash`].
     pub(crate) fn hash(&self) -> Result<Hash, OperationalError>
     where
-        KV: KeyValueStore,
+        KV: ReadableKeyValueStore,
     {
         let (receive, command) = Command::new_hash();
         self.sender
@@ -381,7 +385,7 @@ impl<KV> MerkleWorker<KV> {
         commit: CommitId,
     ) -> Result<Self, Error>
     where
-        KV: BackgroundPersistentKeyValueStore,
+        KV: BackgroundReadableKeyValueStore,
     {
         let layer = MerkleLayer::checkout(store, commit)?;
         let worker = MerkleWorker::from_layer(async_handle, layer);
@@ -407,7 +411,7 @@ impl<KV> MerkleWorker<KV> {
         store: Arc<KV>,
     ) -> Result<MerkleLayer<KV, Prove<'static>>, OperationalError>
     where
-        KV: BackgroundKeyValueStore,
+        KV: BackgroundReadableKeyValueStore,
     {
         let (receive, command) = Command::new_clone_with(store);
         self.sender
@@ -435,7 +439,7 @@ mod tests {
     use crate::key::Key;
     use crate::merkle_layer::MerkleLayer;
     use crate::merkle_worker::MerkleWorker;
-    use crate::storage::KeyValueStore;
+    use crate::storage::WriteableKeyValueStore;
     use crate::storage::kv_test;
 
     fn key_strategy() -> impl Strategy<Value = Key> {

--- a/durable-storage/src/persistence_layer.rs
+++ b/durable-storage/src/persistence_layer.rs
@@ -44,8 +44,9 @@ use crate::errors::Error;
 use crate::errors::InvalidArgumentError;
 use crate::errors::OperationalError;
 use crate::repo::DirectoryManager;
-use crate::storage::KeyValueStore;
 use crate::storage::PersistentKeyValueStore;
+use crate::storage::ReadableKeyValueStore;
+use crate::storage::WriteableKeyValueStore;
 
 /// The name of the column family used for storing blob-keyed data.
 const BLOB_CF: &str = "blob";
@@ -264,9 +265,43 @@ impl PersistenceLayer {
     }
 }
 
-impl KeyValueStore for PersistenceLayer {
+impl ReadableKeyValueStore for PersistenceLayer {
     type Repo = DirectoryManager;
 
+    fn blob_get(&self, key: impl AsRef<[u8]>) -> Result<impl AsRef<[u8]>, Error> {
+        let key = key.as_ref();
+        let entry = self
+            .db_instance
+            .get_pinned_cf(self.blob_cf(), key)
+            .map_err(|error| OperationalError::GetFailed {
+                column: BLOB_CF.to_string(),
+                key: key.to_owned(),
+                error,
+            })?;
+
+        match entry {
+            Some(value) => Ok(value),
+            None => Err(InvalidArgumentError::KeyNotFound)?,
+        }
+    }
+
+    fn get(&self, key: impl AsRef<[u8]>) -> Result<impl AsRef<[u8]>, Error> {
+        let value = self.db_instance.get_pinned(key.as_ref()).map_err(|error| {
+            OperationalError::GetFailed {
+                column: "default".to_owned(),
+                key: key.as_ref().to_owned(),
+                error,
+            }
+        })?;
+
+        match value {
+            Some(value) => Ok(value),
+            None => Err(InvalidArgumentError::KeyNotFound)?,
+        }
+    }
+}
+
+impl WriteableKeyValueStore for PersistenceLayer {
     fn new(repo: &Self::Repo) -> Result<Self, OperationalError> {
         let tempdir = repo.temp_database_dir()?;
         let new_db_path = tempdir.path().join("checkpoint");
@@ -287,23 +322,6 @@ impl KeyValueStore for PersistenceLayer {
 
     fn try_clone(&self, repo: &Self::Repo) -> Result<Self, OperationalError> {
         Self::clone_as_checkpoint(&self.db_instance, repo)
-    }
-
-    fn blob_get(&self, key: impl AsRef<[u8]>) -> Result<impl AsRef<[u8]>, Error> {
-        let key = key.as_ref();
-        let entry = self
-            .db_instance
-            .get_pinned_cf(self.blob_cf(), key)
-            .map_err(|error| OperationalError::GetFailed {
-                column: BLOB_CF.to_string(),
-                key: key.to_owned(),
-                error,
-            })?;
-
-        match entry {
-            Some(value) => Ok(value),
-            None => Err(InvalidArgumentError::KeyNotFound)?,
-        }
     }
 
     fn blob_set(
@@ -330,21 +348,6 @@ impl KeyValueStore for PersistenceLayer {
                 key: key.to_owned(),
                 error,
             })
-    }
-
-    fn get(&self, key: impl AsRef<[u8]>) -> Result<impl AsRef<[u8]>, Error> {
-        let value = self.db_instance.get_pinned(key.as_ref()).map_err(|error| {
-            OperationalError::GetFailed {
-                column: "default".to_owned(),
-                key: key.as_ref().to_owned(),
-                error,
-            }
-        })?;
-
-        match value {
-            Some(value) => Ok(value),
-            None => Err(InvalidArgumentError::KeyNotFound)?,
-        }
     }
 
     fn set(&self, key: impl AsRef<[u8]>, value: impl AsRef<[u8]>) -> Result<(), OperationalError> {

--- a/durable-storage/src/registry.rs
+++ b/durable-storage/src/registry.rs
@@ -42,10 +42,11 @@ use crate::database::Database;
 use crate::errors::Error;
 use crate::errors::InvalidArgumentError;
 use crate::errors::OperationalError;
-use crate::merkle_worker::BackgroundKeyValueStore;
 use crate::merkle_worker::BackgroundPersistentKeyValueStore;
+use crate::merkle_worker::BackgroundReadableKeyValueStore;
+use crate::merkle_worker::BackgroundWriteableKeyValueStore;
 use crate::repo::RegistryRepo;
-use crate::storage::KeyValueStore;
+use crate::storage::ReadableKeyValueStore;
 
 #[derive(Debug, Encode, Decode)]
 /// Structure to store the result of serialising a registry.
@@ -55,12 +56,12 @@ struct RegistryManifest {
 
 /// Registry that owns a set of databases and the repository used to manage
 /// registry state.
-pub struct Registry<KV: KeyValueStore, M: Mode> {
+pub struct Registry<KV: ReadableKeyValueStore, M: Mode> {
     inner: M::Select<RegistryTemplate<KV>>,
     databases: Vector<Database<KV, M>, M>,
 }
 
-impl<KV: BackgroundKeyValueStore> Registry<KV, Normal> {
+impl<KV: BackgroundReadableKeyValueStore> Registry<KV, Normal> {
     /// Creates a new, empty Registry.
     ///
     /// The registry owns a Tokio [`Runtime`] and a register state repository.
@@ -90,7 +91,7 @@ impl<KV: BackgroundKeyValueStore> Registry<KV, Normal> {
 
 impl<'normal, KV> ProvableExt<'normal, 'static, OperationalError> for Registry<KV, Normal>
 where
-    KV: BackgroundKeyValueStore,
+    KV: BackgroundReadableKeyValueStore,
     KV::Repo: Clone,
 {
     type Prover = Registry<KV, Prove<'static>>;
@@ -111,7 +112,7 @@ where
     }
 }
 
-impl<KV: KeyValueStore> Registry<KV, Prove<'static>> {
+impl<KV: ReadableKeyValueStore> Registry<KV, Prove<'static>> {
     /// Produce a [`Proof`] of the operations performed against this
     /// Prove-mode registry.
     ///
@@ -209,7 +210,7 @@ where
     }
 }
 
-impl<KV: KeyValueStore, M: Mode> Registry<KV, M> {
+impl<KV: ReadableKeyValueStore, M: Mode> Registry<KV, M> {
     /// Check the given `index` is valid for a database in the registry.
     fn validate_index(&self, index: usize) -> Result<(), InvalidArgumentError>
     where
@@ -247,7 +248,7 @@ impl<KV: KeyValueStore, M: Mode> Registry<KV, M> {
     /// databases from the end.
     pub fn resize_tick(&mut self, new_size: usize) -> Result<(), Error>
     where
-        KV: BackgroundKeyValueStore,
+        KV: BackgroundWriteableKeyValueStore,
         M: RegistryMode + VectorMode,
     {
         match self.len().abs_diff(new_size) {
@@ -283,7 +284,7 @@ impl<KV: KeyValueStore, M: Mode> Registry<KV, M> {
     /// Copy the contents of database at `src_index` to database at `dst_index`.
     pub fn copy_database(&mut self, src_index: usize, dst_index: usize) -> Result<(), Error>
     where
-        KV: BackgroundKeyValueStore,
+        KV: BackgroundWriteableKeyValueStore,
         M: RegistryMode + VectorMode,
     {
         self.validate_index(src_index)?;
@@ -303,7 +304,7 @@ impl<KV: KeyValueStore, M: Mode> Registry<KV, M> {
     /// database is replaced with an empty database.
     pub fn move_database(&mut self, src_index: usize, dst_index: usize) -> Result<(), Error>
     where
-        KV: BackgroundKeyValueStore,
+        KV: BackgroundWriteableKeyValueStore,
         M: RegistryMode + VectorMode,
     {
         self.validate_index(src_index)?;
@@ -322,7 +323,7 @@ impl<KV: KeyValueStore, M: Mode> Registry<KV, M> {
     /// Clear the database at the given `index`.
     pub fn clear_database(&mut self, index: usize) -> Result<(), Error>
     where
-        KV: BackgroundKeyValueStore,
+        KV: BackgroundWriteableKeyValueStore,
         M: RegistryMode + VectorMode,
     {
         self.validate_index(index)?;
@@ -331,7 +332,7 @@ impl<KV: KeyValueStore, M: Mode> Registry<KV, M> {
     }
 }
 
-impl<KV: BackgroundKeyValueStore, M: CloneRegistryMode> Registry<KV, M>
+impl<KV: BackgroundWriteableKeyValueStore, M: CloneRegistryMode> Registry<KV, M>
 where
     KV::Repo: Clone,
 {
@@ -343,7 +344,7 @@ where
     }
 }
 
-impl<KV: KeyValueStore, M: Mode, F: Fold> Foldable<F> for Registry<KV, M>
+impl<KV: ReadableKeyValueStore, M: Mode, F: Fold> Foldable<F> for Registry<KV, M>
 where
     Database<KV, M>: Foldable<F>,
     Vector<Database<KV, M>, M>: Foldable<F>,
@@ -353,7 +354,7 @@ where
     }
 }
 
-impl<KV: KeyValueStore> FromProof for Registry<KV, Verify> {
+impl<KV: ReadableKeyValueStore> FromProof for Registry<KV, Verify> {
     // TODO (TZX-161): for a verify mode Registry, the resulting registry state is currently
     // only usable if `proof` is the ProofTree. Otherwise, if created using the stream
     // deserialiser, verification will fail (as this does not support capturing the owned proof).
@@ -373,9 +374,9 @@ impl<KV: KeyValueStore> FromProof for Registry<KV, Verify> {
 /// Modal template for the [`Registry`]
 ///
 /// This is used to select the appropriate implementation for the mode.
-struct RegistryTemplate<KV: KeyValueStore>(PhantomData<KV>, Infallible);
+struct RegistryTemplate<KV: ReadableKeyValueStore>(PhantomData<KV>, Infallible);
 
-impl<KV: KeyValueStore> Modal for RegistryTemplate<KV> {
+impl<KV: ReadableKeyValueStore> Modal for RegistryTemplate<KV> {
     type Normal = NormalImpl<KV>;
 
     type Prove<'normal> = ProveImpl<KV>;
@@ -390,12 +391,12 @@ impl<KV: KeyValueStore> Modal for RegistryTemplate<KV> {
 )]
 pub trait RegistryMode: VectorMode {
     /// Create a new database.
-    fn try_new_database<KV: BackgroundKeyValueStore>(
+    fn try_new_database<KV: BackgroundWriteableKeyValueStore>(
         inner: &Self::Select<RegistryTemplate<KV>>,
     ) -> Result<Database<KV, Self>, OperationalError>;
 
     /// Copy the database at `src_index` over the one at `dst_index`.
-    fn copy_database<KV: BackgroundKeyValueStore>(
+    fn copy_database<KV: BackgroundWriteableKeyValueStore>(
         inner: &Self::Select<RegistryTemplate<KV>>,
         databases: &mut Vector<Database<KV, Self>, Self>,
         src_index: usize,
@@ -404,7 +405,7 @@ pub trait RegistryMode: VectorMode {
 
     /// Move the database at `src_index` over the one at `dst_index`, leaving an empty database
     /// at `src_index`.
-    fn move_database<KV: BackgroundKeyValueStore>(
+    fn move_database<KV: BackgroundWriteableKeyValueStore>(
         inner: &Self::Select<RegistryTemplate<KV>>,
         databases: &mut Vector<Database<KV, Self>, Self>,
         src_index: usize,
@@ -412,7 +413,7 @@ pub trait RegistryMode: VectorMode {
     ) -> Result<(), OperationalError>;
 
     /// Clear the database at `index`.
-    fn clear_database<KV: BackgroundKeyValueStore>(
+    fn clear_database<KV: BackgroundWriteableKeyValueStore>(
         inner: &Self::Select<RegistryTemplate<KV>>,
         databases: &mut Vector<Database<KV, Self>, Self>,
         index: usize,
@@ -424,13 +425,13 @@ pub trait RegistryMode: VectorMode {
     reason = "This method should not be used outside of this module"
 )]
 impl RegistryMode for Normal {
-    fn try_new_database<KV: BackgroundKeyValueStore>(
+    fn try_new_database<KV: BackgroundWriteableKeyValueStore>(
         inner: &Self::Select<RegistryTemplate<KV>>,
     ) -> Result<Database<KV, Self>, OperationalError> {
         Database::try_new(inner.runtime.handle(), &inner.repo)
     }
 
-    fn copy_database<KV: BackgroundKeyValueStore>(
+    fn copy_database<KV: BackgroundWriteableKeyValueStore>(
         inner: &Self::Select<RegistryTemplate<KV>>,
         databases: &mut Vector<Database<KV, Self>, Self>,
         src_index: usize,
@@ -441,7 +442,7 @@ impl RegistryMode for Normal {
         Ok(())
     }
 
-    fn move_database<KV: BackgroundKeyValueStore>(
+    fn move_database<KV: BackgroundWriteableKeyValueStore>(
         inner: &Self::Select<RegistryTemplate<KV>>,
         databases: &mut Vector<Database<KV, Self>, Self>,
         src_index: usize,
@@ -453,7 +454,7 @@ impl RegistryMode for Normal {
         Ok(())
     }
 
-    fn clear_database<KV: BackgroundKeyValueStore>(
+    fn clear_database<KV: BackgroundWriteableKeyValueStore>(
         inner: &Self::Select<RegistryTemplate<KV>>,
         databases: &mut Vector<Database<KV, Self>, Self>,
         index: usize,
@@ -468,7 +469,7 @@ impl RegistryMode for Normal {
     reason = "This method should not be used outside of this module"
 )]
 impl RegistryMode for Prove<'static> {
-    fn try_new_database<KV: BackgroundKeyValueStore>(
+    fn try_new_database<KV: BackgroundWriteableKeyValueStore>(
         inner: &Self::Select<RegistryTemplate<KV>>,
     ) -> Result<Database<KV, Self>, OperationalError> {
         let persistence = Arc::new(KV::new(&inner.repo)?);
@@ -484,7 +485,7 @@ impl RegistryMode for Prove<'static> {
     // the source slot's initial tree, but are recorded against the destination slot — the
     // source's fold blinds them, so such proofs under-include data and fail to verify.
 
-    fn copy_database<KV: BackgroundKeyValueStore>(
+    fn copy_database<KV: BackgroundWriteableKeyValueStore>(
         _inner: &Self::Select<RegistryTemplate<KV>>,
         databases: &mut Vector<Database<KV, Self>, Self>,
         src_index: usize,
@@ -495,7 +496,7 @@ impl RegistryMode for Prove<'static> {
         Ok(())
     }
 
-    fn move_database<KV: BackgroundKeyValueStore>(
+    fn move_database<KV: BackgroundWriteableKeyValueStore>(
         _inner: &Self::Select<RegistryTemplate<KV>>,
         databases: &mut Vector<Database<KV, Self>, Self>,
         src_index: usize,
@@ -506,7 +507,7 @@ impl RegistryMode for Prove<'static> {
         Ok(())
     }
 
-    fn clear_database<KV: BackgroundKeyValueStore>(
+    fn clear_database<KV: BackgroundWriteableKeyValueStore>(
         _inner: &Self::Select<RegistryTemplate<KV>>,
         databases: &mut Vector<Database<KV, Self>, Self>,
         index: usize,
@@ -521,13 +522,13 @@ impl RegistryMode for Prove<'static> {
     reason = "This method should not be used outside of this module"
 )]
 impl RegistryMode for Verify {
-    fn try_new_database<KV: BackgroundKeyValueStore>(
+    fn try_new_database<KV: BackgroundWriteableKeyValueStore>(
         _inner: &Self::Select<RegistryTemplate<KV>>,
     ) -> Result<Database<KV, Self>, OperationalError> {
         Ok(<Database<KV, Verify>>::empty())
     }
 
-    fn copy_database<KV: BackgroundKeyValueStore>(
+    fn copy_database<KV: BackgroundWriteableKeyValueStore>(
         _inner: &Self::Select<RegistryTemplate<KV>>,
         databases: &mut Vector<Database<KV, Self>, Self>,
         src_index: usize,
@@ -538,7 +539,7 @@ impl RegistryMode for Verify {
         Ok(())
     }
 
-    fn move_database<KV: BackgroundKeyValueStore>(
+    fn move_database<KV: BackgroundWriteableKeyValueStore>(
         inner: &Self::Select<RegistryTemplate<KV>>,
         databases: &mut Vector<Database<KV, Self>, Self>,
         src_index: usize,
@@ -550,7 +551,7 @@ impl RegistryMode for Verify {
         Ok(())
     }
 
-    fn clear_database<KV: BackgroundKeyValueStore>(
+    fn clear_database<KV: BackgroundWriteableKeyValueStore>(
         inner: &Self::Select<RegistryTemplate<KV>>,
         databases: &mut Vector<Database<KV, Self>, Self>,
         index: usize,
@@ -563,7 +564,7 @@ impl RegistryMode for Verify {
 /// Modes that implement this marker support cloning of the [`Registry`] type
 pub trait CloneRegistryMode: Mode {
     /// See [`Registry::try_clone`]
-    fn try_clone<KV: BackgroundKeyValueStore>(
+    fn try_clone<KV: BackgroundWriteableKeyValueStore>(
         this: &Registry<KV, Self>,
     ) -> Result<Registry<KV, Self>, OperationalError>
     where
@@ -571,7 +572,7 @@ pub trait CloneRegistryMode: Mode {
 }
 
 impl CloneRegistryMode for Normal {
-    fn try_clone<KV: BackgroundKeyValueStore>(
+    fn try_clone<KV: BackgroundWriteableKeyValueStore>(
         this: &Registry<KV, Self>,
     ) -> Result<Registry<KV, Self>, OperationalError>
     where
@@ -596,18 +597,18 @@ impl CloneRegistryMode for Normal {
 }
 
 /// Registry implementation for the [`Normal`] mode
-struct NormalImpl<KV: KeyValueStore> {
+struct NormalImpl<KV: ReadableKeyValueStore> {
     repo: KV::Repo,
     runtime: Arc<Runtime>,
 }
 
 /// Registry implementation for the [`Prove`] mode.
-struct ProveImpl<KV: KeyValueStore> {
+struct ProveImpl<KV: ReadableKeyValueStore> {
     repo: KV::Repo,
 }
 
 /// Registry implementation for the [`Verify`] mode.
-struct VerifyImpl<KV: KeyValueStore>(PhantomData<KV>);
+struct VerifyImpl<KV: ReadableKeyValueStore>(PhantomData<KV>);
 
 #[cfg(test)]
 pub(super) mod tests {
@@ -642,19 +643,19 @@ pub(super) mod tests {
     use crate::errors::InvalidArgumentError;
     use crate::errors::OperationalError;
     use crate::key::Key;
-    use crate::merkle_worker::BackgroundKeyValueStore;
     use crate::merkle_worker::BackgroundPersistentKeyValueStore;
+    use crate::merkle_worker::BackgroundWriteableKeyValueStore;
     use crate::repo::RegistryRepo;
     use crate::storage::TestKeyValueStoreSetup;
     use crate::storage::kv_test;
 
-    pub(super) fn setup_registry<KV: BackgroundKeyValueStore>(
+    pub(super) fn setup_registry<KV: BackgroundWriteableKeyValueStore>(
         repo: KV::Repo,
     ) -> Registry<KV, Normal> {
         Registry::new(repo).expect("Registry should be created")
     }
 
-    pub(super) fn setup_size_2_registry<KV: BackgroundKeyValueStore>(
+    pub(super) fn setup_size_2_registry<KV: BackgroundWriteableKeyValueStore>(
         repo: KV::Repo,
     ) -> Registry<KV, Normal> {
         let mut registry = setup_registry::<KV>(repo);
@@ -669,7 +670,7 @@ pub(super) mod tests {
         registry
     }
 
-    fn setup_prove_registry<KV: BackgroundKeyValueStore>(
+    fn setup_prove_registry<KV: BackgroundWriteableKeyValueStore>(
         repo: KV::Repo,
     ) -> Registry<KV, Prove<'static>> {
         Registry {
@@ -678,7 +679,7 @@ pub(super) mod tests {
         }
     }
 
-    fn setup_prove_size_2_registry<KV: BackgroundKeyValueStore>(
+    fn setup_prove_size_2_registry<KV: BackgroundWriteableKeyValueStore>(
         repo: KV::Repo,
     ) -> Registry<KV, Prove<'static>> {
         let mut registry = setup_prove_registry::<KV>(repo);
@@ -691,14 +692,15 @@ pub(super) mod tests {
         registry
     }
 
-    fn setup_verify_registry<KV: BackgroundKeyValueStore>() -> Registry<KV, Verify> {
+    fn setup_verify_registry<KV: BackgroundWriteableKeyValueStore>() -> Registry<KV, Verify> {
         Registry {
             inner: VerifyImpl(PhantomData),
             databases: <Verify as VectorMode>::new(Vec::new()),
         }
     }
 
-    fn setup_verify_size_2_registry<KV: BackgroundKeyValueStore>() -> Registry<KV, Verify> {
+    fn setup_verify_size_2_registry<KV: BackgroundWriteableKeyValueStore>() -> Registry<KV, Verify>
+    {
         let mut registry = setup_verify_registry::<KV>();
         registry
             .resize_tick(1)
@@ -709,7 +711,7 @@ pub(super) mod tests {
         registry
     }
 
-    fn seed_copy_move<KV: BackgroundKeyValueStore>(
+    fn seed_copy_move<KV: BackgroundWriteableKeyValueStore>(
         registry: &mut Registry<KV, Normal>,
         src_index: usize,
         dst_index: usize,
@@ -741,7 +743,7 @@ pub(super) mod tests {
         (src_pairs, key_c)
     }
 
-    fn assert_pairs_present<KV: BackgroundKeyValueStore>(
+    fn assert_pairs_present<KV: BackgroundWriteableKeyValueStore>(
         registry: &Registry<KV, Normal>,
         db_index: usize,
         pairs: &[(Key, &'static [u8])],
@@ -760,7 +762,7 @@ pub(super) mod tests {
         }
     }
 
-    fn assert_pairs_absent<KV: BackgroundKeyValueStore>(
+    fn assert_pairs_absent<KV: BackgroundWriteableKeyValueStore>(
         registry: &Registry<KV, Normal>,
         db_index: usize,
         pairs: &[(Key, &'static [u8])],
@@ -775,7 +777,7 @@ pub(super) mod tests {
         }
     }
 
-    pub(super) fn populate_database_with_key_value<KV: BackgroundKeyValueStore>(
+    pub(super) fn populate_database_with_key_value<KV: BackgroundWriteableKeyValueStore>(
         registry: &mut Registry<KV, Normal>,
         db_index: usize,
         key_bytes: &[u8],
@@ -787,13 +789,13 @@ pub(super) mod tests {
             .expect("Writing to database should succeed");
     }
 
-    kv_test!(test_new, KV: BackgroundKeyValueStore, {
+    kv_test!(test_new, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, repo) = KV::setup_repo();
         let registry = setup_registry::<KV>(repo);
         assert!(registry.is_empty());
     });
 
-    kv_test!(test_resize, KV: BackgroundKeyValueStore, {
+    kv_test!(test_resize, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, repo) = KV::setup_repo();
         let mut registry = setup_registry::<KV>(repo);
 
@@ -814,7 +816,7 @@ pub(super) mod tests {
         assert!(registry.resize_tick(5).is_err());
     });
 
-    kv_test!(test_get_database, KV: BackgroundKeyValueStore, {
+    kv_test!(test_get_database, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, repo) = KV::setup_repo();
         let mut registry = setup_registry::<KV>(repo);
 
@@ -829,7 +831,7 @@ pub(super) mod tests {
         }
     });
 
-    kv_test!(test_copy_database, KV: BackgroundKeyValueStore, {
+    kv_test!(test_copy_database, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, repo) = KV::setup_repo();
         let mut registry = setup_size_2_registry::<KV>(repo);
 
@@ -852,7 +854,7 @@ pub(super) mod tests {
         );
     });
 
-    kv_test!(test_database_operations_invalid_index, KV: BackgroundKeyValueStore, {
+    kv_test!(test_database_operations_invalid_index, KV: BackgroundWriteableKeyValueStore, {
         macro_rules! assert_invalid_index_error {
             ($result:expr, $operation:expr, $direction:expr) => {
                 assert!(
@@ -886,7 +888,7 @@ pub(super) mod tests {
         assert_invalid_index_error!(registry.clear_database(2), "clear", "");
     });
 
-    kv_test!(test_move_database, KV: BackgroundKeyValueStore, {
+    kv_test!(test_move_database, KV: BackgroundWriteableKeyValueStore, {
         // Test that the source database is emptied and the destination database
         // has all the data, and any data previously in the destination is lost.
 
@@ -906,7 +908,7 @@ pub(super) mod tests {
         assert_pairs_absent::<KV>(&registry, src_index, &src_pairs);
     });
 
-    kv_test!(test_database_operations_same_index, KV: BackgroundKeyValueStore, {
+    kv_test!(test_database_operations_same_index, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, repo) = KV::setup_repo();
         let mut registry = setup_size_2_registry::<KV>(repo);
 
@@ -925,7 +927,7 @@ pub(super) mod tests {
         assert_pairs_present::<KV>(&registry, 0, &src_pairs);
     });
 
-    kv_test!(test_clear_database, KV: BackgroundKeyValueStore, {
+    kv_test!(test_clear_database, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, repo) = KV::setup_repo();
         let mut registry = setup_size_2_registry::<KV>(repo);
 
@@ -1127,7 +1129,7 @@ pub(super) mod tests {
         ));
     });
 
-    kv_test!(test_hashing_prove_registry_does_not_record_reads, KV: BackgroundKeyValueStore, {
+    kv_test!(test_hashing_prove_registry_does_not_record_reads, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, repo) = KV::setup_repo();
 
         let key_a = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
@@ -1176,7 +1178,7 @@ pub(super) mod tests {
         );
     });
 
-    kv_test!(test_prove_clear_database, KV: BackgroundKeyValueStore, {
+    kv_test!(test_prove_clear_database, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, repo) = KV::setup_repo();
         let mut registry = setup_prove_size_2_registry::<KV>(repo);
 
@@ -1201,7 +1203,7 @@ pub(super) mod tests {
         );
     });
 
-    kv_test!(test_prove_copy_database, KV: BackgroundKeyValueStore, {
+    kv_test!(test_prove_copy_database, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, repo) = KV::setup_repo();
         let mut registry = setup_prove_size_2_registry::<KV>(repo);
 
@@ -1227,7 +1229,7 @@ pub(super) mod tests {
             .assert_database_value(&key, b"src");
     });
 
-    kv_test!(test_prove_database_clone_independence, KV: BackgroundKeyValueStore, {
+    kv_test!(test_prove_database_clone_independence, KV: BackgroundWriteableKeyValueStore, {
         // Cloning via copy should produce an independent database — mutations to the source
         // after the copy must not propagate to the destination.
         let (_keepalive, repo) = KV::setup_repo();
@@ -1260,7 +1262,7 @@ pub(super) mod tests {
             .assert_database_value(&key, b"original");
     });
 
-    kv_test!(test_prove_database_ops, KV: BackgroundKeyValueStore, {
+    kv_test!(test_prove_database_ops, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, repo) = KV::setup_repo();
         let mut registry = setup_prove_size_2_registry::<KV>(repo);
 
@@ -1281,7 +1283,7 @@ pub(super) mod tests {
         );
     });
 
-    kv_test!(test_prove_invalid_index, KV: BackgroundKeyValueStore, {
+    kv_test!(test_prove_invalid_index, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, repo) = KV::setup_repo();
         let mut registry = setup_prove_size_2_registry::<KV>(repo);
 
@@ -1305,7 +1307,7 @@ pub(super) mod tests {
         ));
     });
 
-    kv_test!(test_prove_move_database, KV: BackgroundKeyValueStore, {
+    kv_test!(test_prove_move_database, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, repo) = KV::setup_repo();
         let mut registry = setup_prove_size_2_registry::<KV>(repo);
 
@@ -1334,13 +1336,13 @@ pub(super) mod tests {
             .assert_database_value(&key, b"value");
     });
 
-    kv_test!(test_prove_new, KV: BackgroundKeyValueStore, {
+    kv_test!(test_prove_new, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, repo) = KV::setup_repo();
         let registry = setup_prove_registry::<KV>(repo);
         assert!(registry.is_empty());
     });
 
-    kv_test!(test_prove_resize, KV: BackgroundKeyValueStore, {
+    kv_test!(test_prove_resize, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, repo) = KV::setup_repo();
         let mut registry = setup_prove_registry::<KV>(repo);
 
@@ -1364,7 +1366,7 @@ pub(super) mod tests {
     // Reading through a `Registry<Prove>` populated from snapshots of Normal-mode source
     // data records a proof; replaying the same reads through the resulting
     // `Registry<Verify>` must yield the same values.
-    kv_test!(test_verify_replays_prove_reads, KV: BackgroundKeyValueStore, {
+    kv_test!(test_verify_replays_prove_reads, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, repo) = KV::setup_repo();
 
         let key_a = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
@@ -1476,7 +1478,7 @@ pub(super) mod tests {
         );
     });
 
-    kv_test!(test_verify_clear_database, KV: BackgroundKeyValueStore, {
+    kv_test!(test_verify_clear_database, KV: BackgroundWriteableKeyValueStore, {
         let mut registry = setup_verify_size_2_registry::<KV>();
 
         let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
@@ -1500,7 +1502,7 @@ pub(super) mod tests {
         );
     });
 
-    kv_test!(test_verify_copy_database, KV: BackgroundKeyValueStore, {
+    kv_test!(test_verify_copy_database, KV: BackgroundWriteableKeyValueStore, {
         let mut registry = setup_verify_size_2_registry::<KV>();
 
         let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
@@ -1525,7 +1527,7 @@ pub(super) mod tests {
             .assert_database_value(&key, b"src");
     });
 
-    kv_test!(test_verify_database_clone_independence, KV: BackgroundKeyValueStore, {
+    kv_test!(test_verify_database_clone_independence, KV: BackgroundWriteableKeyValueStore, {
         // Cloning via copy should produce an independent database — mutations to the source
         // after the copy must not propagate to the destination.
         let mut registry = setup_verify_size_2_registry::<KV>();
@@ -1557,7 +1559,7 @@ pub(super) mod tests {
             .assert_database_value(&key, b"original");
     });
 
-    kv_test!(test_verify_database_ops, KV: BackgroundKeyValueStore, {
+    kv_test!(test_verify_database_ops, KV: BackgroundWriteableKeyValueStore, {
         // Exercise read/write/delete on a verify-mode database obtained from the registry.
         let mut registry = setup_verify_size_2_registry::<KV>();
 
@@ -1578,7 +1580,7 @@ pub(super) mod tests {
         );
     });
 
-    kv_test!(test_verify_invalid_index, KV: BackgroundKeyValueStore, {
+    kv_test!(test_verify_invalid_index, KV: BackgroundWriteableKeyValueStore, {
         let mut registry = setup_verify_size_2_registry::<KV>();
 
         assert!(matches!(
@@ -1601,7 +1603,7 @@ pub(super) mod tests {
         ));
     });
 
-    kv_test!(test_verify_move_database, KV: BackgroundKeyValueStore, {
+    kv_test!(test_verify_move_database, KV: BackgroundWriteableKeyValueStore, {
         let mut registry = setup_verify_size_2_registry::<KV>();
 
         let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
@@ -1629,12 +1631,12 @@ pub(super) mod tests {
             .assert_database_value(&key, b"value");
     });
 
-    kv_test!(test_verify_new, KV: BackgroundKeyValueStore, {
+    kv_test!(test_verify_new, KV: BackgroundWriteableKeyValueStore, {
         let registry = setup_verify_registry::<KV>();
         assert!(registry.is_empty());
     });
 
-    kv_test!(test_verify_resize, KV: BackgroundKeyValueStore, {
+    kv_test!(test_verify_resize, KV: BackgroundWriteableKeyValueStore, {
         let mut registry = setup_verify_registry::<KV>();
 
         while registry.len() < 4 {
@@ -1667,7 +1669,7 @@ pub(super) mod tests {
     ///    registry.
     ///
     /// Returns the registries produced by both passes.
-    fn deserialise_proof_via_bytes<KV: BackgroundKeyValueStore>(
+    fn deserialise_proof_via_bytes<KV: BackgroundWriteableKeyValueStore>(
         proof: &Proof,
     ) -> (Registry<KV, Verify>, Registry<KV, Verify>) {
         let bytes = serialise_proof(proof);
@@ -1696,7 +1698,7 @@ pub(super) mod tests {
     ///
     /// Future full e2e tests should additionally pass the whole proof to
     /// allow registry partial hash fold to function if these don't apply.
-    fn registry_root_hash_small<KV: BackgroundKeyValueStore>(
+    fn registry_root_hash_small<KV: BackgroundWriteableKeyValueStore>(
         registry: &Registry<KV, Verify>,
     ) -> Hash {
         PartialHash::from_foldable(None, registry)
@@ -1704,7 +1706,7 @@ pub(super) mod tests {
             .expect("Database captures owned proof, should be able to hash")
     }
 
-    kv_test!(test_proof_via_bytes_end_to_end, KV: BackgroundKeyValueStore, {
+    kv_test!(test_proof_via_bytes_end_to_end, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, repo) = KV::setup_repo();
 
         let key_a = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
@@ -1810,7 +1812,7 @@ pub(super) mod tests {
     // touched database is present, its merkle-tree siblings are blinded, and every other database
     // is absent (absorbed into a blinded ancestor). The proof must still round-trip and let the
     // verifier replay the touched read.
-    kv_test!(test_touch_one_database_yields_minimal_proof, KV: BackgroundKeyValueStore, {
+    kv_test!(test_touch_one_database_yields_minimal_proof, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, repo) = KV::setup_repo();
         let mut registry = setup_registry::<KV>(repo);
         for n in 1..=16 {
@@ -1866,7 +1868,7 @@ pub(super) mod tests {
     // Such a proof is fully blinded — the whole registry collapses to a single blind leaf carrying
     // its root hash — rather than exposing each database (which would yield a present contents
     // subtree with no length node, rejected by the deserialiser).
-    kv_test!(test_untouched_nonempty_registry_proof_is_fully_blinded, KV: BackgroundKeyValueStore, {
+    kv_test!(test_untouched_nonempty_registry_proof_is_fully_blinded, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, repo) = KV::setup_repo();
 
         let mut registry = setup_size_2_registry::<KV>(repo);
@@ -1905,7 +1907,7 @@ pub(super) mod tests {
 
     // TODO (TZX-161): once the stream deserialiser can capture owned proofs, the first pass
     // should become verifiable on its own and this test should be updated.
-    kv_test!(test_proof_via_bytes_requires_second_deserialisation, KV: BackgroundKeyValueStore, {
+    kv_test!(test_proof_via_bytes_requires_second_deserialisation, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, repo) = KV::setup_repo();
 
         let key_a = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
@@ -1973,7 +1975,7 @@ pub(super) mod tests {
         );
     });
 
-    kv_test!(test_proof_database_hash_queries_replay_in_verify_mode, KV: BackgroundKeyValueStore, {
+    kv_test!(test_proof_database_hash_queries_replay_in_verify_mode, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, repo) = KV::setup_repo();
 
         let key_c = Key::new(&[3]).expect("Size less than KEY_MAX_SIZE");
@@ -2042,7 +2044,7 @@ pub(super) mod tests {
     });
 
     kv_test!(
-        test_proof_copy_database_preserves_hash_invariants, KV: BackgroundKeyValueStore, {
+        test_proof_copy_database_preserves_hash_invariants, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, repo) = KV::setup_repo();
 
         let mut registry = setup_size_2_registry::<KV>(repo);
@@ -2091,7 +2093,7 @@ pub(super) mod tests {
     });
 
     kv_test!(
-        test_proof_move_database_preserves_hash_invariants, KV: BackgroundKeyValueStore, {
+        test_proof_move_database_preserves_hash_invariants, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, repo) = KV::setup_repo();
 
         let mut registry = setup_size_2_registry::<KV>(repo);
@@ -2140,7 +2142,7 @@ pub(super) mod tests {
     });
 
     kv_test!(
-        test_proof_clear_database_preserves_hash_invariants, KV: BackgroundKeyValueStore, {
+        test_proof_clear_database_preserves_hash_invariants, KV: BackgroundWriteableKeyValueStore, {
         let (_keepalive, repo) = KV::setup_repo();
 
         let mut registry = setup_size_2_registry::<KV>(repo);

--- a/durable-storage/src/storage.rs
+++ b/durable-storage/src/storage.rs
@@ -19,11 +19,25 @@ use crate::commit::CommitId;
 use crate::errors::Error;
 use crate::errors::OperationalError;
 
-/// Types that implement this trait can be used as the underlying key-value store
-pub trait KeyValueStore: Sized {
+/// Types that implement this trait can serve reads from a key-value store.
+///
+/// This is the half of the store interface that requires no ability to modify the stored data.
+/// Note that [`ReadableKeyValueStore::Repo`] lives here rather than on
+/// [`WriteableKeyValueStore`]: a store which cannot be written to still needs to know the
+/// repository its data is read from.
+pub trait ReadableKeyValueStore: Sized {
     /// Type of repository required to initialise a key value store.
     type Repo;
 
+    /// Retrieves the data associated with the given blob key.
+    fn blob_get(&self, key: impl AsRef<[u8]>) -> Result<impl AsRef<[u8]>, Error>;
+
+    /// Retrieves a value associated with the given key.
+    fn get(&self, key: impl AsRef<[u8]>) -> Result<impl AsRef<[u8]>, Error>;
+}
+
+/// Types that implement this trait can be used as the underlying key-value store
+pub trait WriteableKeyValueStore: ReadableKeyValueStore {
     /// Create a new instance of the key-value store.
     ///
     /// The backend may make use of the repo provided, for persistence - if required.
@@ -31,9 +45,6 @@ pub trait KeyValueStore: Sized {
 
     /// Attempt to make a copy of the key-value store.
     fn try_clone(&self, repo: &Self::Repo) -> Result<Self, OperationalError>;
-
-    /// Retrieves the data associated with the given blob key.
-    fn blob_get(&self, key: impl AsRef<[u8]>) -> Result<impl AsRef<[u8]>, Error>;
 
     /// Register data under a blob key.
     fn blob_set(
@@ -44,9 +55,6 @@ pub trait KeyValueStore: Sized {
 
     /// Deletes a value associated with the given blob key.
     fn blob_delete(&self, key: impl AsRef<[u8]>) -> Result<(), OperationalError>;
-
-    /// Retrieves a value associated with the given key.
-    fn get(&self, key: impl AsRef<[u8]>) -> Result<impl AsRef<[u8]>, Error>;
 
     /// Sets a value for the given key.
     fn set(&self, key: impl AsRef<[u8]>, value: impl AsRef<[u8]>) -> Result<(), OperationalError>;
@@ -64,7 +72,7 @@ pub trait KeyValueStore: Sized {
 }
 
 /// Types that implement this trait can be used as a persistent key-value store
-pub trait PersistentKeyValueStore: KeyValueStore + Sized {
+pub trait PersistentKeyValueStore: WriteableKeyValueStore + Sized {
     /// Commits the current state of the store to the given path.
     ///
     /// Implementations will treat the path as a directory.
@@ -91,7 +99,7 @@ cfg_if::cfg_if! {
         pub(crate) type TestKeyValueStore = crate::persistence_layer::PersistenceLayer;
 
         /// Repository type required to initialise [`TestKeyValueStore`].
-        pub(crate) type TestRepo = <TestKeyValueStore as KeyValueStore>::Repo;
+        pub(crate) type TestRepo = <TestKeyValueStore as ReadableKeyValueStore>::Repo;
 
         /// Create a test repository for [`TestKeyValueStore`].
         ///
@@ -99,7 +107,7 @@ cfg_if::cfg_if! {
         /// - `keepalive` is a temporary directory handle that must stay in scope for the lifetime
         ///   of `repo`.
         /// - `repo` is the backend repository value to pass into
-        ///   [`KeyValueStore::new`] / [`KeyValueStore::try_clone`].
+        ///   [`WriteableKeyValueStore::new`] / [`WriteableKeyValueStore::try_clone`].
         ///
         /// TODO RV-942: Refactor the function to avoid the need for `keepalive` return value.
         pub(crate) fn setup_repo() -> (octez_riscv_test_utils::TestableTmpdir, TestRepo) {
@@ -126,8 +134,8 @@ cfg_if::cfg_if! {
 
         // TODO: This trait currently duplicates the functionality of the `TestKeyValueStore` mechanism defined above.
         // Tests which use the `kv_test!` macro will be refactored to use `TestKeyValueStoreSetup`, which can supersede
-        // `KeyValueStore` once all tests have been rewritten.
-        pub(crate) trait TestKeyValueStoreSetup: KeyValueStore + std::fmt::Debug {
+        // `WriteableKeyValueStore` once all tests have been rewritten.
+        pub(crate) trait TestKeyValueStoreSetup: WriteableKeyValueStore + std::fmt::Debug {
             /// Temporary directory handle that must stay in scope for the lifetime of the repo
             type Keepalive;
 
@@ -223,7 +231,7 @@ cfg_if::cfg_if! {
                     $(#[$attr])* $fun_name, $ty_name $(: $ty_bound)?,
                     ret_ty = (
                         <$ty_name as $crate::storage::TestKeyValueStoreSetup>::Keepalive,
-                        <$ty_name as $crate::storage::KeyValueStore>::Repo,
+                        <$ty_name as $crate::storage::ReadableKeyValueStore>::Repo,
                     ),
                     setup_values = (_keepalive, $repo),
                     setup = $setup,
@@ -244,7 +252,7 @@ cfg_if::cfg_if! {
                         ::tokio::runtime::Runtime,
                         ::tokio::runtime::Handle,
                         <$ty_name as $crate::storage::TestKeyValueStoreSetup>::Keepalive,
-                        <$ty_name as $crate::storage::KeyValueStore>::Repo,
+                        <$ty_name as $crate::storage::ReadableKeyValueStore>::Repo,
                     ),
                     setup_values = (_runtime, $handle, _keepalive, $repo),
                     setup = $setup,
@@ -269,7 +277,7 @@ cfg_if::cfg_if! {
                                 $(+ $ty_bound)?,
                     >() -> $ret_ty
                     where
-                        <$ty_name as $crate::storage::KeyValueStore>::Repo:
+                        <$ty_name as $crate::storage::ReadableKeyValueStore>::Repo:
                             $crate::repo::RegistryRepo,
                     {
                         $setup
@@ -318,7 +326,7 @@ cfg_if::cfg_if! {
                                 $(+ $ty_bound)?,
                     >()
                     where
-                        <$ty_name as $crate::storage::KeyValueStore>::Repo:
+                        <$ty_name as $crate::storage::ReadableKeyValueStore>::Repo:
                             $crate::repo::RegistryRepo,
                     {}
 
@@ -350,7 +358,7 @@ cfg_if::cfg_if! {
     }
 }
 
-/// Options for storing MAVL values in a [`KeyValueStore`]
+/// Options for storing MAVL values in a [`WriteableKeyValueStore`]
 #[derive(Debug, Clone, Default)]
 pub struct StoreOptions {
     /// Persist the key-value pairs from MAVL nodes
@@ -383,12 +391,12 @@ impl StoreOptions {
     }
 }
 
-/// This trait marks values that can be persisted into a [`KeyValueStore`].
+/// This trait marks values that can be persisted into a [`WriteableKeyValueStore`].
 pub trait Storable: Foldable<HashFold> {
     /// Persist this value into `store` according to `options`.
     fn store(
         &self,
-        store: &impl KeyValueStore,
+        store: &impl WriteableKeyValueStore,
         options: &StoreOptions,
     ) -> Result<(), OperationalError>;
 }
@@ -396,21 +404,21 @@ pub trait Storable: Foldable<HashFold> {
 impl<T: Storable> Storable for Arc<T> {
     fn store(
         &self,
-        store: &impl KeyValueStore,
+        store: &impl WriteableKeyValueStore,
         options: &StoreOptions,
     ) -> Result<(), OperationalError> {
         T::store(self, store, options)
     }
 }
 
-/// This trait marks values that can be reconstructed from a [`KeyValueStore`] by content hash.
+/// This trait marks values that can be reconstructed from a [`ReadableKeyValueStore`] by content hash.
 pub trait Loadable: Sized {
     /// Load a value identified by `id` from `store`.
-    fn load(id: Hash, store: &impl KeyValueStore) -> Result<Self, OperationalError>;
+    fn load(id: Hash, store: &impl ReadableKeyValueStore) -> Result<Self, OperationalError>;
 }
 
 impl<T: Loadable> Loadable for Arc<T> {
-    fn load(id: Hash, store: &impl KeyValueStore) -> Result<Self, OperationalError> {
+    fn load(id: Hash, store: &impl ReadableKeyValueStore) -> Result<Self, OperationalError> {
         T::load(id, store).map(Arc::new)
     }
 }

--- a/durable-storage/src/storage/in_memory.rs
+++ b/durable-storage/src/storage/in_memory.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-//! In-memory storage backend [`KeyValueStore`]-compatible with the Persistence layer
+//! In-memory storage backend [`WriteableKeyValueStore`]-compatible with the Persistence layer
 
 use std::collections::HashMap;
 #[cfg(test_utils)]
@@ -15,7 +15,8 @@ use std::sync::RwLock;
 use bytes::Bytes;
 use bytes::BytesMut;
 
-use super::KeyValueStore;
+use super::ReadableKeyValueStore;
+use super::WriteableKeyValueStore;
 use crate::errors::Error;
 use crate::errors::InvalidArgumentError;
 use crate::errors::OperationalError;
@@ -88,16 +89,8 @@ impl InMemoryKeyValueStore {
     }
 }
 
-impl KeyValueStore for InMemoryKeyValueStore {
+impl ReadableKeyValueStore for InMemoryKeyValueStore {
     type Repo = InMemoryRepo;
-
-    fn new(_repo: &Self::Repo) -> Result<Self, OperationalError> {
-        Ok(Self::default())
-    }
-
-    fn try_clone(&self, _repo: &Self::Repo) -> Result<Self, OperationalError> {
-        self.try_clone()
-    }
 
     fn blob_get(&self, key: impl AsRef<[u8]>) -> Result<impl AsRef<[u8]>, Error> {
         let blob_store = self
@@ -110,6 +103,29 @@ impl KeyValueStore for InMemoryKeyValueStore {
             .ok_or(InvalidArgumentError::KeyNotFound)?;
 
         Ok(data.clone())
+    }
+
+    fn get(&self, key: impl AsRef<[u8]>) -> Result<impl AsRef<[u8]>, Error> {
+        let store = self
+            .values
+            .read()
+            .map_err(|_| OperationalError::LockPoisoned)?;
+
+        let value = store
+            .get(key.as_ref())
+            .ok_or(InvalidArgumentError::KeyNotFound)?;
+
+        Ok(value.clone())
+    }
+}
+
+impl WriteableKeyValueStore for InMemoryKeyValueStore {
+    fn new(_repo: &Self::Repo) -> Result<Self, OperationalError> {
+        Ok(Self::default())
+    }
+
+    fn try_clone(&self, _repo: &Self::Repo) -> Result<Self, OperationalError> {
+        self.try_clone()
     }
 
     fn blob_set(
@@ -139,19 +155,6 @@ impl KeyValueStore for InMemoryKeyValueStore {
         blob_store.remove(key.as_ref());
 
         Ok(())
-    }
-
-    fn get(&self, key: impl AsRef<[u8]>) -> Result<impl AsRef<[u8]>, Error> {
-        let store = self
-            .values
-            .read()
-            .map_err(|_| OperationalError::LockPoisoned)?;
-
-        let value = store
-            .get(key.as_ref())
-            .ok_or(InvalidArgumentError::KeyNotFound)?;
-
-        Ok(value.clone())
     }
 
     fn set(&self, key: impl AsRef<[u8]>, value: impl AsRef<[u8]>) -> Result<(), OperationalError> {

--- a/durable-storage/src/test_helpers/database.rs
+++ b/durable-storage/src/test_helpers/database.rs
@@ -38,8 +38,8 @@ use crate::errors::Error;
 use crate::errors::OperationalError;
 use crate::key::KEY_MAX_SIZE;
 use crate::key::Key;
-use crate::merkle_worker::BackgroundKeyValueStore;
 use crate::merkle_worker::BackgroundPersistentKeyValueStore;
+use crate::merkle_worker::BackgroundWriteableKeyValueStore;
 use crate::test_helpers::OperationView;
 use crate::test_helpers::StepOutcome;
 use crate::test_helpers::outcome_from_value;
@@ -342,7 +342,7 @@ pub(crate) trait DatabaseOps<KV: BackgroundPersistentKeyValueStore>:
     ) -> Result<CommitId, OperationalError>;
 }
 
-impl<KV: BackgroundKeyValueStore, M: DatabaseMode> DatabaseValueOps for Database<KV, M> {
+impl<KV: BackgroundWriteableKeyValueStore, M: DatabaseMode> DatabaseValueOps for Database<KV, M> {
     fn set(&mut self, key: Key, data: Bytes) -> Result<(), Error> {
         Database::set(self, key, data)
     }
@@ -399,7 +399,9 @@ impl<KV: BackgroundPersistentKeyValueStore> DatabaseOps<KV> for Database<KV, Nor
 }
 
 #[cfg(any(test, rocksdb_test_utils))]
-impl<KV: BackgroundKeyValueStore, M: DatabaseMode> DatabaseValueOps for TracedDatabase<KV, M> {
+impl<KV: BackgroundWriteableKeyValueStore, M: DatabaseMode> DatabaseValueOps
+    for TracedDatabase<KV, M>
+{
     fn set(&mut self, key: Key, data: Bytes) -> Result<(), Error> {
         TracedDatabase::set(self, key, data)
     }
@@ -707,7 +709,7 @@ pub(crate) fn apply_database_step<D: DatabaseValueOps>(
 /// `None` if `operation` is not a provable step. The Prove- and Verify-mode outcomes are
 /// asserted to be equal before returning; the returned outcome is the (identical) Prove-mode one.
 #[cfg(any(test, rocksdb_test_utils))]
-pub(crate) fn prove_and_verify_database_operation<KV: BackgroundKeyValueStore>(
+pub(crate) fn prove_and_verify_database_operation<KV: BackgroundWriteableKeyValueStore>(
     database: &Database<KV, Normal>,
     operation: &DatabaseOperation,
 ) -> Option<(Vec<u8>, StepOutcome)> {

--- a/durable-storage/src/test_helpers/registry.rs
+++ b/durable-storage/src/test_helpers/registry.rs
@@ -37,8 +37,8 @@ use crate::commit::CommitId;
 use crate::database::DatabaseMode;
 use crate::errors::OperationalError;
 use crate::key::Key;
-use crate::merkle_worker::BackgroundKeyValueStore;
 use crate::merkle_worker::BackgroundPersistentKeyValueStore;
+use crate::merkle_worker::BackgroundWriteableKeyValueStore;
 use crate::registry::Registry;
 use crate::registry::RegistryMode;
 use crate::repo::RegistryRepo;
@@ -150,7 +150,7 @@ impl OperationView for RegistryOperationView {
 
 pub(crate) fn grow_registry<KV, M>(registry: &mut Registry<KV, M>)
 where
-    KV: BackgroundKeyValueStore,
+    KV: BackgroundWriteableKeyValueStore,
     M: RegistryMode,
 {
     let new = registry.len();
@@ -187,7 +187,7 @@ fn apply_registry_step<KV, M>(
     len: usize,
 ) -> Result<Option<StepOutcome>, OperationalError>
 where
-    KV: BackgroundKeyValueStore,
+    KV: BackgroundWriteableKeyValueStore,
     M: RegistryMode + DatabaseMode,
 {
     let outcome = match op {
@@ -249,7 +249,7 @@ pub(crate) fn prove_and_verify_registry_operation<KV>(
     op: &RegistryOperation,
 ) -> Option<(Vec<u8>, StepOutcome)>
 where
-    KV: BackgroundKeyValueStore,
+    KV: BackgroundWriteableKeyValueStore,
     KV::Repo: Clone,
 {
     let pre_root = Hash::from_foldable(registry);

--- a/pvm/src/pvm/durable_storage.rs
+++ b/pvm/src/pvm/durable_storage.rs
@@ -20,7 +20,7 @@ use octez_riscv_data::mode::Provable;
 use octez_riscv_durable_storage::errors::OperationalError;
 use octez_riscv_durable_storage::registry::CloneRegistryMode;
 use octez_riscv_durable_storage::registry::Registry;
-use octez_riscv_durable_storage::storage::KeyValueStore;
+use octez_riscv_durable_storage::storage::WriteableKeyValueStore;
 
 /// Implementing types provide an interface for durable storage
 pub trait DurableStorage<M: Mode>: Sized {
@@ -29,7 +29,8 @@ pub trait DurableStorage<M: Mode>: Sized {
         M: CloneRegistryMode;
 }
 
-impl<KV: KeyValueStore + Send + Sync + 'static, M: Mode> DurableStorage<M> for Registry<KV, M>
+impl<KV: WriteableKeyValueStore + Send + Sync + 'static, M: Mode> DurableStorage<M>
+    for Registry<KV, M>
 where
     KV::Repo: Clone,
 {

--- a/pvm/src/storage/rocksdb_store.rs
+++ b/pvm/src/storage/rocksdb_store.rs
@@ -16,8 +16,9 @@ use octez_riscv_durable_storage::errors::Error;
 use octez_riscv_durable_storage::errors::InvalidArgumentError;
 use octez_riscv_durable_storage::persistence_layer::PersistenceLayer;
 use octez_riscv_durable_storage::repo::DirectoryManager;
-use octez_riscv_durable_storage::storage::KeyValueStore;
 use octez_riscv_durable_storage::storage::PersistentKeyValueStore;
+use octez_riscv_durable_storage::storage::ReadableKeyValueStore;
+use octez_riscv_durable_storage::storage::WriteableKeyValueStore;
 
 use super::PersistentBlobStore;
 use super::StorageError;


### PR DESCRIPTION
- part of TZX-201

<!-- 
    Link Linear issues using magic words. Examples of these are "Closes RV-XXX", "Part of RV-YYY"
    or "Relates to RV-ZZZ".
-->

# What

Split `KeyValueStore` into `ReadableKeyValueStore` and `WriteableKeyValueStore`

Constrain every path that only reads the store - or only mutates the in-memory Merkle tree - from `KeyValueStore` to `ReadableKeyValueStore`

# Why

No functional changes here - but subsequently unblocks adding a full `checkout_readonly` method, whilst ensuring that such a registry _cannot_ mutate the underlying store. This makes it safe to open a checkout directly, rather than going through an intermediate copy: and ultimately allowing the rollup node's RPC flow to be more efficient - as it only requires read-access to the store

# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
