### PR TITLE
test(nds): add metrics for disk-space usage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -19,3 +19,7 @@ ignore:
   # Ignore test-only modules
   - "**/test.rs"
   - "**/tests.rs"
+  # Argument parsing for the space accounting harness: no logic, and not reachable from the
+  # test suite, so it can only ever report as uncovered. The harness itself is covered by
+  # the restricted tests in `gc_space::scenario`.
+  - "durable-storage/src/bin/gc_space.rs"

--- a/durable-storage/Cargo.toml
+++ b/durable-storage/Cargo.toml
@@ -83,6 +83,11 @@ name = "long_test"
 path = "src/bin/long_test.rs"
 required-features = ["rocksdb", "unstable-test-utils"]
 
+[[bin]]
+name = "gc_space"
+path = "src/bin/gc_space.rs"
+required-features = ["rocksdb", "unstable-test-utils"]
+
 [[bench]]
 name = "avl_tree"
 harness = false

--- a/durable-storage/Makefile
+++ b/durable-storage/Makefile
@@ -9,6 +9,7 @@ check:
 	@cargo clippy --all-targets --no-default-features -- --deny warnings
 	@cargo clippy -p xtask --all-targets -- --deny warnings
 	@cargo clippy --features unstable-test-utils --bin long_test -- --deny warnings
+	@cargo clippy --features unstable-test-utils --bin gc_space -- --deny warnings
 
 # distinct from the workspace-level test in that it actually turns off
 # rocksdb: using the in-memory implementation instead

--- a/durable-storage/src/avl/node.rs
+++ b/durable-storage/src/avl/node.rs
@@ -921,6 +921,48 @@ where
     }
 }
 
+/// Visit every node body reachable from the tree stored under `tree_hash`.
+///
+/// `visit` receives the blob key each body is stored under and the length of the stored bytes,
+/// once per body reached. Nothing is materialised in memory: a body is stored under the hash of
+/// the *tree* holding it, and its `left`/`right` fields are the hashes of the child trees, so the
+/// stored representation can be walked directly. Empty trees are never stored, so a child hash
+/// equal to [`Tree::empty_hash`] terminates that branch.
+///
+/// Shared subtrees are visited once per reference, since content-addressed children may be
+/// reachable by more than one path. `visit` should deduplicate by the visited hash if required.
+#[cfg(rocksdb_test_utils)]
+pub(crate) fn walk_stored_tree(
+    store: &impl ReadableKeyValueStore,
+    tree_hash: Hash,
+    mut visit: impl FnMut(Hash, usize),
+) -> Result<(), OperationalError> {
+    let empty = Tree::<Hash>::empty_hash();
+    let mut pending = vec![tree_hash];
+
+    while let Some(hash) = pending.pop() {
+        if hash == empty {
+            continue;
+        }
+
+        let bytes = store
+            .blob_get(hash)
+            .map_err(|error| OperationalError::CommitDataMissing {
+                root: hash,
+                source: Box::new(error),
+            })?;
+        let bytes = bytes.as_ref();
+
+        visit(hash, bytes.len());
+
+        let StoredNode { left, right, .. } = deserialise(bytes)?;
+        pending.push(left);
+        pending.push(right);
+    }
+
+    Ok(())
+}
+
 impl<TreeId: Loadable, DataId: DataLoadable> Loadable for Node<TreeId, DataId, Normal> {
     fn load(id: Hash, store: &impl ReadableKeyValueStore) -> Result<Self, OperationalError> {
         let StoredNode {

--- a/durable-storage/src/avl/tree.rs
+++ b/durable-storage/src/avl/tree.rs
@@ -230,6 +230,15 @@ impl<NodeId> Tree<NodeId> {
         Tree::<Hash>::from(Some(node_hash)).hash()
     }
 
+    /// The hash of the empty [`Tree`].
+    ///
+    /// Empty trees are never stored, so this is the hash that terminates a walk over the stored
+    /// representation of a tree: a child hash equal to it has no body to read.
+    #[cfg(rocksdb_test_utils)]
+    pub(crate) fn empty_hash() -> Hash {
+        *EMPTY_TREE_HASH
+    }
+
     /// Take the root [`Node`] out of this tree, leaving the [`Tree`] empty.
     pub(crate) const fn take(&mut self) -> Option<NodeId> {
         self.0.take()

--- a/durable-storage/src/bin/gc_space.rs
+++ b/durable-storage/src/bin/gc_space.rs
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2026 Nomadic Labs <contact@nomadic-labs.com>
+//
+// SPDX-License-Identifier: MIT
+
+//! Binary for the durable storage space accounting harness.
+//!
+//! Reports how much of a commit's Merkle node data is still reachable and how much is dead. See
+//! [`octez_riscv_durable_storage::gc_space`] for what is measured and why.
+//!
+//! Point `--repo-dir` at a volume with room to spare: the base state is recorded there and reused
+//! by later runs of the same shape, which matters because prepopulating dominates a large run. Each
+//! run resets the repository to that base state first, so reusing a directory does not fold earlier
+//! runs' commits into what is reported.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Parser;
+use octez_riscv_durable_storage::gc_space::SpaceConfig;
+
+#[derive(Debug, Parser)]
+#[command(version, long_about = None)]
+struct Cli {
+    /// Number of databases in the registry.
+    #[arg(long, default_value_t = 1)]
+    databases: usize,
+
+    /// Keys written to each database before the measured commits begin.
+    #[arg(long, default_value_t = 100_000)]
+    keys: usize,
+
+    /// Length of each key, in bytes.
+    ///
+    /// The Etherlink trace has a median path of 33 bytes and a p90 of 99, with storage slots
+    /// (`/evm/world_state/eth_accounts/<address>/storage/<slot>`) around 130. Keys are stored inline
+    /// in each Merkle node, so this drives node size directly.
+    #[arg(long, default_value_t = 130)]
+    key_size: usize,
+
+    /// Length of an ordinary value, in bytes. The trace's median write is 32.
+    #[arg(long, default_value_t = 32)]
+    value_size: usize,
+
+    /// Fraction of keys holding a large value, reproducing the trace's contract-code tail.
+    #[arg(long, default_value_t = 0.0)]
+    large_value_fraction: f64,
+
+    /// Length of a large value, in bytes. The trace's largest write is 131220.
+    #[arg(long, default_value_t = 131_220)]
+    large_value_size: usize,
+
+    /// Number of commits to make and measure.
+    #[arg(long, default_value_t = 20)]
+    commits: usize,
+
+    /// Keys modified before each commit, spread across the registry's databases.
+    #[arg(long, default_value_t = 1_000)]
+    modified_keys: usize,
+
+    /// Measure every this many commits. Raise it at large scales, where scanning a column family
+    /// costs more than the commits do.
+    #[arg(long, default_value_t = 1)]
+    sample_every: usize,
+
+    /// Seed for choosing which keys each commit modifies.
+    #[arg(long, default_value_t = 0)]
+    seed: u64,
+
+    /// Where the repository lives. A fresh temporary directory when absent, which is removed on
+    /// exit along with the base state.
+    #[arg(long)]
+    repo_dir: Option<PathBuf>,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    if cli.databases == 0 {
+        anyhow::bail!("--databases must be at least 1");
+    }
+
+    if cli.keys == 0 {
+        anyhow::bail!("--keys must be at least 1");
+    }
+
+    if cli.sample_every == 0 {
+        anyhow::bail!("--sample-every must be at least 1");
+    }
+
+    if !(0.0..=1.0).contains(&cli.large_value_fraction) {
+        anyhow::bail!("--large-value-fraction must be between 0 and 1");
+    }
+
+    SpaceConfig {
+        databases: cli.databases,
+        keys_per_database: cli.keys,
+        key_size: cli.key_size,
+        value_size: cli.value_size,
+        large_value_fraction: cli.large_value_fraction,
+        large_value_size: cli.large_value_size,
+        commits: cli.commits,
+        modified_keys: cli.modified_keys,
+        sample_every: cli.sample_every,
+        seed: cli.seed,
+        repo_dir: cli.repo_dir,
+    }
+    .run()
+}

--- a/durable-storage/src/bin/gc_space.rs
+++ b/durable-storage/src/bin/gc_space.rs
@@ -70,6 +70,12 @@ struct Cli {
     /// exit along with the base state.
     #[arg(long)]
     repo_dir: Option<PathBuf>,
+
+    /// After the last commit, delete every commit not reachable from it and measure again.
+    ///
+    /// Shows what collecting at directory granularity reclaims, and what dead node data survives it.
+    #[arg(long)]
+    simulate_dir_gc: bool,
 }
 
 fn main() -> Result<()> {
@@ -103,6 +109,7 @@ fn main() -> Result<()> {
         sample_every: cli.sample_every,
         seed: cli.seed,
         repo_dir: cli.repo_dir,
+        simulate_dir_gc: cli.simulate_dir_gc,
     }
     .run()
 }

--- a/durable-storage/src/gc_space.rs
+++ b/durable-storage/src/gc_space.rs
@@ -36,4 +36,7 @@ mod report;
 mod sample;
 mod scenario;
 
+// Only the long-test binaries report sizes, so nothing needs this in a test build.
+#[cfg(not(test))]
+pub(crate) use measure::disk_usage;
 pub use scenario::SpaceConfig;

--- a/durable-storage/src/gc_space.rs
+++ b/durable-storage/src/gc_space.rs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Nomadic Labs <contact@nomadic-labs.com>
+//
+// SPDX-License-Identifier: MIT
+
+//! Space accounting harness for committed durable storage.
+//!
+//! This exists to answer one question: of the bytes a commit occupies on disk, how many are still
+//! needed to serve it?
+//!
+//! The two column families behave completely differently, which is the whole point of measuring:
+//!
+//! - Values are keyed by your key, so writing a key again makes the previous value an obsolete
+//!   version that compaction discards. The value column family stays proportional to the key space
+//!   that is live in it.
+//! - Merkle node bodies are keyed by content hash, so every version of every node is a distinct
+//!   key that nothing ever deletes. The blob column family accumulates every node ever written.
+//!
+//! So for the blob column family this harness reports a **live** figure (the bodies reachable from
+//! the committed root, found by walking the stored representation) and a **dead** figure
+//! (everything else in it). Dead bytes are what garbage collection could reclaim and what nothing
+//! reclaims today.
+//!
+//! Keys and values are derived from their indices rather than stored, so a run at ten million keys
+//! does not need a ten-million-entry key list in memory. Derivation is deterministic, so a given
+//! seed and shape always produce the same state.
+//!
+//! Prepopulating a large registry costs far more than the commits being measured, so the base state
+//! is recorded in the repository directory and reused when the shape matches. Point `--repo-dir` at
+//! a volume with room to spare and successive runs skip straight to the commit sequence. Each run
+//! resets the repository to that base state before measuring, so reusing a directory does not carry
+//! earlier runs' commits into the figures.
+
+mod measure;
+mod report;
+mod sample;
+mod scenario;
+
+pub use scenario::SpaceConfig;

--- a/durable-storage/src/gc_space.rs
+++ b/durable-storage/src/gc_space.rs
@@ -31,6 +31,7 @@
 //! earlier runs' commits into the figures.
 
 mod measure;
+mod prune;
 mod report;
 mod sample;
 mod scenario;

--- a/durable-storage/src/gc_space/measure.rs
+++ b/durable-storage/src/gc_space/measure.rs
@@ -176,10 +176,31 @@ fn measure_blob(
 }
 
 /// Occupancy of a directory tree, counting each inode's blocks once.
-fn disk_usage(root: &Path) -> Result<DiskUsage> {
+pub(super) fn disk_usage(root: &Path) -> Result<DiskUsage> {
     let mut usage = DiskUsage::default();
     let mut seen: HashSet<(u64, u64)> = HashSet::new();
     accumulate_disk_usage(root, &mut usage, &mut seen)?;
+
+    Ok(usage)
+}
+
+/// Occupancy of the committed history: the database commit directories and the registry manifests,
+/// leaving out the working databases.
+///
+/// Note this is what the history *references*, not what deleting it would free: commits hard-link
+/// the working database's files, so blocks counted here can be held by the working database too.
+/// Use [`SpaceConfig::simulate_dir_gc`] for what deletion actually reclaims.
+pub(super) fn commits_disk_usage(repo_path: &Path) -> Result<DiskUsage> {
+    let mut usage = DiskUsage::default();
+    let mut seen: HashSet<(u64, u64)> = HashSet::new();
+
+    // One `seen` set across both roots, so an inode linked from each is still counted once.
+    for root in [
+        repo_path.join("databases").join("commits"),
+        repo_path.join("registries"),
+    ] {
+        accumulate_disk_usage(&root, &mut usage, &mut seen)?;
+    }
 
     Ok(usage)
 }

--- a/durable-storage/src/gc_space/measure.rs
+++ b/durable-storage/src/gc_space/measure.rs
@@ -1,0 +1,308 @@
+// SPDX-FileCopyrightText: 2026 Nomadic Labs <contact@nomadic-labs.com>
+//
+// SPDX-License-Identifier: MIT
+
+//! One measurement of a committed registry.
+//!
+//! [`measure`] produces a [`Sample`]. Everything else here is one of its figures: what the
+//! column families hold, what the directory tree occupies, what the history pins, and how the
+//! files are spread over LSM levels.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::fs;
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::Context;
+use anyhow::Result;
+use octez_riscv_data::hash::Hash;
+
+use super::sample::BlobBreakdown;
+use super::sample::DiskUsage;
+use super::sample::FileSet;
+use super::sample::LevelSummary;
+use super::sample::PinnedBytes;
+use super::sample::Sample;
+use super::sample::Sharing;
+use super::scenario::Reg;
+use crate::avl::node::walk_stored_tree;
+use crate::commit::CommitId;
+use crate::persistence_layer::ReadOnlyPersistenceLayer;
+use crate::persistence_layer::measurement::CfTotals;
+use crate::persistence_layer::measurement::SstOwner;
+use crate::repo::DirectoryManager;
+use crate::storage::ReadOnlyKeyValueStore;
+
+/// Measure every database of a registry commit, plus the repository as a whole.
+pub(super) fn measure(
+    repo: &DirectoryManager,
+    repo_path: &Path,
+    registry_commit: &CommitId,
+    commit_index: usize,
+    commit_time: Duration,
+    previous: Option<&FileSet>,
+) -> Result<(Sample, FileSet)> {
+    let database_commits = Reg::database_commits(repo, registry_commit)
+        .context("reading the registry manifest being measured")?;
+
+    let mut blob = BlobBreakdown::default();
+    let mut value_stored_bytes = 0;
+    let mut files: FileSet = HashMap::new();
+
+    for (db_index, database_commit) in database_commits.iter().enumerate() {
+        let committed = ReadOnlyPersistenceLayer::checkout_read_only(repo, database_commit)
+            .with_context(|| {
+                format!(
+                    "opening database commit {} read-only",
+                    database_commit.hex_encode()
+                )
+            })?;
+
+        blob.add(&measure_blob(&committed, database_commit)?);
+
+        let values = committed
+            .value_totals()
+            .map_err(|error| anyhow::anyhow!("scanning the value column family: {error}"))?;
+        value_stored_bytes += values.stored_bytes();
+
+        for file in committed
+            .sst_files()
+            .map_err(|error| anyhow::anyhow!("listing SST files: {error}"))?
+        {
+            files.insert((db_index, file.name.clone()), file);
+        }
+    }
+
+    let sample = Sample {
+        commit: commit_index,
+        blob,
+        value_stored_bytes,
+        disk: disk_usage(repo_path).context("measuring repository disk usage")?,
+        pinned: pinned_by_cf(repo_path).context("attributing pinned bytes to column families")?,
+        sharing: previous.map(|previous| sharing_between(previous, &files)),
+        levels: level_summary(&files),
+        commit_dirs: count_commit_dirs(repo_path)?,
+        commit_ms: commit_time.as_millis() as u64,
+    };
+
+    Ok((sample, files))
+}
+
+/// Compare the files two commits pin, to see how much the later one reuses.
+fn sharing_between(previous: &FileSet, current: &FileSet) -> Sharing {
+    let mut sharing = Sharing::default();
+
+    for (key, file) in current {
+        if previous.contains_key(key) {
+            sharing.carried_files += 1;
+            sharing.carried_bytes += file.size;
+        } else {
+            sharing.new_files += 1;
+            sharing.new_bytes += file.size;
+        }
+    }
+
+    for (key, file) in previous {
+        if !current.contains_key(key) {
+            sharing.dropped_files += 1;
+            sharing.dropped_bytes += file.size;
+        }
+    }
+
+    sharing
+}
+
+/// Summarise how files are spread over LSM levels, lowest level first.
+fn level_summary(files: &FileSet) -> Vec<LevelSummary> {
+    let mut levels: HashMap<i32, (u64, u64)> = HashMap::new();
+
+    for file in files.values() {
+        let entry = levels.entry(file.level).or_insert((0, 0));
+        entry.0 += 1;
+        entry.1 += file.size;
+    }
+
+    let mut levels: Vec<LevelSummary> = levels
+        .into_iter()
+        .map(|(level, (files, bytes))| LevelSummary {
+            level,
+            files,
+            bytes,
+        })
+        .collect();
+
+    levels.sort_by_key(|summary| summary.level);
+
+    levels
+}
+
+/// Split one committed database's blob column family into live and dead.
+fn measure_blob(
+    committed: &ReadOnlyPersistenceLayer,
+    database_commit: &CommitId,
+) -> Result<BlobBreakdown> {
+    let totals: CfTotals = committed
+        .blob_totals()
+        .map_err(|error| anyhow::anyhow!("scanning the blob column family: {error}"))?;
+
+    // Deduplicated, because content-addressed subtrees can be reachable by more than one path and
+    // would otherwise be counted once per reference.
+    let mut live: HashSet<Hash> = HashSet::new();
+    let mut live_body_bytes = 0;
+
+    walk_stored_tree(committed, *database_commit.as_hash(), |hash, len| {
+        if live.insert(hash) {
+            live_body_bytes += len as u64;
+        }
+    })
+    .with_context(|| {
+        format!(
+            "walking the tree committed at {}",
+            database_commit.hex_encode()
+        )
+    })?;
+
+    let live_entries = live.len() as u64;
+
+    Ok(BlobBreakdown {
+        entries: totals.entries,
+        stored_bytes: totals.stored_bytes(),
+        live_entries,
+        // Each body is stored under a hash, so the live keys cost a digest apiece.
+        live_bytes: live_body_bytes + live_entries * Hash::DIGEST_SIZE as u64,
+    })
+}
+
+/// Occupancy of a directory tree, counting each inode's blocks once.
+fn disk_usage(root: &Path) -> Result<DiskUsage> {
+    let mut usage = DiskUsage::default();
+    let mut seen: HashSet<(u64, u64)> = HashSet::new();
+    accumulate_disk_usage(root, &mut usage, &mut seen)?;
+
+    Ok(usage)
+}
+
+/// Add the occupancy of `root` to `usage`, skipping inodes already present in `seen`.
+fn accumulate_disk_usage(
+    root: &Path,
+    usage: &mut DiskUsage,
+    seen: &mut HashSet<(u64, u64)>,
+) -> Result<()> {
+    let mut pending = vec![root.to_path_buf()];
+
+    while let Some(dir) = pending.pop() {
+        let entries = fs::read_dir(&dir)
+            .with_context(|| format!("reading the directory {}", dir.display()))?;
+
+        for entry in entries {
+            let entry = entry.with_context(|| format!("reading an entry of {}", dir.display()))?;
+            let metadata = entry
+                .metadata()
+                .with_context(|| format!("reading metadata of {}", entry.path().display()))?;
+
+            if metadata.is_dir() {
+                pending.push(entry.path());
+                continue;
+            }
+
+            usage.files += 1;
+            usage.apparent_bytes += metadata.len();
+            usage.linked_bytes += metadata.blocks() * 512;
+
+            // Hard-linked SSTs are shared between the working database and every checkpoint of
+            // it, so their blocks must only be counted for whichever link is seen first. The gap
+            // this opens against `linked_bytes` is what the sharing saves.
+            if seen.insert((metadata.dev(), metadata.ino())) {
+                usage.unique_bytes += metadata.blocks() * 512;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Attribute the bytes pinned by every database commit to the column family holding them.
+///
+/// The attribution comes from RocksDB's live-file metadata, read once per commit directory, because
+/// the SSTs of both column families share a directory and nothing in their names says which is
+/// which. Inodes are deduplicated across all commits, so a file hard-linked into twenty checkpoints
+/// counts once: the result is what retaining this history actually costs the filesystem, split by
+/// what it is holding.
+fn pinned_by_cf(repo_path: &Path) -> Result<PinnedBytes> {
+    let commits_dir = repo_path.join("databases").join("commits");
+    let mut pinned = PinnedBytes::default();
+    let mut seen: HashSet<(u64, u64)> = HashSet::new();
+
+    let commits =
+        fs::read_dir(&commits_dir).with_context(|| format!("reading {}", commits_dir.display()))?;
+
+    for commit in commits {
+        let commit =
+            commit.with_context(|| format!("reading an entry of {}", commits_dir.display()))?;
+        let dir = commit.path();
+
+        if !dir.is_dir() {
+            continue;
+        }
+
+        // Read the attribution before walking, and close the instance straight after: a sample can
+        // visit many commits and there is no reason to hold them all open at once.
+        let owners = {
+            let committed = ReadOnlyPersistenceLayer::checkout_read_only_from_path(&dir)
+                .with_context(|| format!("opening {} read-only", dir.display()))?;
+
+            committed
+                .sst_column_families()
+                .map_err(|error| anyhow::anyhow!("reading live file metadata: {error}"))?
+        };
+
+        let files = fs::read_dir(&dir).with_context(|| format!("reading {}", dir.display()))?;
+
+        for file in files {
+            let file = file.with_context(|| format!("reading an entry of {}", dir.display()))?;
+            let metadata = file
+                .metadata()
+                .with_context(|| format!("reading metadata of {}", file.path().display()))?;
+
+            if metadata.is_dir() || !seen.insert((metadata.dev(), metadata.ino())) {
+                continue;
+            }
+
+            let bytes = metadata.blocks() * 512;
+
+            match owners.get(file.file_name().to_string_lossy().as_ref()) {
+                Some(SstOwner::Blob) => pinned.blob += bytes,
+                Some(SstOwner::Value) => pinned.value += bytes,
+                // Manifests, options, logs and locks: small, but they are part of the cost.
+                None => pinned.other += bytes,
+            }
+        }
+    }
+
+    Ok(pinned)
+}
+
+/// Count the database commit directories in the repository.
+fn count_commit_dirs(repo_path: &Path) -> Result<u64> {
+    let path = repo_path.join("databases").join("commits");
+
+    let entries = fs::read_dir(&path).with_context(|| format!("reading {}", path.display()))?;
+    let mut dirs = 0;
+
+    for entry in entries {
+        let entry = entry.with_context(|| format!("reading an entry of {}", path.display()))?;
+
+        // A commit is a directory, so anything else the repository keeps here is not one.
+        if entry
+            .file_type()
+            .with_context(|| format!("reading the type of {}", entry.path().display()))?
+            .is_dir()
+        {
+            dirs += 1;
+        }
+    }
+
+    Ok(dirs)
+}

--- a/durable-storage/src/gc_space/measure.rs
+++ b/durable-storage/src/gc_space/measure.rs
@@ -176,7 +176,9 @@ fn measure_blob(
 }
 
 /// Occupancy of a directory tree, counting each inode's blocks once.
-pub(super) fn disk_usage(root: &Path) -> Result<DiskUsage> {
+///
+/// Shared with the long tests, which report the size of their repository as it grows.
+pub(crate) fn disk_usage(root: &Path) -> Result<DiskUsage> {
     let mut usage = DiskUsage::default();
     let mut seen: HashSet<(u64, u64)> = HashSet::new();
     accumulate_disk_usage(root, &mut usage, &mut seen)?;

--- a/durable-storage/src/gc_space/prune.rs
+++ b/durable-storage/src/gc_space/prune.rs
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2026 Nomadic Labs <contact@nomadic-labs.com>
+//
+// SPDX-License-Identifier: MIT
+
+//! Collection at directory granularity, and what it frees.
+//!
+//! At this granularity collection is no more than the removal of every commit directory that no
+//! retained root reaches. What survives it is the point — see [`prune_unreachable`].
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::Path;
+
+use anyhow::Context;
+use anyhow::Result;
+use octez_riscv_data::hash::Hash;
+
+use super::measure::commits_disk_usage;
+use super::measure::disk_usage;
+use super::sample::DiskUsage;
+use super::scenario::Reg;
+use crate::commit::CommitId;
+use crate::repo::DirectoryManager;
+
+/// Delete every commit not reachable from `retained`, and report what that frees.
+///
+/// This is collection at directory granularity: the reachable database commits are read from the
+/// retained registry manifest, and every other commit directory and manifest is removed. Blocks
+/// come back only where no surviving link remains, which is exactly the point — the dead node data
+/// inside the retained commit survives this untouched, because the retained commit still needs the
+/// files holding it.
+pub(super) fn prune_unreachable(
+    repo: &DirectoryManager,
+    repo_path: &Path,
+    retained: &[CommitId],
+) -> Result<PruneOutcome> {
+    let mut reachable: HashSet<CommitId> = HashSet::new();
+
+    for commit in retained {
+        reachable.extend(
+            Reg::database_commits(repo, commit).context("reading a retained registry manifest")?,
+        );
+    }
+
+    let mut outcome = PruneOutcome {
+        before: disk_usage(repo_path).context("measuring usage before pruning")?,
+        ..PruneOutcome::default()
+    };
+
+    let commits_dir = repo_path.join("databases").join("commits");
+    let entries =
+        fs::read_dir(&commits_dir).with_context(|| format!("reading {}", commits_dir.display()))?;
+
+    for entry in entries {
+        let entry =
+            entry.with_context(|| format!("reading an entry of {}", commits_dir.display()))?;
+
+        // A commit is a directory, and `remove_dir_all` below would fail on anything else.
+        if !entry
+            .file_type()
+            .with_context(|| format!("reading the type of {}", entry.path().display()))?
+            .is_dir()
+        {
+            continue;
+        }
+
+        // A directory is named after its commit, so the name identifies what it holds.
+        let retain = commit_id_of_name(&entry.file_name().to_string_lossy())
+            .is_some_and(|id| reachable.contains(&id));
+
+        if retain {
+            continue;
+        }
+
+        fs::remove_dir_all(entry.path())
+            .with_context(|| format!("removing {}", entry.path().display()))?;
+        outcome.databases_removed += 1;
+    }
+
+    let registries_dir = repo_path.join("registries").join("commits");
+    let entries = fs::read_dir(&registries_dir)
+        .with_context(|| format!("reading {}", registries_dir.display()))?;
+
+    for entry in entries {
+        let entry =
+            entry.with_context(|| format!("reading an entry of {}", registries_dir.display()))?;
+
+        let name = entry.file_name().to_string_lossy().into_owned();
+
+        if retained.iter().any(|commit| commit.hex_encode() == name) {
+            continue;
+        }
+
+        fs::remove_file(entry.path())
+            .with_context(|| format!("removing {}", entry.path().display()))?;
+        outcome.registries_removed += 1;
+    }
+
+    outcome.after = disk_usage(repo_path).context("measuring usage after pruning")?;
+    outcome.after_commits =
+        commits_disk_usage(repo_path).context("measuring committed history after pruning")?;
+
+    Ok(outcome)
+}
+
+/// What a simulated directory-level collection removed and freed.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PruneOutcome {
+    /// Repository occupancy before pruning.
+    pub before: DiskUsage,
+
+    /// Repository occupancy after pruning.
+    pub after: DiskUsage,
+
+    /// Committed history occupancy after pruning.
+    pub after_commits: DiskUsage,
+
+    /// Database commit directories removed.
+    pub databases_removed: u64,
+
+    /// Registry manifests removed.
+    pub registries_removed: u64,
+}
+
+impl PruneOutcome {
+    /// Bytes returned to the filesystem, counted as allocated blocks.
+    pub fn freed_bytes(&self) -> u64 {
+        self.before
+            .unique_bytes
+            .saturating_sub(self.after.unique_bytes)
+    }
+}
+
+/// Parse a hex commit directory or file name back into a [`CommitId`].
+fn commit_id_of_name(name: &str) -> Option<CommitId> {
+    let bytes = hex::decode(name).ok()?;
+    let hash: [u8; Hash::DIGEST_SIZE] = bytes.as_slice().try_into().ok()?;
+
+    Some(CommitId::from(Hash::from(hash)))
+}

--- a/durable-storage/src/gc_space/report.rs
+++ b/durable-storage/src/gc_space/report.rs
@@ -9,6 +9,7 @@
 use std::io;
 use std::io::Write;
 
+use super::prune::PruneOutcome;
 use super::sample::Sample;
 use super::sample::Sharing;
 
@@ -185,6 +186,50 @@ pub(super) fn summarise(out: &mut impl Write, samples: &[Sample]) -> io::Result<
         last.commit_dirs,
         mib(last.disk.apparent_bytes),
         mib(last.disk.shared_bytes()),
+    )?;
+
+    Ok(())
+}
+
+/// Report what a directory-level collection reclaimed, and what it could not.
+///
+/// The second figure is the one that matters: whatever dead node data remains after this is data no
+/// directory deletion can ever reach, because the retained commit still references the files it
+/// sits in.
+pub(super) fn report_prune(
+    out: &mut impl Write,
+    outcome: &PruneOutcome,
+    last: Option<&Sample>,
+) -> io::Result<()> {
+    writeln!(out)?;
+    writeln!(
+        out,
+        "simulated directory-level collection: removed {} database commit(s) and {} manifest(s)",
+        outcome.databases_removed, outcome.registries_removed,
+    )?;
+    writeln!(
+        out,
+        "  repository went from {:.1} MiB to {:.1} MiB, freeing {:.1} MiB",
+        mib(outcome.before.unique_bytes),
+        mib(outcome.after.unique_bytes),
+        mib(outcome.freed_bytes()),
+    )?;
+    writeln!(
+        out,
+        "  retained history now occupies {:.1} MiB",
+        mib(outcome.after_commits.unique_bytes),
+    )?;
+
+    let Some(last) = last else {
+        return Ok(());
+    };
+
+    writeln!(
+        out,
+        "  still dead and now unreachable by any directory deletion: {:.1} MiB of node data \
+         ({:.1}% of the surviving blob column family)",
+        mib(last.blob.dead_bytes()),
+        last.blob.dead_fraction() * 100.0,
     )?;
 
     Ok(())

--- a/durable-storage/src/gc_space/report.rs
+++ b/durable-storage/src/gc_space/report.rs
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: 2026 Nomadic Labs <contact@nomadic-labs.com>
+//
+// SPDX-License-Identifier: MIT
+
+//! Helpers for converting samples into printed output.
+//!
+//! One line per sample while the run proceeds, then a summary of what the whole sequence showed.
+
+use std::io;
+use std::io::Write;
+
+use super::sample::Sample;
+use super::sample::Sharing;
+
+pub(super) fn report_header(out: &mut impl Write) -> io::Result<()> {
+    writeln!(out)?;
+    writeln!(
+        out,
+        "{:>7}  {:>10}  {:>10}  {:>10}  {:>7}  {:>10}  {:>10}  {:>9}  {:>10}  {:>7}",
+        "commit",
+        "blob MiB",
+        "live MiB",
+        "dead MiB",
+        "dead %",
+        "value MiB",
+        "disk MiB",
+        "commit ms",
+        "new MiB",
+        "shared %"
+    )?;
+
+    Ok(())
+}
+
+pub(super) fn report(out: &mut impl Write, sample: &Sample) -> io::Result<()> {
+    // The last two columns are the sharing question: how many bytes this commit added that the
+    // previous one could not share, and what fraction it did manage to reuse.
+    let (new, shared) = match &sample.sharing {
+        Some(sharing) => (
+            format!("{:.1}", mib(sharing.new_bytes)),
+            format!("{:.1}%", sharing.carried_fraction() * 100.0),
+        ),
+        None => ("-".to_owned(), "-".to_owned()),
+    };
+
+    writeln!(
+        out,
+        "{:>7}  {:>10.1}  {:>10.1}  {:>10.1}  {:>6.1}%  {:>10.1}  {:>10.1}  {:>9}  {:>10}  {:>7}",
+        sample.commit,
+        mib(sample.blob.stored_bytes),
+        mib(sample.blob.live_bytes),
+        mib(sample.blob.dead_bytes()),
+        sample.blob.dead_fraction() * 100.0,
+        mib(sample.value_stored_bytes),
+        mib(sample.disk.unique_bytes),
+        sample.commit_ms,
+        new,
+        shared,
+    )?;
+
+    Ok(())
+}
+
+/// Report the headline figures: how much dead node data each commit leaves behind, and how much of
+/// the storage that has become by the end.
+pub(super) fn summarise(out: &mut impl Write, samples: &[Sample]) -> io::Result<()> {
+    let (Some(first), Some(last)) = (samples.first(), samples.last()) else {
+        return Ok(());
+    };
+
+    let commits = last.commit.saturating_sub(first.commit);
+
+    writeln!(out)?;
+    writeln!(out, "over {commits} commit(s):")?;
+
+    if commits > 0 {
+        let dead_growth = last
+            .blob
+            .dead_bytes()
+            .saturating_sub(first.blob.dead_bytes());
+        let blob_growth = last
+            .blob
+            .stored_bytes
+            .saturating_sub(first.blob.stored_bytes);
+
+        writeln!(
+            out,
+            "  dead node data grew by {:.1} MiB, {:.2} MiB per commit",
+            mib(dead_growth),
+            mib(dead_growth) / commits as f64,
+        )?;
+        writeln!(
+            out,
+            "  blob column family grew by {:.1} MiB, {:.2} MiB per commit",
+            mib(blob_growth),
+            mib(blob_growth) / commits as f64,
+        )?;
+
+        // The two figures a different shape can be extrapolated from: how many nodes a commit
+        // rewrites (which follows the tree's depth) and what a node costs to store.
+        let node_growth = last.blob.entries.saturating_sub(first.blob.entries);
+
+        if node_growth > 0 {
+            writeln!(
+                out,
+                "  {} node(s) written, {} per commit, averaging {} B stored per node",
+                node_growth,
+                node_growth / commits as u64,
+                blob_growth / node_growth,
+            )?;
+        }
+
+        // What retention costs, and which half of the storage it is spent holding. The `blob` part
+        // is duplication a shared Merkle store would remove outright, as opposed to the dead node
+        // data above, which only deleting the node keys can reclaim.
+        let pinned = last.pinned;
+        let pinned_growth = pinned.total().saturating_sub(first.pinned.total());
+
+        writeln!(
+            out,
+            "  history pins {:.1} MiB ({:.1} MiB Merkle, {:.1} MiB values, {:.1} MiB other), \
+             growing {:.1} MiB per commit",
+            mib(pinned.total()),
+            mib(pinned.blob),
+            mib(pinned.value),
+            mib(pinned.other),
+            mib(pinned_growth) / commits as f64,
+        )?;
+
+        if pinned.total() > 0 {
+            writeln!(
+                out,
+                "  {:.1}% of what the history pins is Merkle node data, which a shared store would \
+                 stop duplicating per commit",
+                pinned.blob as f64 / pinned.total() as f64 * 100.0,
+            )?;
+        }
+
+        // Why retention costs what it does. If commits shared everything they could, `new` would be
+        // about the size of what each commit changed; the gap is compaction rewriting untouched
+        // data, which the previous checkpoint then pins in its old form.
+        let shared: Vec<&Sharing> = samples.iter().filter_map(|s| s.sharing.as_ref()).collect();
+
+        if !shared.is_empty() {
+            let new_bytes: u64 = shared.iter().map(|s| s.new_bytes).sum();
+            let new_files: u64 = shared.iter().map(|s| s.new_files).sum();
+            let mean_carried =
+                shared.iter().map(|s| s.carried_fraction()).sum::<f64>() / shared.len() as f64;
+
+            writeln!(
+                out,
+                "  sharing: each measured commit reused {:.1}% of the previous commit's bytes, \
+                 adding {:.1} MiB in {} new file(s) on average",
+                mean_carried * 100.0,
+                mib(new_bytes) / shared.len() as f64,
+                new_files / shared.len() as u64,
+            )?;
+        }
+
+        writeln!(out, "  levels at the last commit:")?;
+
+        for level in &last.levels {
+            writeln!(
+                out,
+                "    L{}: {} file(s), {:.1} MiB",
+                level.level,
+                level.files,
+                mib(level.bytes)
+            )?;
+        }
+    }
+
+    writeln!(
+        out,
+        "  {:.1}% of the blob column family is now dead ({:.1} MiB of {:.1} MiB)",
+        last.blob.dead_fraction() * 100.0,
+        mib(last.blob.dead_bytes()),
+        mib(last.blob.stored_bytes),
+    )?;
+    writeln!(
+        out,
+        "  repository occupies {:.1} MiB across {} commit directories ({:.1} MiB apparent, and \
+         hard links save {:.1} MiB)",
+        mib(last.disk.unique_bytes),
+        last.commit_dirs,
+        mib(last.disk.apparent_bytes),
+        mib(last.disk.shared_bytes()),
+    )?;
+
+    Ok(())
+}
+
+fn mib(bytes: u64) -> f64 {
+    bytes as f64 / (1024.0 * 1024.0)
+}

--- a/durable-storage/src/gc_space/sample.rs
+++ b/durable-storage/src/gc_space/sample.rs
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: 2026 Nomadic Labs <contact@nomadic-labs.com>
+//
+// SPDX-License-Identifier: MIT
+
+//! What one measurement of the repository records.
+//!
+//! [`Sample`] is the whole of it; the types it is built from each answer a different question
+//! about the same commit, so they are grouped here rather than beside the code that fills them
+//! in.
+
+use std::collections::HashMap;
+
+use crate::persistence_layer::measurement::SstFile;
+
+/// Byte totals for one committed database.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct BlobBreakdown {
+    /// Entries in the blob column family, live and dead together.
+    pub entries: u64,
+
+    /// Bytes stored in the blob column family, live and dead together.
+    pub stored_bytes: u64,
+
+    /// Distinct node bodies reachable from the committed root.
+    pub live_entries: u64,
+
+    /// Bytes of the node bodies reachable from the committed root, including their keys.
+    pub live_bytes: u64,
+}
+
+impl BlobBreakdown {
+    /// Bytes no longer reachable from the committed root. This is what collection could reclaim.
+    pub fn dead_bytes(&self) -> u64 {
+        self.stored_bytes.saturating_sub(self.live_bytes)
+    }
+
+    /// Fraction of the blob column family that is dead, between 0 and 1.
+    pub fn dead_fraction(&self) -> f64 {
+        if self.stored_bytes == 0 {
+            return 0.0;
+        }
+
+        self.dead_bytes() as f64 / self.stored_bytes as f64
+    }
+
+    /// Fold another database's totals into these.
+    pub(super) fn add(&mut self, other: &Self) {
+        self.entries += other.entries;
+        self.stored_bytes += other.stored_bytes;
+        self.live_entries += other.live_entries;
+        self.live_bytes += other.live_bytes;
+    }
+}
+
+/// Disk occupancy of a directory tree, counting shared files once.
+///
+/// Commits are RocksDB checkpoints, which hard-link their SST files, so summing file sizes
+/// massively overstates what a repository costs. `unique_bytes` counts the blocks behind each inode
+/// once, which is what the filesystem actually spends.
+///
+/// Two figures say what that is cheaper *than*, and they are not interchangeable.
+/// `apparent_bytes` is the naive sum of file lengths, so comparing it with `unique_bytes` mixes two
+/// corrections that pull in opposite directions: sharing takes bytes away, while rounding each file
+/// up to whole blocks puts them back. `linked_bytes` measures the same blocks as `unique_bytes` and
+/// differs only in counting them once per link, so their difference is the sharing on its own.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DiskUsage {
+    /// Sum of file lengths, counting hard-linked files once per link.
+    pub apparent_bytes: u64,
+
+    /// Blocks allocated, counting hard-linked files once per link.
+    pub linked_bytes: u64,
+
+    /// Blocks allocated, counting each inode once.
+    pub unique_bytes: u64,
+
+    /// Files encountered, counting hard-linked files once per link.
+    pub files: u64,
+}
+
+impl DiskUsage {
+    /// Blocks that sharing saves, being the same blocks counted per link and then per inode.
+    ///
+    /// Both sides are block-measured, so no rounding is folded into the answer.
+    pub fn shared_bytes(&self) -> u64 {
+        self.linked_bytes.saturating_sub(self.unique_bytes)
+    }
+}
+
+/// Unique bytes pinned by the committed history, split by what they hold.
+///
+/// Retained checkpoints hard-link the files that existed when they were taken, so as compaction
+/// rewrites SSTs the history ends up pinning several versions of the same data. This is what that
+/// costs, attributed to the column family each file belongs to — which matters because moving the
+/// Merkle side into a shared store would remove the `blob` part from every commit at a stroke.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PinnedBytes {
+    /// Pinned bytes holding Merkle node bodies.
+    pub blob: u64,
+
+    /// Pinned bytes holding values.
+    pub value: u64,
+
+    /// Pinned bytes in files that are not SSTs, such as manifests and options.
+    pub other: u64,
+}
+
+impl PinnedBytes {
+    /// Total pinned bytes.
+    pub fn total(&self) -> u64 {
+        self.blob + self.value + self.other
+    }
+}
+
+/// How much of what a commit pins it shares with the previously measured commit.
+///
+/// This is the measurement the whole retention story rests on. A checkpoint hard-links the files
+/// that were live when it was taken, so untouched data should cost nothing to retain: the next
+/// checkpoint links the same inodes. `new_bytes` is what that assumption fails by — files written
+/// between the two commits, which the earlier checkpoint does not share and which therefore add to
+/// the repository. It should be close to the data a commit actually changed; anything much larger
+/// is compaction rewriting files that did not need to change.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Sharing {
+    /// Files present in both commits, so stored once.
+    pub carried_files: u64,
+
+    /// Bytes in files present in both commits.
+    pub carried_bytes: u64,
+
+    /// Files present only in the later commit, so added to the repository.
+    pub new_files: u64,
+
+    /// Bytes in files present only in the later commit.
+    pub new_bytes: u64,
+
+    /// Files present only in the earlier commit, still pinned by it.
+    pub dropped_files: u64,
+
+    /// Bytes in files present only in the earlier commit.
+    pub dropped_bytes: u64,
+}
+
+impl Sharing {
+    /// Fraction of the later commit's bytes that were already on disk, between 0 and 1.
+    pub fn carried_fraction(&self) -> f64 {
+        let total = self.carried_bytes + self.new_bytes;
+
+        if total == 0 {
+            return 0.0;
+        }
+
+        self.carried_bytes as f64 / total as f64
+    }
+}
+
+/// Files and bytes at one LSM level, summed over the registry's databases.
+///
+/// Included because the shape of the tree explains the sharing: if a database fits inside the base
+/// level, every compaction from level zero rewrites all of it.
+#[derive(Debug, Clone)]
+pub struct LevelSummary {
+    /// LSM level.
+    pub level: i32,
+
+    /// Files at this level.
+    pub files: u64,
+
+    /// Bytes at this level.
+    pub bytes: u64,
+}
+
+/// The SST files a commit pins, keyed by database index and file name.
+///
+/// Keyed that way because file numbering is per instance, so the same name means the same file only
+/// within one database's lineage.
+pub(super) type FileSet = HashMap<(usize, String), SstFile>;
+
+/// One measurement of the repository, after a commit.
+#[derive(Debug, Clone)]
+pub struct Sample {
+    /// Index of the commit just made, counting from 1. Zero is the base state.
+    pub commit: usize,
+
+    /// Blob column family totals, summed over the registry's databases.
+    pub blob: BlobBreakdown,
+
+    /// Bytes stored in the value column families, summed over the registry's databases.
+    pub value_stored_bytes: u64,
+
+    /// Occupancy of the whole repository directory.
+    pub disk: DiskUsage,
+
+    /// What the committed history pins, attributed by column family.
+    pub pinned: PinnedBytes,
+
+    /// Sharing with the previously measured commit, absent for the first measurement.
+    pub sharing: Option<Sharing>,
+
+    /// Distribution of files over LSM levels.
+    pub levels: Vec<LevelSummary>,
+
+    /// Database commit directories present in the repository.
+    pub commit_dirs: u64,
+
+    /// How long the commit took.
+    pub commit_ms: u64,
+}

--- a/durable-storage/src/gc_space/scenario.rs
+++ b/durable-storage/src/gc_space/scenario.rs
@@ -30,8 +30,10 @@ use serde::Serialize;
 use tezos_smart_rollup_constants::core::MAX_FILE_CHUNK_SIZE;
 
 use super::measure::measure;
+use super::prune::prune_unreachable;
 use super::report::report;
 use super::report::report_header;
+use super::report::report_prune;
 use super::report::summarise;
 use crate::commit::CommitId;
 use crate::database::Database;
@@ -96,6 +98,14 @@ pub struct SpaceConfig {
     /// Where the repository lives. A fresh temporary directory when absent, in which case nothing
     /// survives the run.
     pub repo_dir: Option<PathBuf>,
+
+    /// After the last commit, delete every commit not reachable from it and measure again.
+    ///
+    /// This is what collecting at directory granularity would reclaim, so running with it splits
+    /// the storage into three parts: what a directory-level collection frees, what remains and is
+    /// still needed, and what remains but is dead. The last part is the dead node data, which sits
+    /// in files the surviving commit still references and which no directory deletion can reach.
+    pub simulate_dir_gc: bool,
 }
 
 impl SpaceConfig {
@@ -185,6 +195,8 @@ impl SpaceConfig {
 
         let mut rng = StdRng::seed_from_u64(self.seed);
 
+        let mut last_commit = base_commit;
+
         for commit_index in 1..=self.commits {
             modify(&mut registry, &self, &mut rng, commit_index)
                 .with_context(|| format!("applying modifications for commit {commit_index}"))?;
@@ -194,6 +206,7 @@ impl SpaceConfig {
                 .commit()
                 .with_context(|| format!("committing at commit {commit_index}"))?;
             let commit_time = started.elapsed();
+            last_commit = commit;
 
             if commit_index % self.sample_every != 0 && commit_index != self.commits {
                 continue;
@@ -214,6 +227,17 @@ impl SpaceConfig {
         }
 
         summarise(&mut out, &samples)?;
+
+        if self.simulate_dir_gc {
+            // The base state is retained alongside the last commit, not because a collection would
+            // keep it, but because a persistent `--repo-dir` records it for later runs to check out.
+            // Pruning it would leave `gc_space_base.json` naming a commit whose directory is gone, and
+            // the next run of the same shape would fail instead of reusing the base.
+            let retained = [last_commit, base_commit];
+            let outcome = prune_unreachable(&repo, &repo_path, &retained)
+                .context("simulating a directory-level collection")?;
+            report_prune(&mut out, &outcome, samples.last())?;
+        }
 
         Ok(())
     }
@@ -576,7 +600,7 @@ mod tests {
     /// A run small enough for the test suite, still covering every measurement the harness makes:
     /// more than one database, a large-value tail, and enough commits for a sample to be a delta of
     /// the one before it.
-    fn restricted_config(repo_dir: &Path) -> SpaceConfig {
+    fn restricted_config(repo_dir: &Path, simulate_dir_gc: bool) -> SpaceConfig {
         SpaceConfig {
             databases: 2,
             keys_per_database: 100,
@@ -591,6 +615,7 @@ mod tests {
             sample_every: 1,
             seed: 0,
             repo_dir: Some(repo_dir.to_path_buf()),
+            simulate_dir_gc,
         }
     }
 
@@ -599,8 +624,45 @@ mod tests {
     fn space_harness_restricted() {
         let tmp = TestableTmpdir::new();
 
-        restricted_config(tmp.path())
+        restricted_config(tmp.path(), false)
             .run()
             .expect("the short space harness run should succeed");
+    }
+
+    /// A recorded base state built for a different shape has to be ignored and rebuilt, and the
+    /// commits it left behind cleared. Also samples every other commit rather than all of them.
+    #[test]
+    fn space_harness_restricted_rebuilds_mismatched_base() {
+        let tmp = TestableTmpdir::new();
+
+        restricted_config(tmp.path(), false)
+            .run()
+            .expect("the run that records the base state should succeed");
+
+        let mut config = restricted_config(tmp.path(), false);
+        // Part of the base shape, so the recorded state no longer matches.
+        config.keys_per_database += 1;
+        config.commits = 3;
+        config.sample_every = 2;
+
+        config
+            .run()
+            .expect("the run that rebuilds a mismatched base state should succeed");
+    }
+
+    /// The same shape run twice over one directory, the second time collecting. Covers the paths a
+    /// single run cannot reach: reading back a recorded base state, resetting the repository to it,
+    /// and pruning the commits the retained roots no longer hold.
+    #[test]
+    fn space_harness_restricted_reuses_base_and_collects() {
+        let tmp = TestableTmpdir::new();
+
+        restricted_config(tmp.path(), false)
+            .run()
+            .expect("the run that records the base state should succeed");
+
+        restricted_config(tmp.path(), true)
+            .run()
+            .expect("the run that reuses the base state and collects should succeed");
     }
 }

--- a/durable-storage/src/gc_space/scenario.rs
+++ b/durable-storage/src/gc_space/scenario.rs
@@ -1,0 +1,606 @@
+// SPDX-FileCopyrightText: 2026 Nomadic Labs <contact@nomadic-labs.com>
+//
+// SPDX-License-Identifier: MIT
+
+//! The shape of the scenario, and the state to measure it on.
+//!
+//! [`SpaceConfig`] is the shape. The rest builds a registry of that shape — a recorded base
+//! state is reused when one matches and prepopulated when none does — and then modifies it once
+//! per commit. Keys and values are derived from their indices, so no run has to hold a key list.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+use std::time::Duration;
+use std::time::Instant;
+
+use anyhow::Context;
+use anyhow::Result;
+use bytes::Bytes;
+use octez_riscv_data::hash::Hash;
+use octez_riscv_data::mode::Normal;
+use rand::RngExt;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use serde::Deserialize;
+use serde::Serialize;
+use tezos_smart_rollup_constants::core::MAX_FILE_CHUNK_SIZE;
+
+use super::measure::measure;
+use super::report::report;
+use super::report::report_header;
+use super::report::summarise;
+use crate::commit::CommitId;
+use crate::database::Database;
+use crate::key::Key;
+use crate::persistence_layer::PersistenceLayer;
+use crate::registry::Registry;
+use crate::repo::DirectoryManager;
+
+/// The registry type this harness measures.
+pub(super) type Reg = Registry<PersistenceLayer, Normal>;
+
+/// Name of the file recording a reusable base state in the repository directory.
+const BASE_STATE_FILE: &str = "gc_space_base.json";
+
+/// How often to report progress while prepopulating.
+const PREPOPULATE_PROGRESS_INTERVAL: usize = 250_000;
+
+/// Shape of the scenario to measure.
+#[derive(Debug, Clone)]
+pub struct SpaceConfig {
+    /// Number of databases in the registry.
+    pub databases: usize,
+
+    /// Keys written to each database before the measured commits begin.
+    pub keys_per_database: usize,
+
+    /// Length of each key, in bytes.
+    pub key_size: usize,
+
+    /// Length of an ordinary value, in bytes.
+    ///
+    /// The Etherlink trace in `benches/erc20_core/store_accesses.json` has a median write of 32
+    /// bytes — balances and storage slots — so that is the size that characterises the workload.
+    pub value_size: usize,
+
+    /// Fraction of keys holding a large value instead, between 0 and 1.
+    ///
+    /// The same trace has a heavy tail: contract code and similar reach 131,220 bytes. A fraction
+    /// of keys is given [`SpaceConfig::large_value_size`] to reproduce that, chosen deterministically
+    /// per key so a key keeps its class across commits, the way a code slot stays code.
+    pub large_value_fraction: f64,
+
+    /// Length of a large value, in bytes.
+    ///
+    /// Values beyond `MAX_FILE_CHUNK_SIZE` cannot be written in one call, so these are built in
+    /// chunks through successive offset writes — which is what a kernel storing contract code does.
+    pub large_value_size: usize,
+
+    /// Number of commits to make and measure.
+    pub commits: usize,
+
+    /// Keys modified before each commit, spread across the registry's databases.
+    pub modified_keys: usize,
+
+    /// Measure every this many commits. Scanning a column family is linear in its size, so at
+    /// large scales it is worth sampling less often than every commit.
+    pub sample_every: usize,
+
+    /// Seed for choosing which keys each commit modifies.
+    pub seed: u64,
+
+    /// Where the repository lives. A fresh temporary directory when absent, in which case nothing
+    /// survives the run.
+    pub repo_dir: Option<PathBuf>,
+}
+
+impl SpaceConfig {
+    /// The parts of the shape that determine the base state, used to decide whether a recorded
+    /// base state can be reused.
+    fn base_shape(&self) -> BaseShape {
+        BaseShape {
+            databases: self.databases,
+            keys_per_database: self.keys_per_database,
+            key_size: self.key_size,
+            value_size: self.value_size,
+            large_value_per_mille: (self.large_value_fraction * 1000.0) as u32,
+            large_value_size: self.large_value_size,
+        }
+    }
+
+    /// Whether the key at `key_index` holds a large value.
+    ///
+    /// Decided from the index alone, so it is stable across commits and needs no bookkeeping.
+    fn is_large_key(&self, db_index: usize, key_index: usize) -> bool {
+        if self.large_value_fraction <= 0.0 {
+            return false;
+        }
+
+        let per_mille = (self.large_value_fraction * 1000.0) as u64;
+
+        mix(db_index as u64 ^ mix(key_index as u64)) % 1000 < per_mille
+    }
+
+    /// The size of the value held at `key_index`.
+    fn value_size_of(&self, db_index: usize, key_index: usize) -> usize {
+        if self.is_large_key(db_index, key_index) {
+            self.large_value_size
+        } else {
+            self.value_size
+        }
+    }
+
+    /// Run the scenario and report.
+    pub fn run(self) -> Result<()> {
+        // Everything the run prints goes to one handle, taken once here and lent to whatever
+        // reports. Locking it once also keeps the table's rows from interleaving.
+        let mut out = io::stderr().lock();
+        // Kept alive for the whole run: dropping it removes the repository.
+        let temp_dir = match self.repo_dir {
+            Some(_) => None,
+            None => Some(tempfile::tempdir().context("creating a temporary repository directory")?),
+        };
+
+        let repo_path = match (&self.repo_dir, &temp_dir) {
+            (Some(path), _) => path.clone(),
+            (None, Some(temp)) => temp.path().to_path_buf(),
+            (None, None) => unreachable!("one of the two is always set"),
+        };
+
+        fs::create_dir_all(&repo_path).with_context(|| {
+            format!("creating the repository directory {}", repo_path.display())
+        })?;
+
+        let repo = DirectoryManager::new(&repo_path).context("opening the repository")?;
+
+        writeln!(
+            out,
+            "repository: {}\nshape: {} database(s) x {} keys x {} B values, {} commits x {} modified keys",
+            repo_path.display(),
+            self.databases,
+            self.keys_per_database,
+            self.value_size,
+            self.commits,
+            self.modified_keys,
+        )?;
+
+        let (mut registry, base_commit) = base_registry(&mut out, &repo, &repo_path, &self)?;
+
+        // Every repository-wide figure below counts the whole directory, so anything an earlier
+        // run left in it would be measured as part of this one.
+        reset_to_base(&mut out, &repo, &repo_path, &base_commit)?;
+
+        let mut samples = Vec::new();
+
+        // The base state is sample zero, so the first measured commit has something to be a delta of.
+        let (base, mut files) = measure(&repo, &repo_path, &base_commit, 0, Duration::ZERO, None)
+            .context("measuring the base state")?;
+        report_header(&mut out)?;
+        report(&mut out, &base)?;
+        samples.push(base);
+
+        let mut rng = StdRng::seed_from_u64(self.seed);
+
+        for commit_index in 1..=self.commits {
+            modify(&mut registry, &self, &mut rng, commit_index)
+                .with_context(|| format!("applying modifications for commit {commit_index}"))?;
+
+            let started = Instant::now();
+            let commit = registry
+                .commit()
+                .with_context(|| format!("committing at commit {commit_index}"))?;
+            let commit_time = started.elapsed();
+
+            if commit_index % self.sample_every != 0 && commit_index != self.commits {
+                continue;
+            }
+
+            let (sample, current) = measure(
+                &repo,
+                &repo_path,
+                &commit,
+                commit_index,
+                commit_time,
+                Some(&files),
+            )
+            .with_context(|| format!("measuring commit {commit_index}"))?;
+            files = current;
+            report(&mut out, &sample)?;
+            samples.push(sample);
+        }
+
+        summarise(&mut out, &samples)?;
+
+        Ok(())
+    }
+}
+
+/// Identifies a prepopulated base state, so a run can tell whether the one on disk is the one it
+/// wants. The commit sequence is deliberately not part of this: it starts from the base state and
+/// never alters it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+struct BaseShape {
+    databases: usize,
+    keys_per_database: usize,
+    key_size: usize,
+    value_size: usize,
+    large_value_per_mille: u32,
+    large_value_size: usize,
+}
+
+/// A recorded base state that later runs can check out instead of prepopulating again.
+#[derive(Debug, Serialize, Deserialize)]
+struct BaseState {
+    shape: BaseShape,
+
+    /// Hex-encoded registry commit of the prepopulated state.
+    commit: String,
+}
+
+/// Obtain the prepopulated registry to run the commit sequence against, reusing a recorded base
+/// state when the shape matches and building one otherwise.
+///
+/// Either way what comes back is a *checkout*, never the registry that did the prepopulating. A
+/// database that has just been written to holds a different LSM shape from a checkout of its own
+/// commit, so returning the one that built the base would make the first run against a directory
+/// report different occupancy, pinning and sharing figures from every run after it.
+fn base_registry(
+    out: &mut impl Write,
+    repo: &DirectoryManager,
+    repo_path: &Path,
+    config: &SpaceConfig,
+) -> Result<(Reg, CommitId)> {
+    if let Some(commit) = recorded_base(out, repo_path, config)? {
+        writeln!(
+            out,
+            "reusing the recorded base state {}",
+            commit.hex_encode()
+        )?;
+
+        let registry =
+            Reg::checkout(repo.clone(), commit).context("checking out the base state")?;
+
+        return Ok((registry, commit));
+    }
+
+    let mut registry = Reg::new(repo.clone());
+
+    for size in 1..=config.databases {
+        registry
+            .resize_tick(size)
+            .with_context(|| format!("growing the registry to {size} database(s)"))?;
+    }
+
+    prepopulate(out, &mut registry, config)?;
+
+    writeln!(out, "committing the base state...")?;
+    let started = Instant::now();
+    let commit = registry.commit().context("committing the base state")?;
+    writeln!(
+        out,
+        "base state committed as {} in {:.1}s",
+        commit.hex_encode(),
+        started.elapsed().as_secs_f64()
+    )?;
+
+    record_base(repo_path, config, &commit)?;
+
+    // Measure a checkout of the base state even on the run that builds it. Dropping the registry
+    // first releases the working database it prepopulated into, so the checkout below starts from
+    // the committed files alone.
+    drop(registry);
+
+    let registry = Reg::checkout(repo.clone(), commit).context("checking out the base state")?;
+
+    Ok((registry, commit))
+}
+
+/// Delete every commit the base state does not reach, so a reused repository measures what a
+/// fresh one would.
+///
+/// A persistent `--repo-dir` is how a run avoids prepopulating again, but it also keeps whatever
+/// earlier runs committed, and occupancy, the commit directory count, what the history pins and
+/// what a simulated collection frees are all repository-wide. Clearing them up front is what makes
+/// successive runs comparable. It matters for a mismatched recorded base too: that base is ignored
+/// and rebuilt, but its commits stay on disk until this removes them.
+fn reset_to_base(
+    out: &mut impl Write,
+    repo: &DirectoryManager,
+    repo_path: &Path,
+    base: &CommitId,
+) -> Result<()> {
+    let reachable =
+        Reg::database_commits(repo, base).context("reading the base state's registry manifest")?;
+
+    let mut removed = 0;
+
+    let commits_dir = repo_path.join("databases").join("commits");
+    let entries =
+        fs::read_dir(&commits_dir).with_context(|| format!("reading {}", commits_dir.display()))?;
+
+    for entry in entries {
+        let entry =
+            entry.with_context(|| format!("reading an entry of {}", commits_dir.display()))?;
+
+        // A commit is a directory, and `remove_dir_all` would fail on anything else.
+        if !entry
+            .file_type()
+            .with_context(|| format!("reading the type of {}", entry.path().display()))?
+            .is_dir()
+        {
+            continue;
+        }
+
+        let name = entry.file_name().to_string_lossy().into_owned();
+
+        if reachable.iter().any(|commit| commit.hex_encode() == name) {
+            continue;
+        }
+
+        fs::remove_dir_all(entry.path())
+            .with_context(|| format!("removing {}", entry.path().display()))?;
+        removed += 1;
+    }
+
+    let registries_dir = repo_path.join("registries").join("commits");
+    let entries = fs::read_dir(&registries_dir)
+        .with_context(|| format!("reading {}", registries_dir.display()))?;
+
+    for entry in entries {
+        let entry =
+            entry.with_context(|| format!("reading an entry of {}", registries_dir.display()))?;
+
+        if entry.file_name().to_string_lossy() == base.hex_encode() {
+            continue;
+        }
+
+        fs::remove_file(entry.path())
+            .with_context(|| format!("removing {}", entry.path().display()))?;
+        removed += 1;
+    }
+
+    if removed > 0 {
+        writeln!(
+            out,
+            "removed {removed} commit(s) left by earlier runs, resetting to the base state"
+        )?;
+    }
+
+    Ok(())
+}
+
+/// Read a recorded base state, if one is present and was built for this shape.
+fn recorded_base(
+    out: &mut impl Write,
+    repo_path: &Path,
+    config: &SpaceConfig,
+) -> Result<Option<CommitId>> {
+    let path = repo_path.join(BASE_STATE_FILE);
+
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let bytes = fs::read(&path)
+        .with_context(|| format!("reading the base state file {}", path.display()))?;
+    let base: BaseState = serde_json::from_slice(&bytes)
+        .with_context(|| format!("parsing the base state file {}", path.display()))?;
+
+    if base.shape != config.base_shape() {
+        writeln!(
+            out,
+            "ignoring the recorded base state: it was built for a different shape ({:?})",
+            base.shape
+        )?;
+        return Ok(None);
+    }
+
+    let bytes = hex::decode(&base.commit).context("decoding the recorded base commit")?;
+    let hash: [u8; Hash::DIGEST_SIZE] = bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("recorded base commit is not {} bytes", Hash::DIGEST_SIZE))?;
+
+    Ok(Some(CommitId::from(Hash::from(hash))))
+}
+
+/// Record a base state so later runs of the same shape can skip prepopulating.
+fn record_base(repo_path: &Path, config: &SpaceConfig, commit: &CommitId) -> Result<()> {
+    let path = repo_path.join(BASE_STATE_FILE);
+    let base = BaseState {
+        shape: config.base_shape(),
+        commit: commit.hex_encode(),
+    };
+
+    let bytes = serde_json::to_vec_pretty(&base).context("encoding the base state")?;
+    fs::write(&path, bytes)
+        .with_context(|| format!("writing the base state file {}", path.display()))?;
+
+    Ok(())
+}
+
+/// Fill every database with `keys_per_database` keys.
+fn prepopulate(out: &mut impl Write, registry: &mut Reg, config: &SpaceConfig) -> Result<()> {
+    let total = config.databases * config.keys_per_database;
+    let started = Instant::now();
+    let mut written = 0;
+
+    for db_index in 0..config.databases {
+        let database = registry
+            .database_mut(db_index)
+            .with_context(|| format!("getting database {db_index}"))?;
+
+        for key_index in 0..config.keys_per_database {
+            store_value(database, config, db_index, key_index, 0)
+                .with_context(|| format!("writing key {key_index} in database {db_index}"))?;
+
+            written += 1;
+
+            if written % PREPOPULATE_PROGRESS_INTERVAL == 0 {
+                writeln!(
+                    out,
+                    "prepopulating: {written}/{total} keys ({:.1}s elapsed)",
+                    started.elapsed().as_secs_f64()
+                )?;
+            }
+        }
+    }
+
+    writeln!(
+        out,
+        "prepopulated {total} keys in {:.1}s",
+        started.elapsed().as_secs_f64()
+    )?;
+
+    Ok(())
+}
+
+/// Overwrite `modified_keys` existing keys, chosen uniformly across the registry.
+///
+/// The value depends on the commit index, so each modification really changes the value and
+/// therefore the node hashes along its path to the root.
+fn modify(
+    registry: &mut Reg,
+    config: &SpaceConfig,
+    rng: &mut StdRng,
+    generation: usize,
+) -> Result<()> {
+    // Group the picks by database so each database is borrowed once rather than per key.
+    let mut picks: HashMap<usize, Vec<usize>> = HashMap::new();
+
+    for _ in 0..config.modified_keys {
+        let db_index = rng.random_range(0..config.databases);
+        let key_index = rng.random_range(0..config.keys_per_database);
+        picks.entry(db_index).or_default().push(key_index);
+    }
+
+    for (db_index, key_indices) in picks {
+        let database = registry
+            .database_mut(db_index)
+            .with_context(|| format!("getting database {db_index}"))?;
+
+        for key_index in key_indices {
+            store_value(database, config, db_index, key_index, generation)
+                .with_context(|| format!("writing key {key_index} in database {db_index}"))?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Write the value for a key, in chunks when it is too large for a single call.
+///
+/// `set` is capped at [`MAX_FILE_CHUNK_SIZE`], so anything above it is built by successive offset
+/// writes, which is how a kernel stores contract code. The offset path also exercises the merge
+/// operator, unlike `set`.
+fn store_value(
+    database: &mut Database<PersistenceLayer, Normal>,
+    config: &SpaceConfig,
+    db_index: usize,
+    key_index: usize,
+    generation: usize,
+) -> Result<()> {
+    let key = derive_key(db_index, key_index, config.key_size);
+    let size = config.value_size_of(db_index, key_index);
+
+    if size <= MAX_FILE_CHUNK_SIZE {
+        database.set(key, derive_value(db_index, key_index, generation, size))?;
+
+        return Ok(());
+    }
+
+    let value = derive_value(db_index, key_index, generation, size);
+
+    for (chunk, offset) in value
+        .chunks(MAX_FILE_CHUNK_SIZE)
+        .zip((0..).step_by(MAX_FILE_CHUNK_SIZE))
+    {
+        database.write(key.clone(), offset, value.slice_ref(chunk))?;
+    }
+
+    Ok(())
+}
+
+/// Derive the key at `key_index` in database `db_index`.
+///
+/// Derived rather than stored so that a run at ten million keys needs no key list, and mixed so
+/// that keys are spread through the tree the way real ones would be rather than arriving in order.
+fn derive_key(db_index: usize, key_index: usize, key_size: usize) -> Key {
+    let mut bytes = vec![0; key_size];
+    let mut state = mix(db_index as u64) ^ mix(key_index as u64 + 1);
+
+    for chunk in bytes.chunks_mut(8) {
+        state = mix(state);
+        let source = state.to_le_bytes();
+        let len = chunk.len();
+        chunk.copy_from_slice(&source[..len]);
+    }
+
+    Key::new(&bytes).expect("a derived key should be within the size limit")
+}
+
+/// Derive the value for a key at a given generation.
+fn derive_value(db_index: usize, key_index: usize, generation: usize, value_size: usize) -> Bytes {
+    let mut bytes = vec![0; value_size];
+    let mut state =
+        mix(db_index as u64) ^ mix(key_index as u64 + 1) ^ mix(generation as u64 + 0x9E37_79B9);
+
+    for chunk in bytes.chunks_mut(8) {
+        state = mix(state);
+        let source = state.to_le_bytes();
+        let len = chunk.len();
+        chunk.copy_from_slice(&source[..len]);
+    }
+
+    Bytes::from(bytes)
+}
+
+/// SplitMix64, to turn indices into well-spread bytes without carrying an RNG around.
+const fn mix(value: u64) -> u64 {
+    let mut z = value.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+#[cfg(test)]
+mod tests {
+    use octez_riscv_test_utils::TestableTmpdir;
+
+    use super::*;
+
+    /// A run small enough for the test suite, still covering every measurement the harness makes:
+    /// more than one database, a large-value tail, and enough commits for a sample to be a delta of
+    /// the one before it.
+    fn restricted_config(repo_dir: &Path) -> SpaceConfig {
+        SpaceConfig {
+            databases: 2,
+            keys_per_database: 100,
+            key_size: 40,
+            value_size: 32,
+            large_value_fraction: 0.1,
+            // Above MAX_FILE_CHUNK_SIZE, so the offset-write path in `store_value` is
+            // exercised alongside the single-call one.
+            large_value_size: 5000,
+            commits: 2,
+            modified_keys: 10,
+            sample_every: 1,
+            seed: 0,
+            repo_dir: Some(repo_dir.to_path_buf()),
+        }
+    }
+
+    /// A short run of the space harness, prepopulating its own base state.
+    #[test]
+    fn space_harness_restricted() {
+        let tmp = TestableTmpdir::new();
+
+        restricted_config(tmp.path())
+            .run()
+            .expect("the short space harness run should succeed");
+    }
+}

--- a/durable-storage/src/lib.rs
+++ b/durable-storage/src/lib.rs
@@ -32,6 +32,10 @@ pub mod avl;
 pub mod commit;
 pub mod database;
 pub mod errors;
+// The space accounting harness scans committed column families directly, so it is only available
+// when `rocksdb` is enabled.
+#[cfg(rocksdb_test_utils)]
+pub mod gc_space;
 pub mod key;
 // The long-running test exercises the persistence backend directly, so it is
 // only available when `rocksdb` is enabled.

--- a/durable-storage/src/long_test/database/mod.rs
+++ b/durable-storage/src/long_test/database/mod.rs
@@ -156,12 +156,12 @@ pub fn run_long_test(config: LongTestConfig) -> Result<()> {
                 #[cfg(not(test))]
                 {
                     let snapshot_dir = persistent_repo.database_commit_dir(&base.commit);
-                    let snapshot_size = super::harness::dir_size(&snapshot_dir)
+                    let snapshot_size = crate::gc_space::disk_usage(&snapshot_dir)
                         .context("measuring the size of the latest snapshot")?;
                     eprintln!(
                         "epoch {epoch} ok (db contains {} entries, latest snapshot: {:.2} MiB)",
                         base.model.data.len(),
-                        snapshot_size as f64 / (1024.0 * 1024.0),
+                        snapshot_size.unique_bytes as f64 / (1024.0 * 1024.0),
                     );
                 }
                 #[cfg(test)]
@@ -230,10 +230,10 @@ pub fn run_long_test(config: LongTestConfig) -> Result<()> {
         drop(runtime);
 
         let repo_size =
-            super::harness::dir_size(&repo_dir).context("measuring the size of the repo")?;
+            crate::gc_space::disk_usage(&repo_dir).context("measuring the size of the repo")?;
         eprintln!(
             "total repo size: {:.2} MiB",
-            repo_size as f64 / (1024.0 * 1024.0)
+            repo_size.unique_bytes as f64 / (1024.0 * 1024.0)
         );
     }
 

--- a/durable-storage/src/long_test/harness.rs
+++ b/durable-storage/src/long_test/harness.rs
@@ -145,19 +145,3 @@ pub(crate) fn read_failure_file<T: serde::de::DeserializeOwned>(
         fs::File::open(failure_dir.join(name)).context(format!("opening failure file {name}"))?;
     serde_json::from_reader(file).context(format!("decoding {name}"))
 }
-
-/// Total size in bytes of all files under `dir`, recursively.
-#[cfg(not(test))]
-pub(crate) fn dir_size(dir: &Path) -> std::io::Result<u64> {
-    let mut size = 0;
-    for entry in fs::read_dir(dir)? {
-        let entry = entry?;
-        let metadata = entry.metadata()?;
-        if metadata.is_dir() {
-            size += dir_size(&entry.path())?;
-        } else {
-            size += metadata.len();
-        }
-    }
-    Ok(size)
-}

--- a/durable-storage/src/long_test/registry/mod.rs
+++ b/durable-storage/src/long_test/registry/mod.rs
@@ -171,13 +171,13 @@ pub fn run_long_test(
                 // Size reporting only via the binary, not the crate test.
                 #[cfg(not(test))]
                 {
-                    let repo_size = super::harness::dir_size(&repo_dir)
+                    let repo_size = crate::gc_space::disk_usage(&repo_dir)
                         .context("measuring the size of the repo")?;
                     eprintln!(
                         "epoch {epoch} ok ({} databases, {} entries, repo: {:.2} MiB)",
                         base.model.len(),
                         base.model.total_entries(),
-                        repo_size as f64 / (1024.0 * 1024.0),
+                        repo_size.unique_bytes as f64 / (1024.0 * 1024.0),
                     );
                 }
                 #[cfg(test)]

--- a/durable-storage/src/persistence_layer.rs
+++ b/durable-storage/src/persistence_layer.rs
@@ -496,6 +496,9 @@ impl ReadOnlyKeyValueStore for ReadOnlyPersistenceLayer {
     }
 }
 
+#[cfg(rocksdb_test_utils)]
+pub mod measurement;
+
 impl WriteableKeyValueStore for PersistenceLayer {
     fn new(repo: &Self::Repo) -> Result<Self, OperationalError> {
         let tempdir = repo.temp_database_dir()?;

--- a/durable-storage/src/persistence_layer/measurement.rs
+++ b/durable-storage/src/persistence_layer/measurement.rs
@@ -1,0 +1,194 @@
+// SPDX-FileCopyrightText: 2026 Nomadic Labs <contact@nomadic-labs.com>
+//
+// SPDX-License-Identifier: MIT
+
+//! Measurement of a committed database, for space accounting.
+//!
+//! These read a commit's column families directly: how many entries each holds, what they
+//! occupy, and which SST files hold them. They are whole-column-family scans, so they belong
+//! to the harnesses rather than to any path where performance matters — which is why they sit
+//! here rather than beside the production code that opens the instance.
+
+use std::collections::HashMap;
+
+use super::BLOB_CF;
+use super::KV_CF;
+use super::ReadOnlyPersistenceLayer;
+use super::blob_cf_of;
+
+/// One SST file of a committed database.
+///
+/// A *sorted string table* is the immutable file RocksDB keeps key-value pairs in: a memtable is
+/// flushed into a new SST at level zero, and compaction merges those into fewer, larger SSTs at
+/// deeper levels. Everything a database holds that is not a log or a manifest sits in one of
+/// these, so they are the unit disk usage is attributed in — and since a checkpoint hard-links
+/// them rather than copying them, they are also the unit two commits share.
+#[derive(Debug, Clone)]
+pub struct SstFile {
+    /// File name, as it appears in the commit directory.
+    pub name: String,
+
+    /// Which column family's data it holds.
+    pub owner: SstOwner,
+
+    /// LSM level it sits at.
+    pub level: i32,
+
+    /// Size in bytes, as RocksDB reports it.
+    pub size: u64,
+
+    /// Number of entries it holds.
+    pub entries: u64,
+}
+
+/// Which column family an SST file holds data for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SstOwner {
+    /// Merkle node bodies.
+    Blob,
+
+    /// Values.
+    Value,
+}
+
+/// Byte totals for one column family, counted by scanning every entry in it.
+///
+/// These are the bytes as stored logically, before compression or any per-SST overhead. Compare
+/// against [`ReadOnlyPersistenceLayer::sst_bytes`] for what the files actually occupy.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct CfTotals {
+    /// Number of key-value pairs.
+    pub entries: u64,
+
+    /// Total length of all keys.
+    pub key_bytes: u64,
+
+    /// Total length of all values.
+    pub value_bytes: u64,
+}
+
+impl CfTotals {
+    /// Total bytes stored, keys and values together.
+    pub fn stored_bytes(&self) -> u64 {
+        self.key_bytes + self.value_bytes
+    }
+}
+
+/// Count the entries and bytes in the column family `cf` by iterating all of it.
+///
+/// A full scan rather than a RocksDB estimate, because the point of measuring is to know how much
+/// of a column family is dead, and an estimate cannot be subtracted from an exact live figure.
+fn scan_cf(
+    db: &rocksdb::DB,
+    cf: &rocksdb::ColumnFamily,
+) -> Result<CfTotals, Box<dyn std::error::Error>> {
+    let mut totals = CfTotals::default();
+    let mut iter = db.raw_iterator_cf(cf);
+    iter.seek_to_first();
+
+    while iter.valid() {
+        totals.entries += 1;
+        totals.key_bytes += iter.key().map_or(0, |key| key.len() as u64);
+        totals.value_bytes += iter.value().map_or(0, |value| value.len() as u64);
+        iter.next();
+    }
+
+    // An iterator that stopped because of an error also reports `!valid()`, so the loop above
+    // cannot tell a complete scan from a truncated one without this.
+    iter.status()?;
+
+    Ok(totals)
+}
+
+/// Which column family an SST file belongs to, from the name RocksDB reports for it.
+///
+/// A database has exactly these two families, so any other name means the instance is not one of
+/// ours — and attributing its bytes to either family would be a guess.
+fn sst_owner_of(column_family: &str) -> Result<SstOwner, Box<dyn std::error::Error>> {
+    match column_family {
+        BLOB_CF => Ok(SstOwner::Blob),
+        KV_CF => Ok(SstOwner::Value),
+        other => Err(format!("unexpected column family {other} in a database instance").into()),
+    }
+}
+
+/// Measurement of a committed database, for space accounting.
+///
+/// Only available to the harnesses: these are whole-column-family scans, far too expensive to sit
+/// on any path where performance matters.
+impl ReadOnlyPersistenceLayer {
+    /// Scan the column family holding Merkle node bodies.
+    pub fn blob_totals(&self) -> Result<CfTotals, Box<dyn std::error::Error>> {
+        scan_cf(&self.db_instance, blob_cf_of(&self.db_instance))
+    }
+
+    /// Scan the column family holding values.
+    pub fn value_totals(&self) -> Result<CfTotals, Box<dyn std::error::Error>> {
+        let cf = self
+            .db_instance
+            .cf_handle(KV_CF)
+            .ok_or("the rocksdb instance should always contain the default cf")?;
+
+        scan_cf(&self.db_instance, cf)
+    }
+
+    /// Every SST file of this instance, with the level and column family it belongs to.
+    ///
+    /// Comparing these sets between successive commits is how sharing is measured: a checkpoint
+    /// hard-links the files live when it was taken, so a file present in two checkpoints of the
+    /// same database is one file on disk, and a file present in only the later one was written by
+    /// compaction or a flush in between.
+    pub fn sst_files(&self) -> Result<Vec<SstFile>, Box<dyn std::error::Error>> {
+        self.db_instance
+            .live_files()?
+            .into_iter()
+            .map(|file| {
+                Ok(SstFile {
+                    owner: sst_owner_of(&file.column_family_name)?,
+                    name: file.name.trim_start_matches('/').to_owned(),
+                    level: file.level,
+                    size: file.size as u64,
+                    entries: file.num_entries,
+                })
+            })
+            .collect()
+    }
+
+    /// Which column family each SST file of this instance belongs to, keyed by file name.
+    ///
+    /// The SST files of both column families sit in one directory with no distinguishing names, so
+    /// attributing disk to one or the other has to come from RocksDB's own metadata. Any leading
+    /// separator is stripped from the names so they match directory entries directly.
+    pub fn sst_column_families(
+        &self,
+    ) -> Result<HashMap<String, SstOwner>, Box<dyn std::error::Error>> {
+        let mut owners = HashMap::new();
+
+        for file in self.db_instance.live_files()? {
+            let owner = sst_owner_of(&file.column_family_name)?;
+
+            owners.insert(file.name.trim_start_matches('/').to_owned(), owner);
+        }
+
+        Ok(owners)
+    }
+
+    /// Size of the SST files backing both column families, as RocksDB reports it.
+    pub fn sst_bytes(&self) -> Result<u64, Box<dyn std::error::Error>> {
+        let mut total = 0;
+
+        for cf in [
+            blob_cf_of(&self.db_instance),
+            self.db_instance
+                .cf_handle(KV_CF)
+                .ok_or("the rocksdb instance should always contain the default cf")?,
+        ] {
+            total += self
+                .db_instance
+                .property_int_value_cf(cf, "rocksdb.total-sst-files-size")?
+                .unwrap_or(0);
+        }
+
+        Ok(total)
+    }
+}


### PR DESCRIPTION
- Relates to TZX-209

# What

`gc_space`, a harness that measures what a commit costs on disk and how much of that is still
needed: live against dead Merkle node data, what the retained history pins, and how much of each
commit the previous one already holds. `--simulate-dir-gc` removes every commit no retained root
reaches and reports what that frees.

Also fixes the long tests' per-epoch repository size, which summed file lengths and so counted a
hard-linked SST once per link, growing with the retention window rather than with the data.

Measurement only, gated behind `rocksdb` + `unstable-test-utils` — which is why the patch-coverage
check fails by construction.

There'll be follow ups to start running this in CI, and tracking in datadog

# Why

Of the bytes a commit occupies, how many are still needed to serve it? The two column families
answer differently. Values are keyed by your key, so an overwrite becomes an obsolete version that
compaction reclaims. Merkle node bodies are keyed by content hash, so every version is a distinct
live key that nothing ever deletes. The dead figure for the Merkle side is what justifies
collecting at all, and `--simulate-dir-gc` shows why deleting directories cannot recover it: those
dead bodies sit in files the retained commits still reference.

# How

Keys and values are derived from their indices, so a run at ten million keys holds no key list, and
the base state is recorded in `--repo-dir` and reused when the shape matches. Live bodies come from
walking the stored representation from the committed root; the totals they are subtracted from come
from a full column-family scan, since an estimate cannot be subtracted from an exact figure.
Occupancy counts blocks per unique inode, because checkpoints hard-link their SSTs — that walk is
what the long tests now share.

# Manually Testing

```
make -C durable-storage check
cargo nextest run -p octez-riscv-durable-storage

cargo run --release --features unstable-test-utils --bin gc_space -- \
  --databases 2 --keys 500 --commits 3 --modified-keys 20 --simulate-dir-gc
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
