### PR TITLE
fix(data): bound NDS proof verification by proof size, not claimed length

### DIFF
--- a/data/src/components/bytes.rs
+++ b/data/src/components/bytes.rs
@@ -42,6 +42,7 @@ use crate::foldable::Unfoldable;
 use crate::foldable::seq_tree;
 use crate::foldable::seq_tree::DepthAdjustedSeqAsTree;
 use crate::foldable::seq_tree::IndexableSeqAsTree;
+use crate::foldable::seq_tree::PrunedSeqAsTree;
 use crate::foldable::seq_tree::tree_depth;
 use crate::hash::Hash;
 use crate::hash::PartialHash;
@@ -459,13 +460,23 @@ where
             }
         };
 
+        // Reports whether a run of pages holds any data. Pages the proof said nothing about are
+        // left undefined, which is what lets the fold skip over them rather than walk a page count
+        // the proof chose for us.
+        let has_state = |pages: Range<usize>| {
+            let start = pages.start.saturating_mul(PAGE_SIZE);
+            let end = pages.end.saturating_mul(PAGE_SIZE).min(length);
+
+            self.bytes.data.is_any_defined(start..end)
+        };
+
         let original_pages = original_length.div_ceil(PAGE_SIZE);
         let pages = length.div_ceil(PAGE_SIZE);
 
         let mut builder = builder.into_node_fold();
         builder.add(&length_node);
         builder.add(&DepthAdjustedSeqAsTree {
-            inner: IndexableSeqAsTree::new(pages, NODE_ARITY, &generator),
+            inner: PrunedSeqAsTree::new(pages, NODE_ARITY, &generator, &has_state),
             original_depth: tree_depth(original_pages, NODE_ARITY),
             current_depth: tree_depth(pages, NODE_ARITY),
         });

--- a/data/src/components/bytes/tests.rs
+++ b/data/src/components/bytes/tests.rs
@@ -12,13 +12,17 @@ use tezos_smart_rollup_constants::core::MAX_FILE_CHUNK_SIZE;
 
 use super::test_utils::BytesOp;
 use super::test_utils::MAX_PROOF_OFFSETS;
+use crate::codec::Bincode;
+use crate::codec::LeafEncode;
 use crate::components::bytes::Bytes;
+use crate::components::bytes::NODE_ARITY;
 use crate::components::bytes::PAGE_SIZE;
 use crate::components::bytes::test_utils::BytesMutOp;
 use crate::components::bytes::test_utils::MAX_PROOF_LENGTH;
 use crate::components::bytes::test_utils::NDS_BYTES_LENGTH;
 use crate::foldable::Foldable;
 use crate::foldable::Unfoldable;
+use crate::foldable::seq_tree::tree_depth;
 use crate::foldable::tests::TestFolder;
 use crate::hash::Hash;
 use crate::hash::PartialHash;
@@ -632,4 +636,210 @@ fn test_bytes_largest_valid_proof_nds() {
 
         assert!(proof.len() <= MAX_PROOF_LENGTH);
     });
+}
+
+/// Folding a verify-mode value must cost what the proof contains, not what it claims to describe.
+///
+/// The length reaching the fold is recovered from the proof, and nothing bounds what it may assert:
+/// a proof describing a value of any size can still hash correctly. Nothing has been read or
+/// written here, so every page below the items node stands unchanged and that node contributes
+/// exactly the hash the proof already carries for it. Walking the pages to discover as much would
+/// take time proportional to the claimed length, which at this size is not a wait anyone will sit
+/// through.
+#[test]
+fn verify_fold_skips_pages_holding_no_state() {
+    // Four tebibytes, or a little over four billion pages.
+    let length = 1usize << 42;
+
+    let length_leaf = MerkleProof::leaf_read(
+        LeafEncode::<Bincode>::leaf_encode(&(length as u64)).expect("Encoding length should work"),
+    );
+    let pages = MerkleProof::leaf_blind(Hash::hash_bytes(b"untouched pages"));
+    let proof = MerkleProof::node_without_data(vec![length_leaf, pages]);
+
+    let bytes = Bytes::<Verify>::absent(length);
+
+    assert_eq!(
+        PartialHash::from_foldable(Some(proof.clone()), &bytes),
+        PartialHash::Present(proof.root_hash()),
+        "An untouched value should re-hash to exactly what the proof committed to"
+    );
+}
+
+/// A page the step wrote to must be descended into and re-hashed, not folded away.
+///
+/// The proof spells out the path down to page 0 and blinds every sibling along the way, which is
+/// what a prover emits for a step touching one page of a large value. The whole page is written,
+/// since leaving it partly defined would be rejected as incoherent before any of this was reached.
+///
+/// Note what this does and does not pin down. Every node on the path is present in the proof, so
+/// `skip_unchanged_subtree` declines on those regardless of what `has_state` reports - the
+/// shortcut could not fire here even if the predicate were wrong. What this covers is the opposite
+/// risk: that an honest proof of a touched page still folds to a hash rather than being rejected.
+/// The predicate itself is pinned by
+/// [`verify_fold_rejects_a_partial_write_into_a_blinded_subtree`].
+#[test]
+fn verify_fold_descends_into_pages_holding_state() {
+    let length = 1usize << 42;
+    let pages = length.div_ceil(PAGE_SIZE);
+
+    // Path to page 0, with the sibling at each level blinded.
+    let mut items = MerkleProof::leaf_read(vec![0u8; 4]);
+    for level in 0..tree_depth(pages, NODE_ARITY) {
+        items = MerkleProof::node_without_data(vec![
+            items,
+            MerkleProof::leaf_blind(Hash::hash_bytes(&[level as u8, 0x5a])),
+        ]);
+    }
+
+    let length_leaf = MerkleProof::leaf_read(
+        LeafEncode::<Bincode>::leaf_encode(&(length as u64)).expect("Encoding length should work"),
+    );
+    let proof = MerkleProof::node_without_data(vec![length_leaf, items]);
+
+    let mut bytes = Bytes::<Verify>::absent(length);
+    bytes.write(0, &[1u8; PAGE_SIZE]);
+
+    let hash = PartialHash::from_foldable(Some(proof.clone()), &bytes);
+
+    let PartialHash::Present(hash) = hash else {
+        panic!("A coherent state over a well-formed proof should hash, got {hash:?}")
+    };
+    assert_ne!(
+        hash,
+        proof.root_hash(),
+        "A written page must not be folded away"
+    );
+}
+
+/// A write covering only part of a blinded subtree must be rejected.
+///
+/// This is the case the `has_state` predicate exists to catch. The proof carries a single blind for
+/// the whole page sequence and one page underneath it is written, so the old contents of the
+/// remaining pages are still needed and are not there: the written page hashes to something, its
+/// neighbours defer to a proof that says nothing about them, and mixing the two is what
+/// `InvalidProof` reports. Were the predicate to under-report, the fold would answer from the blind
+/// and quietly accept a state the proof cannot support.
+///
+/// Note that blinding alone is not what makes this fail - overwriting the region in full succeeds,
+/// per [`verify_fold_accepts_a_full_overwrite_of_a_blinded_subtree`]. It fails because the write is
+/// partial, leaving pages whose previous contents nothing can supply.
+#[test]
+fn verify_fold_rejects_a_partial_write_into_a_blinded_subtree() {
+    let length = 1usize << 42;
+
+    let length_leaf = MerkleProof::leaf_read(
+        LeafEncode::<Bincode>::leaf_encode(&(length as u64)).expect("Encoding length should work"),
+    );
+    let pages = MerkleProof::leaf_blind(Hash::hash_bytes(b"untouched pages"));
+    let proof = MerkleProof::node_without_data(vec![length_leaf, pages]);
+
+    let mut bytes = Bytes::<Verify>::absent(length);
+    bytes.write(0, &[1u8; PAGE_SIZE]);
+
+    assert_eq!(
+        PartialHash::from_foldable(Some(proof), &bytes),
+        PartialHash::InvalidProof,
+        "A page written underneath a blind cannot be re-hashed from that blind"
+    );
+}
+
+/// A write beneath a node the proof says nothing about must be rejected too.
+///
+/// Unlike the blinded case there is no hash to fall back on at all: the written page hashes to
+/// something, the page beside it defers to a proof carrying nothing for it, and `InvalidProof` is
+/// what mixing the two reports.
+///
+/// This pins the rejection rather than the shortcut. The mixture arises among the leaves, beside
+/// the shortcut rather than through it, so the outcome holds however `skip_unchanged_subtree`
+/// answers for an absent subtree - unlike
+/// [`verify_fold_rejects_a_partial_write_into_a_blinded_subtree`], which does discriminate the predicate.
+/// What both guard is the present/absent mixing rule in `PartialHashNodeFold::done`, without which
+/// this write would be quietly accepted.
+#[test]
+fn verify_fold_rejects_a_write_under_an_absent_node() {
+    let length = 1usize << 42;
+
+    // The proof carries the length and nothing else - the page sequence is absent from it entirely.
+    let length_leaf = MerkleProof::leaf_read(
+        LeafEncode::<Bincode>::leaf_encode(&(length as u64)).expect("Encoding length should work"),
+    );
+    let proof = MerkleProof::node_without_data(vec![length_leaf]);
+
+    let mut bytes = Bytes::<Verify>::absent(length);
+    bytes.write(0, &[1u8; PAGE_SIZE]);
+
+    assert_eq!(
+        PartialHash::from_foldable(Some(proof), &bytes),
+        PartialHash::InvalidProof,
+        "A page written where the proof carries nothing cannot be re-hashed"
+    );
+}
+
+/// Overwriting a blinded region in full must succeed: none of the old contents are needed to
+/// re-hash it.
+///
+/// This is the counterpart to [`verify_fold_rejects_a_partial_write_into_a_blinded_subtree`]. Every
+/// page under the blind is defined, so each hashes from what the state now holds and the subtree
+/// re-hashes from those - the blind is never consulted. Asserting against the hash of a concrete
+/// [`Normal`] value of the same contents pins that it reproduces the real hash, rather than merely
+/// avoiding rejection.
+#[test]
+fn verify_fold_accepts_a_full_overwrite_of_a_blinded_subtree() {
+    let contents = [7u8; 4 * PAGE_SIZE];
+
+    let length_leaf = MerkleProof::leaf_read(
+        LeafEncode::<Bincode>::leaf_encode(&(contents.len() as u64))
+            .expect("Encoding length should work"),
+    );
+    let pages = MerkleProof::leaf_blind(Hash::hash_bytes(b"the contents being replaced"));
+    let proof = MerkleProof::node_without_data(vec![length_leaf, pages]);
+
+    let mut bytes = Bytes::<Verify>::absent(contents.len());
+    bytes.write(0, &contents);
+
+    let expected = Hash::from_foldable(&Bytes::<Normal>::from(&contents[..]));
+
+    assert_eq!(
+        PartialHash::from_foldable(Some(proof), &bytes),
+        PartialHash::Present(expected),
+        "A fully overwritten blinded region should re-hash to what its contents actually hash to"
+    );
+}
+
+/// A resize that crosses a power-of-arity boundary changes the page tree's depth, so the reference
+/// proof no longer has the shape the state does and `DepthAdjustedSeqAsTree` re-scopes it. That has
+/// to stay bounded when the claimed length is huge, since the claim is the proof's to make.
+///
+/// Here a value claiming a tebibyte grows by one byte, taking the page count from `2^30` to
+/// `2^30 + 1` and the depth from 30 to 31, so the proof is padded with a dummy layer. Only the page
+/// holding the new byte is descended into; the rest of the tree is skipped from the blind the proof
+/// carries. Walking it instead would mean a billion pages.
+#[test]
+fn verify_fold_stays_bounded_across_a_depth_adjusting_resize() {
+    let original_length = 1usize << 40;
+
+    let length_leaf = MerkleProof::leaf_read(
+        LeafEncode::<Bincode>::leaf_encode(&(original_length as u64))
+            .expect("Encoding length should work"),
+    );
+    let pages = MerkleProof::leaf_blind(Hash::hash_bytes(b"a tebibyte of untouched pages"));
+    let proof = MerkleProof::node_without_data(vec![length_leaf, pages]);
+
+    let mut bytes = Bytes::<Verify>::absent(original_length);
+    bytes.resize(original_length + 1);
+
+    assert_eq!(
+        tree_depth(original_length.div_ceil(PAGE_SIZE), NODE_ARITY) + 1,
+        tree_depth((original_length + 1).div_ceil(PAGE_SIZE), NODE_ARITY),
+        "The resize should be the one that pushes the page tree a level deeper"
+    );
+
+    let hash = PartialHash::from_foldable(Some(proof), &bytes);
+
+    assert!(
+        matches!(hash, PartialHash::Present(_)),
+        "The grown page is defined and every other page is unchanged, so this should hash; got \
+         {hash:?}"
+    );
 }

--- a/data/src/components/vector.rs
+++ b/data/src/components/vector.rs
@@ -13,6 +13,7 @@ use std::convert::Infallible;
 use std::marker::PhantomData;
 use std::ops::Index;
 use std::ops::IndexMut;
+use std::ops::Range;
 
 use bincode::Decode;
 use bincode::Encode;
@@ -37,6 +38,7 @@ use crate::foldable::Unfoldable;
 use crate::foldable::seq_tree;
 use crate::foldable::seq_tree::DepthAdjustedSeqAsTree;
 use crate::foldable::seq_tree::IndexableSeqAsTree;
+use crate::foldable::seq_tree::PrunedSeqAsTree;
 use crate::foldable::seq_tree::tree_depth;
 use crate::hash::Hash;
 use crate::hash::PartialHash;
@@ -261,8 +263,11 @@ where
                 .unwrap_or(Partial::Absent)
         };
 
+        // Items the proof said nothing about are left undefined, which is what lets the fold skip
+        // over them rather than walk an item count the proof chose for us.
+        let has_state = |items: Range<usize>| self.vector.items.is_any_defined(items);
         node.add(&DepthAdjustedSeqAsTree {
-            inner: IndexableSeqAsTree::new(length, NODE_ARITY, &get_item),
+            inner: PrunedSeqAsTree::new(length, NODE_ARITY, &get_item, &has_state),
             original_depth: tree_depth(original_length, NODE_ARITY),
             current_depth: tree_depth(length, NODE_ARITY),
         });

--- a/data/src/components/vector/tests.rs
+++ b/data/src/components/vector/tests.rs
@@ -15,6 +15,8 @@ use proptest::proptest;
 use proptest::test_runner::TestCaseResult;
 
 use super::Vector;
+use crate::codec::Bincode;
+use crate::codec::LeafEncode;
 use crate::components::atom::Atom;
 use crate::components::atom::tests::AtomMutOp;
 use crate::components::atom::tests::AtomOp;
@@ -35,6 +37,7 @@ use crate::merkle_proof::FromProof;
 use crate::merkle_proof::proof_binary;
 use crate::merkle_proof::proof_tree::MerkleProof;
 use crate::merkle_proof::proof_tree::MerkleProofFold;
+use crate::merkle_proof::proof_tree::ProofTree;
 use crate::mode::Normal;
 use crate::mode::Provable;
 use crate::mode::ProvableExt;
@@ -570,4 +573,30 @@ fn fold_unfold_bytes() {
 
         prop_assert_eq!(vector, unfolded);
     });
+}
+
+/// A registry proof may claim any number of databases: the count is recovered from the proof, and
+/// nothing bounds it - such a proof can still hash correctly, so no later check would catch it.
+/// Both parsing such a proof and folding the result back into a hash must therefore cost what the
+/// proof contains rather than what it claims to describe.
+#[test]
+fn huge_claimed_length_costs_nothing_to_parse_or_fold() {
+    // Over a quintillion databases.
+    let length = 1u64 << 60;
+
+    let length_leaf = MerkleProof::leaf_read(
+        LeafEncode::<Bincode>::leaf_encode(&length).expect("Encoding length should work"),
+    );
+    let items = MerkleProof::leaf_blind(Hash::hash_bytes(b"untouched databases"));
+    let proof = MerkleProof::node_without_data(vec![length_leaf, items]);
+
+    let vector = Vector::<Atom<u64, Verify>, Verify>::from_proof(ProofTree::present(&proof))
+        .expect("The proof should parse")
+        .into_result();
+
+    assert_eq!(
+        PartialHash::from_foldable(Some(proof.clone()), &vector),
+        PartialHash::Present(proof.root_hash()),
+        "An untouched registry should re-hash to exactly what the proof committed to"
+    );
 }

--- a/data/src/foldable/seq_tree.rs
+++ b/data/src/foldable/seq_tree.rs
@@ -4,7 +4,6 @@
 
 //! Helpers for sequences that need to fold and unfold like trees
 
-use derive_more::From;
 
 use crate::codec::LeafCodec;
 use crate::foldable::Fold;
@@ -13,7 +12,6 @@ use crate::foldable::NodeFold;
 use crate::foldable::NodeUnfold;
 use crate::foldable::Unfold;
 use crate::foldable::UnfoldError;
-use crate::foldable::Unfoldable;
 use crate::hash::PartialHash;
 use crate::hash::PartialHashFold;
 use crate::tree::Tree;
@@ -121,35 +119,6 @@ where
         }
 
         builder.done()
-    }
-}
-
-/// Helper struct for unfolding sequences in a state component.
-#[derive(From)]
-pub struct Many<T, const ARITY: usize, const LEN: usize>(Box<[T; LEN]>);
-
-impl<T, const ARITY: usize, const LEN: usize> Many<T, ARITY, LEN> {
-    /// Turn this into the underlying boxed array.
-    pub fn into_boxed_array(self) -> Box<[T; LEN]> {
-        self.0
-    }
-}
-
-impl<T: Unfoldable, const ARITY: usize, const LEN: usize> Unfoldable for Many<T, ARITY, LEN> {
-    fn unfold<U: Unfold>(source: U) -> Result<Self, UnfoldError> {
-        let mut leaves = Vec::with_capacity(LEN);
-
-        descend_tree(source, ARITY, LEN, &mut |_, source| {
-            let leaf = T::unfold(source)?;
-            leaves.push(leaf);
-            Ok(())
-        })?;
-
-        let Ok(boxed_array): Result<Box<[T; LEN]>, _> = leaves.into_boxed_slice().try_into() else {
-            unreachable!("Unexpected number of leaves collected")
-        };
-
-        Ok(Many::from(boxed_array))
     }
 }
 
@@ -305,9 +274,7 @@ pub fn tree_depth(length: usize, arity: usize) -> u32 {
 mod tests {
     use crate::foldable::Foldable;
     use crate::foldable::Unfold;
-    use crate::foldable::Unfoldable;
     use crate::foldable::seq_tree::IndexableSeqAsTree;
-    use crate::foldable::seq_tree::Many;
     use crate::foldable::seq_tree::descend_tree;
     use crate::foldable::tests::TestFolder;
     use crate::foldable::tests::TestTree;
@@ -395,24 +362,5 @@ mod tests {
                 assert_eq!(*x, Some(i));
             }
         });
-    }
-
-    /// Test the `Many` utility struct for unfolding.
-    #[test]
-    fn many_unfold() {
-        type Data = Many<((u8, u8), u8, u8), 5, 71>;
-
-        let mut data = Vec::with_capacity(71);
-        for i in 0u8..71 {
-            data.push(((i, i + 2), 200 - i, 2 * i));
-        }
-
-        let generator = |i: usize| data[i].fold(TestFolder);
-
-        let driver = IndexableSeqAsTree::new(71, 5, &generator);
-        let tree = driver.fold(TestFolder);
-
-        let unfolded = Data::unfold(tree.clone()).unwrap();
-        assert_eq!(&unfolded.into_boxed_array()[..], &data);
     }
 }

--- a/data/src/foldable/seq_tree.rs
+++ b/data/src/foldable/seq_tree.rs
@@ -4,6 +4,7 @@
 
 //! Helpers for sequences that need to fold and unfold like trees
 
+use std::ops::Range;
 
 use crate::codec::LeafCodec;
 use crate::foldable::Fold;
@@ -115,6 +116,141 @@ where
                 arity: self.arity,
                 generator: self.generator,
                 _leaf: std::marker::PhantomData,
+            });
+        }
+
+        builder.done()
+    }
+}
+/// Driver for folding a sequence as a tree in verify mode, skipping subtrees that hold no state.
+///
+/// [`IndexableSeqAsTree`] visits every leaf, which is what you want when the length is known to be
+/// sound. In verify mode it is not: the length is recovered from the proof, and nothing bounds what
+/// it may claim, so folding leaf by leaf would let a proof decide how much work the verifier does.
+/// This driver asks `has_state` before descending, and folds a subtree with nothing underneath it
+/// straight to the hash the reference proof already carries for it.
+///
+/// The two agree by construction. A subtree with nothing defined below it folds every leaf to
+/// [`PartialHash::Previous`], and an all-`Previous` node reports whatever the proof said about it -
+/// which is what [`PartialHashFold::skip_unchanged_subtree`] returns. Where that equivalence does
+/// not hold, `skip_unchanged_subtree` declines and the descent happens as usual.
+pub struct PrunedSeqAsTree<'a, Item, Generator, HasState> {
+    /// Total length of the sequence (i.e. not just the number of items in the current chunk)
+    total_len: usize,
+
+    /// Depth of the current chunk
+    current_depth: u32,
+
+    /// Index where the current chunk starts
+    current_start: usize,
+
+    /// Maximum number of children per node
+    arity: usize,
+
+    /// Item generator (e.g. retrieval function for items)
+    generator: &'a Generator,
+
+    /// Reports whether any item in the given index range holds state
+    has_state: &'a HasState,
+
+    _item: std::marker::PhantomData<Item>,
+}
+
+impl<'a, Item, Generator, HasState> PrunedSeqAsTree<'a, Item, Generator, HasState> {
+    /// Construct the driver for an indexable sequence whose items may be absent.
+    ///
+    /// `has_state` is given a range of item indices and reports whether any item in it is defined.
+    /// It must not under-report: claiming a populated range is empty would fold that state away.
+    pub fn new(
+        len: usize,
+        arity: usize,
+        generator: &'a Generator,
+        has_state: &'a HasState,
+    ) -> Self {
+        Self {
+            total_len: len,
+            current_depth: tree_depth(len, arity),
+            current_start: 0,
+            arity,
+            generator,
+            has_state,
+            _item: std::marker::PhantomData,
+        }
+    }
+
+    /// Range of item indices covered by the node currently being folded.
+    fn covered_range(&self) -> Range<usize> {
+        let width = self
+            .arity
+            .checked_pow(self.current_depth)
+            .unwrap_or(usize::MAX);
+        let end = self.current_start.saturating_add(width).min(self.total_len);
+
+        self.current_start..end
+    }
+}
+
+impl<'a, Codec, Item, Generator, HasState> Foldable<PartialHashFold<Codec>>
+    for PrunedSeqAsTree<'a, Item, Generator, HasState>
+where
+    Codec: LeafCodec,
+    Item: Foldable<PartialHashFold<Codec>>,
+    Generator: Fn(usize) -> Item,
+    HasState: Fn(Range<usize>) -> bool,
+{
+    fn fold(&self, builder: PartialHashFold<Codec>) -> PartialHash {
+        // As in `IndexableSeqAsTree`, a single-item sequence is folded as a bare leaf.
+        if self.total_len == 1 {
+            return (self.generator)(self.current_start).fold(builder);
+        }
+
+        let mut builder = builder;
+
+        let covered = self.covered_range();
+
+        // An empty sequence folds to the hash of an empty node. That is a value in its own right
+        // rather than something to defer to the reference proof for, so leave it to the descent -
+        // and it costs nothing anyway, having no children to walk.
+        if !covered.is_empty() && !(self.has_state)(covered) {
+            match builder.skip_unchanged_subtree() {
+                Ok(hash) => return hash,
+                Err(unchanged) => builder = unchanged,
+            }
+        }
+
+        let mut builder = builder.into_node_fold();
+
+        // Time to add leaves.
+        if self.current_depth <= 1 {
+            for idx in self.current_start..self.current_start + self.arity {
+                if idx >= self.total_len {
+                    break;
+                }
+
+                let item = (self.generator)(idx);
+                builder.add(&item);
+            }
+
+            return builder.done();
+        }
+
+        let next_chunk_len = self.arity.pow(self.current_depth - 1);
+
+        for child_no in 0..self.arity {
+            let next_start = self.current_start + child_no * next_chunk_len;
+
+            if next_start >= self.total_len {
+                break;
+            }
+
+            builder.add(&PrunedSeqAsTree {
+                total_len: self.total_len,
+                current_depth: self.current_depth - 1,
+                current_start: next_start,
+                arity: self.arity,
+                generator: self.generator,
+                has_state: self.has_state,
+                _item: std::marker::PhantomData,
             });
         }
 
@@ -272,12 +408,22 @@ pub fn tree_depth(length: usize, arity: usize) -> u32 {
 
 #[cfg(test)]
 mod tests {
+    use std::ops::Range;
+
+    use proptest::prop_assert_eq;
+
     use crate::foldable::Foldable;
     use crate::foldable::Unfold;
+    use crate::foldable::seq_tree::DepthAdjustedSeqAsTree;
     use crate::foldable::seq_tree::IndexableSeqAsTree;
+    use crate::foldable::seq_tree::PrunedSeqAsTree;
     use crate::foldable::seq_tree::descend_tree;
+    use crate::foldable::seq_tree::tree_depth;
     use crate::foldable::tests::TestFolder;
     use crate::foldable::tests::TestTree;
+    use crate::hash::Hash;
+    use crate::hash::PartialHash;
+    use crate::merkle_proof::proof_tree::MerkleProof;
     use crate::serialisation::serialise;
 
     /// Build a Merkle tree with the given arity from the provided leaves.
@@ -362,5 +508,234 @@ mod tests {
                 assert_eq!(*x, Some(i));
             }
         });
+    }
+
+    /// Build a reference proof shaped like the sequence tree.
+    ///
+    /// `blinds` replaces a subtree with a blind, and `truncs` drops a node's last child so the
+    /// proof carries fewer children than the state expects. Both are consumed in depth-first order,
+    /// letting proptest explore proofs no honest prover would emit - which is the point, since a
+    /// hostile proof is exactly what the verifier has to survive.
+    fn build_reference_proof(
+        total_len: usize,
+        arity: usize,
+        depth: u32,
+        start: usize,
+        blinds: &mut impl Iterator<Item = bool>,
+        truncs: &mut impl Iterator<Item = bool>,
+    ) -> MerkleProof {
+        if total_len == 1 {
+            return MerkleProof::leaf_read(vec![start as u8]);
+        }
+
+        if blinds.next().unwrap_or(false) {
+            return MerkleProof::leaf_blind(Hash::hash_bytes(&[start as u8, depth as u8]));
+        }
+
+        let mut children = Vec::new();
+
+        if depth <= 1 {
+            for idx in start..start + arity {
+                if idx >= total_len {
+                    break;
+                }
+
+                children.push(MerkleProof::leaf_read(vec![idx as u8]));
+            }
+        } else {
+            let chunk = arity.pow(depth - 1);
+
+            for child_no in 0..arity {
+                let next_start = start + child_no * chunk;
+                if next_start >= total_len {
+                    break;
+                }
+
+                children.push(build_reference_proof(
+                    total_len,
+                    arity,
+                    depth - 1,
+                    next_start,
+                    blinds,
+                    truncs,
+                ));
+            }
+        }
+
+        if truncs.next().unwrap_or(false) && children.len() > 1 {
+            children.pop();
+        }
+
+        MerkleProof::node_without_data(children)
+    }
+
+    /// [`PrunedSeqAsTree`] decides the state hash, and acceptance is pinned by that hash, so it has
+    /// to agree with a full descent on every input - not merely on the ones an honest prover emits.
+    ///
+    /// Among the shapes this covers is state set at a single index inside an otherwise undefined
+    /// range: the path down to that index holds state at every level and is descended, while its
+    /// siblings are folded from whatever the proof carries for them. It also covers a proof that
+    /// blinds a subtree the state has written to, and one that supplies fewer children than the
+    /// state expects - the latter has to come out `InvalidProof`, which is why the shortcut refuses
+    /// to answer for a present node from its root hash alone.
+    #[test]
+    fn pruned_fold_agrees_with_full_descent() {
+        proptest::proptest!(|(
+            arity in 2usize..=4,
+            len in 1usize..=30usize,
+            defined in proptest::collection::vec(proptest::bool::ANY, 30),
+            blinds in proptest::collection::vec(proptest::bool::ANY, 80),
+            truncs in proptest::collection::vec(proptest::bool::ANY, 80),
+        )| {
+            let is_defined = |idx: usize| defined.get(idx).copied().unwrap_or(false);
+
+            // Mirrors what the real generators produce: a defined item hashes to itself, an
+            // undefined one defers to the proof exactly as `Partial::Absent` does.
+            let generator = |idx: usize| {
+                if is_defined(idx) {
+                    PartialHash::Present(Hash::hash_bytes(&[idx as u8, 0xab]))
+                } else {
+                    PartialHash::Previous
+                }
+            };
+            let has_state = |range: Range<usize>| range.into_iter().any(is_defined);
+
+            let mut blind_iter = blinds.iter().copied();
+            let mut trunc_iter = truncs.iter().copied();
+            let proof = build_reference_proof(
+                len,
+                arity,
+                tree_depth(len, arity),
+                0,
+                &mut blind_iter,
+                &mut trunc_iter,
+            );
+
+            let full = PartialHash::from_foldable(
+                Some(proof.clone()),
+                &IndexableSeqAsTree::new(len, arity, &generator),
+            );
+            let pruned = PartialHash::from_foldable(
+                Some(proof),
+                &PrunedSeqAsTree::new(len, arity, &generator, &has_state),
+            );
+
+            prop_assert_eq!(full, pruned);
+        });
+    }
+
+    /// Resizing across a power-of-arity boundary changes the tree's depth, and
+    /// [`DepthAdjustedSeqAsTree`] re-scopes the reference proof to compensate - narrowing it by
+    /// taking first children, or padding it with dummy layers. That is the one place where the proof
+    /// and the state tree are deliberately not the same shape, so the shortcut has to agree with a
+    /// full descent there too.
+    ///
+    /// Lengths are drawn at `arity^k` and one either side, so the adjustment is exercised in both
+    /// directions, including the registry's case of a large claimed size resized by one across the
+    /// boundary.
+    #[test]
+    fn pruned_fold_agrees_with_full_descent_across_a_depth_adjustment() {
+        proptest::proptest!(|(
+            arity in 2usize..=4,
+            exp in 1u32..=4,
+            orig_delta in -1i64..=1,
+            len_delta in -1i64..=1,
+            defined in proptest::collection::vec(proptest::bool::ANY, 300),
+            blinds in proptest::collection::vec(proptest::bool::ANY, 200),
+            truncs in proptest::collection::vec(proptest::bool::ANY, 200),
+        )| {
+            let boundary = arity.pow(exp) as i64;
+            let original_len = (boundary + orig_delta).max(0) as usize;
+            let len = (boundary + len_delta).max(0) as usize;
+
+            let is_defined = |idx: usize| defined.get(idx).copied().unwrap_or(false);
+            let generator = |idx: usize| {
+                if is_defined(idx) {
+                    PartialHash::Present(Hash::hash_bytes(&[idx as u8, 0xab]))
+                } else {
+                    PartialHash::Previous
+                }
+            };
+            let has_state = |range: Range<usize>| range.into_iter().any(is_defined);
+
+            // The proof describes the sequence as it was, so it is shaped at the original length.
+            let proof_len = original_len.max(1);
+            let mut blind_iter = blinds.iter().copied();
+            let mut trunc_iter = truncs.iter().copied();
+            let proof = build_reference_proof(
+                proof_len,
+                arity,
+                tree_depth(proof_len, arity),
+                0,
+                &mut blind_iter,
+                &mut trunc_iter,
+            );
+
+            let original_depth = tree_depth(original_len, arity);
+            let current_depth = tree_depth(len, arity);
+
+            let full = PartialHash::from_foldable(
+                Some(proof.clone()),
+                &DepthAdjustedSeqAsTree {
+                    inner: IndexableSeqAsTree::new(len, arity, &generator),
+                    original_depth,
+                    current_depth,
+                },
+            );
+            let pruned = PartialHash::from_foldable(
+                Some(proof),
+                &DepthAdjustedSeqAsTree {
+                    inner: PrunedSeqAsTree::new(len, arity, &generator, &has_state),
+                    original_depth,
+                    current_depth,
+                },
+            );
+
+            prop_assert_eq!(full, pruned);
+        });
+    }
+
+    /// Short sequences, explicitly.
+    ///
+    /// An empty sequence folds to the hash of an empty node - a value in its own right rather than
+    /// something to defer to the reference proof for - and a single-item one folds as a bare leaf.
+    /// Skipping either would answer `Previous`, or a blind's hash, and both are wrong.
+    ///
+    /// Proptest found this case originally and its seeds are checked in, but those are RNG seeds
+    /// rather than recorded inputs: they stop covering this the moment the strategy that consumed
+    /// them changes, and nothing says so. Hence stating the case outright.
+    #[test]
+    fn pruned_fold_agrees_with_full_descent_on_short_sequences() {
+        let generator = |_idx: usize| PartialHash::Previous;
+        let has_state = |_range: Range<usize>| false;
+
+        let proofs = [
+            (
+                "blinded",
+                MerkleProof::leaf_blind(Hash::hash_bytes(b"blinded")),
+            ),
+            (
+                "node",
+                MerkleProof::node_without_data(vec![MerkleProof::leaf_read(vec![0u8])]),
+            ),
+            ("read leaf", MerkleProof::leaf_read(vec![1u8])),
+        ];
+
+        for arity in [2usize, 4, 32] {
+            for len in [0usize, 1, 2] {
+                for (name, proof) in &proofs {
+                    let full = PartialHash::from_foldable(
+                        Some(proof.clone()),
+                        &IndexableSeqAsTree::new(len, arity, &generator),
+                    );
+                    let pruned = PartialHash::from_foldable(
+                        Some(proof.clone()),
+                        &PrunedSeqAsTree::new(len, arity, &generator, &has_state),
+                    );
+
+                    assert_eq!(full, pruned, "arity {arity}, len {len}, {name} proof");
+                }
+            }
+        }
     }
 }

--- a/data/src/hash.rs
+++ b/data/src/hash.rs
@@ -398,6 +398,38 @@ impl<C: LeafCodec> PartialHashFold<C> {
         }
     }
 
+    /// Fold a subtree that holds no state of its own, without descending into it.
+    ///
+    /// Nothing read or written beneath a subtree means every leaf under it would fold to
+    /// [`PartialHash::Previous`], and the node would collapse back to whatever the reference proof
+    /// already says about it. Answering straight away avoids a descent whose cost is set by the
+    /// sequence length rather than by the proof - and in verify mode that length comes from the
+    /// proof itself.
+    ///
+    /// Returns `Err(self)` where the shortcut would not match a full descent, leaving the caller
+    /// to descend as it otherwise would.
+    pub fn skip_unchanged_subtree(self) -> Result<PartialHash, Self> {
+        match self.proof.as_deref() {
+            // Without a reference proof every leaf below folds to `Previous`, and `done` turns an
+            // all-`Previous` node into `Previous` as well.
+            None => Ok(PartialHash::Previous),
+
+            // A blinded subtree stands in for exactly this hash: descending would fold each leaf
+            // to `Previous` and recover it from the node's own `node_hash`.
+            Some(Tree::Leaf(MerkleProofLeaf::Blind(hash))) => Ok(PartialHash::Present(*hash)),
+
+            // A present node has to be descended. Its children carry hashes of their own, and
+            // whether they line up with the shape the state expects is precisely what descending
+            // establishes - a node holding fewer children than the state has to keep reporting
+            // `InvalidProof`, which answering from the root hash here would paper over.
+            Some(Tree::Node(_)) => Err(self),
+
+            // A read leaf where the state expects a subtree is a malformed proof. Let the descent
+            // report it the way it always has.
+            Some(Tree::Leaf(MerkleProofLeaf::Read(_))) => Err(self),
+        }
+    }
+
     /// Replace the reference proof outright.
     ///
     /// Use when a sub-structure carries its own captured proof that should override whatever the

--- a/data/src/merkle_proof.rs
+++ b/data/src/merkle_proof.rs
@@ -276,6 +276,23 @@ where
 {
     let mut ctx = proof.into_node()?;
 
+    // An absent or blinded node carries no information about its descendants, so descending into
+    // one costs time proportional to `total_leaves` - a figure the proof itself supplies - rather
+    // than to the size of the proof. Stop here instead.
+    //
+    // This is a correctness requirement rather than an optimisation. Nothing bounds what a proof
+    // may claim here, and hashing is no help: a proof carrying an astronomically large length can
+    // still hash correctly, so there is no later check that would catch it. The bound has to be
+    // structural.
+    //
+    // Pruning does not change the proof that gets reconstructed. Both deserialisers hand out
+    // absent branches beneath an absent or blinded node without consuming any input, and
+    // `OwnedProofTree::node_from_children` discards the children of such a node outright, so the
+    // recovered tree - and the state hash taken from it - is identical either way.
+    if !matches!(ctx.presence(), Partial::Present(())) {
+        return ctx.done(());
+    }
+
     // Time to add leaves.
     if current_depth <= 1 {
         for idx in current_start..current_start + arity {

--- a/data/src/merkle_proof.rs
+++ b/data/src/merkle_proof.rs
@@ -19,7 +19,6 @@ use crate::codec::LeafCodec;
 use crate::codec::LeafDecode;
 use crate::codec::LeafDecodeError;
 use crate::foldable::Foldable;
-use crate::foldable::seq_tree::Many;
 use crate::foldable::seq_tree::tree_depth;
 use crate::hash::Hash;
 use crate::hash::PartialHash;
@@ -258,30 +257,6 @@ impl<C: LeafCodec, Item: FromProof<C>, const LEN: usize> FromProof<C> for [Item;
 
         let items = items.map(|opt| opt.expect("All items should have been filled"));
         proof.done(items)
-    }
-}
-
-impl<C: LeafCodec, Item: FromProof<C>, const ARITY: usize, const LEN: usize> FromProof<C>
-    for Many<Item, ARITY, LEN>
-{
-    fn from_proof<Proof: Deserialiser<Codec = C>>(proof: Proof) -> SuspendedResult<Proof, Self> {
-        let mut leaves = Vec::with_capacity(LEN);
-
-        let result = descend_tree(proof, ARITY, LEN, &mut |_idx, proof| {
-            let result = Item::from_proof(proof)?;
-            let result = result.map(|leaf| {
-                leaves.push(leaf);
-            });
-            Ok(result)
-        })?;
-
-        let Ok(boxed_array): Result<Box<[Item; LEN]>, _> = leaves.into_boxed_slice().try_into()
-        else {
-            panic!("Unexpected number of leaves collected")
-        };
-
-        let result = result.map(|_| Many::from(boxed_array));
-        Ok(result)
     }
 }
 

--- a/data/src/merkle_proof/tests.rs
+++ b/data/src/merkle_proof/tests.rs
@@ -27,6 +27,7 @@ use crate::merkle_proof::proof_binary::StreamDeserialiser;
 use crate::merkle_proof::proof_binary::StreamInput;
 use crate::merkle_proof::proof_binary::StreamParserComb;
 use crate::merkle_proof::proof_tree::MerkleProof;
+use crate::merkle_proof::proof_tree::OwnedProofTree;
 use crate::merkle_proof::proof_tree::ProofTree;
 use crate::merkle_proof::proof_tree::ProofTreeResult;
 use crate::merkle_proof::tag::InvalidTagError;
@@ -563,4 +564,64 @@ fn round_trip_descend_tree_indexable_seq_as_tree() {
     proptest!(|(data: Vec<usize>, arity in 1..17usize)| {
         test(data, NonZeroUsize::new(arity).unwrap())?;
     });
+}
+
+/// A proof that blinds a subtree must not cost the verifier anything proportional to the number of
+/// leaves that subtree claims to stand in for.
+///
+/// The leaf count handed to [`descend_tree`] comes from a length leaf carried by the proof itself,
+/// and nothing bounds what it may claim - a proof asserting `usize::MAX` items can still hash
+/// correctly, so no later check would catch it. Were the descent to walk the implied tree rather
+/// than the nodes actually present, this test would visit on the order of 2^64 nodes: finite, but
+/// not in any time anyone will wait for.
+#[test]
+fn descend_tree_prunes_blinded_subtrees() {
+    let blinded = MerkleProof::leaf_blind(Hash::hash_bytes(b"blinded subtree"));
+
+    for arity in [2usize, 4, 32] {
+        let mut visited = 0usize;
+
+        let proof_tree: ProofTree<'_> = ProofTree::present(&blinded);
+        descend_tree(proof_tree, arity, usize::MAX, &mut |_idx, proof| {
+            let leaf = proof.into_leaf::<usize>()?;
+            Ok(leaf.map(|_| visited += 1))
+        })
+        .map(ProofTreeResult::into_result)
+        .expect("A blinded subtree should parse");
+
+        assert_eq!(visited, 0, "No leaf sits underneath a blinded node");
+    }
+}
+
+/// As [`descend_tree_prunes_blinded_subtrees`], but over the stream deserialiser - the shape the
+/// verifier actually meets when a proof arrives as bytes.
+///
+/// Also pins the property that makes the pruning safe: the proof recovered from a pruned descent is
+/// the same one a full descent would have recovered, so the state hash derived from it is unchanged.
+#[test]
+fn descend_tree_prunes_blinded_subtrees_in_stream_proofs() {
+    let blinded = MerkleProof::leaf_blind(Hash::hash_bytes(b"blinded subtree"));
+    let bytes = serialise(&blinded).expect("Serialising the proof should not fail");
+
+    let mut visited = 0usize;
+    let deser = StreamDeserialiser::<Bincode>::new_present(StreamInput::new(&bytes));
+
+    let (_, recovered) = descend_tree(deser, 2, usize::MAX, &mut |_idx, proof| {
+        let leaf = proof.into_leaf::<usize>()?;
+        Ok(leaf.map(|_| visited += 1))
+    })
+    .expect("A blinded subtree should parse")
+    .into_result()
+    .expect("The proof should be fully consumed");
+
+    assert_eq!(visited, 0, "No leaf sits underneath a blinded node");
+
+    let OwnedProofTree::Present(recovered) = recovered else {
+        panic!("The recovered proof should be present")
+    };
+    assert_eq!(
+        recovered.root_hash(),
+        blinded.root_hash(),
+        "Pruning must not change the proof that gets reconstructed"
+    );
 }


### PR DESCRIPTION
Closes TZX-208

# What

- `descend_tree` no longer descends into absent or blinded subtrees.
- Verify-mode folding of `Bytes` and `Vector` skips subtrees that hold no state, via `PrunedSeqAsTree` and `PartialHashFold::skip_unchanged_subtree`.
- Removes the unused `Many` helper.

# Why

`sequence_as_tree_from_proof` recovers a sequence length from a leaf in the proof — a `Bytes` value length, or a registry `Vector` size — and uses it as the number of leaves to visit. Nothing bounds what that figure may claim, and hashing is no help: a proof carrying an astronomical length can still hash correctly, so there is no later check that would catch it. A small proof could therefore ask the verifier to do a large and effectively unbounded amount of work.

The same length is used again on the way out, since the verify-mode `PartialHashFold` implementations build an `IndexableSeqAsTree` over it and walk every node. Bounding parsing alone would not have been enough.

`Many` had no callers, and was the only consumer of `descend_tree` that assumed one visit per index, so pruning would have broken it.

# How

No limit is placed on the claimed length, so proofs describing legitimately large values keep working. Both halves are bounded structurally instead.

Parsing stops at an absent or blinded node, making work proportional to the nodes actually present — bounded by the proof's byte length, since a present node costs at least a tag byte per level. This changes neither which proofs are accepted nor the hashes derived from them: both deserialisers already yield absent branches beneath such a node without consuming input, and `OwnedProofTree::node_from_children` discards their children outright.

Hashing folds a subtree with nothing beneath it straight to the hash the reference proof already carries. That shortcut is narrow by design, since acceptance is pinned by the committed state hash: it applies only to the two cases provably identical to a full descent — no reference proof, and a blinded subtree. A present node is still descended, so one carrying fewer children than the state expects keeps reporting `InvalidProof`. An empty sequence is left alone too, folding to the hash of an empty node.

For anyone splitting these commits: the second is a prerequisite for the third having any effect on `Vector`, whose fold predicate asks whether any item in a range is defined — and before pruning, every item below the claimed length was.

# Manually Testing

```
make all
```

# Regressions

Adds `data/proptest-regressions/components/vector/tests.txt`: the zero-length cases proptest found while this was written, kept so they stay covered.

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
