### PR TITLE
refactor(nds): replace Node's `Atom<Key>` with dedicated `NodeKey` component

### DIFF
--- a/data/src/components/atom.rs
+++ b/data/src/components/atom.rs
@@ -123,17 +123,6 @@ impl<T: 'static> Atom<T, Prove<'_>> {
     pub fn was_accessed(&self) -> bool {
         self.atom.read.get() || self.atom.current.is_some()
     }
-
-    /// Access the underlying value - without recording the deref.
-    ///
-    /// Must only be used _during_ proof generation/folding - never
-    /// during operations that must record accesses.
-    pub fn unrecorded_deref(&self) -> &T {
-        self.atom
-            .current
-            .as_deref()
-            .unwrap_or_else(|| self.atom.previous.deref())
-    }
 }
 
 impl<'normal, T: 'static> Provable<'normal> for Atom<T, Normal> {

--- a/durable-storage/src/avl.rs
+++ b/durable-storage/src/avl.rs
@@ -4,6 +4,7 @@
 
 //! Implementation of a Merkleisable AVL tree.
 
+pub mod key;
 pub mod node;
 pub mod resolver;
 pub mod tree;

--- a/durable-storage/src/avl/key.rs
+++ b/durable-storage/src/avl/key.rs
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: 2026 Trilitech <contact@trili.tech>
+//
+// SPDX-License-Identifier: MIT
+
+//! Key-component optimised for the AVL node representation.
+//!
+//! Specifically, this contains an optimised [`PartialOrd`] representation -
+//! that compares by hashes as much as possible (in [`Prove`] and [`Verify`] modes).
+//!
+//! [`PartialOrd`]: std::cmp::PartialOrd
+
+use std::cell::Cell;
+use std::cmp::Ordering;
+use std::convert::Infallible;
+
+use octez_riscv_data::merkle_proof::Partial;
+use octez_riscv_data::mode::Modal;
+use octez_riscv_data::mode::Mode;
+use octez_riscv_data::mode::Normal;
+use octez_riscv_data::mode::Prove;
+use octez_riscv_data::mode::Verify;
+use octez_riscv_data::mode::utils::Source;
+use octez_riscv_data::mode::utils::not_found;
+use perfect_derive::perfect_derive;
+
+use crate::key::Key;
+
+/// The AVL-node key representation of a [`Key`].
+#[perfect_derive(Debug)]
+pub struct NodeKey<M: Mode> {
+    key: M::Select<KeyTemplate>,
+}
+
+impl<M: NodeKeyMode> NodeKey<M> {
+    /// Create a new [`NodeKey`] component with the given initial key.
+    pub fn new(key: Key) -> Self {
+        M::new(key)
+    }
+
+    /// Compare `Self` against a plain [`Key`].
+    ///
+    /// *NB* we do not implement [`PartialOrd`] - as that forces us
+    /// to return an `Option<Ordering>`, which would be semantically
+    /// unclear as to what `None` means. Likewise, we cannot impl
+    /// [`Ord`] as that is only available when comparing a type
+    /// against itself.
+    #[expect(
+        clippy::should_implement_trait,
+        reason = "`Ord`/`PartialOrd` are problematic here (see docstring)"
+    )]
+    pub fn cmp(&self, key: &Key) -> Ordering {
+        M::cmp(self, key)
+    }
+}
+
+impl<M: NodeKeyMode> PartialEq<Key> for NodeKey<M> {
+    fn eq(&self, other: &Key) -> bool {
+        M::eq(self, other)
+    }
+}
+
+/// Modal template for the [`NodeKey`] component.
+///
+/// This type helps us pick the representation of [`NodeKey`]
+/// for each mode by implementing [`Modal`].
+struct KeyTemplate(Infallible);
+
+impl Modal for KeyTemplate {
+    type Normal = Key;
+
+    type Prove<'normal> = ProveImpl<'normal>;
+
+    type Verify = VerifyImpl;
+}
+
+/// Mode types that implement this trait support common operations on [`NodeKey`] components
+///
+/// The methods of the [`NodeKey`] type provide a more convenient interface to the functionality of
+/// this trait.
+pub trait NodeKeyMode: private::NodeKeyImpl {}
+
+mod private {
+    use std::cmp::Ordering;
+
+    use octez_riscv_data::mode::Mode;
+
+    use super::NodeKey;
+    use crate::key::Key;
+
+    /// Private trait to ensure callers go through the
+    /// [`NodeKey`] methods, rather than the [`NodeKeyMode`]
+    /// trait.
+    ///
+    /// [`NodeKeyMode`]: super::NodeKeyMode
+    pub trait NodeKeyImpl: Mode {
+        /// Create a new [`NodeKey`] from a [`Key`].
+        fn new(key: Key) -> NodeKey<Self>;
+
+        /// Implementation of [`PartialEq`] against a [`Key`].
+        fn eq(this: &NodeKey<Self>, rhs: &Key) -> bool;
+
+        /// Implementation of ordering against a [`Key`].
+        ///
+        /// See [`NodeKey::cmp`] for further details.
+        fn cmp(this: &NodeKey<Self>, rhs: &Key) -> Ordering;
+
+        /// Implementation of [`Clone`].
+        ///
+        /// This clones the entire component, not just the held [`Key`]. Consider
+        /// this when cloning components in [`Prove`] mode.
+        ///
+        /// [`Prove`]: octez_riscv_data::mode::Prove
+        fn clone(this: &NodeKey<Self>) -> NodeKey<Self>;
+    }
+}
+
+impl NodeKeyMode for Normal {}
+
+impl private::NodeKeyImpl for Normal {
+    fn new(key: Key) -> NodeKey<Self> {
+        NodeKey { key }
+    }
+
+    fn eq(this: &NodeKey<Self>, rhs: &Key) -> bool {
+        this.key.eq(rhs)
+    }
+
+    fn cmp(this: &NodeKey<Self>, rhs: &Key) -> Ordering {
+        this.key.cmp(rhs)
+    }
+
+    fn clone(this: &NodeKey<Self>) -> NodeKey<Self> {
+        NodeKey {
+            key: this.key.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ProveImpl<'normal> {
+    inner: Source<'normal, Key>,
+    read: Cell<bool>,
+}
+
+impl<'normal> NodeKeyMode for Prove<'normal> {}
+
+impl<'normal> private::NodeKeyImpl for Prove<'normal> {
+    fn new(key: Key) -> NodeKey<Self> {
+        let prove_impl = ProveImpl {
+            inner: Source::owned(key),
+            read: Cell::new(false),
+        };
+
+        NodeKey { key: prove_impl }
+    }
+
+    fn eq(this: &NodeKey<Self>, rhs: &Key) -> bool {
+        this.key.read.set(true);
+        this.key.inner.eq(rhs)
+    }
+
+    fn cmp(this: &NodeKey<Self>, rhs: &Key) -> Ordering {
+        this.key.read.set(true);
+        this.key.inner.cmp(rhs)
+    }
+
+    fn clone(this: &NodeKey<Self>) -> NodeKey<Self> {
+        NodeKey {
+            key: this.key.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct VerifyImpl {
+    inner: Partial<Key>,
+}
+
+impl NodeKeyMode for Verify {}
+
+impl private::NodeKeyImpl for Verify {
+    fn new(key: Key) -> NodeKey<Self> {
+        let verify_impl = VerifyImpl {
+            inner: Partial::Present(key),
+        };
+
+        NodeKey { key: verify_impl }
+    }
+
+    fn eq(this: &NodeKey<Self>, rhs: &Key) -> bool {
+        match &this.key.inner {
+            Partial::Absent | Partial::Blinded(_) => {
+                // SAFETY: `not_found` is safe to call because
+                //         we're in `Verify` mode.
+                unsafe { not_found() }
+            }
+            Partial::Present(key) => key.eq(rhs),
+        }
+    }
+
+    fn cmp(this: &NodeKey<Self>, rhs: &Key) -> Ordering {
+        match &this.key.inner {
+            Partial::Absent | Partial::Blinded(_) => {
+                // SAFETY: `not_found` is safe to call because
+                //         we're in `Verify` mode.
+                unsafe { not_found() }
+            }
+            Partial::Present(key) => key.cmp(rhs),
+        }
+    }
+
+    fn clone(this: &NodeKey<Self>) -> NodeKey<Self> {
+        NodeKey {
+            key: this.key.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/durable-storage/src/avl/key.rs
+++ b/durable-storage/src/avl/key.rs
@@ -12,11 +12,29 @@
 use std::cell::Cell;
 use std::cmp::Ordering;
 use std::convert::Infallible;
+use std::ops::Deref;
 
+use octez_riscv_data::codec::LeafCodec;
+use octez_riscv_data::codec::LeafDecode;
+use octez_riscv_data::codec::LeafEncode;
+use octez_riscv_data::foldable::Fold;
+use octez_riscv_data::foldable::FoldLeaf;
+use octez_riscv_data::foldable::Foldable;
+use octez_riscv_data::hash::Hash;
+use octez_riscv_data::hash::HashFold;
+use octez_riscv_data::hash::PartialHash;
+use octez_riscv_data::hash::PartialHashFold;
+use octez_riscv_data::merkle_proof::Deserialiser;
+use octez_riscv_data::merkle_proof::FromProof;
 use octez_riscv_data::merkle_proof::Partial;
+use octez_riscv_data::merkle_proof::Suspended;
+use octez_riscv_data::merkle_proof::SuspendedResult;
+use octez_riscv_data::merkle_proof::proof_tree::MerkleProofFold;
+use octez_riscv_data::merkle_proof::proof_tree::MinimumPresence;
 use octez_riscv_data::mode::Modal;
 use octez_riscv_data::mode::Mode;
 use octez_riscv_data::mode::Normal;
+use octez_riscv_data::mode::Provable;
 use octez_riscv_data::mode::Prove;
 use octez_riscv_data::mode::Verify;
 use octez_riscv_data::mode::utils::Source;
@@ -53,9 +71,137 @@ impl<M: NodeKeyMode> NodeKey<M> {
     }
 }
 
+impl<'normal> NodeKey<Prove<'normal>> {
+    /// Was the value accessed (read or written) during proof generation?
+    fn was_accessed(&self) -> bool {
+        self.key.read.get()
+    }
+
+    /// Compare `Self` against a plain [`Key`] - without recording the access.
+    ///
+    /// Must only be used _during_ proof generation/folding - never
+    /// during operations that must record accesses.
+    ///
+    /// See [`NodeKey::cmp`] for why this does not go through [`PartialOrd`].
+    ///
+    /// [`PartialOrd`]: std::cmp::PartialOrd
+    pub fn unrecorded_cmp(&self, key: &Key) -> Ordering {
+        self.key.inner.cmp(key)
+    }
+}
+
+impl<M: NodeKeyMode> Clone for NodeKey<M> {
+    fn clone(&self) -> Self {
+        M::clone(self)
+    }
+}
+
 impl<M: NodeKeyMode> PartialEq<Key> for NodeKey<M> {
     fn eq(&self, other: &Key) -> bool {
         M::eq(self, other)
+    }
+}
+
+impl NodeKey<Normal> {
+    /// Convert a NodeKey into proof mode.
+    pub fn into_proof(self) -> NodeKey<Prove<'static>> {
+        NodeKey {
+            key: ProveImpl {
+                inner: Source::Owned(Box::new(self.key)),
+                read: Cell::new(false),
+            },
+        }
+    }
+}
+
+impl AsRef<Key> for NodeKey<Normal> {
+    fn as_ref(&self) -> &Key {
+        &self.key
+    }
+}
+
+impl<'normal> Provable<'normal> for NodeKey<Normal> {
+    type Prover = NodeKey<Prove<'normal>>;
+
+    fn start_proof(&'normal self) -> Self::Prover {
+        NodeKey {
+            key: ProveImpl {
+                inner: Source::Borrowed(&self.key),
+                read: Cell::new(false),
+            },
+        }
+    }
+}
+
+impl<F: FoldLeaf> Foldable<F> for NodeKey<Normal>
+where
+    Key: LeafEncode<F::Codec>,
+{
+    fn fold(&self, builder: F) -> F::Folded {
+        builder
+            .fold_leaf(&self.key)
+            .expect("Should be able to serialise key")
+    }
+}
+
+impl<'normal, C: LeafCodec> Foldable<HashFold<C>> for NodeKey<Prove<'normal>>
+where
+    Key: LeafEncode<C>,
+{
+    fn fold(&self, builder: HashFold<C>) -> <HashFold<C> as Fold>::Folded {
+        builder
+            .fold_leaf(self.key.inner.deref())
+            .expect("Should be able to hash NodeKey")
+    }
+}
+
+impl<'normal, C: LeafCodec> Foldable<MerkleProofFold<C>> for NodeKey<Prove<'normal>>
+where
+    Key: LeafEncode<C>,
+{
+    fn fold(&self, builder: MerkleProofFold<C>) -> <MerkleProofFold<C> as Fold>::Folded {
+        let data = <Key as LeafEncode<C>>::leaf_encode(self.key.inner.deref())
+            .expect("Serialisation should not fail");
+
+        // Determine whether the value has been read or written during proof generation. If so, we
+        // must keep it in the Merkle tree (not blind it).
+        let constraint = if self.was_accessed() {
+            MinimumPresence::Present
+        } else {
+            MinimumPresence::MayOmit
+        };
+
+        builder.into_leaf(constraint, data)
+    }
+}
+
+impl<C: LeafCodec> Foldable<PartialHashFold<C>> for NodeKey<Verify>
+where
+    Key: LeafEncode<C>,
+{
+    fn fold(&self, builder: PartialHashFold<C>) -> <PartialHashFold<C> as Fold>::Folded {
+        let hash = match &self.key.inner {
+            Partial::Absent => return builder.previous(),
+            Partial::Blinded(hash) => *hash,
+            Partial::Present(value) => {
+                Hash::hash_leaf::<C, _>(value).expect("Hashing should not fail")
+            }
+        };
+
+        PartialHash::Present(hash)
+    }
+}
+
+impl<C: LeafCodec> FromProof<C> for NodeKey<Verify>
+where
+    Key: LeafDecode<C>,
+{
+    fn from_proof<Proof: Deserialiser<Codec = C>>(proof: Proof) -> SuspendedResult<Proof, Self> {
+        let result = proof.into_leaf()?.map(|key| NodeKey {
+            key: VerifyImpl { inner: key },
+        });
+
+        Ok(result)
     }
 }
 

--- a/durable-storage/src/avl/key/tests.rs
+++ b/durable-storage/src/avl/key/tests.rs
@@ -4,6 +4,13 @@
 
 //! Tests for [`NodeKey`]
 
+use octez_riscv_data::hash::Hash;
+use octez_riscv_data::hash::PartialHash;
+use octez_riscv_data::merkle_proof::FromProof;
+use octez_riscv_data::merkle_proof::proof_tree::MerkleProof;
+use octez_riscv_data::merkle_proof::proof_tree::ProofTree;
+use octez_riscv_data::mode::Provable;
+use octez_riscv_data::mode::utils::catch_not_found;
 use octez_riscv_data::mode_test;
 use proptest::prelude::*;
 
@@ -41,3 +48,108 @@ mode_test!(new_cmp, F: NodeKeyMode, {
         prop_assert_eq!(lhs.cmp(&rhs), key_cmp, "NodeKey::cmp behaves identically to Key::cmp");
     });
 });
+
+/// [`NodeKey`] behaves the same across different modes for eq
+#[test]
+fn node_key_eq_verifies_correctly() {
+    proptest!(|(lhs: Key, rhs: Key)| {
+        let key_normal = NodeKey::new(lhs);
+
+        let eq_normal = key_normal.eq(&rhs);
+        let hash_normal = Hash::from_foldable(&key_normal);
+
+        // Prove mode
+        let key_prove = key_normal.start_proof();
+
+        let eq_prove = key_prove.eq(&rhs);
+        let hash_prove = Hash::from_foldable(&key_prove);
+
+        prop_assert_eq!(eq_normal, eq_prove);
+        prop_assert_eq!(hash_normal, hash_prove);
+
+        let merkle_proof = MerkleProof::from_foldable(&key_prove);
+
+        // Verify mode
+        let key_verify = NodeKey::from_proof(ProofTree::present(&merkle_proof))
+            .expect("from_proof should succeed")
+            .into_result();
+
+        let eq_verify = key_verify.eq(&rhs);
+        let hash_verify = PartialHash::from_foldable(Some(merkle_proof), &key_verify)
+            .to_hash()
+            .unwrap();
+
+        prop_assert_eq!(eq_normal, eq_verify);
+        prop_assert_eq!(hash_normal, hash_verify);
+    });
+}
+
+/// [`NodeKey`] behaves the same across different modes for cmp
+#[test]
+fn node_key_cmp_verifies_correctly() {
+    proptest!(|(lhs: Key, rhs: Key)| {
+        let key_normal = NodeKey::new(lhs);
+
+        let cmp_normal = key_normal.cmp(&rhs);
+        let hash_normal = Hash::from_foldable(&key_normal);
+
+        // Prove mode
+        let key_prove = key_normal.start_proof();
+
+        let cmp_prove = key_prove.cmp(&rhs);
+        let hash_prove = Hash::from_foldable(&key_prove);
+
+        prop_assert_eq!(cmp_normal, cmp_prove);
+        prop_assert_eq!(hash_normal, hash_prove);
+
+        let merkle_proof = MerkleProof::from_foldable(&key_prove);
+
+        // Verify mode
+        let key_verify = NodeKey::from_proof(ProofTree::present(&merkle_proof))
+            .expect("from_proof should succeed")
+            .into_result();
+
+        let cmp_verify = key_verify.cmp(&rhs);
+        let hash_verify = PartialHash::from_foldable(Some(merkle_proof), &key_verify)
+            .to_hash()
+            .unwrap();
+
+        prop_assert_eq!(cmp_normal, cmp_verify);
+        prop_assert_eq!(hash_normal, hash_verify);
+    });
+}
+
+#[test]
+fn verify_absent() {
+    let key = Key::new(&[1; 42]).unwrap();
+
+    let node_key = NodeKey::from_proof(ProofTree::absent())
+        .expect("Should create absent NodeKey")
+        .into_result();
+
+    let value = catch_not_found(|| node_key.eq(&key)).ok();
+    assert_eq!(value, None);
+
+    let cmp_value = catch_not_found(|| node_key.cmp(&key)).ok();
+    assert_eq!(cmp_value, None);
+}
+
+/// Test pinning NodeKey initial behaviour onto the same behaviour
+/// as Atom<Key>
+#[test]
+fn verify_blinded() {
+    let key = Key::new(&[1; 42]).unwrap();
+    let hash = Hash::hash_encodable(&key).unwrap();
+
+    let proof = MerkleProof::leaf_blind(hash);
+
+    let node_key = NodeKey::from_proof(ProofTree::present(&proof))
+        .expect("Should create absent NodeKey")
+        .into_result();
+
+    let eq_value = catch_not_found(|| node_key.eq(&key)).ok();
+    assert_eq!(eq_value, None);
+
+    let cmp_value = catch_not_found(|| node_key.cmp(&key)).ok();
+    assert_eq!(cmp_value, None);
+}

--- a/durable-storage/src/avl/key/tests.rs
+++ b/durable-storage/src/avl/key/tests.rs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2025 TriliTech <contact@trili.tech>
+//
+// SPDX-License-Identifier: MIT
+
+//! Tests for [`NodeKey`]
+
+use octez_riscv_data::mode_test;
+use proptest::prelude::*;
+
+use super::NodeKey;
+use super::NodeKeyMode;
+use crate::key::Key;
+
+mode_test!(new_equal, F: NodeKeyMode, {
+    proptest!(|(key: Key)| {
+        let node_key = NodeKey::<F>::new(key.clone());
+
+        prop_assert!(node_key.eq(&key), "A NodeKey is equal to the key the node was created from");
+    });
+});
+
+mode_test!(new_not_equal, F: NodeKeyMode, {
+    proptest!(|(
+        (lhs, rhs) in (any::<Key>(), any::<Key>())
+        .prop_filter("Testing with non-equal keys", |(lhs, rhs)| lhs != rhs)
+    )| {
+        let lhs = NodeKey::<F>::new(lhs);
+
+        prop_assert!(lhs.ne(&rhs), "A NodeKey is not equal to a key different to the one the node was created from");
+    });
+});
+
+mode_test!(new_cmp, F: NodeKeyMode, {
+    proptest!(|(
+        (lhs, rhs) in (any::<Key>(), any::<Key>())
+    )| {
+        let key_cmp = lhs.cmp(&rhs);
+
+        let lhs = NodeKey::<F>::new(lhs);
+
+        prop_assert_eq!(lhs.cmp(&rhs), key_cmp, "NodeKey::cmp behaves identically to Key::cmp");
+    });
+});

--- a/durable-storage/src/avl/node.rs
+++ b/durable-storage/src/avl/node.rs
@@ -6,7 +6,6 @@
 
 use std::borrow::Borrow;
 use std::cmp::Ordering;
-use std::ops::Deref;
 use std::sync::OnceLock;
 
 use bincode::Decode;
@@ -29,6 +28,8 @@ use octez_riscv_data::serialisation::deserialise;
 use octez_riscv_data::serialisation::serialise;
 use perfect_derive::perfect_derive;
 
+use super::key::NodeKey;
+use super::key::NodeKeyMode;
 use super::resolver::LazyDataId;
 use super::resolver::LazyTreeId;
 use super::resolver::ProveNode;
@@ -66,7 +67,7 @@ pub struct Node<TreeId, DataId, M: Mode> {
     balance_factor: Atom<i8, M>,
 
     /// The [`Key`] used to locate this [`Node`] within the AVL tree.
-    key: Atom<Key, M>,
+    key: NodeKey<M>,
 
     data: DataId,
     left: TreeId,
@@ -102,7 +103,7 @@ impl Node<LazyTreeId, LazyDataId, Normal> {
     ) -> Self {
         Node {
             balance_factor: Atom::new(balance_factor),
-            key: Atom::new(key),
+            key: NodeKey::new(key),
             data,
             left,
             right,
@@ -115,7 +116,7 @@ impl Node<LazyTreeId, LazyDataId, Normal> {
         &self,
         resolver: &impl AvlResolver<super::resolver::LazyNodeId, LazyDataId, LazyTreeId, Normal>,
     ) -> Result<&Bytes<Normal>, OperationalError> {
-        resolver.resolve_bytes(&self.data, &self.key)
+        resolver.resolve_bytes(&self.data, self.key.as_ref())
     }
 }
 
@@ -174,7 +175,7 @@ impl<TreeId, DataId, M: Mode> Node<TreeId, DataId, M> {
     }
 }
 
-impl<TreeId, DataId, M: AtomMode> Node<TreeId, DataId, M> {
+impl<TreeId, DataId, M: AtomMode + NodeKeyMode> Node<TreeId, DataId, M> {
     /// Find the id of the [`Node`] within the subtree of this [`Node`] with a given [`Key`].
     pub(super) fn get<'a, NodeId>(
         mut node: &'a NodeId,
@@ -214,7 +215,7 @@ impl<TreeId, DataId, M: AtomMode> Node<TreeId, DataId, M> {
     {
         Node {
             balance_factor: Atom::new(0),
-            key: Atom::new(key),
+            key: NodeKey::new(key),
             data: data.into(),
             left: TreeId::default(),
             right: TreeId::default(),
@@ -228,12 +229,12 @@ impl<TreeId, DataId, M: AtomMode> Node<TreeId, DataId, M> {
     ) -> Result<(D, Self), <D::Parent as Deserialiser>::Error>
     where
         Atom<i8, M>: FromProof<<D::Parent as Deserialiser>::Codec>,
-        Atom<Key, M>: FromProof<<D::Parent as Deserialiser>::Codec>,
+        NodeKey<M>: FromProof<<D::Parent as Deserialiser>::Codec>,
         DataId: FromProof<<D::Parent as Deserialiser>::Codec>,
         TreeId: FromProof<<D::Parent as Deserialiser>::Codec>,
     {
         let (ctx, balance_factor) = ctx.next_branch::<Atom<i8, M>>()?;
-        let (ctx, key) = ctx.next_branch::<Atom<Key, M>>()?;
+        let (ctx, key) = ctx.next_branch::<NodeKey<M>>()?;
         let (ctx, data) = ctx.next_branch::<DataId>()?;
         let (ctx, left) = ctx.next_branch::<TreeId>()?;
         let (ctx, right) = ctx.next_branch::<TreeId>()?;
@@ -257,7 +258,7 @@ impl<TreeId, DataId, M: AtomMode> Node<TreeId, DataId, M> {
     pub(crate) fn hash(&self) -> &Hash
     where
         Atom<i8, M>: Foldable<HashFold>,
-        Atom<Key, M>: Foldable<HashFold>,
+        NodeKey<M>: Foldable<HashFold>,
         DataId: Foldable<HashFold>,
         TreeId: Foldable<HashFold>,
     {
@@ -268,12 +269,6 @@ impl<TreeId, DataId, M: AtomMode> Node<TreeId, DataId, M> {
     #[inline]
     pub(crate) fn balance_factor_atom(&self) -> &Atom<i8, M> {
         &self.balance_factor
-    }
-
-    /// The [`Atom`] holding the [`Key`] of this [`Node`].
-    #[inline]
-    pub(crate) fn key_atom(&self) -> &Atom<Key, M> {
-        &self.key
     }
 
     /// The difference in heights between child branches.
@@ -288,9 +283,9 @@ impl<TreeId, DataId, M: AtomMode> Node<TreeId, DataId, M> {
         &mut self.balance_factor
     }
 
-    /// The [`Key`] used for determining the [`Node`].
+    /// The [`NodeKey`] used for determining the [`Node`].
     #[inline]
-    pub(crate) fn key(&self) -> &Key {
+    pub(crate) fn key(&self) -> &NodeKey<M> {
         &self.key
     }
 
@@ -484,7 +479,7 @@ impl<TreeId, DataId, M: AtomMode> Node<TreeId, DataId, M> {
         match self.key.cmp(key) {
             // The key already exists and should be updated.
             Ordering::Equal => {
-                let bytes = resolver.resolve_mut_bytes(&mut self.data, &self.key)?;
+                let bytes = resolver.resolve_mut_bytes(&mut self.data, key)?;
                 data(bytes)?;
                 self.invalidate_hash();
                 Ok(false)
@@ -793,7 +788,7 @@ impl<TreeId, DataId, M: AtomMode> Node<TreeId, DataId, M> {
 }
 
 #[cfg(test)]
-impl<TreeId, DataId, M: AtomMode> Node<TreeId, DataId, M> {
+impl<TreeId, DataId, M: AtomMode + NodeKeyMode> Node<TreeId, DataId, M> {
     /// Returns true if the balance factors stored in the [`Node`]'s subtree are correct.
     pub(super) fn has_correct_balance_factors<NodeId>(
         &self,
@@ -804,7 +799,7 @@ impl<TreeId, DataId, M: AtomMode> Node<TreeId, DataId, M> {
         TreeId: std::fmt::Debug,
         DataId: std::fmt::Debug,
         Atom<i8, M>: std::fmt::Debug,
-        Atom<Key, M>: std::fmt::Debug,
+        NodeKey<M>: std::fmt::Debug,
     {
         let left_height = self.left_ref(resolver)?.height(resolver)?;
         let right_height = self.right_ref(resolver)?.height(resolver)?;
@@ -861,18 +856,23 @@ impl<TreeId, DataId, M: AtomMode> Node<TreeId, DataId, M> {
         min: &Key,
         max: &Key,
         resolver: &impl AvlResolver<NodeId, DataId, TreeId, M>,
-    ) -> Result<bool, OperationalError> {
-        if self.key() < min || self.key() > max {
+    ) -> Result<bool, OperationalError>
+    where
+        NodeKey<M>: AsRef<Key>,
+    {
+        if resolver.compare_key(self, min).is_lt() || resolver.compare_key(self, max).is_gt() {
             return Ok(false);
         }
 
+        let key = self.key().as_ref();
+
         let left_in_order = self
             .left_ref(resolver)?
-            .is_inorder_inner(min, self.key(), resolver)?;
+            .is_inorder_inner(min, key, resolver)?;
 
-        let right_in_order =
-            self.right_ref(resolver)?
-                .is_inorder_inner(self.key(), max, resolver)?;
+        let right_in_order = self
+            .right_ref(resolver)?
+            .is_inorder_inner(key, max, resolver)?;
 
         Ok(left_in_order && right_in_order)
     }
@@ -892,7 +892,7 @@ where
         // child *trees* (the same values folded into this node's hash).
         let repr = StoredNode {
             balance_factor: self.balance_factor.read(),
-            key: self.key.deref().clone(),
+            key: self.key.as_ref().clone(),
             data: Hash::from_foldable(&self.data),
             left: Hash::from_foldable(&self.left),
             right: Hash::from_foldable(&self.right),
@@ -909,7 +909,7 @@ where
 
         // Are we in charge of writing the value data to the KV store?
         if options.node_data() {
-            let key: &[u8] = self.key.as_ref();
+            let key: &[u8] = self.key.as_ref().as_ref();
             let value: &[u8] = self.data.borrow();
             store.set(key, value)?;
         }
@@ -982,11 +982,11 @@ impl<TreeId: Loadable, DataId: DataLoadable> Loadable for Node<TreeId, DataId, N
             deserialise(bytes.as_ref())?
         };
 
-        let key = Atom::new(key);
-
         // The stored representation does not include the `data` field, so we need to load it
         // separately from the KV store.
         let data = DataId::load(data, &key, store)?;
+
+        let key = NodeKey::new(key);
 
         let left = TreeId::load(left, store)?;
         let right = TreeId::load(right, store)?;
@@ -1007,7 +1007,7 @@ where
     F: Fold,
     M: Mode,
     Atom<i8, M>: Foldable<F>,
-    Atom<Key, M>: Foldable<F>,
+    NodeKey<M>: Foldable<F>,
     DataId: Foldable<F>,
     TreeId: Foldable<F>,
 {

--- a/durable-storage/src/avl/resolver.rs
+++ b/durable-storage/src/avl/resolver.rs
@@ -62,6 +62,7 @@ use trait_set::trait_set;
 
 use super::node::Node;
 use super::tree::Tree;
+use crate::avl::key::NodeKey;
 use crate::errors::OperationalError;
 use crate::key::Key;
 use crate::storage::Loadable;
@@ -731,7 +732,7 @@ impl<'inner> KeyResolver<ProveTreeId, Bytes<Prove<'inner>>, Prove<'inner>> for C
     ) -> Ordering {
         // this is safe w.r.t. proof-generation: Self is a resolver only used during
         // the MerkleProofFold.
-        node.key_atom().unrecorded_deref().cmp(key)
+        node.key().unrecorded_cmp(key)
     }
 }
 
@@ -823,7 +824,7 @@ impl ProveTreeId {
 #[derive(Debug)]
 pub(crate) struct DeletedNodeFields {
     pub(crate) balance_factor: Atom<i8, Prove<'static>>,
-    pub(crate) key: Atom<Key, Prove<'static>>,
+    pub(crate) key: NodeKey<Prove<'static>>,
     pub(crate) data: Bytes<Prove<'static>>,
 }
 
@@ -927,7 +928,7 @@ impl<R> ProveResolver<R> {
             if let Some(lazy_id) = &id.lazy_id {
                 let fields = DeletedNodeFields {
                     balance_factor: node.balance_factor_atom().clone(),
-                    key: node.key_atom().clone(),
+                    key: node.key().clone(),
                     data: node.data().clone(),
                 };
                 self.deleted_nodes
@@ -1040,7 +1041,7 @@ where
         let node = prove_node.as_ref();
         let fields = DeletedNodeFields {
             balance_factor: node.balance_factor_atom().clone(),
-            key: node.key_atom().clone(),
+            key: node.key().clone(),
             data: node.data().clone(),
         };
 

--- a/durable-storage/src/avl/tree.rs
+++ b/durable-storage/src/avl/tree.rs
@@ -29,6 +29,7 @@ use octez_riscv_data::merkle_proof::SuspendedResult;
 use octez_riscv_data::mode::utils::not_found;
 use perfect_derive::perfect_derive;
 
+use super::key::NodeKeyMode;
 use super::node::Node;
 use super::resolver::ProveNodeId;
 use super::resolver::VerifyNodeId;
@@ -108,7 +109,7 @@ impl<NodeId> Tree<NodeId> {
     /// Delete the [`Node`] in the [`Tree`] with a given key.
     ///
     /// Returns true if the [`Tree`] has shrunk in size.
-    pub fn delete<TreeId, DataId, M: AtomMode>(
+    pub fn delete<TreeId, DataId, M: AtomMode + NodeKeyMode>(
         &mut self,
         key: &Key,
         resolver: &mut impl AvlResolver<NodeId, DataId, TreeId, M>,
@@ -169,7 +170,7 @@ impl<NodeId> Tree<NodeId> {
 
     #[inline]
     /// Find the id of the [`Node`] in the [`Tree`] with a given [`Key`].
-    pub(crate) fn get<'a, TreeId: 'a, DataId: 'a, M: AtomMode + 'a>(
+    pub(crate) fn get<'a, TreeId: 'a, DataId: 'a, M: AtomMode + NodeKeyMode + 'a>(
         &'a self,
         key: &Key,
         resolver: &impl AvlResolver<NodeId, DataId, TreeId, M>,
@@ -184,7 +185,7 @@ impl<NodeId> Tree<NodeId> {
     /// Set the value of the [`Node`] with a given key.
     ///
     /// Returns true if the [`Tree`] has grown in size.
-    pub fn set<TreeId, DataId, M: BytesMode + AtomMode>(
+    pub fn set<TreeId, DataId, M: BytesMode + AtomMode + NodeKeyMode>(
         &mut self,
         key: &Key,
         data: &[u8],
@@ -246,7 +247,7 @@ impl<NodeId> Tree<NodeId> {
 
     #[inline]
     /// The difference in heights between any child branches in the [`Tree`].
-    pub(super) fn balance_factor<TreeId, DataId, M: AtomMode>(
+    pub(super) fn balance_factor<TreeId, DataId, M: AtomMode + NodeKeyMode>(
         &self,
         resolver: &impl NodeResolver<NodeId, DataId, TreeId, M>,
     ) -> Result<i8, OperationalError> {
@@ -278,7 +279,7 @@ impl<NodeId> Tree<NodeId> {
     ///  - The occupied [`Tree`] with the minimum [`Key`].
     ///  - The minimum [`Tree`]'s right child, if it hasn't been moved to its new position.
     ///  - True if the [`Tree`] has shrunk in size.
-    pub(super) fn take_min<TreeId, DataId, M: AtomMode>(
+    pub(super) fn take_min<TreeId, DataId, M: AtomMode + NodeKeyMode>(
         &mut self,
         resolver: &mut impl AvlResolver<NodeId, DataId, TreeId, M>,
     ) -> Result<(Tree<NodeId>, Tree<NodeId>, bool), OperationalError>
@@ -306,7 +307,7 @@ impl<NodeId> Tree<NodeId> {
     /// `data` defines what data is upserted.
     ///
     /// Returns true if the [`Tree`] has grown in size.
-    pub(crate) fn upsert<TreeId, DataId, M: BytesMode + AtomMode>(
+    pub(crate) fn upsert<TreeId, DataId, M: BytesMode + AtomMode + NodeKeyMode>(
         &mut self,
         key: &Key,
         offset: usize,
@@ -348,7 +349,7 @@ impl<NodeId> Tree<NodeId> {
     /// given offset, overwriting existing data if the node already exists.
     ///
     /// Returns true if the [`Tree`] has grown in size.
-    pub(crate) fn write<TreeId, DataId, M: BytesMode + AtomMode>(
+    pub(crate) fn write<TreeId, DataId, M: BytesMode + AtomMode + NodeKeyMode>(
         &mut self,
         key: &Key,
         offset: usize,
@@ -386,7 +387,7 @@ impl<NodeId> Tree<NodeId> {
     ///
     /// The [`Tree`] must already have balance factor in the range of -2..=2, else it is an invalid
     /// AVL tree.
-    fn rebalance<TreeId, DataId, M: AtomMode>(
+    fn rebalance<TreeId, DataId, M: AtomMode + NodeKeyMode>(
         &mut self,
         resolver: &mut impl AvlResolver<NodeId, DataId, TreeId, M>,
     ) -> Result<(), OperationalError>
@@ -507,6 +508,7 @@ mod tests {
     use proptest::test_runner::TestCaseError;
 
     use super::*;
+    use crate::avl::key::NodeKey;
     use crate::avl::resolver::ArcNodeId;
     use crate::avl::resolver::ArcResolver;
     use crate::avl::resolver::ArcTreeId;
@@ -518,7 +520,7 @@ mod tests {
 
     impl<NodeId> Tree<NodeId> {
         /// Asserts that the [`Tree`] is a valid AVL tree
-        pub(crate) fn check<TreeId, DataId, M: AtomMode>(
+        pub(crate) fn check<TreeId, DataId, M: AtomMode + NodeKeyMode>(
             &self,
             resolver: &impl AvlResolver<NodeId, DataId, TreeId, M>,
         ) -> Result<(), OperationalError>
@@ -527,7 +529,7 @@ mod tests {
             TreeId: std::fmt::Debug,
             DataId: std::fmt::Debug,
             Atom<i8, M>: std::fmt::Debug,
-            Atom<Key, M>: std::fmt::Debug,
+            NodeKey<M>: std::fmt::Debug + AsRef<Key>,
         {
             let inorder = self.is_inorder(resolver)?;
             let is_balanced = self.is_balanced(resolver)?;
@@ -545,10 +547,13 @@ mod tests {
         }
 
         /// Returns true if the [`Tree`] is in-order.
-        pub(crate) fn is_inorder<TreeId, DataId, M: AtomMode>(
+        pub(crate) fn is_inorder<TreeId, DataId, M: AtomMode + NodeKeyMode>(
             &self,
             resolver: &impl AvlResolver<NodeId, DataId, TreeId, M>,
-        ) -> Result<bool, OperationalError> {
+        ) -> Result<bool, OperationalError>
+        where
+            NodeKey<M>: AsRef<Key>,
+        {
             self.is_inorder_inner(
                 &Key::new(&[u8::MIN]).expect("Size less than KEY_MAX_SIZE"),
                 &Key::new(&[u8::MAX; KEY_MAX_SIZE]).expect("Size less than KEY_MAX_SIZE"),
@@ -557,7 +562,7 @@ mod tests {
         }
 
         /// Returns true if the balance factors stored in any [`Node`]'s subtree are correct.
-        pub(crate) fn has_correct_balance_factors<TreeId, DataId, M: AtomMode>(
+        pub(crate) fn has_correct_balance_factors<TreeId, DataId, M: AtomMode + NodeKeyMode>(
             &self,
             resolver: &impl AvlResolver<NodeId, DataId, TreeId, M>,
         ) -> Result<bool, OperationalError>
@@ -566,7 +571,7 @@ mod tests {
             TreeId: std::fmt::Debug,
             DataId: std::fmt::Debug,
             Atom<i8, M>: std::fmt::Debug,
-            Atom<Key, M>: std::fmt::Debug,
+            NodeKey<M>: std::fmt::Debug,
         {
             match self.root() {
                 None => Ok(true),
@@ -577,7 +582,7 @@ mod tests {
         }
 
         /// Returns the height of the [`Tree`].
-        pub(crate) fn height<TreeId, DataId, M: AtomMode>(
+        pub(crate) fn height<TreeId, DataId, M: AtomMode + NodeKeyMode>(
             &self,
             resolver: &impl AvlResolver<NodeId, DataId, TreeId, M>,
         ) -> Result<u32, OperationalError> {
@@ -588,7 +593,7 @@ mod tests {
         }
 
         /// Returns true if the [`Tree`] is balanced.
-        pub(crate) fn is_balanced<TreeId, DataId, M: AtomMode>(
+        pub(crate) fn is_balanced<TreeId, DataId, M: AtomMode + NodeKeyMode>(
             &self,
             resolver: &impl AvlResolver<NodeId, DataId, TreeId, M>,
         ) -> Result<bool, OperationalError> {
@@ -601,12 +606,15 @@ mod tests {
         }
 
         /// Returns true if the [`Tree`] is in-order and all values lie between the `min` and `max`.
-        pub(crate) fn is_inorder_inner<TreeId, DataId, M: AtomMode>(
+        pub(crate) fn is_inorder_inner<TreeId, DataId, M: AtomMode + NodeKeyMode>(
             &self,
             min: &Key,
             max: &Key,
             resolver: &impl AvlResolver<NodeId, DataId, TreeId, M>,
-        ) -> Result<bool, OperationalError> {
+        ) -> Result<bool, OperationalError>
+        where
+            NodeKey<M>: AsRef<Key>,
+        {
             match self.root() {
                 None => Ok(true),
                 Some(node) => resolver
@@ -807,7 +815,7 @@ mod tests {
     fn iterated_keys(tree: &Tree<ArcNodeId>) -> Result<Vec<Key>, OperationalError> {
         let resolver = ArcResolver;
         tree.iter(&resolver)
-            .map(|node| node.map(|node| node.key().clone()))
+            .map(|node| node.map(|node| node.key().as_ref().clone()))
             .collect()
     }
 
@@ -904,7 +912,7 @@ mod tests {
 
         loop {
             match iter.next() {
-                Some(Ok(node)) => observed_prefix.push(node.key().clone()),
+                Some(Ok(node)) => observed_prefix.push(node.key().as_ref().clone()),
                 Some(Err(OperationalError::ResolverInvariantViolated)) => break,
                 Some(Err(err)) => {
                     return Err(TestCaseError::fail(format!(

--- a/durable-storage/src/key.rs
+++ b/durable-storage/src/key.rs
@@ -100,11 +100,32 @@ impl<'de> serde::Deserialize<'de> for Key {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
+    use proptest::collection::vec;
+    use proptest::prelude::Arbitrary;
+    use proptest::prelude::BoxedStrategy;
+    use proptest::prelude::Strategy;
+    use proptest::prelude::any;
     use proptest::proptest;
 
     use super::KEY_MAX_SIZE;
     use super::Key;
+
+    /// Generate Keys of any length up to [`KEY_MAX_SIZE`].
+    impl Arbitrary for Key {
+        type Parameters = ();
+
+        type Strategy = BoxedStrategy<Key>;
+
+        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+            vec(any::<u8>(), 0..=KEY_MAX_SIZE)
+                .prop_map(|bytes| {
+                    Key::new(bytes.as_slice())
+                        .expect("All byte sequences of length <= KEY_MAX_SIZE are valid keys")
+                })
+                .boxed()
+        }
+    }
 
     proptest! {
         #[test]

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -5,7 +5,7 @@
 
 //! A Merkleised key-value store layer.
 //!
-//! [`MerkleLayer`] wraps a [`KeyValueStore`] (KV) and duplicates all stored data in an AVL
+//! [`MerkleLayer`] wraps a [`ReadableKeyValueStore`] (KV) and duplicates all stored data in an AVL
 //! [`Tree`]. When [`MerkleLayer::commit`] is called, the tree is serialised and stored in the KV
 //! and the root hash of the tree is used to identify that commitment of the layer as a
 //! [`CommitId`]. The inverse operation, [`MerkleLayer::checkout`], takes a [`CommitId`] and
@@ -729,7 +729,7 @@ impl<KV: ReadableKeyValueStore> Foldable<MerkleProofFold> for InitialNodeFold<'_
                 &deleted_node.data,
             )
         } else {
-            let key = initial_node.key();
+            let key = initial_node.key().as_ref();
             let cached_only_resolver = CachedOnlyResolver;
             let cached_id = self
                 .prove_impl
@@ -740,11 +740,7 @@ impl<KV: ReadableKeyValueStore> Foldable<MerkleProofFold> for InitialNodeFold<'_
             let cached = cached_only_resolver
                 .resolve(cached_id)
                 .expect("Working-tree lookup should not fail for an accessed node.");
-            (
-                cached.balance_factor_atom(),
-                cached.key_atom(),
-                cached.data(),
-            )
+            (cached.balance_factor_atom(), cached.key(), cached.data())
         };
 
         // Fold balance_factor + key + data from the prove-mode node (they carry per-field read
@@ -2006,7 +2002,7 @@ mod tests {
 
             assert_eq!(node.hash(), loaded_node.hash());
             assert_eq!(node.balance_factor(), loaded_node.balance_factor());
-            assert_eq!(node.key(), loaded_node.key());
+            assert_eq!(node.key().as_ref(), loaded_node.key().as_ref());
 
             let node_data = node.resolve_data(&merkle_layer.inner.resolver).expect("Loading data should succeed");
             assert_eq!(node_data, loaded_node.data());


### PR DESCRIPTION
- Part of TZX-189

# What

Move the avl node's `key` field into a dedicated 'NodeKey' component

# Why

Pre-requisite to implementing Key paging/more efficient (w.r.t. proof size) comparison.

Additionally, removes the `Atom::unrecorded_deref` - as nothing outside the `data` crate uses it (it was introduced recently for improving proof sizes around rotations).


# Manually Testing

```
make all
```

# Regressions

None - the initial version of `NodeKey` is 100% backwards compatible

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
