### PR TITLE
fix(dursto): remove backend phantom data from `Verify` registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2183,9 +2183,9 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.17.3+10.4.2"
+version = "0.19.0+11.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
+checksum = "4f45e86edad8e88efe97dbf384b4e48e1ff0f111eabf154c7b09d7a1e5fb573c"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -2193,6 +2193,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "lz4-sys",
+ "rustflags",
  "zstd-sys",
 ]
 
@@ -3429,9 +3430,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
+checksum = "d8d90add70d1d420ee487bce4a1449880a8d147451c6051b2ee5f8354553dcbf"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -3467,6 +3468,12 @@ checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
+
+[[package]]
+name = "rustflags"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a39e0e9135d7a7208ee80aa4e3e4b88f0f5ad7be92153ed70686c38a03db2e63"
 
 [[package]]
 name = "rustix"
@@ -4950,7 +4957,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ rand = "0.10.1"
 range-collections = "0.4.6"
 rkyv = { version = "0.8", features = ["bytes-1"] }
 rustc-demangle = "0.1"
-rocksdb = "0.24.0"
+rocksdb = "0.25.0"
 rustc_apfloat = "0.2.3"
 serde_json = "1.0.150"
 serde_with = { version = "3", features = ["hex"] }

--- a/durable-storage/src/registry.rs
+++ b/durable-storage/src/registry.rs
@@ -472,7 +472,7 @@ impl<KV: ReadableKeyValueStore> FromProof for Registry<KV, Verify> {
     ) -> SuspendedResult<Proof, Self> {
         let suspended = Vector::<Database<KV, Verify>, Verify>::from_proof(proof)?;
         Ok(suspended.map(|databases| Self {
-            inner: VerifyImpl(PhantomData),
+            inner: VerifyImpl,
             databases,
         }))
     }
@@ -488,7 +488,7 @@ impl<KV: ReadableKeyValueStore> Modal for RegistryTemplate<KV> {
 
     type Prove<'normal> = ProveImpl<KV>;
 
-    type Verify = VerifyImpl<KV>;
+    type Verify = VerifyImpl;
 }
 
 /// Modes that implement this support operations on [`Registry`]
@@ -746,12 +746,10 @@ struct ProveImpl<KV: ReadableKeyValueStore> {
 }
 
 /// Registry implementation for the [`Verify`] mode.
-struct VerifyImpl<KV: ReadableKeyValueStore>(PhantomData<KV>);
+struct VerifyImpl;
 
 #[cfg(test)]
 pub(super) mod tests {
-    use std::marker::PhantomData;
-
     use bytes::Bytes;
     use octez_riscv_data::codec;
     use octez_riscv_data::components::vector::VectorMode;
@@ -865,7 +863,7 @@ pub(super) mod tests {
 
     fn setup_verify_registry<KV: BackgroundWriteableKeyValueStore>() -> Registry<KV, Verify> {
         Registry {
-            inner: VerifyImpl(PhantomData),
+            inner: VerifyImpl,
             databases: <Verify as VectorMode>::new(Vec::new()),
         }
     }


### PR DESCRIPTION
# What

Removes unused phantom data field from Verify-mode Registry and bumps RocksDB version to 0.25.0.

# Why

Not needed in Verify mode. Prevents bumping RocksDB because in this version `DBCommon`, which is the type of a field of the persistence layer backend type, is no longer unwind safe and we need to be able to catch `not_found` panics in Verify-mode components.

# Manually Testing

```
make all
```

# Tasks for the Author

- [ ] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [ ] Eliminate dead code and other spurious artefacts introduced in your changes.
- [ ] Document new public functions, methods and types.
- [ ] Make sure the documentation for updated functions, methods, and types is correct.
- [ ] Add tests for bugs that have been fixed.
- [ ] [Explain changes](#regressions) to regression test captures when applicable.
- [ ] Write commit messages in agreement with our guidelines.
- [ ] Self-review your changes to ensure they are high-quality.
- [ ] Complete all of the above before assigning this MR to reviewers.
