### PR TITLE
fix(nds): ensure database copies are truly independent

### DIFF
--- a/durable-storage/src/avl/node.rs
+++ b/durable-storage/src/avl/node.rs
@@ -1089,7 +1089,7 @@ trait DataLoadable: Sized {
 
 impl DataLoadable for Bytes<Normal> {
     fn load(
-        _id: Hash,
+        id: Hash,
         key: &Key,
         store: &impl ReadableKeyValueStore,
     ) -> Result<Self, OperationalError> {
@@ -1103,6 +1103,19 @@ impl DataLoadable for Bytes<Normal> {
                     })?;
             Bytes::from(bytes.as_ref())
         };
+
+        // This value folds by hashing its own bytes, so an unchecked load would let whatever the
+        // store returned become the node's hash. Check it against the hash the node commits to
+        // for the same reason the lazy identifier does.
+        let found = Hash::from_foldable(&data);
+
+        if found != id {
+            return Err(OperationalError::CommitValueMismatch {
+                key: key.clone(),
+                expected: id,
+                found,
+            });
+        }
 
         Ok(data)
     }

--- a/durable-storage/src/avl/node.rs
+++ b/durable-storage/src/avl/node.rs
@@ -30,6 +30,7 @@ use perfect_derive::perfect_derive;
 
 use super::key::NodeKey;
 use super::key::NodeKeyMode;
+use super::resolver::DataResolver;
 use super::resolver::LazyDataId;
 use super::resolver::LazyTreeId;
 use super::resolver::ProveNode;
@@ -37,7 +38,6 @@ use super::resolver::TreeResolver;
 use super::tree::Tree;
 use crate::avl::resolver::AvlResolver;
 use crate::errors::Error;
-use crate::errors::InvalidArgumentError;
 use crate::errors::OperationalError;
 use crate::key::Key;
 use crate::storage::Loadable;
@@ -82,15 +82,24 @@ pub struct Node<TreeId, DataId, M: Mode> {
 
 impl Node<LazyTreeId, LazyDataId, Normal> {
     /// Converts the [`Node`] to prove mode.
-    pub fn into_proof(self) -> ProveNode {
-        Node {
+    ///
+    /// A node's value is not loaded when the node is, but a prove-mode value carries the bytes
+    /// it is proved against and their length, so it is resolved here - through the resolver
+    /// that owns the store this node came from - rather than assumed already present.
+    pub fn into_proof(
+        self,
+        resolver: &impl DataResolver<LazyDataId, Normal>,
+    ) -> Result<ProveNode, OperationalError> {
+        resolver.resolve_bytes(&self.data, self.key.as_ref())?;
+
+        Ok(Node {
             balance_factor: self.balance_factor.into_proof(),
             key: self.key.into_proof(),
             data: self.data.into_proof(),
             left: self.left.into_proof(),
             right: self.right.into_proof(),
             hash: self.hash.clone(),
-        }
+        })
     }
 
     #[cfg(test)]
@@ -880,7 +889,7 @@ impl<TreeId, DataId, M: AtomMode + NodeKeyMode> Node<TreeId, DataId, M> {
 
 impl<TreeId: Storable, DataId> Storable for Node<TreeId, DataId, Normal>
 where
-    DataId: Foldable<HashFold> + Borrow<[u8]>,
+    DataId: Foldable<HashFold> + DataStorable,
 {
     fn store(
         &self,
@@ -909,9 +918,7 @@ where
 
         // Are we in charge of writing the value data to the KV store?
         if options.node_data() {
-            let key: &[u8] = self.key.as_ref().as_ref();
-            let value: &[u8] = self.data.borrow();
-            store.set(key, value)?;
+            self.data.store_data(self.key.as_ref(), store)?;
         }
 
         self.left.store(store, options)?;
@@ -1022,6 +1029,53 @@ where
     }
 }
 
+/// Helper trait for writing a node's value to a [`WriteableKeyValueStore`].
+///
+/// A node loaded from a store carries only the hash its value was committed with, and there is
+/// nothing to write for such a node: the store this layer resolves from already holds that value,
+/// and it is the store being written. `Borrow<[u8]>` cannot express "nothing to write" - it would
+/// have to produce bytes that are not there - so storing goes through this trait instead.
+///
+/// This makes `MerkleLayer::commit` writing the layer's own persistence a precondition rather than
+/// a coincidence: committing a checked-out layer into some other store would leave the values it
+/// never loaded behind.
+trait DataStorable {
+    /// Write the value for `key` to `store`.
+    fn store_data(
+        &self,
+        key: &Key,
+        store: &impl WriteableKeyValueStore,
+    ) -> Result<(), OperationalError>;
+}
+
+impl DataStorable for Bytes<Normal> {
+    fn store_data(
+        &self,
+        key: &Key,
+        store: &impl WriteableKeyValueStore,
+    ) -> Result<(), OperationalError> {
+        let value: &[u8] = self.borrow();
+        store.set(key, value)
+    }
+}
+
+impl DataStorable for LazyDataId {
+    fn store_data(
+        &self,
+        key: &Key,
+        store: &impl WriteableKeyValueStore,
+    ) -> Result<(), OperationalError> {
+        // A value still held as a hash was never mutated through this layer, so the store this
+        // layer resolves from already holds it - and that is the store being written. Loading it
+        // would read bytes back only to write the same ones again.
+        let Some(value) = self.loaded() else {
+            return Ok(());
+        };
+
+        store.set(key, Borrow::<[u8]>::borrow(value))
+    }
+}
+
 /// Helper trait for node data that can be reconstructed
 /// from a [`ReadableKeyValueStore`] by content hash and key.
 trait DataLoadable: Sized {
@@ -1057,30 +1111,14 @@ impl DataLoadable for Bytes<Normal> {
 impl DataLoadable for LazyDataId {
     fn load(
         id: Hash,
-        key: &Key,
-        store: &impl ReadableKeyValueStore,
+        _key: &Key,
+        _store: &impl ReadableKeyValueStore,
     ) -> Result<Self, OperationalError> {
-        // TODO (RV-998): go all in on laziness
-        let data = match store.get(key.as_ref()) {
-            Ok(bytes) => {
-                let bytes = Bytes::from(bytes.as_ref());
-                LazyDataId::from(bytes)
-            }
-            // On deletion, the persistence layer has already deleted the value from the
-            // KV-store. Therefore, loading fails with `KeyNotFound`. To ensure deletion
-            // still succeeds, we wrap the value. This is okay as the node will be deleted
-            // immediately.
-            //
-            // Attempting to do anything with the data (except hashing) will fail.
-            Err(Error::InvalidArgument(InvalidArgumentError::KeyNotFound)) => LazyDataId::from(id),
-            Err(error) => {
-                return Err(OperationalError::CommitValueMissing {
-                    key: key.clone(),
-                    source: Box::new(error),
-                });
-            }
-        };
-
-        Ok(data)
+        // Keeping the hash rather than the bytes is what makes a node's fold independent of which
+        // store answered: an identifier holding bytes and no hash folds by hashing them, so an
+        // eager load here let whichever store was asked decide the node's hash.
+        //
+        // Deleting a key needs no value at all, so nothing here has to touch the store.
+        Ok(LazyDataId::from(id))
     }
 }

--- a/durable-storage/src/avl/resolver.rs
+++ b/durable-storage/src/avl/resolver.rs
@@ -27,7 +27,6 @@
 //! [`Tree`]: crate::avl::tree::Tree
 //! [`Node`]: crate::avl::node::Node
 
-use std::borrow::Borrow;
 use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
@@ -375,6 +374,14 @@ impl LazyDataId {
             .into_proof()
     }
 
+    /// The value, if it has already been loaded.
+    ///
+    /// Lets a caller that must not trigger a load - such as writing node data back to the store it
+    /// was resolved from - tell "not loaded" from "loaded and empty".
+    pub(crate) fn loaded(&self) -> Option<&Bytes<Normal>> {
+        self.0.inner.get()
+    }
+
     /// Attempt to load the bytes value from the database, returning
     /// a reference to the bytes.
     pub(crate) fn try_get(
@@ -457,18 +464,6 @@ impl From<Bytes<Normal>> for LazyDataId {
 impl From<Hash> for LazyDataId {
     fn from(value: Hash) -> Self {
         Self(LazyId::from(value))
-    }
-}
-
-impl Borrow<[u8]> for LazyDataId {
-    fn borrow(&self) -> &[u8] {
-        let Some(bytes) = self.0.inner.get() else {
-            unreachable!(
-                "All LazyDataId instances are currently populated, except for nodes under deletion"
-            );
-        };
-
-        bytes.borrow()
     }
 }
 
@@ -977,7 +972,8 @@ impl<R> ProveResolver<R> {
 impl<R> Resolver<ProveNodeId, ProveNode> for ProveResolver<R>
 where
     R: Resolver<LazyNodeId, Node<LazyTreeId, LazyDataId, Normal>>
-        + Resolver<LazyTreeId, Tree<LazyNodeId>>,
+        + Resolver<LazyTreeId, Tree<LazyNodeId>>
+        + DataResolver<LazyDataId, Normal>,
 {
     fn resolve<'b>(&self, id: &'b ProveNodeId) -> Result<&'b ProveNode, OperationalError> {
         if let Some(inner) = id.cache.get() {
@@ -989,7 +985,7 @@ where
             .as_ref()
             .expect("Any node that is not cached must have the lazy id present.");
         let resolved_node = self.resolve_and_track_node(lazy_id)?;
-        let prove_node: ProveNode = resolved_node.clone().into_proof();
+        let prove_node: ProveNode = resolved_node.clone().into_proof(&self.inner)?;
         id.cache
             .set(Rc::new(prove_node))
             .map_err(|_| OperationalError::ResolverInvariantViolated)?;
@@ -1014,7 +1010,7 @@ where
             .as_ref()
             .expect("Any node that is not cached must have the lazy id present.");
         let resolved_node = self.resolve_and_track_node(lazy_id)?;
-        let prove_node: ProveNode = resolved_node.clone().into_proof();
+        let prove_node: ProveNode = resolved_node.clone().into_proof(&self.inner)?;
         id.cache
             .set(Rc::new(prove_node))
             .map_err(|_| OperationalError::ResolverInvariantViolated)?;

--- a/durable-storage/src/avl/resolver.rs
+++ b/durable-storage/src/avl/resolver.rs
@@ -401,54 +401,93 @@ impl LazyDataId {
 
     /// Attempt to load the bytes value from the database, returning
     /// a mutable reference to the bytes.
+    ///
+    /// The load is not checked against the hash the node commits to: the store is written before
+    /// the tree operation is queued, so the bytes it returns are already the mutated ones. The
+    /// hash is dropped only once the value is in hand, so a load that fails leaves the identifier
+    /// still folding by the hash the node commits to.
     fn try_get_mut(
         &mut self,
         key: &Key,
         store: &impl ReadableKeyValueStore,
     ) -> Result<&mut Bytes<Normal>, OperationalError> {
+        if self.0.inner.get().is_none() {
+            let bytes = self.read_unchecked(key, store)?;
+
+            // `&mut self` is exclusive access to this identifier - it is reached only through
+            // `Arc::make_mut` on the owning node - and the value was absent a line ago, so no
+            // other initialisation can have got in first.
+            if self.0.inner.set(bytes).is_err() {
+                unreachable!("A value cannot be initialised twice under exclusive access");
+            }
+        }
+
         // evict the cached-hash, if any - the value will be mutated
         self.0.hash = None;
 
-        if let Some(bytes) = self.0.inner.get_mut() {
-            let temp = bytes as *mut Bytes<Normal>;
-            // This unsafe workaround is required because the rust borrow-checker
-            // is unable to identify the `bytes` mutable reference being dropped straight
-            // away if the condition is false.
-            //
-            // SAFETY: This is a value `&mut Bytes<Normal>` reference with no other
-            // references to the same Bytes being used after this return.
-            return Ok(unsafe { &mut *temp });
-        }
-
-        self.try_load_inner(key, store)?;
-        let bytes = self.0.inner.get_mut().expect("Try load succeeded");
+        let Some(bytes) = self.0.inner.get_mut() else {
+            unreachable!("The value is present: it was loaded above if it was not already");
+        };
 
         Ok(bytes)
     }
 
-    /// Attempt to load the value from a key-value store.
+    /// Read the value for `key` from `store`.
     ///
-    /// The stored representation of nodes does not include the `data` field,
-    /// so we need to load it separately from the KV store.
+    /// The stored representation of nodes does not include the `data` field, so it has to be
+    /// loaded separately from the KV store.
     ///
-    /// If this succeeds, the inner lazy-id is guaranteed to be
-    /// initialised.
-    fn try_load_inner(
+    /// Returns the bytes as the store gave them: not checked against the hash the node commits to,
+    /// and not cached on this identifier. Establishing that the value belongs to this tree - or
+    /// that no committed hash applies to it - is left to the caller.
+    fn read_unchecked(
         &self,
         key: &Key,
         store: &impl ReadableKeyValueStore,
-    ) -> Result<(), OperationalError> {
+    ) -> Result<Bytes<Normal>, OperationalError> {
         let bytes = store
             .get(key)
             .map_err(|error| OperationalError::CommitValueMissing {
                 key: key.clone(),
                 source: Box::new(error),
             })?;
-        let bytes = Bytes::from(bytes.as_ref());
 
-        // TODO (RV-987): ensure eventual consistency
-        // It's possible it's been initialised by another thread,
-        // but this should not affect overall semantics (see RV-987)
+        Ok(Bytes::from(bytes.as_ref()))
+    }
+
+    /// Attempt to load the value from a key-value store, checking it against the hash the node
+    /// commits to.
+    ///
+    /// A store whose value has moved on ahead of the tree is caught here, as is a store belonging
+    /// to a different layer entirely.
+    ///
+    /// If this succeeds, the inner lazy-id is guaranteed to be initialised.
+    fn try_load_inner(
+        &self,
+        key: &Key,
+        store: &impl ReadableKeyValueStore,
+    ) -> Result<(), OperationalError> {
+        let bytes = self.read_unchecked(key, store)?;
+
+        // An identifier with no value has a hash, so a missing one is a broken invariant rather
+        // than a value to wave through unchecked: only `try_get_mut` clears the hash, and only
+        // once the value is in hand.
+        let expected = self
+            .0
+            .hash()
+            .ok_or(OperationalError::ResolverInvariantViolated)?;
+        let found = Hash::from_foldable(&bytes);
+
+        if found != *expected {
+            return Err(OperationalError::CommitValueMismatch {
+                key: key.clone(),
+                expected: *expected,
+                found,
+            });
+        }
+
+        // Another thread may have initialised this already, which is harmless: the check above
+        // means every initialisation carries the value the node commits to.
         let _ = self.0.inner.set(bytes);
 
         Ok(())
@@ -938,34 +977,25 @@ impl<R> ProveResolver<R> {
         }
     }
 
-    /// Track node access and resolve the underlying lazy node in one step.
-    fn resolve_and_track_node<'a>(
-        &self,
-        id: &'a LazyNodeId,
-    ) -> Result<&'a Node<LazyTreeId, LazyDataId, Normal>, OperationalError>
-    where
-        R: Resolver<LazyNodeId, Node<LazyTreeId, LazyDataId, Normal>>,
-    {
-        self.accessed_items
-            .borrow_mut()
-            .nodes
-            .insert(Hash::from_foldable(id));
-        self.inner.resolve(id)
+    /// Record that the node with this hash was accessed during the step.
+    ///
+    /// Only a resolution that *completed* is recorded. The fold blinds a node it has no access
+    /// for, and reads the read flags of one it does out of the prove-mode projection the
+    /// resolution caches - so an access recorded for a resolution that then failed leaves the
+    /// fold with a node it may neither blind nor read, and it panics on the missing projection.
+    /// A failed operation is something the caller is handed back; a fold that cannot run is not.
+    ///
+    /// Lazy loading is what makes this reachable: the node body loads, and only then does the
+    /// value it commits to turn out to be missing from the store, or not to hash to it.
+    fn track_node(&self, hash: Hash) {
+        self.accessed_items.borrow_mut().nodes.insert(hash);
     }
 
-    /// Track tree access and resolve the underlying lazy tree in one step.
-    fn resolve_and_track_tree<'a>(
-        &self,
-        id: &'a LazyTreeId,
-    ) -> Result<&'a Tree<LazyNodeId>, OperationalError>
-    where
-        R: Resolver<LazyTreeId, Tree<LazyNodeId>>,
-    {
-        self.accessed_items
-            .borrow_mut()
-            .trees
-            .insert(Hash::from_foldable(id));
-        self.inner.resolve(id)
+    /// Record that the tree with this hash was accessed during the step.
+    ///
+    /// Recorded after the resolution completes, for the reason given on [`Self::track_node`].
+    fn track_tree(&self, hash: Hash) {
+        self.accessed_items.borrow_mut().trees.insert(hash);
     }
 }
 
@@ -984,11 +1014,17 @@ where
             .lazy_id
             .as_ref()
             .expect("Any node that is not cached must have the lazy id present.");
-        let resolved_node = self.resolve_and_track_node(lazy_id)?;
+
+        // Taken before resolving, so it is the hash the initial tree folds this node by.
+        let hash = Hash::from_foldable(lazy_id);
+
+        let resolved_node = self.inner.resolve(lazy_id)?;
         let prove_node: ProveNode = resolved_node.clone().into_proof(&self.inner)?;
         id.cache
             .set(Rc::new(prove_node))
             .map_err(|_| OperationalError::ResolverInvariantViolated)?;
+
+        self.track_node(hash);
 
         Ok(id.cache.wait())
     }
@@ -1009,11 +1045,17 @@ where
             .lazy_id
             .as_ref()
             .expect("Any node that is not cached must have the lazy id present.");
-        let resolved_node = self.resolve_and_track_node(lazy_id)?;
+
+        // Taken before resolving, so it is the hash the initial tree folds this node by.
+        let hash = Hash::from_foldable(lazy_id);
+
+        let resolved_node = self.inner.resolve(lazy_id)?;
         let prove_node: ProveNode = resolved_node.clone().into_proof(&self.inner)?;
         id.cache
             .set(Rc::new(prove_node))
             .map_err(|_| OperationalError::ResolverInvariantViolated)?;
+
+        self.track_node(hash);
 
         Ok(Rc::make_mut(
             id.cache.get_mut().expect("inner was just set"),
@@ -1054,11 +1096,15 @@ where
             return Ok(inner);
         }
 
-        let resolved = self.resolve_and_track_tree(&id.tree)?;
+        let hash = Hash::from_foldable(&id.tree);
+
+        let resolved = self.inner.resolve(&id.tree)?;
         let result_tree: Tree<ProveNodeId> = resolved.clone().into_proof();
         id.inner
             .set(result_tree)
             .map_err(|_| OperationalError::ResolverInvariantViolated)?;
+
+        self.track_tree(hash);
 
         Ok(id.inner.wait())
     }
@@ -1075,11 +1121,15 @@ where
             }
         }
 
-        let resolved = self.resolve_and_track_tree(&id.tree)?;
+        let hash = Hash::from_foldable(&id.tree);
+
+        let resolved = self.inner.resolve(&id.tree)?;
         let result_tree: Tree<ProveNodeId> = resolved.clone().into_proof();
         id.inner
             .set(result_tree)
             .map_err(|_| OperationalError::ResolverInvariantViolated)?;
+
+        self.track_tree(hash);
 
         Ok(id.inner.get_mut().expect("inner was just set"))
     }

--- a/durable-storage/src/database.rs
+++ b/durable-storage/src/database.rs
@@ -1347,6 +1347,63 @@ pub(crate) mod tests {
         ));
     }
 
+    // A checked-out node no longer arrives with its value materialised, so a `set` or a `write`
+    // against a committed key resolves that value itself - a `write` after the store already
+    // holds it, since the store is written before the tree operation is queued.
+    kv_test!(test_database_set_and_write_after_checkout, KV: BackgroundPersistentKeyValueStore, {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .build()
+            .expect("Creating a Tokio runtime should succeed");
+        let handle = runtime.handle();
+        let (_keepalive, repo) = KV::setup_repo();
+
+        let key = Key::new(b"probe").expect("Size less than KEY_MAX_SIZE");
+
+        let mut database = new_database::<KV>(handle, &repo);
+        database
+            .set(key.clone(), Bytes::from_static(b"a value with room to write into"))
+            .expect("Setting should succeed");
+        let commit = database.commit(&repo).expect("Commit should succeed");
+
+        // Checkout, then overwrite a committed key outright.
+        let mut checked_out = TracedDatabase::<KV>::checkout(handle, &repo, commit)
+            .expect("Checkout should succeed");
+        checked_out
+            .set(key.clone(), Bytes::from_static(b"replaced outright"))
+            .expect("Setting a committed key after checkout should succeed");
+        checked_out.assert_database_value(&key, b"replaced outright");
+        let after_set = checked_out.hash().expect("Hashing after a set should succeed");
+
+        // Checkout again, and this time write into the middle of a committed value.
+        let mut checked_out = TracedDatabase::<KV>::checkout(handle, &repo, commit)
+            .expect("Checkout should succeed");
+        checked_out
+            .write(key.clone(), 7, Bytes::from_static(b"WITH"))
+            .expect("Writing into a committed value after checkout should succeed");
+        checked_out.assert_database_value(&key, b"a valueWITHh room to write into");
+        let after_write = checked_out.hash().expect("Hashing after a write should succeed");
+
+        // Reads are answered by the store, so the value assertions above hold however the tree
+        // resolved. Pin the tree itself against a database built from scratch with the same
+        // content: a tree that folded another value commits to a different root.
+        let expect_root = |value| {
+            let mut expected = new_database::<KV>(handle, &repo);
+            expected
+                .set(key.clone(), value)
+                .expect("Setting should succeed");
+            expected.hash().expect("Hashing should succeed")
+        };
+
+        assert_eq!(after_set, expect_root(Bytes::from_static(b"replaced outright")));
+        assert_eq!(
+            after_write,
+            expect_root(Bytes::from_static(b"a valueWITHh room to write into"))
+        );
+
+        (checked_out.into_trace(),)
+    });
+
     kv_test!(test_database_checkout_unknown_commit_fails, KV: BackgroundPersistentKeyValueStore, {
         use octez_riscv_data::hash::Hash;
 

--- a/durable-storage/src/errors.rs
+++ b/durable-storage/src/errors.rs
@@ -25,6 +25,15 @@ pub enum OperationalError {
     #[error("Commit is missing data for the value of key {key:?}")]
     CommitValueMissing { key: Key, source: Box<Error> },
 
+    #[error(
+        "Value loaded for key {key:?} hashes to {found:?}, but the node commits to {expected:?}"
+    )]
+    CommitValueMismatch {
+        key: Key,
+        expected: Hash,
+        found: Hash,
+    },
+
     #[cfg(rocksdb)]
     #[error("Unable to create checkpoint: {error}")]
     CheckpointCreationFailed { error: rocksdb::Error },

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -1055,6 +1055,74 @@ mod tests {
         );
     }
 
+    // Reading a copy must not change the root the source commits to.
+    //
+    // The source and the copy share tree structure while each holds a store of its own, so
+    // resolving a shared identifier fills it from whichever store the resolving layer holds.
+    // Nothing is mutated, so copy-on-write never engages: a read on the copy is enough.
+    kv_test!(#[ignore] test_reading_a_copy_does_not_change_the_source_root, KV: PersistentKeyValueStore, {
+        use std::ops::Deref;
+
+        let keys =
+            [0u16, 1, 2].map(|i| Key::new(&i.to_be_bytes()).expect("Sizes less than KEY_MAX_SIZE"));
+
+        let (_keepalive, repo) = KV::setup_repo();
+
+        // Written to the store as well as the tree, and committed without node data, as
+        // `Database` uses the layer - so a node's value comes from the store, by key.
+        let persistence = Arc::new(KV::new(&repo).unwrap());
+        let mut merkle = MerkleLayer::new(persistence.clone());
+
+        for (i, key) in keys.iter().enumerate() {
+            let value = format!("value-{i}");
+            persistence.set(key, value.as_bytes()).unwrap();
+            merkle.set(key, value.as_bytes()).unwrap();
+        }
+
+        let store_options = super::StoreOptions::default().without_node_data();
+
+        let commit = merkle.commit(&store_options).unwrap();
+        persistence.commit(&repo, &commit).unwrap();
+
+        let [_, _, rhs] = keys;
+
+        // Two independent checkouts of that one commit: the source, and a twin to compare it to.
+        let persistence_0 = Arc::new(KV::checkout(&repo, &commit).unwrap());
+        let persistence_2 = Arc::new(KV::checkout(&repo, &commit).unwrap());
+
+        let merkle_0 = MerkleLayer::checkout(persistence_0.clone(), commit).unwrap();
+        let merkle_2 = MerkleLayer::checkout(persistence_2.clone(), commit).unwrap();
+
+        // The twin alone: hashing the source here would memoise its root hash in the node the
+        // copy shares, hiding the fault until something invalidated it.
+        assert_eq!(merkle_2.hash(), *commit.as_hash());
+
+        let persistence_1 = Arc::new(
+            WriteableKeyValueStore::try_clone(persistence_0.deref(), &repo).unwrap(),
+        );
+        let merkle_1 = merkle_0.clone_with(persistence_1.clone());
+
+        // The two stores now disagree at `rhs`.
+        persistence_1.set(&rhs, b"only-in-the-copy").unwrap();
+
+        // The copy is never mutated: this is a read. Whether it succeeds or is refused is not
+        // what matters here - what matters is that it leaves the source alone.
+        let _ = merkle_1.get(&rhs);
+
+        // Checking the root alone is not enough: an identifier that still carries its committed
+        // hash folds by that hash, so the root can be right while the tree holds foreign bytes.
+        let value = merkle_0
+            .get(&rhs)
+            .expect("Reading the source should succeed")
+            .expect("The source holds a value at `rhs`");
+
+        let mut read = vec![0u8; value.len()];
+        value.read(0, &mut read);
+        assert_eq!(read.as_slice(), b"value-2");
+
+        assert_eq!(merkle_0.hash(), merkle_2.hash());
+    });
+
     kv_test!(test_mavl_cow, KV, {
         let keys = [Key::new(&[0]), Key::new(&[1]), Key::new(&[2])]
             .map(|r| r.expect("Sizes less than KEY_MAX_SIZE"));

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -233,6 +233,10 @@ impl<KV> FromProof for MerkleLayer<KV, Verify> {
 
 impl<KV, M: MerkleLayerMode> MerkleLayer<KV, M> {
     /// Clone the Merkle layer. The new layer will commit to the provided persistence layer.
+    ///
+    /// In order to ensure the resulting clone of the merkle layer behaves as expected - it's
+    /// required that the given `persistence` store is itself a clone of the `src`'s backing
+    /// persistence layer.
     pub fn clone_with(&self, persistence: Arc<KV>) -> Self
     where
         KV: ReadableKeyValueStore,
@@ -1121,6 +1125,52 @@ mod tests {
         assert_eq!(read.as_slice(), b"value-2");
 
         assert_eq!(merkle_0.hash(), merkle_2.hash());
+    });
+
+    // Committing a checked-out layer must not need the values it never loaded: those are already
+    // in the store it resolves from, which is the store being written. Deleting a key needs no
+    // value either, and must not start needing one - so a deletion is committed here too, leaving
+    // a sibling behind that is still only a hash.
+    kv_test!(test_commit_with_node_data_after_checkout, KV: PersistentKeyValueStore, {
+        let [kept, dropped] =
+            [0u16, 1].map(|i| Key::new(&i.to_be_bytes()).expect("Sizes less than KEY_MAX_SIZE"));
+        let (_keepalive, repo) = KV::setup_repo();
+
+        let options = super::StoreOptions::default().with_node_data();
+
+        let persistence = Arc::new(KV::new(&repo).unwrap());
+        let mut merkle = MerkleLayer::new(persistence.clone());
+        merkle.set(&kept, b"the value that stays").unwrap();
+        merkle.set(&dropped, b"the value that goes").unwrap();
+
+        let commit = merkle.commit(&options).expect("Committing should succeed");
+        persistence.commit(&repo, &commit).unwrap();
+
+        let checked_out_persistence = Arc::new(KV::checkout(&repo, &commit).unwrap());
+        let mut checked_out =
+            MerkleLayer::checkout(checked_out_persistence, commit).expect("Checkout should succeed");
+
+        // Nothing was mutated, so there is no value here to write back.
+        assert_eq!(
+            checked_out.commit(&options).expect("Committing a checked-out layer should succeed"),
+            commit
+        );
+
+        // Drops one key without ever loading its value, leaving the survivor still unloaded.
+        checked_out.delete(&dropped).expect("Deleting should succeed");
+        let after_delete = checked_out
+            .commit(&options)
+            .expect("Committing a deletion should succeed");
+        assert_ne!(after_delete, commit);
+
+        // The survivor is still readable, so the deletion did not disturb the value it kept.
+        let value = checked_out
+            .get(&kept)
+            .expect("Reading the survivor should succeed")
+            .expect("The survivor holds a value");
+        let mut read = vec![0u8; value.len()];
+        value.read(0, &mut read);
+        assert_eq!(read.as_slice(), b"the value that stays");
     });
 
     kv_test!(test_mavl_cow, KV, {

--- a/durable-storage/src/merkle_layer.rs
+++ b/durable-storage/src/merkle_layer.rs
@@ -662,7 +662,7 @@ impl<KV: ReadableKeyValueStore> Foldable<MerkleProofFold> for MerkleLayer<KV, Pr
         }
 
         // The database was touched.
-        // Unlike a child subtree, the root tree is never resolved via `resolve_and_track_tree` -
+        // Unlike a child subtree, the root tree's access is never tracked -
         // using `InitialTreeFold` would incorrectly blind the root tree.
         fold_resolved_tree(&self.inner.initial_tree, &self.inner, builder)
     }
@@ -1064,8 +1064,16 @@ mod tests {
     // The source and the copy share tree structure while each holds a store of its own, so
     // resolving a shared identifier fills it from whichever store the resolving layer holds.
     // Nothing is mutated, so copy-on-write never engages: a read on the copy is enough.
-    kv_test!(#[ignore] test_reading_a_copy_does_not_change_the_source_root, KV: PersistentKeyValueStore, {
+    kv_test!(test_reading_a_copy_does_not_change_the_source_root, KV: PersistentKeyValueStore, {
         use std::ops::Deref;
+
+        use octez_riscv_data::components::bytes::Bytes;
+        use octez_riscv_data::hash::Hash;
+        use octez_riscv_data::mode::Normal;
+
+        use crate::errors::OperationalError;
+
+        let hash_of = |bytes: &[u8]| Hash::from_foldable(&Bytes::<Normal>::from(bytes));
 
         let keys =
             [0u16, 1, 2].map(|i| Key::new(&i.to_be_bytes()).expect("Sizes less than KEY_MAX_SIZE"));
@@ -1109,9 +1117,17 @@ mod tests {
         // The two stores now disagree at `rhs`.
         persistence_1.set(&rhs, b"only-in-the-copy").unwrap();
 
-        // The copy is never mutated: this is a read. Whether it succeeds or is refused is not
-        // what matters here - what matters is that it leaves the source alone.
-        let _ = merkle_1.get(&rhs);
+        // The copy is never mutated: this is a read. From this commit it is also refused, naming
+        // the key and the two hashes that disagree - serving those bytes is what would leave the
+        // tree inconsistent with itself, since the first write to `rhs` would fold them in.
+        match merkle_1.get(&rhs) {
+            Err(OperationalError::CommitValueMismatch { key, expected, found }) => {
+                assert_eq!(key, rhs);
+                assert_eq!(expected, hash_of(b"value-2"));
+                assert_eq!(found, hash_of(b"only-in-the-copy"));
+            }
+            other => panic!("Reading a diverged value should be refused, got {other:?}"),
+        }
 
         // Checking the root alone is not enough: an identifier that still carries its committed
         // hash folds by that hash, so the root can be right while the tree holds foreign bytes.
@@ -1171,6 +1187,54 @@ mod tests {
         let mut read = vec![0u8; value.len()];
         value.read(0, &mut read);
         assert_eq!(read.as_slice(), b"the value that stays");
+    });
+
+    // The out-of-order deletes the worker tolerates make a failed value load reachable on a write,
+    // and a layer that cannot be hashed afterwards would take down the caller that was only
+    // handed an error. So the failure has to leave the tree hashable, not merely report itself.
+    kv_test!(test_a_failed_load_leaves_the_node_foldable, KV: PersistentKeyValueStore, {
+        use crate::storage::ReadableKeyValueStore;
+
+        let key = Key::new(b"probe").expect("Sizes less than KEY_MAX_SIZE");
+        let (_keepalive, repo) = KV::setup_repo();
+
+        let persistence = Arc::new(KV::new(&repo).unwrap());
+        let mut merkle = MerkleLayer::new(persistence.clone());
+        persistence.set(&key, b"the committed value").unwrap();
+        merkle.set(&key, b"the committed value").unwrap();
+
+        let commit = merkle
+            .commit(&super::StoreOptions::default().without_node_data())
+            .expect("Committing should succeed");
+        persistence.commit(&repo, &commit).unwrap();
+
+        let persistence = Arc::new(KV::checkout(&repo, &commit).unwrap());
+        let mut merkle = MerkleLayer::checkout(persistence.clone(), commit).expect("Checkout should succeed");
+
+        // The value the tree still commits to is no longer in the store to load.
+        persistence.delete(&key).unwrap();
+        assert!(persistence.get(&key).is_err(), "The store should no longer hold the value");
+
+        assert!(
+            merkle.write(&key, 0, b"WITH").is_err(),
+            "Writing a value that cannot be loaded should fail"
+        );
+
+        // Still folds by the hash the node commits to, rather than panicking on an identifier
+        // left holding neither a hash nor a value.
+        assert_eq!(merkle.hash(), *commit.as_hash());
+
+        // The same has to hold of a proof over the failure. A read that fails records no access,
+        // so the node it could not resolve is blinded rather than left for the fold to look up a
+        // projection that was never cached.
+        let prove = merkle.start_proof();
+        assert!(
+            prove.get(&key).is_err(),
+            "Reading a value that cannot be loaded should fail in prove mode too"
+        );
+
+        let proof = MerkleProof::from_foldable(&prove);
+        assert_eq!(proof.root_hash(), *commit.as_hash());
     });
 
     kv_test!(test_mavl_cow, KV, {

--- a/durable-storage/src/registry.rs
+++ b/durable-storage/src/registry.rs
@@ -1183,7 +1183,7 @@ pub(super) mod tests {
         registry.verify_manifest(&root_commit, &expected_db_hashes);
     });
 
-    kv_test!(#[ignore] test_mutating_a_copy_does_not_change_the_source_root, KV: BackgroundPersistentKeyValueStore, {
+    kv_test!(test_mutating_a_copy_does_not_change_the_source_root, KV: BackgroundPersistentKeyValueStore, {
         let keys =
             [0u16, 1, 2].map(|i| Key::new(&i.to_be_bytes()).expect("Sizes less than KEY_MAX_SIZE"));
 

--- a/durable-storage/src/storage.rs
+++ b/durable-storage/src/storage.rs
@@ -406,6 +406,13 @@ impl StoreOptions {
     /// Turning this option on ensures the nodes are persisted completely. When using the
     /// [`crate::merkle_layer::MerkleLayer`] in isolation, this is necessary as there is no other
     /// component that will be writing the key-value data to the store.
+    ///
+    /// That completeness is bounded by what the layer holds: only the values it has actually
+    /// loaded are written. A value still held as the hash it was committed with was never mutated
+    /// through that layer, so the store being written is already the store that holds it, and
+    /// there is nothing to write for it. Committing into a store that does not already hold those
+    /// values therefore leaves them behind - see
+    /// [`crate::merkle_layer::MerkleLayer::clone_with`].
     pub fn with_node_data(self) -> Self {
         Self { node_data: true }
     }


### PR DESCRIPTION
- Closes TZX-212
- Part of RV-998

# What

Fix the 'copy pollution' bug recorded as TZX-212: a read on a database copy bled a value back into
the original, moving the root the original commits to.

# Why

Source of non-determinism. A layer's committed root stopped describing its own contents, so two
nodes that had seen the same writes could disagree on their root.

# How

`MerkleLayer::checkout` resolves the root eagerly, and `clone_with` clones the already-initialised
identifiers inside it - so a source and its copy share tree structure while each holds a store of
its own. Resolving one of those shared identifiers filled it from whichever store the resolving
layer held, and the identifier then folded by hashing those bytes, discarding the hash the node was
committed with. Nothing is mutated on that path, so copy-on-write never engaged: a read was enough.

1. We now load data lazily, only as required. As used by `Registry/Database` (normal mode) - this is only for `set` and `write`
2. We additionally enforce that for `read` on the  merkle layer directly, that the value loaded is consistent (which prevents incorrect values being loaded into the tree)

# Manually Testing

```
cargo nextest run -p octez-riscv-durable-storage
```

To see the bug rather than take its absence on trust, check out the first commit and run the
layer-level test with `--ignored`; it fails there and passes at the tip:

```
cargo test -p octez-riscv-durable-storage test_reading_a_copy_does_not_change_the_source_root -- --ignored
```

It's also worth noting that

```
cargo bench -p octez-riscv-durable-storage --bench avl_storage
AVL cold set/delete (persisted, lazy resolution)
                        time:   [23.739 ms 23.868 ms 24.041 ms]
                        change: [−37.244% −36.294% −35.300%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Improves a lot here (versus main) - while we do now do an extra hash on `read`, for `set/delete` this doesn't apply - and we load far fewer data values into the nodes

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.
