### PR TITLE
feat(nds): garbage collect commit directories older than a given registry commit

### DIFF
--- a/docs/new-durable-storage/garbage-collection.mdx
+++ b/docs/new-durable-storage/garbage-collection.mdx
@@ -3,13 +3,13 @@ title: "Garbage collection"
 description: "What the durable storage reclaims, what it does not, and why values and Merkle nodes need different mechanisms"
 ---
 
-The durable storage keeps every state it has ever committed.
-Nothing removes a commit, so disk use only ever grows.
+The durable storage reclaims the values a commit holds once no retained commit needs them, and none of what its Merkle nodes hold.
+Disk use therefore still grows without bound, but only in one of the two halves of a commit.
 
-A rollup node cannot run that way.
 `octez-smart-rollup-node` expects its context to drop states older than a chosen one, so that a node keeps only the history it still needs.
+That is the operation this page describes, and the half of it that is missing.
 
-This page describes how commits occupy disk today, which parts of them the storage already reclaims, and which parts it cannot reclaim at all.
+This page describes how commits occupy disk, which parts of them the storage reclaims, and which parts it cannot reclaim at all.
 The two halves of a commit behave completely differently, and the difference is what the garbage collection design follows from.
 
 ## How commits occupy disk
@@ -65,10 +65,44 @@ No amount of commit deletion reclaims it, because the dead nodes sit in files th
 Reclaiming them requires deleting the node keys themselves and letting compaction rewrite the files.
 </Warning>
 
-### There is no entry point
+### Collecting at a root
 
-Nothing in the crate exposes a garbage collection operation.
-The only reachability logic that exists is `long_test/registry/gc.rs`, which the long-running test uses to bound its own disk use: it computes the database commits reachable from the registry manifests it retains, and removes the rest.
+A *root* here is a registry commit id: the hash of an entire registry state, and so the root of the Merkle tree over it.
+
+Collecting at a root drops the registry commits recorded before it, together with the database commits that none of the surviving registry commits still reference.
+
+A repository records the order in which commits were made, as a sequence number per root, in a journal beside the manifests.
+Collection retains by that order: every root recorded at or after the target survives, and the rest are dropped.
+Retaining by insertion order rather than by ancestry keeps states whose provenance is unclear, such as one committed without a parent.
+Where a root has been committed more than once, the storage keeps its highest position, so re-committing a state can only extend how long it is retained — which is also how you pin a root you want kept.
+The target itself is read the other way about: its *earliest* position is the floor, so collecting at a state that has been committed twice drops only what preceded the first time it was reached, and never the states committed in between.
+
+```text
+                                   floor: the target's earliest position
+                                   |
+  position     1      4      7     |    10      12      15
+  root        r1     r2     r3     |     T      r5      r6
+              +------ dropped -----+     +------ retained ------+
+```
+
+A commit id stays the registry root hash, so committing the same state twice remains idempotent.
+Sequence numbers are recorded beside a root, not folded into its identity.
+
+Database commits are content-addressed and therefore shared: unrelated registry commits name the same database commit whenever their states agree.
+Removal follows reachability rather than recorded order, so a database commit survives for as long as any retained registry commit still names it.
+
+Collection is safe to interrupt and repeat.
+It prunes the journal to the retained roots, removes the manifests of the registry commits it dropped, then removes the database commits no retained manifest reaches.
+Everything retained is intact at each point in between, and each step after the first enumerates what is present rather than what the journal says should be, so a round left unfinished is picked up by the next one.
+Pruning first is also what makes a stale target safe: a root an earlier round already collected past is no longer in the journal, so collecting at it is refused rather than taken as a floor that would retain commits whose data has already gone.
+
+<Warning>
+Collection must not run while the repository is being committed to, and two collections must not overlap.
+Neither is enforced.
+</Warning>
+
+This reclaims the value side of a commit only.
+The Merkle nodes it held stay where they are, for the reason above: they sit in files that the retained commits still need.
 
 ## Why retaining a commit costs more than its changes
 
@@ -120,35 +154,7 @@ Everything above describes how the storage behaves today.
 Sections move out of here as the work lands.
 </Note>
 
-The two halves of a commit are reclaimed by two different mechanisms, for the reasons above.
-
-### Retained roots
-
-A *root* here is a registry commit id: the hash of an entire registry state, and so the root of the Merkle tree over it.
-A repository records the order in which commits were made, as a sequence number per root.
-Collecting at a root `H` retains every root whose sequence number is at least that of `H`, and drops the rest.
-
-```text
-                                   floor: the sequence number of H
-                                   |
-  sequence     1      4      7     |    10      12      15
-  root        r1     r2     r3     |     H      r5      r6
-              +------ dropped -----+     +------ retained ------+
-```
-
-Retaining by insertion order rather than by ancestry keeps states whose provenance is unclear, such as a state committed without a parent.
-Where a root has been committed more than once, the storage keeps the highest sequence number for it.
-
-Parents and sequence numbers are recorded beside a root, not folded into its identity.
-A commit id therefore stays the registry root hash, so committing the same state twice stays the no-op it already is.
-
-### Key-value side: directory reachability
-
-Values keep their current layout of one checkpoint directory per database commit.
-Collection computes the database commits reachable from the retained registry manifests, then removes the unreachable commit directories and manifests.
-The work is crash-safe and resumable, because removing an already-removed directory is not an error.
-
-This also keeps commit directories openable read-only by other processes, which is how external tooling reads a running node's storage.
+What remains is the Merkle side, which the mechanism above cannot reach.
 
 ### Merkle side: one shared store
 
@@ -199,7 +205,7 @@ A future mode that drops individual newer roots, such as collecting abandoned br
 
 Committing separates into two operations.
 
-A **partial commit** writes the value checkpoint, the registry manifest and the root record.
+A **partial commit** writes the value checkpoint, the registry manifest and the journal entry, which is what committing does today.
 A **full commit** additionally checkpoints the shared Merkle store into a numbered slot.
 The rollup node chooses when to take a full commit, and distinguishes the two.
 
@@ -219,6 +225,8 @@ What the split removes is the Merkle store's flush from every commit: the store 
 
 ### Interface
 
-The storage exposes collection as an operation that starts in the background, together with the operations a rollup node needs to observe and control it: whether a collection has finished, cancelling one, and waiting for one to complete.
+Collection runs to completion in the caller's thread today.
+The storage instead exposes it as an operation that starts in the background, together with the operations a rollup node needs to observe and control it: whether a collection has finished, cancelling one, and waiting for one to complete.
+Serialising it against committing, which the caller is currently responsible for, belongs with those.
 
 Exporting a snapshot copies everything reachable from one root into a fresh store, which is the same traversal collection performs, so the two share an implementation.

--- a/durable-storage/Makefile
+++ b/durable-storage/Makefile
@@ -70,7 +70,7 @@ build-gc-space:
 space-metrics: build-gc-space
 	@cargo run --release --features rocksdb,unstable-test-utils --bin gc_space -- \
 		--databases 1 --keys 100000 --commits 10 --modified-keys 1000 \
-		--sample-every 1 --json-out $(SPACE_SAMPLES) --simulate-dir-gc
+		--sample-every 1 --json-out $(SPACE_SAMPLES) --collect
 	@cargo run -p bench-metrics -- --shape pr $(MARKDOWN) space $(SPACE_SAMPLES)
 
 # Same, at the scale worth tracking over time. Intended to be driven by
@@ -80,7 +80,7 @@ space-metrics-reference: build-gc-space
 	@cargo run --release --features rocksdb,unstable-test-utils --bin gc_space -- \
 		--databases $(REFERENCE_DATABASES) --keys $(REFERENCE_KEYS) --commits 20 \
 		--modified-keys $(REFERENCE_MODIFIED) --sample-every 2 \
-		--json-out $(SPACE_SAMPLES) --simulate-dir-gc
+		--json-out $(SPACE_SAMPLES) --collect
 	@cargo run -p bench-metrics -- --shape $(REFERENCE_SHAPE) $(MARKDOWN) \
 		space $(SPACE_SAMPLES)
 

--- a/durable-storage/src/bin/gc_space.rs
+++ b/durable-storage/src/bin/gc_space.rs
@@ -75,11 +75,13 @@ struct Cli {
     #[arg(long)]
     json_out: Option<PathBuf>,
 
-    /// After the last commit, delete every commit not reachable from it and measure again.
+    /// After the last commit, collect at it and measure again.
+    ///
+    /// Collection at the final commit deletes all commits not reachable from it.
     ///
     /// Shows what collecting at directory granularity reclaims, and what dead node data survives it.
     #[arg(long)]
-    simulate_dir_gc: bool,
+    collect: bool,
 }
 
 fn main() -> Result<()> {
@@ -114,7 +116,7 @@ fn main() -> Result<()> {
         seed: cli.seed,
         repo_dir: cli.repo_dir,
         json_out: cli.json_out,
-        simulate_dir_gc: cli.simulate_dir_gc,
+        collect: cli.collect,
     }
     .run()
 }

--- a/durable-storage/src/collect.rs
+++ b/durable-storage/src/collect.rs
@@ -1,0 +1,352 @@
+// SPDX-FileCopyrightText: 2026 Trilitech <contact@trili.tech>
+//
+// SPDX-License-Identifier: MIT
+
+//! Reclaiming the commits a repository no longer needs.
+//!
+//! Collecting at a root drops every registry commit recorded before it, together with the database
+//! commits none of the surviving registry commits still reference. Database commits are shared -
+//! they are content-addressed, so unrelated registry commits name the same one whenever their
+//! states agree - which is why removal follows reachability rather than the order commits were
+//! made in.
+//!
+//! This reclaims the value side of a commit. A database commit directory is a set of hard links,
+//! so unlinking the last directory that references a file frees it, and values are keyed by user
+//! key, so overwrites become obsolete versions that compaction discards. Merkle nodes are
+//! content-addressed and every version of a node is a distinct live key, so no amount of directory
+//! removal reclaims them; that needs deletion of the node keys themselves and is a separate
+//! mechanism.
+//!
+//! # Interruption
+//!
+//! Collection is safe to interrupt and repeat. It runs in three steps, ordered so that everything
+//! retained is intact at every point in between:
+//!
+//! 1. prune the journal to the retained roots,
+//! 2. remove the manifests of registry commits that were dropped,
+//! 3. remove the database commits no retained manifest reaches.
+//!
+//! Pruning first is what makes a repeat safe rather than merely possible. A target older than one
+//! already collected at is no longer in the journal, so it is refused instead of being treated as
+//! a floor that retains states whose data has already gone. Each later step enumerates what is
+//! actually present rather than what the journal says should be, so work left unfinished by an
+//! interruption is picked up by the next round.
+//!
+//! # Concurrency
+//!
+//! Collection must not run while the repository is being committed to, and two collections must
+//! not overlap. Neither is enforced here.
+
+use std::collections::HashSet;
+
+use crate::commit::CommitId;
+use crate::errors::GcError;
+use crate::errors::OperationalError;
+use crate::journal;
+use crate::registry;
+use crate::repo::RegistryRepo;
+
+/// What a collection round reclaimed.
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
+pub struct Collected {
+    /// Registry commits whose manifests were removed.
+    pub registry_commits: usize,
+
+    /// Database commits that were removed.
+    pub database_commits: usize,
+}
+
+/// Drop everything the repository no longer needs to serve `target` and the commits after it.
+///
+/// Retains every registry commit recorded at or after `target`, and every database commit one of
+/// those still references. Fails with [`CollectionTargetNotRecorded`] if the journal holds no
+/// entry for `target`, which is also how a target that an earlier round already collected past is
+/// refused.
+///
+/// [`CollectionTargetNotRecorded`]: crate::errors::GcArgumentError::CollectionTargetNotRecorded
+pub fn collect<Repo: RegistryRepo>(repo: &Repo, target: &CommitId) -> Result<Collected, GcError> {
+    let retained_roots = journal::roots_to_retain(&repo.read_commit_journal()?, target)?;
+
+    // Read before anything is removed. These manifests are all retained, so they would survive the
+    // steps below either way, but reading them first keeps the reachable set independent of how
+    // far a previous interrupted round got.
+    let reachable = reachable_database_commits(repo, &retained_roots)?;
+
+    repo.prune_journal(&retained_roots)?;
+
+    let mut collected = Collected::default();
+
+    for id in repo.registry_commits()? {
+        if retained_roots.contains(&id) {
+            continue;
+        }
+
+        repo.remove_registry_commit(&id)?;
+        collected.registry_commits += 1;
+    }
+
+    for id in repo.database_commits()? {
+        if reachable.contains(&id) {
+            continue;
+        }
+
+        repo.remove_database_commit(&id)?;
+        collected.database_commits += 1;
+    }
+
+    Ok(collected)
+}
+
+/// The database commits referenced by any of `roots`.
+///
+/// A root with no manifest is skipped rather than failing the round. A commit writes its manifest
+/// before recording its root, so an interruption leaves a manifest with no root rather than the
+/// other way about; what leaves a root with no manifest is a caller that recorded one itself
+/// without committing it. Skipping it keeps that from holding up the commits that do have
+/// manifests.
+fn reachable_database_commits<Repo: RegistryRepo>(
+    repo: &Repo,
+    roots: &HashSet<CommitId>,
+) -> Result<HashSet<CommitId>, OperationalError> {
+    let mut reachable = HashSet::new();
+
+    for root in roots {
+        match registry::database_commits(repo, root) {
+            Ok(databases) => reachable.extend(databases),
+            Err(OperationalError::CommitNotFound) => continue,
+            Err(error) => return Err(error),
+        }
+    }
+
+    Ok(reachable)
+}
+
+#[cfg(all(test, rocksdb_test_utils))]
+mod tests {
+    use bytes::Bytes;
+    use octez_riscv_data::mode::Normal;
+    use octez_riscv_test_utils::TestableTmpdir;
+
+    use super::*;
+    use crate::errors::GcArgumentError;
+    use crate::key::Key;
+    use crate::persistence_layer::PersistenceLayer;
+    use crate::registry::Registry;
+    use crate::repo::DirectoryManager;
+
+    /// A repository holding a registry of one database, committed once per call to `commit`.
+    struct Fixture {
+        _tmp: TestableTmpdir,
+        repo: DirectoryManager,
+        registry: Registry<PersistenceLayer, Normal>,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let tmp = TestableTmpdir::new();
+            let repo = DirectoryManager::new(tmp.path())
+                .expect("creating the directory manager should succeed");
+
+            let mut registry = Registry::<PersistenceLayer, Normal>::new(repo.clone());
+            registry
+                .resize_tick(1)
+                .expect("resizing the registry should succeed");
+
+            Self {
+                _tmp: tmp,
+                repo,
+                registry,
+            }
+        }
+
+        /// Set `key` to `value` in the registry's first database and commit.
+        fn commit(&mut self, key: &[u8], value: &[u8]) -> CommitId {
+            self.commit_to(0, key, value)
+        }
+
+        /// Set `key` to `value` in database `index` and commit.
+        fn commit_to(&mut self, index: usize, key: &[u8], value: &[u8]) -> CommitId {
+            let key = Key::new(key).expect("the key should be valid");
+            self.registry
+                .database_mut(index)
+                .expect("the database should exist")
+                .set(key, Bytes::copy_from_slice(value))
+                .expect("setting should succeed");
+
+            self.registry.commit().expect("committing should succeed")
+        }
+
+        fn registry_commits(&self) -> HashSet<CommitId> {
+            self.repo
+                .registry_commits()
+                .expect("listing registry commits should succeed")
+                .into_iter()
+                .collect()
+        }
+
+        fn database_commits(&self) -> HashSet<CommitId> {
+            self.repo
+                .database_commits()
+                .expect("listing database commits should succeed")
+                .into_iter()
+                .collect()
+        }
+    }
+
+    // Collecting at the newest root keeps it and drops the ones before it, and the retained root
+    // still checks out - which needs its database commits to have survived.
+    #[test]
+    fn collecting_at_the_newest_root_drops_the_rest() {
+        let mut fixture = Fixture::new();
+
+        let first = fixture.commit(b"a", b"1");
+        let second = fixture.commit(b"a", b"2");
+        let third = fixture.commit(b"a", b"3");
+
+        let collected = collect(&fixture.repo, &third).expect("collection should succeed");
+
+        assert_eq!(collected.registry_commits, 2);
+        assert_eq!(fixture.registry_commits(), HashSet::from([third]));
+        assert!(!fixture.registry_commits().contains(&first));
+        assert!(!fixture.registry_commits().contains(&second));
+
+        // Each commit rewrote the same key, so each has a database commit of its own and the two
+        // dropped roots take theirs with them.
+        assert_eq!(collected.database_commits, 2);
+
+        let retained: HashSet<CommitId> = registry::database_commits(&fixture.repo, &third)
+            .expect("reading the retained manifest should succeed")
+            .into_iter()
+            .collect();
+        assert_eq!(
+            fixture.database_commits(),
+            retained,
+            "the database commits left should be exactly the ones the retained root names"
+        );
+
+        Registry::<PersistenceLayer, Normal>::checkout(fixture.repo.clone(), third)
+            .expect("the retained root should still check out");
+    }
+
+    // A database commit shared with a retained registry commit is kept, even though the registry
+    // commit that also referenced it was dropped. Committing the registry without touching the
+    // database leaves the database commit unchanged, so both roots name it.
+    #[test]
+    fn a_shared_database_commit_survives() {
+        let mut fixture = Fixture::new();
+
+        let first = fixture.commit(b"a", b"1");
+        let shared: HashSet<CommitId> = registry::database_commits(&fixture.repo, &first)
+            .expect("reading the manifest should succeed")
+            .into_iter()
+            .collect();
+
+        // Write to a second database, so the registry root changes while the first database is
+        // untouched and keeps the commit id the dropped root referenced.
+        fixture
+            .registry
+            .resize_tick(2)
+            .expect("resizing should succeed");
+        let second = fixture.commit_to(1, b"b", b"2");
+
+        assert!(
+            registry::database_commits(&fixture.repo, &second)
+                .expect("reading the manifest should succeed")
+                .iter()
+                .any(|id| shared.contains(id)),
+            "the second root should still reference the first database's commit"
+        );
+
+        collect(&fixture.repo, &second).expect("collection should succeed");
+
+        let present = fixture.database_commits();
+        for id in &shared {
+            assert!(
+                present.contains(id),
+                "a database commit a retained root references should survive"
+            );
+        }
+
+        Registry::<PersistenceLayer, Normal>::checkout(fixture.repo.clone(), second)
+            .expect("the retained root should still check out");
+    }
+
+    // Collecting at the oldest root is a no-op, since everything is at or after it.
+    #[test]
+    fn collecting_at_the_oldest_root_removes_nothing() {
+        let mut fixture = Fixture::new();
+
+        let first = fixture.commit(b"a", b"1");
+        fixture.commit(b"a", b"2");
+
+        let before = (fixture.registry_commits(), fixture.database_commits());
+        let collected = collect(&fixture.repo, &first).expect("collection should succeed");
+
+        assert_eq!(collected, Collected::default());
+        assert_eq!(
+            (fixture.registry_commits(), fixture.database_commits()),
+            before
+        );
+    }
+
+    // Repeating a round changes nothing further: removals are idempotent and the second pass finds
+    // nothing left to do.
+    #[test]
+    fn collecting_twice_at_the_same_root_is_idempotent() {
+        let mut fixture = Fixture::new();
+
+        fixture.commit(b"a", b"1");
+        let second = fixture.commit(b"a", b"2");
+
+        collect(&fixture.repo, &second).expect("the first round should succeed");
+        let after_first = (fixture.registry_commits(), fixture.database_commits());
+
+        let collected = collect(&fixture.repo, &second).expect("the second round should succeed");
+
+        assert_eq!(collected, Collected::default());
+        assert_eq!(
+            (fixture.registry_commits(), fixture.database_commits()),
+            after_first
+        );
+    }
+
+    // A root already collected past is refused, rather than accepted as a floor that would retain
+    // commits whose data has already been reclaimed.
+    #[test]
+    fn a_collected_target_is_refused_afterwards() {
+        let mut fixture = Fixture::new();
+
+        let first = fixture.commit(b"a", b"1");
+        let second = fixture.commit(b"a", b"2");
+
+        collect(&fixture.repo, &second).expect("collection should succeed");
+
+        assert!(matches!(
+            collect(&fixture.repo, &first),
+            Err(GcError::InvalidArgument(
+                GcArgumentError::CollectionTargetNotRecorded { .. }
+            ))
+        ));
+    }
+
+    // Committing after a round continues to work, and the roots either side of it are retained
+    // together.
+    #[test]
+    fn committing_after_a_round_still_works() {
+        let mut fixture = Fixture::new();
+
+        fixture.commit(b"a", b"1");
+        let second = fixture.commit(b"a", b"2");
+
+        collect(&fixture.repo, &second).expect("collection should succeed");
+
+        let third = fixture.commit(b"a", b"3");
+
+        assert_eq!(fixture.registry_commits(), HashSet::from([second, third]));
+
+        Registry::<PersistenceLayer, Normal>::checkout(fixture.repo.clone(), third)
+            .expect("the new root should check out");
+        Registry::<PersistenceLayer, Normal>::checkout(fixture.repo.clone(), second)
+            .expect("the root collected at should still check out");
+    }
+}

--- a/durable-storage/src/errors.rs
+++ b/durable-storage/src/errors.rs
@@ -44,6 +44,12 @@ pub enum OperationalError {
         error: std::io::Error,
     },
 
+    #[error("Failed to remove directory {path}: {error}")]
+    DirRemovalFailed {
+        path: PathBuf,
+        error: std::io::Error,
+    },
+
     #[error("Failed to publish the commit staged at {staged} as {commit}: {error}")]
     CommitPublishFailed {
         staged: PathBuf,

--- a/durable-storage/src/errors.rs
+++ b/durable-storage/src/errors.rs
@@ -168,6 +168,36 @@ pub enum InvalidArgumentError {
     DatabaseIndexOutOfBounds,
 }
 
+/// Errors that occur while collecting what a repository no longer needs
+///
+/// Collection is asked for a target, so it has a class of failure the rest of the storage does
+/// not: the target itself can be one that cannot be collected at. That is the caller's to handle
+/// rather than a sign the repository is broken, so it is kept apart from [`OperationalError`] -
+/// the boundary to the node reports an operational error as a failure, and an argument error as a
+/// value the caller can act on.
+#[derive(Debug, thiserror::Error)]
+pub enum GcError {
+    #[error("Operational error: {0}")]
+    Operational(#[from] OperationalError),
+
+    #[error("Invalid argument error: {0}")]
+    InvalidArgument(#[from] GcArgumentError),
+}
+
+/// Errors that occur because collection was asked for something it cannot do
+///
+/// Not fatal, and the repository is left as it was found. As for [`InvalidArgumentError`], these
+/// describe the request rather than the state of the storage.
+#[derive(Debug, thiserror::Error)]
+pub enum GcArgumentError {
+    /// No commit was recorded for the target, so there is no floor to retain from.
+    ///
+    /// Also how a target an earlier round already collected past is refused: its journal entry
+    /// went with the round that passed it.
+    #[error("No commit was recorded for the collection target {target}")]
+    CollectionTargetNotRecorded { target: String },
+}
+
 /// Errors that occur during Durable Storage operations
 #[derive(Debug, thiserror::Error)]
 pub enum Error {

--- a/durable-storage/src/gc_space/measure.rs
+++ b/durable-storage/src/gc_space/measure.rs
@@ -27,7 +27,6 @@ use super::sample::LevelSummary;
 use super::sample::PinnedBytes;
 use super::sample::Sample;
 use super::sample::Sharing;
-use super::scenario::Reg;
 use crate::avl::node::walk_stored_tree;
 use crate::commit::CommitId;
 use crate::persistence_layer::ReadOnlyPersistenceLayer;
@@ -47,7 +46,7 @@ pub(super) fn measure(
 ) -> Result<(Sample, FileSet)> {
     let started = Instant::now();
 
-    let database_commits = Reg::database_commits(repo, registry_commit)
+    let database_commits = crate::registry::database_commits(repo, registry_commit)
         .context("reading the registry manifest being measured")?;
 
     let mut blob = BlobBreakdown::default();
@@ -206,7 +205,7 @@ pub(crate) fn disk_usage(root: &Path) -> Result<DiskUsage> {
 ///
 /// Note this is what the history *references*, not what deleting it would free: commits hard-link
 /// the working database's files, so blocks counted here can be held by the working database too.
-/// Use [`SpaceConfig::simulate_dir_gc`] for what deletion actually reclaims.
+/// Use [`SpaceConfig::collect`] for what deletion actually reclaims.
 pub(super) fn commits_disk_usage(repo_path: &Path) -> Result<DiskUsage> {
     let mut usage = DiskUsage::default();
     let mut seen: HashSet<(u64, u64)> = HashSet::new();

--- a/durable-storage/src/gc_space/prune.rs
+++ b/durable-storage/src/gc_space/prune.rs
@@ -7,94 +7,35 @@
 //! At this granularity collection is no more than the removal of every commit directory that no
 //! retained root reaches. What survives it is the point — see [`prune_unreachable`].
 
-use std::collections::HashSet;
-use std::fs;
 use std::path::Path;
 
 use anyhow::Context;
 use anyhow::Result;
-use octez_riscv_data::hash::Hash;
 
 use super::measure::commits_disk_usage;
 use super::measure::disk_usage;
 use super::sample::DiskUsage;
-use super::scenario::Reg;
+use crate::collect::collect;
 use crate::commit::CommitId;
 use crate::repo::DirectoryManager;
 
-/// Delete every commit not reachable from `retained`, and report what that frees.
+/// Collect at `target`, and report what that frees.
 ///
-/// This is collection at directory granularity: the reachable database commits are read from the
-/// retained registry manifest, and every other commit directory and manifest is removed. Blocks
-/// come back only where no surviving link remains, which is exactly the point — the dead node data
-/// inside the retained commit survives this untouched, because the retained commit still needs the
-/// files holding it.
+/// Blocks come back only where no surviving link remains: the dead node data inside a retained
+/// commit survives untouched, because that commit still needs the files holding it.
 pub(super) fn prune_unreachable(
     repo: &DirectoryManager,
     repo_path: &Path,
-    retained: &[CommitId],
+    target: &CommitId,
 ) -> Result<PruneOutcome> {
-    let mut reachable: HashSet<CommitId> = HashSet::new();
-
-    for commit in retained {
-        reachable.extend(
-            Reg::database_commits(repo, commit).context("reading a retained registry manifest")?,
-        );
-    }
-
     let mut outcome = PruneOutcome {
         before: disk_usage(repo_path).context("measuring usage before pruning")?,
         ..PruneOutcome::default()
     };
 
-    let commits_dir = repo_path.join("databases").join("commits");
-    let entries =
-        fs::read_dir(&commits_dir).with_context(|| format!("reading {}", commits_dir.display()))?;
-
-    for entry in entries {
-        let entry =
-            entry.with_context(|| format!("reading an entry of {}", commits_dir.display()))?;
-
-        // A commit is a directory, and `remove_dir_all` below would fail on anything else.
-        if !entry
-            .file_type()
-            .with_context(|| format!("reading the type of {}", entry.path().display()))?
-            .is_dir()
-        {
-            continue;
-        }
-
-        // A directory is named after its commit, so the name identifies what it holds.
-        let retain = commit_id_of_name(&entry.file_name().to_string_lossy())
-            .is_some_and(|id| reachable.contains(&id));
-
-        if retain {
-            continue;
-        }
-
-        fs::remove_dir_all(entry.path())
-            .with_context(|| format!("removing {}", entry.path().display()))?;
-        outcome.databases_removed += 1;
-    }
-
-    let registries_dir = repo_path.join("registries").join("commits");
-    let entries = fs::read_dir(&registries_dir)
-        .with_context(|| format!("reading {}", registries_dir.display()))?;
-
-    for entry in entries {
-        let entry =
-            entry.with_context(|| format!("reading an entry of {}", registries_dir.display()))?;
-
-        let name = entry.file_name().to_string_lossy().into_owned();
-
-        if retained.iter().any(|commit| commit.hex_encode() == name) {
-            continue;
-        }
-
-        fs::remove_file(entry.path())
-            .with_context(|| format!("removing {}", entry.path().display()))?;
-        outcome.registries_removed += 1;
-    }
+    let collected = collect(repo, target).context("collecting")?;
+    outcome.databases_removed = collected.database_commits as u64;
+    outcome.registries_removed = collected.registry_commits as u64;
 
     outcome.after = disk_usage(repo_path).context("measuring usage after pruning")?;
     outcome.after_commits =
@@ -103,7 +44,7 @@ pub(super) fn prune_unreachable(
     Ok(outcome)
 }
 
-/// What a simulated directory-level collection removed and freed.
+/// What a directory-level collection removed and freed.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct PruneOutcome {
     /// Repository occupancy before pruning.
@@ -129,12 +70,4 @@ impl PruneOutcome {
             .unique_bytes
             .saturating_sub(self.after.unique_bytes)
     }
-}
-
-/// Parse a hex commit directory or file name back into a [`CommitId`].
-fn commit_id_of_name(name: &str) -> Option<CommitId> {
-    let bytes = hex::decode(name).ok()?;
-    let hash: [u8; Hash::DIGEST_SIZE] = bytes.as_slice().try_into().ok()?;
-
-    Some(CommitId::from(Hash::from(hash)))
 }

--- a/durable-storage/src/gc_space/report.rs
+++ b/durable-storage/src/gc_space/report.rs
@@ -261,7 +261,7 @@ pub(super) fn report_prune(
     writeln!(out)?;
     writeln!(
         out,
-        "simulated directory-level collection: removed {} database commit(s) and {} manifest(s)",
+        "directory-level collection: removed {} database commit(s) and {} manifest(s)",
         outcome.databases_removed, outcome.registries_removed,
     )?;
     writeln!(

--- a/durable-storage/src/gc_space/scenario.rs
+++ b/durable-storage/src/gc_space/scenario.rs
@@ -42,10 +42,12 @@ use crate::database::Database;
 use crate::key::Key;
 use crate::persistence_layer::PersistenceLayer;
 use crate::registry::Registry;
+use crate::registry::database_commits;
 use crate::repo::DirectoryManager;
+use crate::repo::RegistryRepo;
 
 /// The registry type this harness measures.
-pub(super) type Reg = Registry<PersistenceLayer, Normal>;
+type Reg = Registry<PersistenceLayer, Normal>;
 
 /// Name of the file recording a reusable base state in the repository directory.
 const BASE_STATE_FILE: &str = "gc_space_base.json";
@@ -104,13 +106,13 @@ pub struct SpaceConfig {
     /// Write one JSON object per sample to this path.
     pub json_out: Option<PathBuf>,
 
-    /// After the last commit, delete every commit not reachable from it and measure again.
+    /// After the last commit, collect at it and measure again.
     ///
-    /// This is what collecting at directory granularity would reclaim, so running with it splits
-    /// the storage into three parts: what a directory-level collection frees, what remains and is
-    /// still needed, and what remains but is dead. The last part is the dead node data, which sits
-    /// in files the surviving commit still references and which no directory deletion can reach.
-    pub simulate_dir_gc: bool,
+    /// This is what collecting at directory granularity reclaims, so running with it splits the
+    /// storage into three parts: what collection frees, what remains and is still needed, and what
+    /// remains but is dead. The last part is the dead node data, which sits in files the surviving
+    /// commit still references and which no directory deletion can reach.
+    pub collect: bool,
 }
 
 impl SpaceConfig {
@@ -245,14 +247,20 @@ impl SpaceConfig {
 
         summarise(&mut out, &samples)?;
 
-        if self.simulate_dir_gc {
-            // The base state is retained alongside the last commit, not because a collection would
-            // keep it, but because a persistent `--repo-dir` records it for later runs to check out.
-            // Pruning it would leave `gc_space_base.json` naming a commit whose directory is gone, and
-            // the next run of the same shape would fail instead of reusing the base.
-            let retained = [last_commit, base_commit];
-            let outcome = prune_unreachable(&repo, &repo_path, &retained)
-                .context("simulating a directory-level collection")?;
+        if self.collect {
+            // The base state is retained alongside the last commit, not because collecting at the last
+            // commit would keep it, but because a persistent `--repo-dir` records it for later runs to
+            // check out. Dropping it would leave `gc_space_base.json` naming a commit whose directory
+            // is gone, and the next run of the same shape would fail instead of reusing the base.
+            //
+            // Recording it again is how a root is pinned: retention goes by the order commits were
+            // recorded in, and a root keeps its highest position, so re-recording moves the base above
+            // the floor without committing anything or touching its identity.
+            repo.record_commit(&base_commit)
+                .context("pinning the base state before collecting")?;
+
+            let outcome = prune_unreachable(&repo, &repo_path, &last_commit)
+                .context("collecting at directory level")?;
             report_prune(&mut out, &outcome, samples.last())?;
         }
 
@@ -364,7 +372,7 @@ fn reset_to_base(
     base: &CommitId,
 ) -> Result<()> {
     let reachable =
-        Reg::database_commits(repo, base).context("reading the base state's registry manifest")?;
+        database_commits(repo, base).context("reading the base state's registry manifest")?;
 
     let mut removed = 0;
 
@@ -649,7 +657,7 @@ mod tests {
     /// A run small enough for the test suite, still covering every measurement the harness makes:
     /// more than one database, a large-value tail, and enough commits for a sample to be a delta of
     /// the one before it.
-    fn restricted_config(repo_dir: &Path, simulate_dir_gc: bool) -> SpaceConfig {
+    fn restricted_config(repo_dir: &Path, collect: bool) -> SpaceConfig {
         SpaceConfig {
             databases: 2,
             keys_per_database: 100,
@@ -665,7 +673,7 @@ mod tests {
             seed: 0,
             repo_dir: Some(repo_dir.to_path_buf()),
             json_out: None,
-            simulate_dir_gc,
+            collect,
         }
     }
 

--- a/durable-storage/src/journal.rs
+++ b/durable-storage/src/journal.rs
@@ -1,0 +1,262 @@
+// SPDX-FileCopyrightText: 2026 Trilitech <contact@trili.tech>
+//
+// SPDX-License-Identifier: MIT
+
+//! The order in which registry commits were made.
+//!
+//! Garbage collection needs to know which commits are newer than the one it is asked to collect
+//! at, and that cannot be read off the commits themselves: a commit id is the registry root hash,
+//! so it says what a state contains and nothing about when it was reached. The journal records the
+//! order beside the roots, leaving their identity untouched and commits idempotent.
+//!
+//! Retention follows insertion order rather than ancestry, so a state committed without a parent
+//! is kept like any other. Collecting at a root keeps every root recorded at or after the first
+//! time that root was recorded.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+use octez_riscv_data::hash::Hash;
+
+use crate::commit::CommitId;
+use crate::errors::GcArgumentError;
+
+/// Position of a registry commit in the order the repository recorded them.
+///
+/// A sequence number is not an entry's position in the journal. Collection drops the entries it
+/// no longer needs, which shifts every entry after them, so each one carries the number it was
+/// given rather than being numbered by where it sits. Numbers increase with each commit recorded
+/// and are never reused, so one read before a round still means the same commit after it.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
+pub struct Seq(u64);
+
+impl Seq {
+    /// The sequence number given to the first commit a repository records.
+    pub const FIRST: Self = Self(0);
+
+    /// The sequence number after this one.
+    pub fn next(self) -> Self {
+        Self(
+            self.0
+                .checked_add(1)
+                .expect("Journal may be corrupted, such a high Seq number is not reachable only through `next` calls"),
+        )
+    }
+
+    /// The underlying position.
+    pub fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+/// A registry root together with the position at which it was recorded.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct JournalEntry {
+    /// Where this commit falls in the recorded order.
+    pub seq: Seq,
+
+    /// The registry root committed at that point.
+    pub root: CommitId,
+}
+
+/// Bytes used by one encoded [`JournalEntry`].
+///
+/// Entries are fixed width so that the journal can be appended to without rewriting it, and so
+/// that a torn write at the end of the file is recognisable by length alone.
+pub(crate) const ENTRY_BYTES: usize = SEQ_BYTES + Hash::DIGEST_SIZE;
+
+/// Bytes used by the sequence number within an encoded entry.
+const SEQ_BYTES: usize = size_of::<u64>();
+
+impl JournalEntry {
+    /// Encode this entry as [`ENTRY_BYTES`] bytes.
+    pub(crate) fn encode(&self) -> [u8; ENTRY_BYTES] {
+        let mut bytes = [0u8; ENTRY_BYTES];
+        bytes[..SEQ_BYTES].copy_from_slice(&self.seq.raw().to_le_bytes());
+        bytes[SEQ_BYTES..].copy_from_slice(self.root.as_hash().as_ref());
+        bytes
+    }
+
+    /// Decode an entry previously written by [`JournalEntry::encode`].
+    pub(crate) fn decode(bytes: &[u8; ENTRY_BYTES]) -> Self {
+        let (seq, root) = bytes.split_at(SEQ_BYTES);
+
+        let seq = u64::from_le_bytes(seq.try_into().expect("the split is a whole u64"));
+        let root: [u8; Hash::DIGEST_SIZE] = root.try_into().expect("the split is a whole digest");
+
+        Self {
+            seq: Seq(seq),
+            root: CommitId::from(Hash::from(root)),
+        }
+    }
+}
+
+/// Decode as many whole entries as `bytes` holds, ignoring a trailing partial one.
+///
+/// A partial entry is a write interrupted by a crash. The commit it belongs to was never returned
+/// to whoever asked for it, so nothing can reference it and dropping it is what recovery wants.
+pub(crate) fn decode_entries(bytes: &[u8]) -> Vec<JournalEntry> {
+    bytes
+        .chunks_exact(ENTRY_BYTES)
+        .map(|chunk| {
+            JournalEntry::decode(chunk.try_into().expect("chunks_exact yields whole entries"))
+        })
+        .collect()
+}
+
+/// The position each root was most recently recorded at.
+///
+/// A root committed more than once keeps its highest position, so re-committing a state can only
+/// ever extend how long it is retained.
+pub fn latest_positions(entries: &[JournalEntry]) -> HashMap<CommitId, Seq> {
+    let mut latest = HashMap::with_capacity(entries.len());
+    for entry in entries {
+        latest
+            .entry(entry.root)
+            .and_modify(|seq: &mut Seq| *seq = (*seq).max(entry.seq))
+            .or_insert(entry.seq);
+    }
+    latest
+}
+
+/// The roots to keep when collecting at `target`.
+///
+/// Every root recorded at or after `target` is retained, `target` itself included. The two
+/// positions this compares are chosen in opposite directions, and both towards keeping a state:
+/// the floor is the *earliest* position `target` was recorded at, while every root is judged by
+/// its latest. A target committed more than once therefore collects from the first time it was
+/// reached rather than the last, so the states committed between its positions - which were
+/// committed after the caller's target and are none of the round's business - are not dropped.
+///
+/// Fails with [`GcArgumentError::CollectionTargetNotRecorded`] if the journal holds no entry for
+/// `target`, since without one there is no floor to compare against and collecting would drop
+/// everything.
+pub fn roots_to_retain(
+    entries: &[JournalEntry],
+    target: &CommitId,
+) -> Result<HashSet<CommitId>, GcArgumentError> {
+    let floor = earliest_position(entries, target).ok_or_else(|| {
+        GcArgumentError::CollectionTargetNotRecorded {
+            target: target.hex_encode(),
+        }
+    })?;
+
+    Ok(latest_positions(entries)
+        .into_iter()
+        .filter_map(|(root, seq)| (seq >= floor).then_some(root))
+        .collect())
+}
+
+/// The position `root` was first recorded at, if the journal holds it at all.
+fn earliest_position(entries: &[JournalEntry], root: &CommitId) -> Option<Seq> {
+    entries
+        .iter()
+        .filter(|entry| &entry.root == root)
+        .map(|entry| entry.seq)
+        .min()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn root(byte: u8) -> CommitId {
+        CommitId::from(Hash::from([byte; Hash::DIGEST_SIZE]))
+    }
+
+    fn entry(seq: u64, byte: u8) -> JournalEntry {
+        JournalEntry {
+            seq: Seq(seq),
+            root: root(byte),
+        }
+    }
+
+    // An encoded entry survives a round trip through the fixed-width representation.
+    #[test]
+    fn encoding_round_trips() {
+        let original = entry(7, 0xab);
+        assert_eq!(JournalEntry::decode(&original.encode()), original);
+    }
+
+    // Whole entries are decoded and a trailing partial one - a write a crash cut short - is
+    // dropped rather than failing the read.
+    #[test]
+    fn decoding_ignores_a_torn_final_entry() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&entry(0, 1).encode());
+        bytes.extend_from_slice(&entry(1, 2).encode());
+        bytes.extend_from_slice(&entry(2, 3).encode()[..ENTRY_BYTES - 1]);
+
+        assert_eq!(decode_entries(&bytes), vec![entry(0, 1), entry(1, 2)]);
+    }
+
+    // Retention takes every root at or after the target, and excludes older ones.
+    #[test]
+    fn retains_the_target_and_everything_after_it() {
+        let entries = vec![entry(0, 1), entry(1, 2), entry(2, 3), entry(3, 4)];
+
+        let retained = roots_to_retain(&entries, &root(3)).expect("the target is recorded");
+
+        assert_eq!(retained, HashSet::from([root(3), root(4)]));
+    }
+
+    // A root committed twice is retained on its most recent position, so an old state that has
+    // been re-committed survives collection at a target recorded between the two.
+    #[test]
+    fn a_recommitted_root_keeps_its_latest_position() {
+        let entries = vec![entry(0, 1), entry(1, 2), entry(2, 1)];
+
+        let retained = roots_to_retain(&entries, &root(2)).expect("the target is recorded");
+
+        assert_eq!(retained, HashSet::from([root(1), root(2)]));
+    }
+
+    // Collecting at the oldest recorded root keeps everything.
+    #[test]
+    fn collecting_at_the_oldest_root_retains_all() {
+        let entries = vec![entry(0, 1), entry(1, 2), entry(2, 3)];
+
+        let retained = roots_to_retain(&entries, &root(1)).expect("the target is recorded");
+
+        assert_eq!(retained, HashSet::from([root(1), root(2), root(3)]));
+    }
+
+    // A target recorded twice collects from the first of its positions, so the states committed
+    // in between - which came after the caller's target - survive the round.
+    #[test]
+    fn a_repeated_target_collects_from_its_earliest_position() {
+        let entries = vec![entry(0, 9), entry(1, 1), entry(2, 2), entry(3, 1)];
+
+        let retained = roots_to_retain(&entries, &root(1)).expect("the target is recorded");
+
+        assert_eq!(
+            retained,
+            HashSet::from([root(1), root(2)]),
+            "the root recorded between the target's two positions should be kept"
+        );
+    }
+
+    // The earliest position is a floor, not an amnesty: what came before the target still goes.
+    #[test]
+    fn a_repeated_target_still_drops_what_preceded_it() {
+        let entries = vec![entry(0, 9), entry(1, 1), entry(2, 1)];
+
+        let retained = roots_to_retain(&entries, &root(1)).expect("the target is recorded");
+
+        assert!(
+            !retained.contains(&root(9)),
+            "a root recorded before every position of the target should be dropped"
+        );
+    }
+
+    // An unrecorded target is refused rather than treated as a floor that retains nothing.
+    #[test]
+    fn an_unrecorded_target_is_refused() {
+        let entries = vec![entry(0, 1)];
+
+        assert!(matches!(
+            roots_to_retain(&entries, &root(9)),
+            Err(GcArgumentError::CollectionTargetNotRecorded { .. })
+        ));
+    }
+}

--- a/durable-storage/src/lib.rs
+++ b/durable-storage/src/lib.rs
@@ -29,6 +29,7 @@
 //!   operations on disk.
 
 pub mod avl;
+pub mod collect;
 pub mod commit;
 pub mod database;
 pub mod errors;

--- a/durable-storage/src/lib.rs
+++ b/durable-storage/src/lib.rs
@@ -36,6 +36,7 @@ pub mod errors;
 // when `rocksdb` is enabled.
 #[cfg(rocksdb_test_utils)]
 pub mod gc_space;
+pub mod journal;
 pub mod key;
 // The long-running test exercises the persistence backend directly, so it is
 // only available when `rocksdb` is enabled.

--- a/durable-storage/src/long_test/registry/gc.rs
+++ b/durable-storage/src/long_test/registry/gc.rs
@@ -20,12 +20,10 @@ use std::num::NonZeroUsize;
 
 use anyhow::Context;
 use anyhow::Result;
-use octez_riscv_data::mode::Normal;
 
 use crate::commit::CommitId;
-use crate::persistence_layer::PersistenceLayer;
-use crate::registry::Registry;
 use crate::repo::DirectoryManager;
+use crate::repo::RegistryRepo;
 use crate::storage::in_memory::InMemoryRepo;
 
 /// Drop epoch snapshots older than the `keep` most-recent, garbage-collecting
@@ -59,16 +57,15 @@ fn prune_registry_commit(
 ) -> Result<()> {
     let mut reachable: HashSet<CommitId> = HashSet::new();
     for commit in retained {
-        for db in Registry::<PersistenceLayer, Normal>::database_commits(persistent_repo, commit)
+        for db in crate::registry::database_commits(persistent_repo, commit)
             .context("reading a retained registry manifest")?
         {
             reachable.insert(db);
         }
     }
 
-    let old_databases =
-        Registry::<PersistenceLayer, Normal>::database_commits(persistent_repo, old)
-            .context("reading the evicted registry manifest")?;
+    let old_databases = crate::registry::database_commits(persistent_repo, old)
+        .context("reading the evicted registry manifest")?;
     for db in old_databases {
         if reachable.contains(&db) {
             continue;
@@ -98,12 +95,15 @@ fn prune_registry_commit(
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
+    use octez_riscv_data::mode::Normal;
     use octez_riscv_test_utils::TestableTmpdir;
 
     use super::*;
     use crate::key::Key;
     use crate::long_test::registry::run_case::advance_base;
     use crate::long_test::registry::run_case::initial_base;
+    use crate::persistence_layer::PersistenceLayer;
+    use crate::registry::Registry;
     use crate::storage::in_memory::InMemoryKeyValueStore;
     use crate::test_helpers::database::DatabaseOperation;
     use crate::test_helpers::registry::RegistryOperation;

--- a/durable-storage/src/long_test/registry/gc.rs
+++ b/durable-storage/src/long_test/registry/gc.rs
@@ -4,30 +4,31 @@
 
 //! Snapshot retention for the [`Registry`] long test.
 //!
-//! A registry commit references many shared, content-addressed database commits,
-//! which can be referenced by other registry commits. When removing a registry commit,
-//! its database commits are removed only if no other retained registry commit still
-//! references them. Deletions apply
-//! to both backends so the persistent repo and the in-memory repo
-//! both stay bounded to the retention window.
+//! Epoch bases are the only commits a run records, so retention is a window over them: keep the
+//! `keep` most recent and hand the oldest of those to the repository's own collection. Driving
+//! [`collect`] rather than a copy of it means the run exercises what ships, and applying it to
+//! both backends keeps the persistent and in-memory repositories bounded the same way - which is
+//! the only place the in-memory repository's side of collection is exercised at all.
 //!
 //! [`Registry`]: crate::registry::Registry
 
-use std::collections::HashSet;
 use std::collections::VecDeque;
-use std::fs;
 use std::num::NonZeroUsize;
 
 use anyhow::Context;
 use anyhow::Result;
 
+use crate::collect::collect;
 use crate::commit::CommitId;
 use crate::repo::DirectoryManager;
-use crate::repo::RegistryRepo;
 use crate::storage::in_memory::InMemoryRepo;
 
-/// Drop epoch snapshots older than the `keep` most-recent, garbage-collecting
-/// the database commits they no longer keep alive.
+/// Drop epoch snapshots older than the `keep` most-recent, reclaiming what they held.
+///
+/// Collecting at the oldest snapshot in the window retains it and everything recorded after it,
+/// which is exactly the window: a run records a commit per epoch base and nothing in between. The
+/// database commits an evicted snapshot shared with a retained one survive, since collection
+/// removes only those no retained manifest reaches.
 pub(super) fn prune(
     persistent_repo: &DirectoryManager,
     in_memory_repo: &InMemoryRepo,
@@ -35,65 +36,23 @@ pub(super) fn prune(
     keep: NonZeroUsize,
 ) -> Result<()> {
     while recent_commits.len() > keep.get() {
-        let old = recent_commits.pop_front().expect("non-empty");
-
-        // Keep the snapshot if a retained epoch still references it
-        if recent_commits.contains(&old) {
-            continue;
-        }
-
-        prune_registry_commit(persistent_repo, in_memory_repo, &old, recent_commits)?;
-    }
-    Ok(())
-}
-
-/// Remove the registry commit `old` and any of its database commits not reachable
-/// from a `retained` registry commit.
-fn prune_registry_commit(
-    persistent_repo: &DirectoryManager,
-    in_memory_repo: &InMemoryRepo,
-    old: &CommitId,
-    retained: &VecDeque<CommitId>,
-) -> Result<()> {
-    let mut reachable: HashSet<CommitId> = HashSet::new();
-    for commit in retained {
-        for db in crate::registry::database_commits(persistent_repo, commit)
-            .context("reading a retained registry manifest")?
-        {
-            reachable.insert(db);
-        }
+        recent_commits.pop_front();
     }
 
-    let old_databases = crate::registry::database_commits(persistent_repo, old)
-        .context("reading the evicted registry manifest")?;
-    for db in old_databases {
-        if reachable.contains(&db) {
-            continue;
-        }
-        let dir = persistent_repo.database_commit_dir(&db);
-        if dir.exists() {
-            fs::remove_dir_all(&dir)
-                .with_context(|| format!("removing database snapshot {}", dir.display()))?;
-        }
-        in_memory_repo
-            .remove_commit(&db)
-            .context("removing an in-memory database snapshot")?;
-    }
+    let Some(oldest) = recent_commits.front() else {
+        return Ok(());
+    };
 
-    let manifest_file = persistent_repo.registry_commit_file(old);
-    if manifest_file.exists() {
-        fs::remove_file(&manifest_file)
-            .with_context(|| format!("removing registry manifest {}", manifest_file.display()))?;
-    }
-    in_memory_repo
-        .remove_registry_commit(old)
-        .context("removing an in-memory registry manifest")?;
+    collect(persistent_repo, oldest).context("collecting the persistent repository")?;
+    collect(in_memory_repo, oldest).context("collecting the in-memory repository")?;
 
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     use bytes::Bytes;
     use octez_riscv_data::mode::Normal;
     use octez_riscv_test_utils::TestableTmpdir;
@@ -155,6 +114,18 @@ mod tests {
             )
             .is_err(),
             "the evicted base should no longer check out in memory"
+        );
+
+        // Both journals were pruned, so neither backend will collect at the evicted base
+        // again - which is what a repeated round relies on to refuse a target whose data has
+        // already gone.
+        assert!(
+            collect(&persistent_repo, &base0.commit).is_err(),
+            "the evicted base should no longer be a persistent collection target"
+        );
+        assert!(
+            collect(&in_memory_repo, &base0.commit).is_err(),
+            "the evicted base should no longer be an in-memory collection target"
         );
 
         // The retained base still checks out fully on both backends, which

--- a/durable-storage/src/long_test/registry/mod.rs
+++ b/durable-storage/src/long_test/registry/mod.rs
@@ -30,7 +30,6 @@ use std::path::Path;
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::bail;
-use octez_riscv_data::mode::Normal;
 use proptest::strategy::Strategy;
 use proptest::strategy::ValueTree;
 use proptest::test_runner::TestError;
@@ -51,7 +50,6 @@ use super::harness::read_failure_file;
 use super::harness::write_failure_file;
 use crate::commit::CommitId;
 use crate::persistence_layer::PersistenceLayer;
-use crate::registry::Registry;
 use crate::repo::DirectoryManager;
 use crate::repo::RegistryRepo;
 use crate::storage::PersistentKeyValueStore;
@@ -285,9 +283,8 @@ fn save_base(
     fs::write(failure_dir.join(MANIFEST_FILE), &manifest)
         .context("writing the registry manifest")?;
 
-    let db_commits =
-        Registry::<PersistenceLayer, Normal>::database_commits(persistent_repo, base_commit)
-            .context("reading the base's database commits")?;
+    let db_commits = crate::registry::database_commits(persistent_repo, base_commit)
+        .context("reading the base's database commits")?;
 
     let persistent_dir = failure_dir.join(PERSISTENT_DBS);
     let in_memory_dir = failure_dir.join(IN_MEMORY_DBS);
@@ -326,9 +323,8 @@ fn restore_base(
         .context("registering the in-memory manifest")?;
 
     // The manifest is now readable from either repo.
-    let db_commits =
-        Registry::<PersistenceLayer, Normal>::database_commits(persistent_repo, base_commit)
-            .context("reading the base's database commits")?;
+    let db_commits = crate::registry::database_commits(persistent_repo, base_commit)
+        .context("reading the base's database commits")?;
 
     let persistent_dir = failure_dir.join(PERSISTENT_DBS);
     let in_memory_dir = failure_dir.join(IN_MEMORY_DBS);

--- a/durable-storage/src/registry.rs
+++ b/durable-storage/src/registry.rs
@@ -57,6 +57,21 @@ struct RegistryManifest {
     database_hashes: Vec<CommitId>,
 }
 
+/// The database commits referenced by the registry committed at `commit_id`.
+///
+/// Reads the manifest through the repository alone. Collection needs this to decide which database
+/// commits a retained registry commit still holds alive, and has no key-value store to reach it
+/// through.
+pub(crate) fn database_commits<Repo: RegistryRepo>(
+    repo: &Repo,
+    commit_id: &CommitId,
+) -> Result<Vec<CommitId>, OperationalError> {
+    let manifest: RegistryManifest =
+        deserialise(&repo.read_registry_commit(commit_id)?).map_err(OperationalError::from)?;
+
+    Ok(manifest.database_hashes)
+}
+
 /// Registry that owns a set of databases and the repository used to manage
 /// registry state.
 pub struct Registry<KV: ReadableKeyValueStore, M: Mode> {
@@ -187,15 +202,6 @@ where
         let databases = Self::checkout_databases(&runtime, &repo, &manifest.database_hashes)?;
 
         Self::from_restored_databases(repo, runtime, databases, commit_id)
-    }
-
-    /// The database commit ids referenced by the registry committed at `commit_id`.
-    #[cfg(rocksdb_test_utils)]
-    pub(crate) fn database_commits(
-        repo: &KV::Repo,
-        commit_id: &CommitId,
-    ) -> Result<Vec<CommitId>, OperationalError> {
-        Ok(Self::read_checkout_manifest(repo, commit_id)?.database_hashes)
     }
 
     fn checkout_databases(

--- a/durable-storage/src/registry.rs
+++ b/durable-storage/src/registry.rs
@@ -235,6 +235,10 @@ where
             .repo
             .write_registry_commit(&registry_commit, &encoded)?;
 
+        // Recorded after the manifest, so that an interrupted commit leaves a manifest that
+        // collection can reclaim, rather than a recorded root with nothing behind it.
+        self.inner.repo.record_commit(&registry_commit)?;
+
         Ok(registry_commit)
     }
 }

--- a/durable-storage/src/repo.rs
+++ b/durable-storage/src/repo.rs
@@ -4,6 +4,10 @@
 
 //! Repository management for the Durable Storage
 
+use std::io::Read;
+use std::io::Seek;
+use std::io::SeekFrom;
+use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -11,6 +15,9 @@ use tempfile::TempDir;
 
 use crate::commit::CommitId;
 use crate::errors::OperationalError;
+use crate::journal;
+use crate::journal::JournalEntry;
+use crate::journal::Seq;
 
 /// The [`DirectoryManager`] represents the root directory where commitments & internal data should
 /// be stored.
@@ -30,6 +37,9 @@ pub struct DirectoryManager {
 
     /// Directory prefix for [`crate::registry::Registry`] commitments
     registry_commits_dir: PathBuf,
+
+    /// Directory holding registry-wide data, including the commit journal
+    registries_dir: PathBuf,
 }
 
 impl DirectoryManager {
@@ -62,14 +72,17 @@ impl DirectoryManager {
         let database_commits_dir = databases_dir.join("commits");
         ensure_dir_exists(&database_commits_dir)?;
 
+        let registries_dir = path.join("registries");
+
         // The directory for registry commits holds files. Each file is named after the commit ID.
-        let registry_commits_dir = path.join("registries").join("commits");
+        let registry_commits_dir = registries_dir.join("commits");
         ensure_dir_exists(&registry_commits_dir)?;
 
         Ok(Self {
             temp_databases_dir,
             database_commits_dir,
             registry_commits_dir,
+            registries_dir,
         })
     }
 
@@ -101,6 +114,50 @@ impl DirectoryManager {
     pub fn registry_commit_file(&self, id: &CommitId) -> PathBuf {
         self.registry_commits_dir.join(id.hex_encode())
     }
+
+    /// The file recording the order in which registry commits were made.
+    pub fn journal_file(&self) -> PathBuf {
+        self.registries_dir.join("journal")
+    }
+
+    /// The journal open for appending, with its last whole entry and the offset just past it.
+    ///
+    /// Reads only the tail, since assigning the next sequence number is on the commit path and the
+    /// journal grows with every commit until collection prunes it. A trailing partial entry is a
+    /// torn write, so the last whole entry is the one before it and the offset is where the next
+    /// entry belongs: appending past torn bytes would leave every later entry misaligned.
+    fn open_journal(&self) -> Result<(std::fs::File, Option<JournalEntry>, u64), OperationalError> {
+        let mut journal = std::fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            // Explicit because entries are written in place: a torn tail is discarded by the
+            // `set_len` that follows the entry written over it, not by opening.
+            .truncate(false)
+            .open(self.journal_file())
+            .map_err(|error| OperationalError::FileWriteFailed { error })?;
+
+        let len = journal
+            .metadata()
+            .map_err(|error| OperationalError::FileReadFailed { error })?
+            .len();
+        let end = len - len % journal::ENTRY_BYTES as u64;
+
+        let Some(last) = end.checked_sub(journal::ENTRY_BYTES as u64) else {
+            return Ok((journal, None, end));
+        };
+
+        journal
+            .seek(SeekFrom::Start(last))
+            .map_err(|error| OperationalError::FileReadFailed { error })?;
+
+        let mut bytes = [0u8; journal::ENTRY_BYTES];
+        journal
+            .read_exact(&mut bytes)
+            .map_err(|error| OperationalError::FileReadFailed { error })?;
+
+        Ok((journal, Some(JournalEntry::decode(&bytes)), end))
+    }
 }
 
 /// Persistence interface for a [`crate::registry::Registry`] repo.
@@ -112,6 +169,16 @@ pub trait RegistryRepo: Clone {
 
     /// Write `bytes` as the registry manifest for `id`.
     fn write_registry_commit(&self, id: &CommitId, bytes: &[u8]) -> Result<(), OperationalError>;
+
+    /// Record `root` as the most recently committed registry root.
+    ///
+    /// Called after the manifest is written, so a crash in between leaves an unrecorded manifest
+    /// rather than a recorded root with nothing behind it. The commit id was never returned to the
+    /// caller in that case, so nothing can reference it and collection is free to reclaim it.
+    fn record_commit(&self, root: &CommitId) -> Result<Seq, OperationalError>;
+
+    /// Every commit recorded by [`RegistryRepo::record_commit`], in the order they were recorded.
+    fn read_commit_journal(&self) -> Result<Vec<JournalEntry>, OperationalError>;
 }
 
 impl RegistryRepo for DirectoryManager {
@@ -130,5 +197,176 @@ impl RegistryRepo for DirectoryManager {
         let commit_path = self.registry_commit_file(id);
         std::fs::write(&commit_path, bytes)
             .map_err(|error| OperationalError::FileWriteFailed { error })
+    }
+
+    fn record_commit(&self, root: &CommitId) -> Result<Seq, OperationalError> {
+        // Opened once: the same handle reads the tail the next number comes from and writes the
+        // entry that follows it.
+        let (mut journal, last, end) = self.open_journal()?;
+
+        let seq = match last {
+            Some(last) => last.seq.next(),
+            None => Seq::FIRST,
+        };
+
+        let entry = JournalEntry { seq, root: *root };
+
+        journal
+            .seek(SeekFrom::Start(end))
+            .map_err(|error| OperationalError::FileWriteFailed { error })?;
+
+        journal
+            .write_all(&entry.encode())
+            .map_err(|error| OperationalError::FileWriteFailed { error })?;
+
+        // Truncating to the new end discards any torn bytes the entry was written over, so the
+        // file stays a whole number of entries.
+        journal
+            .set_len(end + journal::ENTRY_BYTES as u64)
+            .map_err(|error| OperationalError::FileWriteFailed { error })?;
+
+        Ok(seq)
+    }
+
+    fn read_commit_journal(&self) -> Result<Vec<JournalEntry>, OperationalError> {
+        match std::fs::read(self.journal_file()) {
+            Ok(bytes) => Ok(journal::decode_entries(&bytes)),
+            // A repository that has never committed has no journal, which reads as no entries
+            // rather than as a failure.
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+            Err(error) => Err(OperationalError::FileReadFailed { error }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use octez_riscv_data::hash::Hash;
+    use octez_riscv_test_utils::TestableTmpdir;
+
+    use super::*;
+
+    fn root(byte: u8) -> CommitId {
+        CommitId::from(Hash::from([byte; Hash::DIGEST_SIZE]))
+    }
+
+    fn manager(tmp: &TestableTmpdir) -> DirectoryManager {
+        DirectoryManager::new(tmp.path()).expect("creating the directory manager should succeed")
+    }
+
+    // A repository that has never committed reads as an empty journal rather than failing on the
+    // missing file.
+    #[test]
+    fn a_fresh_repository_has_an_empty_journal() {
+        let tmp = TestableTmpdir::new();
+
+        assert!(
+            manager(&tmp)
+                .read_commit_journal()
+                .expect("reading an absent journal should succeed")
+                .is_empty()
+        );
+    }
+
+    // Recorded commits are numbered from zero, in order, and read back in the order they were
+    // recorded.
+    #[test]
+    fn commits_are_recorded_in_order() {
+        let tmp = TestableTmpdir::new();
+        let repo = manager(&tmp);
+
+        let seqs: Vec<Seq> = (1..=3)
+            .map(|byte| {
+                repo.record_commit(&root(byte))
+                    .expect("recording should succeed")
+            })
+            .collect();
+
+        assert_eq!(
+            seqs,
+            vec![Seq::FIRST, Seq::FIRST.next(), Seq::FIRST.next().next()]
+        );
+        assert_eq!(
+            repo.read_commit_journal().expect("reading should succeed"),
+            seqs.into_iter()
+                .zip(1..=3)
+                .map(|(seq, byte)| JournalEntry {
+                    seq,
+                    root: root(byte),
+                })
+                .collect::<Vec<_>>()
+        );
+    }
+
+    // The journal is on disk, so a repository reopened at the same path continues numbering where
+    // it left off instead of restarting and colliding with recorded positions.
+    #[test]
+    fn numbering_continues_across_reopening() {
+        let tmp = TestableTmpdir::new();
+
+        manager(&tmp)
+            .record_commit(&root(1))
+            .expect("recording should succeed");
+        let seq = manager(&tmp)
+            .record_commit(&root(2))
+            .expect("recording should succeed");
+
+        assert_eq!(seq, Seq::FIRST.next());
+        assert_eq!(
+            manager(&tmp)
+                .read_commit_journal()
+                .expect("reading should succeed")
+                .len(),
+            2
+        );
+    }
+
+    // A crash part-way through appending an entry leaves a partial record. Reading skips it, and
+    // the next commit is numbered from the last whole entry, overwriting nothing.
+    #[test]
+    fn a_torn_final_entry_is_ignored_and_renumbered_over() {
+        let tmp = TestableTmpdir::new();
+        let repo = manager(&tmp);
+
+        repo.record_commit(&root(1))
+            .expect("recording should succeed");
+
+        // Simulate the interrupted append of a second entry.
+        let mut torn = std::fs::read(repo.journal_file()).expect("the journal should exist");
+        torn.extend_from_slice(&[0xff; journal::ENTRY_BYTES - 1]);
+        std::fs::write(repo.journal_file(), &torn)
+            .expect("writing the torn journal should succeed");
+
+        assert_eq!(
+            repo.read_commit_journal().expect("reading should succeed"),
+            vec![JournalEntry {
+                seq: Seq::FIRST,
+                root: root(1)
+            }],
+            "the partial entry should not be reported"
+        );
+
+        let seq = repo
+            .record_commit(&root(2))
+            .expect("recording after a torn write should succeed");
+        assert_eq!(seq, Seq::FIRST.next());
+
+        // The point of the renumbering: the torn bytes are gone, so the journal still reads as
+        // whole entries. Appending past them instead would leave every later entry misaligned,
+        // which reads back as a fabricated entry and a dropped tail rather than as an error.
+        assert_eq!(
+            repo.read_commit_journal().expect("reading should succeed"),
+            vec![
+                JournalEntry {
+                    seq: Seq::FIRST,
+                    root: root(1)
+                },
+                JournalEntry {
+                    seq: Seq::FIRST.next(),
+                    root: root(2)
+                }
+            ],
+            "the torn entry should have been overwritten, not appended past"
+        );
     }
 }

--- a/durable-storage/src/repo.rs
+++ b/durable-storage/src/repo.rs
@@ -4,6 +4,7 @@
 
 //! Repository management for the Durable Storage
 
+use std::collections::HashSet;
 use std::io::Read;
 use std::io::Seek;
 use std::io::SeekFrom;
@@ -11,6 +12,7 @@ use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 
+use octez_riscv_data::hash::Hash;
 use tempfile::TempDir;
 
 use crate::commit::CommitId;
@@ -179,6 +181,36 @@ pub trait RegistryRepo: Clone {
 
     /// Every commit recorded by [`RegistryRepo::record_commit`], in the order they were recorded.
     fn read_commit_journal(&self) -> Result<Vec<JournalEntry>, OperationalError>;
+
+    /// Keep only the journal entries whose root is in `retained`, dropping the rest.
+    ///
+    /// Replaces the journal in one step, so an interrupted prune leaves either the old journal or
+    /// the new one.
+    fn prune_journal(&self, retained: &HashSet<CommitId>) -> Result<(), OperationalError>;
+
+    /// Every registry commit the repository currently holds a manifest for.
+    ///
+    /// Unordered. Collection enumerates what is present rather than what the journal mentions, so
+    /// that a manifest left behind by an interrupted commit or an interrupted collection is still
+    /// found.
+    fn registry_commits(&self) -> Result<Vec<CommitId>, OperationalError>;
+
+    /// Every database commit the repository currently holds.
+    ///
+    /// Unordered, and enumerated from what is present for the same reason as
+    /// [`RegistryRepo::registry_commits`].
+    fn database_commits(&self) -> Result<Vec<CommitId>, OperationalError>;
+
+    /// Remove the manifest for the registry commit `id`.
+    ///
+    /// Removing one that is already gone succeeds, so collection can be repeated after an
+    /// interruption.
+    fn remove_registry_commit(&self, id: &CommitId) -> Result<(), OperationalError>;
+
+    /// Remove the database commit `id`.
+    ///
+    /// Idempotent, for the same reason as [`RegistryRepo::remove_registry_commit`].
+    fn remove_database_commit(&self, id: &CommitId) -> Result<(), OperationalError>;
 }
 
 impl RegistryRepo for DirectoryManager {
@@ -237,6 +269,79 @@ impl RegistryRepo for DirectoryManager {
             Err(error) => Err(OperationalError::FileReadFailed { error }),
         }
     }
+
+    fn prune_journal(&self, retained: &HashSet<CommitId>) -> Result<(), OperationalError> {
+        let kept: Vec<u8> = self
+            .read_commit_journal()?
+            .into_iter()
+            .filter(|entry| retained.contains(&entry.root))
+            .flat_map(|entry| entry.encode())
+            .collect();
+
+        // Written beside the journal and renamed over it, so the replacement is atomic: a crash
+        // leaves either the journal as it was or the pruned one, never a half-written mixture.
+        let pending = self.journal_file().with_extension("pending");
+        std::fs::write(&pending, &kept)
+            .map_err(|error| OperationalError::FileWriteFailed { error })?;
+        std::fs::rename(&pending, self.journal_file())
+            .map_err(|error| OperationalError::FileWriteFailed { error })
+    }
+
+    fn registry_commits(&self) -> Result<Vec<CommitId>, OperationalError> {
+        commit_ids_in(&self.registry_commits_dir)
+    }
+
+    fn database_commits(&self) -> Result<Vec<CommitId>, OperationalError> {
+        commit_ids_in(&self.database_commits_dir)
+    }
+
+    fn remove_registry_commit(&self, id: &CommitId) -> Result<(), OperationalError> {
+        match std::fs::remove_file(self.registry_commit_file(id)) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(OperationalError::FileWriteFailed { error }),
+        }
+    }
+
+    fn remove_database_commit(&self, id: &CommitId) -> Result<(), OperationalError> {
+        let dir = self.database_commit_dir(id);
+        match std::fs::remove_dir_all(&dir) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(OperationalError::DirRemovalFailed { path: dir, error }),
+        }
+    }
+}
+
+/// The commit ids named by the entries of `dir`.
+///
+/// Entries whose name is not a commit id are left alone: the durable storage does not put anything
+/// else in these directories, so one that appears belongs to something else and is not ours to
+/// interpret or remove.
+fn commit_ids_in(dir: &Path) -> Result<Vec<CommitId>, OperationalError> {
+    let entries =
+        std::fs::read_dir(dir).map_err(|error| OperationalError::FileReadFailed { error })?;
+
+    let mut ids = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|error| OperationalError::FileReadFailed { error })?;
+
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+
+        let Ok(bytes) = hex::decode(&name) else {
+            continue;
+        };
+
+        let Ok(digest) = <[u8; Hash::DIGEST_SIZE]>::try_from(bytes.as_slice()) else {
+            continue;
+        };
+
+        ids.push(CommitId::from(Hash::from(digest)));
+    }
+
+    Ok(ids)
 }
 
 #[cfg(test)]

--- a/durable-storage/src/storage/in_memory.rs
+++ b/durable-storage/src/storage/in_memory.rs
@@ -32,6 +32,10 @@ pub struct InMemoryRepo {
 
     #[cfg(test_utils)]
     registry_commits: std::sync::Arc<RwLock<HashMap<crate::commit::CommitId, Vec<u8>>>>,
+
+    /// The order in which registry commits were recorded, oldest first.
+    #[cfg(test_utils)]
+    journal: std::sync::Arc<RwLock<Vec<crate::journal::JournalEntry>>>,
 }
 
 #[cfg(test_utils)]
@@ -440,5 +444,31 @@ impl crate::repo::RegistryRepo for InMemoryRepo {
             .map_err(|_| OperationalError::LockPoisoned)?;
         commits.insert(*id, bytes.to_vec());
         Ok(())
+    }
+
+    fn record_commit(
+        &self,
+        root: &crate::commit::CommitId,
+    ) -> Result<crate::journal::Seq, OperationalError> {
+        let mut journal = self
+            .journal
+            .write()
+            .map_err(|_| OperationalError::LockPoisoned)?;
+
+        let seq = match journal.last() {
+            Some(last) => last.seq.next(),
+            None => crate::journal::Seq::FIRST,
+        };
+
+        journal.push(crate::journal::JournalEntry { seq, root: *root });
+
+        Ok(seq)
+    }
+
+    fn read_commit_journal(&self) -> Result<Vec<crate::journal::JournalEntry>, OperationalError> {
+        self.journal
+            .read()
+            .map(|journal| journal.clone())
+            .map_err(|_| OperationalError::LockPoisoned)
     }
 }

--- a/durable-storage/src/storage/in_memory.rs
+++ b/durable-storage/src/storage/in_memory.rs
@@ -48,19 +48,6 @@ impl InMemoryRepo {
             .remove(id);
         Ok(())
     }
-
-    /// Remove the registry manifest stored for `id` if it exists
-    #[cfg(rocksdb_test_utils)]
-    pub(crate) fn remove_registry_commit(
-        &self,
-        id: &crate::commit::CommitId,
-    ) -> Result<(), OperationalError> {
-        self.registry_commits
-            .write()
-            .map_err(|_| OperationalError::LockPoisoned)?
-            .remove(id);
-        Ok(())
-    }
 }
 
 /// In-memory key-value store
@@ -470,5 +457,48 @@ impl crate::repo::RegistryRepo for InMemoryRepo {
             .read()
             .map(|journal| journal.clone())
             .map_err(|_| OperationalError::LockPoisoned)
+    }
+
+    fn prune_journal(
+        &self,
+        retained: &std::collections::HashSet<crate::commit::CommitId>,
+    ) -> Result<(), OperationalError> {
+        self.journal
+            .write()
+            .map_err(|_| OperationalError::LockPoisoned)?
+            .retain(|entry| retained.contains(&entry.root));
+        Ok(())
+    }
+
+    fn registry_commits(&self) -> Result<Vec<crate::commit::CommitId>, OperationalError> {
+        Ok(self
+            .registry_commits
+            .read()
+            .map_err(|_| OperationalError::LockPoisoned)?
+            .keys()
+            .copied()
+            .collect())
+    }
+
+    fn database_commits(&self) -> Result<Vec<crate::commit::CommitId>, OperationalError> {
+        Ok(self
+            .commits
+            .read()
+            .map_err(|_| OperationalError::LockPoisoned)?
+            .keys()
+            .copied()
+            .collect())
+    }
+
+    fn remove_registry_commit(&self, id: &crate::commit::CommitId) -> Result<(), OperationalError> {
+        self.registry_commits
+            .write()
+            .map_err(|_| OperationalError::LockPoisoned)?
+            .remove(id);
+        Ok(())
+    }
+
+    fn remove_database_commit(&self, id: &crate::commit::CommitId) -> Result<(), OperationalError> {
+        self.remove_commit(id)
     }
 }


### PR DESCRIPTION
Part of TZX-209

# What

Record the order of commits made, in an append only journal. Then allow for commits to be collected that are older than a given root (and not referenced since). Finally, bound the registry long test with that collection, in place of the copy of it the test kept.

# Why

`octez-smart-rollup-node` needs the storage to reclaim disk, and today it reclaims
nothing: a repository grows with the total number of commits over its lifetime.

Currently, a commit id is just the registry root hash, so contains no information about when the commit occurred. Two unrelated commits could share the same id, and ancestry is unavailable.

Simply removing directories removes a large proportion of what a repository holds. As commit directories are sets of hard links, removing the last directory containing a given hard link frees it. This is sufficient for garbage collection of the 'key-value' column family.

# How

## Commit Journal 

Each committed root is recorded as a sequence number that increases with
every commit. Identity is untouched, so committing the same state twice still produces
the same id and the same manifest; only the journal grows. Retention follows the recorded
order rather than ancestry, which keeps states whose provenance is unclear. Collecting at
a root keeps every root recorded at or after it, and a root committed more than once
keeps its highest position, so re-committing an old state can only extend how long it
survives. The target is read the other way about: its *earliest* position is the floor,
so collecting at a state that has been committed twice drops only what preceded the first
time it was reached, and never the states committed in between. Both directions err
towards keeping a state.

## Collection 

Database commits are content-addressed and therefore shared — unrelated
registry commits name the same one whenever their states agree — so their removal follows
reachability rather than the order commits were made in.

It is safe to interrupt and repeat. It prunes the journal to the retained roots, removes
the manifests it dropped, then removes the unreachable database commits, in that order, so
everything retained is intact at each point in between. Each step after the first
enumerates what is present rather than what the journal says should be, so a round left
unfinished is picked up by the next one.

Both sit on the repository trait, so the in-memory backend records and collects the same
way the on-disk one does.

For now, collection must not overlap a commit or another collection; that is the caller's
responsibility for now, and is stated in the docs page.

## Long Test Retention

The registry long test advances a shared base once per epoch, then runs a proptest of many
cases against that base. A case checks the base out and applies operations with proofs; it
never commits. Only the epoch advance does. So the only commits a run records are epoch
bases, in the order the epochs ran.

Bounding the repository over a long run therefore means dropping old epoch bases, and the
test used to do that with its own copy of collection: a window of recent bases, and on
eviction a reachability walk over the retained manifests, then database directory and
manifest removals, mirrored by hand onto both backends. That is the mechanism this PR
ships, written a second time, so the retention a run exercised was never quite the
retention that ships — and the two could drift apart without anything noticing.

Now the window is all the test keeps. It trims to the `keep` most recent bases and calls
`collect()` at the oldest one still in the window, once per backend. Retention by recorded
order coincides with a window over epoch bases exactly because nothing between them is ever
recorded, so "every root recorded at or after this one" and "the bases still in the window"
are the same set.

Three things follow from the swap. A long randomised run now exercises the real
`collect()`, including the journal pruning the copy never touched. The bound is tighter,
because the copy only ever considered the database commits of the base it was evicting,
leaving anything else unreachable on disk. And it is the only place the in-memory
repository's side of collection runs at all — see the note under Manually Testing.

Ordering is safe: collection must not overlap a commit, and the call sits between epochs,
after the proptest for that epoch has finished, so nothing else is touching the repository.

# Manually Testing

```
make -C durable-storage check
make -C durable-storage test
cargo nextest run -p octez-riscv-durable-storage
```

The space harness now drives the real `collect()` rather than a copy of it, so the
reclaim figures it reports measure what ships:

```
cargo run --features unstable-test-utils --bin gc_space -- --keys 200000 --commits 20 --collect
```

So does the registry long test, on both backends:

```
make -C durable-storage run-registry-long-test
```

That run is also the only coverage the in-memory repository has for its side of collection.
The `collect` tests reach the trait through `DirectoryManager`, and the crate's two test
flavours are the same build in this respect — the self dev-dependency takes default
features, and `default = ["rocksdb"]`, so `--no-default-features` does not turn rocksdb off
for the test binary — which left nothing running `InMemoryRepo`'s journal and removal
methods.

# Regressions

None. Nothing is deleted by the first commit, and the second only removes commit
directories and manifests that are no longer retained.

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [x] Eliminate dead code and other spurious artefacts introduced in your changes.
- [x] Document new public functions, methods and types.
- [x] Make sure the documentation for updated functions, methods, and types is correct.
- [x] Add tests for bugs that have been fixed.
- [x] [Explain changes](#regressions) to regression test captures when applicable.
- [x] Write commit messages in agreement with our guidelines.
- [x] Self-review your changes to ensure they are high-quality.
- [x] Complete all of the above before assigning this MR to reviewers.

