### PR TITLE
perf(nds): store only the nodes a commit changed

### DIFF
--- a/docs/new-durable-storage/garbage-collection.mdx
+++ b/docs/new-durable-storage/garbage-collection.mdx
@@ -73,29 +73,27 @@ The only reachability logic that exists is `long_test/registry/gc.rs`, which the
 ## Why retaining a commit costs more than its changes
 
 Checkpoints hard-link the files that were live when they were taken, so retaining a commit should cost only what that commit changed: the next checkpoint links the same files for everything untouched.
-Measured, it costs far more than that, and the reason is not the design but two things about how commits are written.
+It costs more than that, and the reason is not the design but how commits reach the store.
 
 Sharing is not all-or-nothing.
-On an ordinary commit, consecutive checkpoints share 90-98% of their bytes, exactly as the layout intends.
-The cost comes from two effects that break that sharing, and they are independent of each other.
+On an ordinary commit, consecutive checkpoints share around 98% of their bytes, which is what the layout intends.
+What breaks it now is compaction, and only compaction — a second cause, commits rewriting nodes that had not changed, has been fixed.
 
-### Commits rewrite every resolved node
+### Commits store only the nodes they changed
 
-`Storable for Node` writes a node's body and then recurses into both children unconditionally.
-The only thing that stops the recursion is a child that has never been resolved into memory: `LazyNodeId::store` returns early when its node is absent, assuming it was persisted before.
+A node records which store it is already in.
+Committing skips such a node and, with it, the whole subtree beneath: nodes are content-addressed, so changing a descendant changes every hash above it, and an unchanged node cannot have a changed descendant.
 
-Nothing tracks whether a resolved node is *dirty*, so committing rewrites every node that has been resolved, changed or not.
-The bodies are byte-identical to what is already stored, but RocksDB has no way to know that: each one is a fresh write that lands in the memtable and is flushed into new files.
+The record is dropped by the same thing that invalidates a node's cached hash, so it survives exactly the mutations that leave the stored copy still correct.
+It names the store rather than being a plain flag, because a tree can be shared between stores: copying a database hands the destination a copy of the source's store and the same in-memory nodes, so a node not yet written owes a copy to each of them.
+A flag would let the first commit satisfy that obligation and the second skip it, leaving a commit that refers to nodes which never reached its store.
 
-Two consequences follow.
-A state that has just been built has its whole tree resolved, so every commit rewrites the whole tree.
-A state that was checked out starts with nothing resolved, but the resolved set only grows — modifying a key resolves its whole path to the root, and nothing ever un-resolves it — so the volume a commit rewrites climbs with every commit since the checkout, converging on the whole tree.
+One cost remains from this: a node written before its tree was shared is not recognised as being in the store that was copied, even though the copy holds it, so it is written again once.
+Distinguishing writes made before the two stores diverged from writes made after would need more than a single identity.
 
-Neither consequence applies to committing the same state twice: a commit id is the hash of the state, so the second call finds the commit already published and takes no checkpoint.
-It still rewrites the resolved tree into the memtable, but it pins nothing new.
+Committing the same state twice now does nothing at either end: the nodes are already recorded as being in this store, and a commit id is the hash of the state, so the publish step finds it already published and takes no checkpoint.
 
-Checking out lazily therefore delays this rather than avoiding it.
-Keeping the rewrite proportional to what changed needs dirty tracking.
+Without this, committing rewrote every node resolved in memory, changed or not — the whole tree for a state just built, and a growing share of it for a state checked out, since the resolved set only ever grows.
 
 ### Compaction rewrites whole levels
 
@@ -107,10 +105,12 @@ Keys are spread by hash, so a level-zero file spans the whole key space and over
 Each compaction therefore rewrites the entire base level into new files, and every checkpoint taken before it stops sharing them.
 
 <Warning>
-Dirty tracking does not fix this second effect, and neither does writing less per commit.
-The trigger counts files, and a forced flush produces a file per commit regardless of size.
-Reducing it means flushing less often, raising the trigger, or not compacting the working database automatically at all.
+Writing less per commit does not reduce this.
+The trigger counts files, and a forced flush produces one per commit regardless of what it holds, so compaction runs on a cadence set by how often you commit rather than by how much you write.
+Reducing it means flushing less often, raising the trigger, or not compacting the working database automatically at all — and each of those leaves more files for a lookup to search, so it needs bloom filters to pay for itself.
 </Warning>
+
+This is now the whole of the gap between what a commit changes and what retaining it costs.
 
 ## Planned mechanism
 

--- a/durable-storage/src/avl/node.rs
+++ b/durable-storage/src/avl/node.rs
@@ -7,6 +7,8 @@
 use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::sync::OnceLock;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering as AtomicOrdering;
 
 use bincode::Decode;
 use bincode::Encode;
@@ -43,6 +45,7 @@ use crate::key::Key;
 use crate::storage::Loadable;
 use crate::storage::ReadableKeyValueStore;
 use crate::storage::Storable;
+use crate::storage::StoreId;
 use crate::storage::StoreOptions;
 use crate::storage::WriteableKeyValueStore;
 
@@ -58,6 +61,61 @@ struct StoredNode {
     data: Hash,
     left: Hash,
     right: Hash,
+}
+
+/// Records the store a node's body has already been written to, so that committing can skip it.
+///
+/// [`Storable::store`] takes `&self`, so the memo is kept behind interior mutability, in the same
+/// spirit as the hash cache on [`Node`].
+///
+/// It records *which* store rather than a bare "already stored" flag because one tree can be
+/// shared between stores: [`crate::registry::Registry::copy_database`] hands the destination a
+/// copy of the source's store and the same in-memory nodes. A node still owing a copy at that
+/// moment owes it to both, and a flag would let the first commit satisfy the obligation and the
+/// second skip it - leaving a commit that refers to nodes which never reached its store.
+///
+/// The low bit records whether that write also included the node's value data, so a
+/// [`StoreOptions::with_node_data`] commit is never skipped on the strength of a
+/// [`StoreOptions::without_node_data`] one that came before it.
+#[derive(Debug, Default)]
+struct StoredIn(AtomicU64);
+
+impl StoredIn {
+    /// The memo of a node that is not known to be in any store.
+    ///
+    /// Distinguishable from a real store because [`StoreId::next`] hands out ids from one.
+    const NOT_STORED: u64 = StoreId::NONE.raw();
+
+    /// Whether the body is already in `store`, with the value data too if `node_data` needs it.
+    fn covers(&self, store: StoreId, node_data: bool) -> bool {
+        let memo = self.0.load(AtomicOrdering::Relaxed);
+        if memo == Self::NOT_STORED {
+            return false;
+        }
+
+        StoreId::from(memo >> 1) == store && (!node_data || memo & 1 == 1)
+    }
+
+    /// Record that the body - and, if `node_data`, the value data - is now in `store`.
+    fn record(&self, store: StoreId, node_data: bool) {
+        self.0.store(
+            (store.raw() << 1) | u64::from(node_data),
+            AtomicOrdering::Relaxed,
+        );
+    }
+
+    /// Forget where the body was written, because it no longer describes this node.
+    fn clear(&self) {
+        self.0.store(Self::NOT_STORED, AtomicOrdering::Relaxed);
+    }
+}
+
+impl Clone for StoredIn {
+    /// A clone holds the same content as the original, so it is in whichever store the original
+    /// had reached.
+    fn clone(&self) -> Self {
+        Self(AtomicU64::new(self.0.load(AtomicOrdering::Relaxed)))
+    }
 }
 
 /// A node that supports rebalancing and Merklisation.
@@ -78,6 +136,12 @@ pub struct Node<TreeId, DataId, M: Mode> {
     ///
     /// An uninitialised hash is a hash that has not been set or has been dirtied.
     hash: OnceLock<Hash>,
+
+    /// Which store this node's body has already been written to, if any.
+    ///
+    /// Cleared by [`Node::invalidate_hash`], so it is dropped by exactly the mutations that
+    /// change what this node hashes to.
+    stored_in: StoredIn,
 }
 
 impl Node<LazyTreeId, LazyDataId, Normal> {
@@ -99,6 +163,7 @@ impl Node<LazyTreeId, LazyDataId, Normal> {
             left: self.left.into_proof(),
             right: self.right.into_proof(),
             hash: self.hash.clone(),
+            stored_in: StoredIn::default(),
         })
     }
 
@@ -117,6 +182,7 @@ impl Node<LazyTreeId, LazyDataId, Normal> {
             left,
             right,
             hash: OnceLock::new(),
+            stored_in: StoredIn::default(),
         }
     }
 
@@ -131,8 +197,12 @@ impl Node<LazyTreeId, LazyDataId, Normal> {
 
 impl<TreeId, DataId, M: Mode> Node<TreeId, DataId, M> {
     /// Mark the hash of this node as dirty.
+    ///
+    /// Also forgets which store the body reached: the node no longer hashes to what was written
+    /// there, so that copy does not describe it any more.
     fn invalidate_hash(&mut self) {
         self.hash = OnceLock::new();
+        self.stored_in.clear();
     }
 
     /// Direct access to the left child identifier.
@@ -229,6 +299,7 @@ impl<TreeId, DataId, M: AtomMode + NodeKeyMode> Node<TreeId, DataId, M> {
             left: TreeId::default(),
             right: TreeId::default(),
             hash: OnceLock::new(),
+            stored_in: StoredIn::default(),
         }
     }
 
@@ -255,6 +326,7 @@ impl<TreeId, DataId, M: AtomMode + NodeKeyMode> Node<TreeId, DataId, M> {
             left,
             right,
             hash: Default::default(),
+            stored_in: StoredIn::default(),
         };
 
         Ok((ctx, node))
@@ -289,6 +361,8 @@ impl<TreeId, DataId, M: AtomMode + NodeKeyMode> Node<TreeId, DataId, M> {
     /// A mutable reference to the difference in heights between child branches.
     #[inline]
     pub(super) fn balance_factor_mut(&mut self) -> &mut i8 {
+        self.invalidate_hash();
+
         &mut self.balance_factor
     }
 
@@ -896,6 +970,15 @@ where
         store: &impl WriteableKeyValueStore,
         options: &StoreOptions,
     ) -> Result<(), OperationalError> {
+        // Nothing to write if this node is already in this store, and nothing below it either.
+        // Nodes are content-addressed: changing a descendant changes every hash above it, so an
+        // unchanged node cannot have a changed descendant. Skipping the body therefore skips the
+        // whole subtree, which is what keeps a commit to the size of what it changed.
+        let store_id = store.store_id();
+        if self.stored_in.covers(store_id, options.node_data()) {
+            return Ok(());
+        }
+
         // The stored representation is more compact. We don't include the `data` field, as that
         // should be written to the KV store separately. `left`/`right` are the hashes of the
         // child *trees* (the same values folded into this node's hash).
@@ -923,6 +1006,10 @@ where
 
         self.left.store(store, options)?;
         self.right.store(store, options)?;
+
+        // Recorded last: until the children are down, a later commit skipping this subtree would
+        // skip nodes that never reached the store.
+        self.stored_in.record(store_id, options.node_data());
 
         Ok(())
     }
@@ -998,6 +1085,12 @@ impl<TreeId: Loadable, DataId: DataLoadable> Loadable for Node<TreeId, DataId, N
         let left = TreeId::load(left, store)?;
         let right = TreeId::load(right, store)?;
 
+        // This node was just read out of `store`, so its body is there and so is its value data -
+        // whether the commit that wrote the tree carried it or the database wrote it directly.
+        // Recording that is what stops a checked-out tree from rewriting every node it touches.
+        let stored_in = StoredIn::default();
+        stored_in.record(store.store_id(), true);
+
         Ok(Self {
             balance_factor: Atom::new(balance_factor),
             key,
@@ -1005,6 +1098,7 @@ impl<TreeId: Loadable, DataId: DataLoadable> Loadable for Node<TreeId, DataId, N
             left,
             right,
             hash: OnceLock::new(),
+            stored_in,
         })
     }
 }

--- a/durable-storage/src/avl/resolver.rs
+++ b/durable-storage/src/avl/resolver.rs
@@ -1388,13 +1388,20 @@ mod tests {
     use crate::storage::in_memory::InMemoryRepo;
 
     /// A wrapper around an in-memory key-value store that counts the number of `blob_get` calls.
-    #[derive(Debug, Default)]
+    #[derive(Debug)]
     struct CountingKeyValueStore {
         inner: InMemoryKeyValueStore,
         blob_get_calls: AtomicUsize,
     }
 
     impl CountingKeyValueStore {
+        fn init() -> Self {
+            Self {
+                inner: InMemoryKeyValueStore::init(),
+                blob_get_calls: Default::default(),
+            }
+        }
+
         fn blob_get_calls(&self) -> usize {
             self.blob_get_calls.load(Ordering::SeqCst)
         }
@@ -1404,6 +1411,10 @@ mod tests {
         type Repo = InMemoryRepo;
 
         type Merkle = crate::merkle_worker::MerkleWorker<Self>;
+        fn store_id(&self) -> crate::storage::StoreId {
+            // Delegated, so that wrapping a store does not make it look like a different one.
+            self.inner.store_id()
+        }
 
         fn blob_get(&self, key: impl AsRef<[u8]>) -> Result<impl AsRef<[u8]>, Error> {
             self.blob_get_calls.fetch_add(1, Ordering::SeqCst);
@@ -1417,7 +1428,7 @@ mod tests {
 
     impl WriteableKeyValueStore for CountingKeyValueStore {
         fn new(_repo: &Self::Repo) -> Result<Self, OperationalError> {
-            Ok(Self::default())
+            Ok(Self::init())
         }
 
         fn try_clone(&self, _repo: &Self::Repo) -> Result<Self, OperationalError> {
@@ -1487,7 +1498,7 @@ mod tests {
         let tree_hash = tree.hash();
         let root_hash = Hash::from_foldable(tree.root().expect("tree should have a root node"));
 
-        let persistence_layer = Arc::new(CountingKeyValueStore::default());
+        let persistence_layer = Arc::new(CountingKeyValueStore::init());
         persist_tree(&tree, persistence_layer.as_ref());
 
         let lazy_resolver = LazyResolver::new(persistence_layer.clone());
@@ -1538,7 +1549,7 @@ mod tests {
 
     #[test]
     fn lazy_resolver_returns_invariant_error_when_hash_is_missing() {
-        let persistence_layer = Arc::new(InMemoryKeyValueStore::default());
+        let persistence_layer = Arc::new(InMemoryKeyValueStore::init());
         let mut lazy_resolver = LazyResolver::new(persistence_layer);
 
         let node_without_hash = LazyNodeId(LazyId {
@@ -1575,7 +1586,7 @@ mod tests {
     #[test]
     fn lazy_resolver_maps_missing_cas_entries_to_commit_data_missing() {
         let missing_hash = Hash::hash_bytes(b"missing");
-        let persistence_layer = Arc::new(InMemoryKeyValueStore::default());
+        let persistence_layer = Arc::new(InMemoryKeyValueStore::init());
         let lazy_resolver = LazyResolver::new(persistence_layer);
 
         let node_id = LazyNodeId::from(missing_hash);
@@ -1604,7 +1615,7 @@ mod tests {
         // into storage is keyed by the tree hash.
         let tree_hash = tree.hash();
 
-        let persistence_layer = Arc::new(CountingKeyValueStore::default());
+        let persistence_layer = Arc::new(CountingKeyValueStore::init());
         persist_tree(&tree, persistence_layer.as_ref());
 
         let mut node_id: LazyNodeId = LazyNodeId::from(tree_hash);
@@ -1638,7 +1649,7 @@ mod tests {
         // Lazy references into storage are keyed by the tree hash (the node body lives there).
         let tree_hash = tree.hash();
 
-        let persistence_layer = Arc::new(CountingKeyValueStore::default());
+        let persistence_layer = Arc::new(CountingKeyValueStore::init());
         persist_tree(&tree, persistence_layer.as_ref());
 
         let mut lazy_tree: Tree<LazyNodeId> = Some(LazyNodeId::from(tree_hash)).into();
@@ -1736,7 +1747,7 @@ mod tests {
         // keyed by the tree hash.
         let persisted_tree_hash = original_tree.hash();
 
-        let persistence_layer = Arc::new(InMemoryKeyValueStore::default());
+        let persistence_layer = Arc::new(InMemoryKeyValueStore::init());
         persist_tree(&original_tree, persistence_layer.as_ref());
 
         let mut lazy_tree: Tree<LazyNodeId> = Some(LazyNodeId::from(persisted_tree_hash)).into();
@@ -1782,7 +1793,7 @@ mod tests {
         // body is now stored directly under it.
         let tree_hash = tree.hash();
 
-        let persistence_layer = Arc::new(CountingKeyValueStore::default());
+        let persistence_layer = Arc::new(CountingKeyValueStore::init());
         persist_tree(&tree, persistence_layer.as_ref());
 
         (tree_hash, tree, persistence_layer)
@@ -1975,7 +1986,7 @@ mod tests {
 
     #[test]
     fn prove_resolver_empty_tree() {
-        let persistence_layer = Arc::new(CountingKeyValueStore::default());
+        let persistence_layer = Arc::new(CountingKeyValueStore::init());
         let lazy_resolver = LazyResolver::new(persistence_layer);
 
         let empty_lazy_tree: LazyTreeId = LazyTreeId::default();

--- a/durable-storage/src/persistence_layer.rs
+++ b/durable-storage/src/persistence_layer.rs
@@ -49,6 +49,7 @@ use crate::repo::DirectoryManager;
 use crate::storage::PersistentKeyValueStore;
 use crate::storage::ReadOnlyKeyValueStore;
 use crate::storage::ReadableKeyValueStore;
+use crate::storage::StoreId;
 use crate::storage::WriteableKeyValueStore;
 
 /// The name of the column family used for storing blob-keyed data.
@@ -391,6 +392,9 @@ pub struct PersistenceLayer {
     /// We need to own this in order to keep alive the temporary directory for the lifetime of the
     /// persistence layer.
     _tempdir: TempDir,
+
+    /// Distinguishes this store from every other, including checkpoints taken of it.
+    store_id: StoreId,
 }
 
 impl PersistenceLayer {
@@ -421,6 +425,7 @@ impl PersistenceLayer {
         Ok(Self {
             db_instance: ManuallyDrop::new(temp_db),
             _tempdir: tempdir,
+            store_id: StoreId::next(),
         })
     }
 
@@ -431,6 +436,10 @@ impl PersistenceLayer {
 
 impl ReadableKeyValueStore for PersistenceLayer {
     type Repo = DirectoryManager;
+
+    fn store_id(&self) -> StoreId {
+        self.store_id
+    }
 
     type Merkle = MerkleWorker<Self>;
 
@@ -453,12 +462,18 @@ pub struct ReadOnlyPersistenceLayer {
     /// Unlike [`PersistenceLayer`], no manual-drop is needed: dropping this closes the handle
     /// and there is nothing to destroy afterwards.
     db_instance: rocksdb::DB,
+
+    /// Distinguishes this view from every other store.
+    store_id: StoreId,
 }
 
 impl ReadableKeyValueStore for ReadOnlyPersistenceLayer {
     type Repo = DirectoryManager;
 
     type Merkle = CommittedRoot;
+    fn store_id(&self) -> StoreId {
+        self.store_id
+    }
 
     fn blob_get(&self, key: impl AsRef<[u8]>) -> Result<impl AsRef<[u8]>, Error> {
         blob_get_from(&self.db_instance, key.as_ref())
@@ -486,6 +501,7 @@ impl ReadOnlyKeyValueStore for ReadOnlyPersistenceLayer {
 
         Ok(Self {
             db_instance: open_committed_read_only(commit_path)?,
+            store_id: StoreId::next(),
         })
     }
 
@@ -515,6 +531,7 @@ impl WriteableKeyValueStore for PersistenceLayer {
         Ok(Self {
             db_instance: ManuallyDrop::new(db),
             _tempdir: tempdir,
+            store_id: StoreId::next(),
         })
     }
 
@@ -741,6 +758,7 @@ impl PersistentKeyValueStore for PersistenceLayer {
         Ok(Self {
             db_instance: ManuallyDrop::new(database),
             _tempdir: working_path,
+            store_id: StoreId::next(),
         })
     }
 

--- a/durable-storage/src/registry.rs
+++ b/durable-storage/src/registry.rs
@@ -1312,6 +1312,28 @@ pub(super) mod tests {
         );
     });
 
+    kv_test!(test_copied_database_commits_shared_nodes_into_its_own_store, KV: BackgroundPersistentKeyValueStore, {
+        let (_keepalive, repo) = KV::setup_repo();
+        let mut registry = setup_size_2_registry::<KV>(repo.clone());
+
+        populate_database_with_key_value::<KV>(&mut registry, 0, &[1], b"alpha");
+
+        // Copying hands the destination a copy of the source's store and the *same* in-memory
+        // nodes, so both databases now owe those nodes a write. Tracking "already stored" as a
+        // bare flag on the node would let the first commit satisfy the obligation and the second
+        // skip it, leaving a commit that refers to nodes which never reached its own store - which
+        // only shows up on checkout, once the in-memory nodes are gone.
+        registry.copy_database(0, 1).expect("Copy should succeed");
+
+        let root_commit = registry.commit().expect("Commit should succeed");
+        let checked_out = Registry::<KV, Normal>::checkout(repo, root_commit)
+            .expect("Checkout should succeed");
+
+        let key = Key::new(&[1]).expect("Size less than KEY_MAX_SIZE");
+        checked_out.databases[0].assert_database_value(&key, b"alpha");
+        checked_out.databases[1].assert_database_value(&key, b"alpha");
+    });
+
     // Not `kv_test!`s: the in-memory backend copies a commit into memory either way, so it has no
     // read-only store.
     #[cfg(rocksdb)]

--- a/durable-storage/src/storage.rs
+++ b/durable-storage/src/storage.rs
@@ -22,6 +22,39 @@ use crate::merkle_worker::CommittedRoot;
 use crate::merkle_worker::MerkleHandle;
 use crate::merkle_worker::MerkleWorker;
 
+/// Identifies one key-value store, so that data can be known to be in *this* store rather than
+/// merely in some store.
+///
+/// A tree is shared between stores by cloning - [`crate::registry::Registry::copy_database`] hands
+/// the destination a copy of the source's store and the same in-memory nodes. Whether a node still
+/// needs storing therefore cannot be a single flag on the node: the same node owes a copy to each
+/// store, and one store satisfying its obligation says nothing about the others.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StoreId(u64);
+
+impl StoreId {
+    /// The id no store has, meaning "not in any store".
+    pub const NONE: Self = Self(0);
+
+    /// Allocate an id no other store holds.
+    pub fn next() -> Self {
+        static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+        Self(NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed))
+    }
+
+    /// The raw value, for recording compactly.
+    pub const fn raw(&self) -> u64 {
+        self.0
+    }
+}
+
+impl From<u64> for StoreId {
+    fn from(raw: u64) -> Self {
+        Self(raw)
+    }
+}
+
 /// Types that implement this trait can serve reads from a key-value store.
 ///
 /// This is the half of the store interface that requires no ability to modify the stored data.
@@ -31,6 +64,12 @@ use crate::merkle_worker::MerkleWorker;
 pub trait ReadableKeyValueStore: Sized {
     /// Type of repository required to initialise a key value store.
     type Repo;
+
+    /// This store's identity, distinct from every other live store including copies of itself.
+    ///
+    /// A copy is a distinct store: it holds what the original held when it was copied, but nothing
+    /// written to the original afterwards. See [`StoreId`].
+    fn store_id(&self) -> StoreId;
 
     /// How a Normal-mode database over this store tracks its Merkle root.
     ///

--- a/durable-storage/src/storage/in_memory.rs
+++ b/durable-storage/src/storage/in_memory.rs
@@ -16,6 +16,7 @@ use bytes::Bytes;
 use bytes::BytesMut;
 
 use super::ReadableKeyValueStore;
+use super::StoreId;
 use super::WriteableKeyValueStore;
 use crate::errors::Error;
 use crate::errors::InvalidArgumentError;
@@ -60,16 +61,28 @@ impl InMemoryRepo {
 }
 
 /// In-memory key-value store
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct InMemoryKeyValueStore {
     /// Holds blobs.
     blobs: RwLock<HashMap<Bytes, Bytes>>,
 
     /// Holds the underlying key-value pairs
     values: RwLock<HashMap<Bytes, BytesMut>>,
+
+    /// Distinguishes this store from every other, including copies of it.
+    store_id: StoreId,
 }
 
 impl InMemoryKeyValueStore {
+    /// Create a new `in-memory` key value store.
+    pub fn init() -> Self {
+        Self {
+            blobs: Default::default(),
+            values: Default::default(),
+            store_id: StoreId::next(),
+        }
+    }
+
     pub fn try_clone(&self) -> Result<Self, OperationalError> {
         let blobs = self
             .blobs
@@ -86,6 +99,9 @@ impl InMemoryKeyValueStore {
         Ok(Self {
             blobs: RwLock::new(blobs),
             values: RwLock::new(values),
+            // A copy is its own store: it holds what the original held at this moment, and nothing
+            // written to the original afterwards.
+            store_id: StoreId::next(),
         })
     }
 }
@@ -94,6 +110,9 @@ impl ReadableKeyValueStore for InMemoryKeyValueStore {
     type Repo = InMemoryRepo;
 
     type Merkle = MerkleWorker<Self>;
+    fn store_id(&self) -> StoreId {
+        self.store_id
+    }
 
     fn blob_get(&self, key: impl AsRef<[u8]>) -> Result<impl AsRef<[u8]>, Error> {
         let blob_store = self
@@ -124,7 +143,7 @@ impl ReadableKeyValueStore for InMemoryKeyValueStore {
 
 impl WriteableKeyValueStore for InMemoryKeyValueStore {
     fn new(_repo: &Self::Repo) -> Result<Self, OperationalError> {
-        Ok(Self::default())
+        Ok(Self::init())
     }
 
     fn try_clone(&self, _repo: &Self::Repo) -> Result<Self, OperationalError> {
@@ -335,6 +354,7 @@ impl super::PersistentKeyValueStore for InMemoryKeyValueStore {
                     .map(|(k, v)| (k, BytesMut::from(v.as_ref())))
                     .collect(),
             ),
+            store_id: StoreId::next(),
         })
     }
 
@@ -356,6 +376,7 @@ impl super::PersistentKeyValueStore for InMemoryKeyValueStore {
                     .map(|(k, v)| (k.clone(), BytesMut::from(v.as_ref())))
                     .collect(),
             ),
+            store_id: StoreId::next(),
         })
     }
 }
@@ -371,7 +392,7 @@ mod tests {
     // `InMemoryKeyValueStore`, which are themselves only used in tests
     #[test]
     fn test_commit_to_path_checkout_roundtrip() {
-        let store = InMemoryKeyValueStore::default();
+        let store = InMemoryKeyValueStore::init();
 
         store
             .blob_set(b"blob-key", b"blob-data")


### PR DESCRIPTION
- Part of TZX-213

# What

Don't persist nodes (of a long-running checkout) that haven't changed since the last time the checkout was committed.

# Why

This prevents re-writing values to storage that were already there verbatim, which causes reduced sharing - as these values are written into new files.

# How

Nodes now record whether they were previously committed, and which store they were committed to.  subsequent commits skip such a node and its subtree(s), if the store-id's match.
This is voided by any mutation - and the node will be committed to store again subsequently.

The store id is used rather than a bare flag, as `copy_database` could otherwise result in a shared node thinking it's persisted, when it could be in `src` but not `dst` (as `src` was committed earlier).


# Manually Testing

```
make all
```

# Tasks for the Author

- [x] Link all Linear issues related to this MR using magic words (e.g. part of, relates to, closes).
- [ ] Eliminate dead code and other spurious artefacts introduced in your changes.
- [ ] Document new public functions, methods and types.
- [ ] Make sure the documentation for updated functions, methods, and types is correct.
- [ ] Add tests for bugs that have been fixed.
- [ ] [Explain changes](#regressions) to regression test captures when applicable.
- [ ] Write commit messages in agreement with our guidelines.
- [ ] Self-review your changes to ensure they are high-quality.
- [ ] Complete all of the above before assigning this MR to reviewers.
